### PR TITLE
removed log4j-api from GHSA-7rjr-3q55-vv33

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-7rjr-3q55-vv33/GHSA-7rjr-3q55-vv33.json
+++ b/advisories/github-reviewed/2021/12/GHSA-7rjr-3q55-vv33/GHSA-7rjr-3q55-vv33.json
@@ -33,25 +33,6 @@
           ]
         }
       ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.apache.logging.log4j:log4j-api"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "2.16.0"
-            }
-          ]
-        }
-      ]
     }
   ],
   "references": [


### PR DESCRIPTION
Updates:
* Affected products

Removing org.apache.logging.log4j:log4j-api as it is not impacted.