### PR TITLE
Advisory improvement for GHSA-566m-qj78-rww5

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-566m-qj78-rww5/GHSA-566m-qj78-rww5.json
+++ b/advisories/github-reviewed/2022/01/GHSA-566m-qj78-rww5/GHSA-566m-qj78-rww5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-566m-qj78-rww5",
-  "modified": "2021-05-20T21:23:19Z",
+  "modified": "2022-02-23T16:54:47Z",
   "published": "2022-01-07T00:21:36Z",
   "aliases": [
     "CVE-2021-23382"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "8.2.13"
+              "fixed": "7.0.36, 8.2.13"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 8.2.13"
+      }
     }
   ],
   "references": [
@@ -57,7 +60,7 @@
     "cwe_ids": [
       "CWE-400"
     ],
-    "severity": "MODERATE",
-    "github_reviewed": true
+    "severity": "moderate",
+    "github_reviewed": null
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products

The fix for the vulnerability was backported in [v7.0.36](https://github.com/postcss/postcss/releases/tag/7.0.36)