### PR TITLE
Exclude experimental React versions from advisory GHSA-hg79-j56m-fxgv

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-hg79-j56m-fxgv/GHSA-hg79-j56m-fxgv.json
+++ b/advisories/github-reviewed/2020/09/GHSA-hg79-j56m-fxgv/GHSA-hg79-j56m-fxgv.json
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.0.1"
             },
             {
               "fixed": "0.14.0"


### PR DESCRIPTION
React publishes experimental versions with a version prefix of "0.0.0-".
This advisory causes false positives for all experimental versions,
therefore the `introduced` version should be changed to `0.0.1`

Full version history:
https://www.npmjs.com/package/react?activeTab=versions