### PR TITLE
Delete staging and head branches on PR close

### DIFF
--- a/.github/workflows/delete_staging_and_head_branches.yaml
+++ b/.github/workflows/delete_staging_and_head_branches.yaml
@@ -1,4 +1,4 @@
-name: Delete PR staging branch
+name: Delete PR staging and head branches
 
 on:
   pull_request_target:
@@ -9,14 +9,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  delete-staging-branch:
+  delete-staging-and-head-branches:
     runs-on: ubuntu-latest
     steps:
      - uses: actions/checkout@v2
-     - name: delete staging branch
+     - name: Delete staging and head branches
        env:
          STAGING_BRANCH: ${{ github.event.pull_request.base.ref }}
+         HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
          set -xeo pipefail
-         git push origin --delete $STAGING_BRANCH
+         git push origin --delete --force $STAGING_BRANCH
+         git push origin --delete --force $HEAD_BRANCH


### PR DESCRIPTION
When a PR is closed, whether it's merged or otherwise, we want to cleanup the staging and head branches. This PR updates the existing action that deletes the staging branch when a PR is merged to now delete both the staging and head branches when a PR is closed.