### PR TITLE
Fix incorrect RubyGems package name in GHSA-x24j-87x9-jvv5

### DIFF
--- a/advisories/github-reviewed/2021/11/GHSA-x24j-87x9-jvv5/GHSA-x24j-87x9-jvv5.json
+++ b/advisories/github-reviewed/2021/11/GHSA-x24j-87x9-jvv5/GHSA-x24j-87x9-jvv5.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "publify-core"
+        "name": "publify_core"
       },
       "ranges": [
         {


### PR DESCRIPTION
`publify-core` does not exist. `publify_core` does (which https://github.com/github/advisory-database/blob/d6004eb8de91ad341605da869ab1b9f1e4abe433/advisories/github-reviewed/2022/02/GHSA-x3rq-r3cm-5vc4/GHSA-x3rq-r3cm-5vc4.json encodes correctly).