### PR TITLE
Fix incorrect package name for GHSA-5629-8855-gf4g

### DIFF
--- a/advisories/github-reviewed/2021/11/GHSA-5629-8855-gf4g/GHSA-5629-8855-gf4g.json
+++ b/advisories/github-reviewed/2021/11/GHSA-5629-8855-gf4g/GHSA-5629-8855-gf4g.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "solidus-core"
+        "name": "solidus_core"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "solidus-core"
+        "name": "solidus_core"
       },
       "ranges": [
         {
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "solidus-core"
+        "name": "solidus_core"
       },
       "ranges": [
         {


### PR DESCRIPTION
`solidus_core` is the correct package name: https://rubygems.org/gems/solidus_core