### PR TITLE
Contribution to "Improper Check for Unusual or Exceptional Conditions in json-smart"

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-v528-7hrm-frqp/GHSA-v528-7hrm-frqp.json
+++ b/advisories/github-reviewed/2021/06/GHSA-v528-7hrm-frqp/GHSA-v528-7hrm-frqp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-v528-7hrm-frqp",
-  "modified": "2022-02-08T21:35:19Z",
+  "modified": "2022-03-03T16:52:53Z",
   "published": "2021-06-16T18:03:47Z",
   "aliases": [
     "CVE-2021-27568"
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.0.0"
+              "introduced": "2.4"
             },
             {
               "fixed": "2.4.1"
@@ -71,6 +71,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "net.minidev:json-smart"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0"
+            },
+            {
+              "fixed": "2.3.1 "
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
@@ -92,15 +111,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rf70210b4d63191c0bfb2a0d5745e104484e71703bf5ad9cb01c980c6@%3Ccommits.druid.apache.org%3E"
+    },
+    {
+      "type": "WEB",
       "url": "https://lists.apache.org/thread.html/rb6287f5aa628c8d9af52b5401ec6cc51b6fc28ab20d318943453e396@%3Ccommits.druid.apache.org%3E"
     },
     {
       "type": "WEB",
       "url": "https://lists.apache.org/thread.html/re237267da268c690df5e1c6ea6a38a7fc11617725e8049490f58a6fa@%3Ccommits.druid.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rf70210b4d63191c0bfb2a0d5745e104484e71703bf5ad9cb01c980c6@%3Ccommits.druid.apache.org%3E"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

this advisory informs about Affected versions < 1.3.2 and >= 2.0.0, < 2.4.1 .
but [nvd.nist.gov](https://nvd.nist.gov/vuln/detail/CVE-2021-27568)’s report excludes version 2.3.1.

version 2.3.1 should be added to Patched versions .

Could you check it, please?

thanks!