### PR TITLE
Contribution to "Remote code injection in Log4j"

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-jfh8-c2jp-5v3q/GHSA-jfh8-c2jp-5v3q.json
+++ b/advisories/github-reviewed/2021/12/GHSA-jfh8-c2jp-5v3q/GHSA-jfh8-c2jp-5v3q.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-jfh8-c2jp-5v3q",
-  "modified": "2022-02-08T20:31:56Z",
+  "modified": "2022-03-04T12:20:05Z",
   "published": "2021-12-10T00:40:56Z",
   "aliases": [
     "CVE-2021-44228"
   ],
   "summary": "Remote code injection in Log4j",
-  "details": "# Summary\n\nLog4j versions prior to 2.16.0 are subject to a remote code execution vulnerability via the ldap JNDI parser.\nAs per [Apache's Log4j security guide](https://logging.apache.org/log4j/2.x/security.html): Apache Log4j2 <=2.14.1 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.16.0, this behavior has been disabled by default.\n\nLog4j version 2.15.0 contained an earlier fix for the vulnerability, but that patch did not disable attacker-controlled JNDI lookups in all situations. For more information, see the `Updated advice for version 2.16.0` section of this advisory.\n\n# Impact\n\nLogging untrusted or user controlled data with a vulnerable version of Log4J may result in Remote Code Execution (RCE) against your application. This includes untrusted data included in logged errors such as exception traces, authentication failures, and other unexpected vectors of user controlled input. \n\n# Affected versions\n\nAny Log4J version prior to v2.15.0 is affected to this specific issue.\n\nThe v1 branch of Log4J which is considered End Of Life (EOL) is vulnerable to other RCE vectors so the recommendation is to still update to 2.16.0 where possible.\n\n## Affected packages\nOnly the `org.apache.logging.log4j:log4j-core` package is directly affected by this vulnerability. The `org.apache.logging.log4j:log4j-api` should be kept at the same version as the `org.apache.logging.log4j:log4j-core` package to ensure compatability if in use.\n\n# Remediation Advice\n\n## Updated advice for version 2.16.0\n\nThe Apache Logging Services team provided updated mitigation advice upon the release of version 2.16.0, which [disables JNDI by default and completely removes support for message lookups](https://logging.apache.org/log4j/2.x/changes-report.html#a2.16.0).\nEven in version 2.15.0, lookups used in layouts to provide specific pieces of context information will still recursively resolve, possibly triggering JNDI lookups. This problem is being tracked as [CVE-2021-45046](https://nvd.nist.gov/vuln/detail/CVE-2021-45046). More information is available on the [GitHub Security Advisory for CVE-2021-45046](https://github.com/advisories/GHSA-7rjr-3q55-vv33).\n\nUsers who want to avoid attacker-controlled JNDI lookups but cannot upgrade to 2.16.0 must [ensure that no such lookups resolve to attacker-provided data and ensure that the the JndiLookup class is not loaded](https://issues.apache.org/jira/browse/LOG4J2-3221).\n\nPlease note that Log4J v1 is End Of Life (EOL) and will not receive patches for this issue. Log4J v1 is also vulnerable to other RCE vectors and we recommend you migrate to Log4J 2.16.0 where possible.",
+  "details": "# Summary\r\n\r\nLog4j versions prior to 2.16.0 are subject to a remote code execution vulnerability via the ldap JNDI parser.\r\nAs per [Apache's Log4j security guide](https://logging.apache.org/log4j/2.x/security.html): Apache Log4j2 <=2.14.1 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.16.0, this behavior has been disabled by default.\r\n\r\nLog4j version 2.15.0 contained an earlier fix for the vulnerability, but that patch did not disable attacker-controlled JNDI lookups in all situations. For more information, see the `Updated advice for version 2.16.0` section of this advisory.\r\n\r\n# Impact\r\n\r\nLogging untrusted or user controlled data with a vulnerable version of Log4J may result in Remote Code Execution (RCE) against your application. This includes untrusted data included in logged errors such as exception traces, authentication failures, and other unexpected vectors of user controlled input. \r\n\r\n# Affected versions\r\n\r\nAny Log4J version prior to v2.15.0 is affected to this specific issue.\r\n\r\nThe v1 branch of Log4J which is considered End Of Life (EOL) is vulnerable to other RCE vectors so the recommendation is to still update to 2.16.0 where possible.\r\n\r\n## Affected packages\r\nOnly the `org.apache.logging.log4j:log4j-core` package is directly affected by this vulnerability. The `org.apache.logging.log4j:log4j-api` should be kept at the same version as the `org.apache.logging.log4j:log4j-core` package to ensure compatability if in use.\r\n\r\n# Remediation Advice\r\n\r\n## Updated advice for version 2.16.0\r\n\r\nThe Apache Logging Services team provided updated mitigation advice upon the release of version 2.16.0, which [disables JNDI by default and completely removes support for message lookups](https://logging.apache.org/log4j/2.x/changes-report.html#a2.16.0).\r\nEven in version 2.15.0, lookups used in layouts to provide specific pieces of context information will still recursively resolve, possibly triggering JNDI lookups. This problem is being tracked as [CVE-2021-45046](https://nvd.nist.gov/vuln/detail/CVE-2021-45046). More information is available on the [GitHub Security Advisory for CVE-2021-45046](https://github.com/advisories/GHSA-7rjr-3q55-vv33).\r\n\r\nUsers who want to avoid attacker-controlled JNDI lookups but cannot upgrade to 2.16.0 must [ensure that no such lookups resolve to attacker-provided data and ensure that the the JndiLookup class is not loaded](https://issues.apache.org/jira/browse/LOG4J2-3221).\r\n\r\nPlease note that Log4J v1 is End Of Life (EOL) and will not receive patches for this issue. Log4J v1 is also vulnerable to other RCE vectors and we recommend you migrate to Log4J 2.16.0 where possible.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,6 +28,47 @@
               "introduced": "0"
             },
             {
+              "fixed": "2.3.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.logging.log4j:log4j-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.3.2"
+            },
+            {
+              "fixed": "2.12.2, 2.12.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.12.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.logging.log4j:log4j-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.12.4"
+            },
+            {
               "fixed": "2.15.0"
             }
           ]
@@ -46,63 +87,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-397453.pdf"
-    },
-    {
-      "type": "WEB",
-      "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-479842.pdf"
-    },
-    {
-      "type": "WEB",
-      "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-661247.pdf"
-    },
-    {
-      "type": "WEB",
-      "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-714170.pdf"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://github.com/advisories/GHSA-7rjr-3q55-vv33"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/cisagov/log4j-affected-db"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/cisagov/log4j-affected-db/blob/develop/SOFTWARE-LIST.md"
-    },
-    {
-      "type": "WEB",
       "url": "https://github.com/tangxiaofeng7/apache-log4j-poc"
-    },
-    {
-      "type": "WEB",
-      "url": "https://issues.apache.org/jira/browse/LOG4J2-3198"
-    },
-    {
-      "type": "WEB",
-      "url": "https://issues.apache.org/jira/browse/LOG4J2-3201 "
-    },
-    {
-      "type": "WEB",
-      "url": "https://issues.apache.org/jira/browse/LOG4J2-3214"
-    },
-    {
-      "type": "WEB",
-      "url": "https://issues.apache.org/jira/browse/LOG4J2-3221"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2021/12/msg00007.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/M5CSVUNV4HWZZXGOKNSK6L7RPM7BOKIB/"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VU57UJDCFIASIO35GC55JMKSRXJMCDFM/"
     },
     {
       "type": "WEB",
@@ -114,19 +99,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/LOG4J2-3198"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/LOG4J2-3201"
+    },
+    {
+      "type": "WEB",
       "url": "https://logging.apache.org/log4j/2.x/manual/migration.html"
     },
     {
       "type": "WEB",
       "url": "https://logging.apache.org/log4j/2.x/security.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://msrc-blog.microsoft.com/2021/12/11/microsofts-response-to-cve-2021-44228-apache-log4j2/"
-    },
-    {
-      "type": "WEB",
-      "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032"
     },
     {
       "type": "WEB",
@@ -138,23 +123,31 @@
     },
     {
       "type": "WEB",
-      "url": "https://twitter.com/kurtseifried/status/1469345530182455296"
+      "url": "http://packetstormsecurity.com/files/165225/Apache-Log4j2-2.14.1-Remote-Code-Execution.html"
     },
     {
       "type": "WEB",
-      "url": "https://www.bentley.com/en/common-vulnerability-exposure/be-2022-0001"
+      "url": "http://www.openwall.com/lists/oss-security/2021/12/10/1"
     },
     {
       "type": "WEB",
-      "url": "https://www.debian.org/security/2021/dsa-5020"
+      "url": "http://www.openwall.com/lists/oss-security/2021/12/10/2"
     },
     {
       "type": "WEB",
-      "url": "https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00646.html"
+      "url": "http://www.openwall.com/lists/oss-security/2021/12/10/3"
     },
     {
       "type": "WEB",
-      "url": "https://www.kb.cert.org/vuls/id/930724"
+      "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/LOG4J2-3214"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VU57UJDCFIASIO35GC55JMKSRXJMCDFM/"
     },
     {
       "type": "WEB",
@@ -162,11 +155,35 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpujan2022.html"
+      "url": "http://www.openwall.com/lists/oss-security/2021/12/13/1"
     },
     {
       "type": "WEB",
-      "url": "http://packetstormsecurity.com/files/165225/Apache-Log4j2-2.14.1-Remote-Code-Execution.html"
+      "url": "http://www.openwall.com/lists/oss-security/2021/12/13/2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/LOG4J2-3221"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-7rjr-3q55-vv33"
+    },
+    {
+      "type": "WEB",
+      "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-661247.pdf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2021/12/msg00007.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://twitter.com/kurtseifried/status/1469345530182455296"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.debian.org/security/2021/dsa-5020"
     },
     {
       "type": "WEB",
@@ -179,6 +196,18 @@
     {
       "type": "WEB",
       "url": "http://packetstormsecurity.com/files/165270/Apache-Log4j2-2.14.1-Remote-Code-Execution.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2021/12/14/4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00646.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.kb.cert.org/vuls/id/930724"
     },
     {
       "type": "WEB",
@@ -202,11 +231,39 @@
     },
     {
       "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2021/12/15/3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-714170.pdf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://msrc-blog.microsoft.com/2021/12/11/microsofts-response-to-cve-2021-44228-apache-log4j2/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-397453.pdf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-479842.pdf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/M5CSVUNV4HWZZXGOKNSK6L7RPM7BOKIB/"
+    },
+    {
+      "type": "WEB",
       "url": "http://packetstormsecurity.com/files/165371/VMware-Security-Advisory-2021-0028.4.html"
     },
     {
       "type": "WEB",
       "url": "http://packetstormsecurity.com/files/165532/Log4Shell-HTTP-Header-Injection.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cisagov/log4j-affected-db/blob/develop/SOFTWARE-LIST.md"
     },
     {
       "type": "WEB",
@@ -218,31 +275,7 @@
     },
     {
       "type": "WEB",
-      "url": "http://www.openwall.com/lists/oss-security/2021/12/10/1"
-    },
-    {
-      "type": "WEB",
-      "url": "http://www.openwall.com/lists/oss-security/2021/12/10/2"
-    },
-    {
-      "type": "WEB",
-      "url": "http://www.openwall.com/lists/oss-security/2021/12/10/3"
-    },
-    {
-      "type": "WEB",
-      "url": "http://www.openwall.com/lists/oss-security/2021/12/13/1"
-    },
-    {
-      "type": "WEB",
-      "url": "http://www.openwall.com/lists/oss-security/2021/12/13/2"
-    },
-    {
-      "type": "WEB",
-      "url": "http://www.openwall.com/lists/oss-security/2021/12/14/4"
-    },
-    {
-      "type": "WEB",
-      "url": "http://www.openwall.com/lists/oss-security/2021/12/15/3"
+      "url": "https://www.oracle.com/security-alerts/cpujan2022.html"
     },
     {
       "type": "PACKAGE",

--- a/advisories/github-reviewed/2021/12/GHSA-jfh8-c2jp-5v3q/GHSA-jfh8-c2jp-5v3q.json
+++ b/advisories/github-reviewed/2021/12/GHSA-jfh8-c2jp-5v3q/GHSA-jfh8-c2jp-5v3q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-jfh8-c2jp-5v3q",
-  "modified": "2022-03-04T12:20:05Z",
+  "modified": "2022-03-04T12:27:02Z",
   "published": "2021-12-10T00:40:56Z",
   "aliases": [
     "CVE-2021-44228"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0.1"
             },
             {
               "fixed": "2.3.1"
@@ -44,17 +44,14 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.3.2"
+              "introduced": "2.4.0"
             },
             {
-              "fixed": "2.12.2, 2.12.3"
+              "fixed": "2.12.2"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 2.12.2"
-      }
+      ]
     },
     {
       "package": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

[NVD about CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) shows that there are security releases for 2.12.2, 2.12.3, and 2.3.1. 

also there are next ranges:
From (including) 2.0.1,	Up to (excluding) 2.3.1
From (including) 2.4.0	Up to (excluding) 2.12.2
From (including) 2.13.0	Up to (excluding) 2.15.0

It seems that CVE-2021-44228 doesn't affect on another versions (eg. 2.12.4).

thanks!