### PR TITLE
Contribution to "Incomplete fix for Apache Log4j vulnerability"

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-7rjr-3q55-vv33/GHSA-7rjr-3q55-vv33.json
+++ b/advisories/github-reviewed/2021/12/GHSA-7rjr-3q55-vv33/GHSA-7rjr-3q55-vv33.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-7rjr-3q55-vv33",
-  "modified": "2022-02-24T18:12:21Z",
+  "modified": "2022-03-04T12:34:51Z",
   "published": "2021-12-14T18:01:28Z",
   "aliases": [
     "CVE-2021-45046"
   ],
   "summary": "Incomplete fix for Apache Log4j vulnerability",
-  "details": "# Impact\n\nThe fix to address [CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. This could allow attackers with control over Thread Context Map (MDC) input data when the logging configuration uses a non-default Pattern Layout with either a Context Lookup (for example, $${ctx:loginId}) or a Thread Context Map pattern (%X, %mdc, or %MDC) to craft malicious input data using a JNDI Lookup pattern resulting in a remote code execution (RCE) attack. \n\n## Affected packages\nOnly the `org.apache.logging.log4j:log4j-core` package is directly affected by this vulnerability. The `org.apache.logging.log4j:log4j-api` should be kept at the same version as the `org.apache.logging.log4j:log4j-core` package to ensure compatability if in use.\n\n# Mitigation\n\nLog4j 2.16.0 fixes this issue by removing support for message lookup patterns and disabling JNDI functionality by default. This issue can be mitigated in prior releases (< 2.16.0) by removing the JndiLookup class from the classpath (example: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class).\n\nLog4j 2.15.0 restricts JNDI LDAP lookups to localhost by default. Note that previous mitigations involving configuration such as to set the system property `log4j2.formatMsgNoLookups` to `true` do NOT mitigate this specific vulnerability.",
+  "details": "# Impact\r\n\r\nThe fix to address [CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. This could allow attackers with control over Thread Context Map (MDC) input data when the logging configuration uses a non-default Pattern Layout with either a Context Lookup (for example, $${ctx:loginId}) or a Thread Context Map pattern (%X, %mdc, or %MDC) to craft malicious input data using a JNDI Lookup pattern resulting in a remote code execution (RCE) attack. \r\n\r\n## Affected packages\r\nOnly the `org.apache.logging.log4j:log4j-core` package is directly affected by this vulnerability. The `org.apache.logging.log4j:log4j-api` should be kept at the same version as the `org.apache.logging.log4j:log4j-core` package to ensure compatability if in use.\r\n\r\n# Mitigation\r\n\r\nLog4j 2.16.0 fixes this issue by removing support for message lookup patterns and disabling JNDI functionality by default. This issue can be mitigated in prior releases (< 2.16.0) by removing the JndiLookup class from the classpath (example: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class).\r\n\r\nLog4j 2.15.0 restricts JNDI LDAP lookups to localhost by default. Note that previous mitigations involving configuration such as to set the system property `log4j2.formatMsgNoLookups` to `true` do NOT mitigate this specific vulnerability.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -25,7 +25,26 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0.1"
+            },
+            {
+              "fixed": "2.12.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.logging.log4j:log4j-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.13.0"
             },
             {
               "fixed": "2.16.0"
@@ -41,12 +60,36 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-45046"
     },
     {
-      "type": "WEB",
-      "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-397453.pdf"
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-jfh8-c2jp-5v3q"
     },
     {
       "type": "WEB",
-      "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-479842.pdf"
+      "url": "https://logging.apache.org/log4j/2.x/security.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.openwall.com/lists/oss-security/2021/12/14/4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2021-44228"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2021/12/14/4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00646.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2021/12/15/3"
     },
     {
       "type": "WEB",
@@ -57,8 +100,32 @@
       "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-714170.pdf"
     },
     {
-      "type": "ADVISORY",
-      "url": "https://github.com/advisories/GHSA-jfh8-c2jp-5v3q"
+      "type": "WEB",
+      "url": "https://www.kb.cert.org/vuls/id/930724"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.debian.org/security/2021/dsa-5022"
+    },
+    {
+      "type": "WEB",
+      "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/alert-cve-2021-44228.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2021/12/18/1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-397453.pdf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-479842.pdf"
     },
     {
       "type": "WEB",
@@ -70,55 +137,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://logging.apache.org/log4j/2.x/security.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032"
-    },
-    {
-      "type": "WEB",
-      "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.cve.org/CVERecord?id=CVE-2021-44228"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.debian.org/security/2021/dsa-5022"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00646.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.kb.cert.org/vuls/id/930724"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.openwall.com/lists/oss-security/2021/12/14/4"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/alert-cve-2021-44228.html"
-    },
-    {
-      "type": "WEB",
       "url": "https://www.oracle.com/security-alerts/cpujan2022.html"
-    },
-    {
-      "type": "WEB",
-      "url": "http://www.openwall.com/lists/oss-security/2021/12/14/4"
-    },
-    {
-      "type": "WEB",
-      "url": "http://www.openwall.com/lists/oss-security/2021/12/15/3"
-    },
-    {
-      "type": "WEB",
-      "url": "http://www.openwall.com/lists/oss-security/2021/12/18/1"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description

[NVD for CVE-2021-45046](https://nvd.nist.gov/vuln/detail/CVE-2021-45046) shows that Log4j 2.16.0 (Java 8) and 2.12.2 (Java 7) fix this issue by removing support for message lookup patterns and disabling JNDI functionality by default.

Ranges:
From (including) 2.0.1 Up to (excluding) 2.12.2
From (including) 2.13.0 Up to (excluding) 2.16.0

so, it seems this vulnerability doesn't affected on another versions of Log4j (eg. 2.12.4).

thanks!