### PR TITLE
Improve GHSA-mg2g-8pwj-r2j2

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-mg2g-8pwj-r2j2/GHSA-mg2g-8pwj-r2j2.json
+++ b/advisories/github-reviewed/2021/06/GHSA-mg2g-8pwj-r2j2/GHSA-mg2g-8pwj-r2j2.json
@@ -25,7 +25,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.0.0"
+            },
+            {
+              "fixed": "3.5.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 3.5.0"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "silverstripe/graphql"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.0.0-alpha1"
             },
             {
               "fixed": "4.0.0-alpha2"
@@ -34,7 +56,7 @@
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 3.5.0"
+        "last_known_affected_version_range": "< 3.5.0"
       }
     }
   ],


### PR DESCRIPTION
I couldn't figure out how to do this via the "Improvement Suggestion" UI. Hopefully it'll still all be fine 🤞 

Per https://www.silverstripe.org/download/security-releases/cve-2020-26136, these are the correct ranges.