### PR TITLE
[npm] fix `npm-lockfile` CVE's affected versions

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-cr6m-62pq-hmqh/GHSA-cr6m-62pq-hmqh.json
+++ b/advisories/github-reviewed/2022/03/GHSA-cr6m-62pq-hmqh/GHSA-cr6m-62pq-hmqh.json
@@ -7,7 +7,7 @@
     "CVE-2022-0841"
   ],
   "summary": "OS Command injection in npm-lockfile",
-  "details": "npm-lockfile before 2.0.4 does not santize unsafe external input and invoke sensitive command execution API with the input, causing command injection vulnerability.",
+  "details": "npm-lockfile v2.0.3 and v2.0.4 does not santize unsafe external input and invoke sensitive command execution API with the input, causing command injection vulnerability.",
   "severity": [
 
   ],
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0.3"
             },
             {
               "fixed": "2.0.5"


### PR DESCRIPTION
This issue only affects v2.0.3 and v2.0.4.

Please let me know if I edited this incorrectly.