### PR TITLE
Updated latest `sylius/sylius` advisory to comply with packagist.org package naming requirements

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-4qrp-27r3-66fj/GHSA-4qrp-27r3-66fj.json
+++ b/advisories/github-reviewed/2022/03/GHSA-4qrp-27r3-66fj/GHSA-4qrp-27r3-66fj.json
@@ -6,7 +6,7 @@
   "aliases": [
     "CVE-2022-24749"
   ],
-  "summary": "Improper sanitize of SVG files during content upload ('Cross-site Scripting') in Sylius/Sylius",
+  "summary": "Improper sanitize of SVG files during content upload ('Cross-site Scripting') in sylius/sylius",
   "details": "### Impact\nThere is a possibility to upload an SVG file containing XSS code in the admin panel. In order to perform an XSS attack, the file itself has to be opened in a new card (or loaded outside of the IMG tag). The problem applies both to the files opened on the admin panel and shop pages.\n\n### Patches\nThe issue is fixed in versions: 1.9.10, 1.10.11, 1.11.2, and above.\n\n### Workarounds\nIf there is a need to upload an SVG image type, on-upload sanitization has to be added. The way to achieve this is to require a library that will do the trick:\n\n```\ncomposer require enshrined/svg-sanitize\n```\n\nThe second step is all about performing a file content sanitization before writing it to the filesystem. It can be done by overwriting the service:\n\n```php\n<?php\n\ndeclare(strict_types=1);\n\nnamespace App\\Uploader;\n\nuse enshrined\\svgSanitize\\Sanitizer;\nuse Gaufrette\\Filesystem;\nuse Sylius\\Component\\Core\\Generator\\ImagePathGeneratorInterface;\nuse Sylius\\Component\\Core\\Generator\\UploadedImagePathGenerator;\nuse Sylius\\Component\\Core\\Model\\ImageInterface;\nuse Sylius\\Component\\Core\\Uploader\\ImageUploaderInterface;\nuse Symfony\\Component\\HttpFoundation\\File\\File;\nuse Webmozart\\Assert\\Assert;\n\nfinal class ImageUploader implements ImageUploaderInterface\n{\n    private const MIME_SVG_XML = 'image/svg+xml';\n    private const MIME_SVG = 'image/svg';\n\n    /** @var Filesystem */\n    protected $filesystem;\n\n    /** @var ImagePathGeneratorInterface */\n    protected $imagePathGenerator;\n\n    /** @var Sanitizer */\n    protected $sanitizer;\n\n    public function __construct(\n        Filesystem $filesystem,\n        ?ImagePathGeneratorInterface $imagePathGenerator = null\n    ) {\n        $this->filesystem = $filesystem;\n\n        if ($imagePathGenerator === null) {\n            @trigger_error(sprintf(\n                'Not passing an $imagePathGenerator to %s constructor is deprecated since Sylius 1.6 and will be not possible in Sylius 2.0.', self::class\n            ), \\E_USER_DEPRECATED);\n        }\n\n        $this->imagePathGenerator = $imagePathGenerator ?? new UploadedImagePathGenerator();\n        $this->sanitizer = new Sanitizer();\n    }\n\n    public function upload(ImageInterface $image): void\n    {\n        if (!$image->hasFile()) {\n            return;\n        }\n\n        /** @var File $file */\n        $file = $image->getFile();\n\n        Assert::isInstanceOf($file, File::class);\n\n        $fileContent = $this->sanitizeContent(file_get_contents($file->getPathname()), $file->getMimeType());\n\n        if (null !== $image->getPath() && $this->has($image->getPath())) {\n            $this->remove($image->getPath());\n        }\n\n        do {\n            $path = $this->imagePathGenerator->generate($image);\n        } while ($this->isAdBlockingProne($path) || $this->filesystem->has($path));\n\n        $image->setPath($path);\n\n        $this->filesystem->write($image->getPath(), $fileContent);\n    }\n\n    public function remove(string $path): bool\n    {\n        if ($this->filesystem->has($path)) {\n            return $this->filesystem->delete($path);\n        }\n\n        return false;\n    }\n\n    protected function sanitizeContent(string $fileContent, string $mimeType): string\n    {\n        if (self::MIME_SVG_XML === $mimeType || self::MIME_SVG === $mimeType) {\n            $fileContent = $this->sanitizer->sanitize($fileContent);\n        }\n\n        return $fileContent;\n    }\n\n    private function has(string $path): bool\n    {\n        return $this->filesystem->has($path);\n    }\n\n    /**\n     * Will return true if the path is prone to be blocked by ad blockers\n     */\n    private function isAdBlockingProne(string $path): bool\n    {\n        return strpos($path, 'ad') !== false;\n    }\n}\n```\n\nAfter that, register service in the container:\n\n```yaml\nservices:\n    sylius.image_uploader:\n        class: App\\Uploader\\ImageUploader\n        arguments:\n            - '@gaufrette.sylius_image_filesystem'\n            - '@Sylius\\Component\\Core\\Generator\\ImagePathGeneratorInterface'\n```\n\n### For more information\nIf you have any questions or comments about this advisory:\n* Open an issue in [Sylius issues](https://github.com/Sylius/Sylius/issues)\n* Email us at security@sylius.com\n",
   "severity": [
     {
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Packagist",
-        "name": "Sylius/Sylius"
+        "name": "sylius/sylius"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Packagist",
-        "name": "Sylius/Sylius"
+        "name": "sylius/sylius"
       },
       "ranges": [
         {
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "Packagist",
-        "name": "Sylius/Sylius"
+        "name": "sylius/sylius"
       },
       "ranges": [
         {


### PR DESCRIPTION
Package name **MUST** be lowercase for `composer/composer` and `packagist.org` to pick it up correctly.

Ref: https://github.com/Roave/SecurityAdvisoriesBuilder/issues/573
Ref: https://github.com/Roave/SecurityAdvisoriesBuilder/runs/5601510148?check_suite_focus=true
Ref: https://twitter.com/Ocramius/status/1504824415866998784