### PR TITLE
Contribution to "Out of bounds read in json-smart"

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-fg2v-w576-w4v3/GHSA-fg2v-w576-w4v3.json
+++ b/advisories/github-reviewed/2022/02/GHSA-fg2v-w576-w4v3/GHSA-fg2v-w576-w4v3.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-fg2v-w576-w4v3",
-  "modified": "2022-02-08T21:24:12Z",
+  "modified": "2022-03-21T13:54:00Z",
   "published": "2022-02-10T22:46:22Z",
   "aliases": [
     "CVE-2021-31684"
   ],
   "summary": "Out of bounds read in json-smart",
-  "details": "A vulnerability was discovered in the indexOf function of JSONParserByteArray in JSON Smart versions prior to 1.3.3 and 2.4.5 which causes a denial of service (DOS) via a crafted web request.",
+  "details": "A vulnerability was discovered in the indexOf function of JSONParserByteArray in JSON Smart versions 1.3 and 2.4 which causes a denial of service (DOS) via a crafted web request.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -44,10 +44,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.0.0"
+              "introduced": "2.4"
             },
             {
-              "fixed": "2.4.5"
+              "fixed": "2.4.4"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

NVD details about CVE-2021-31684 were updated 03/01/2022 and now affected versions are next:
* From (including)1.3  Up to (excluding)1.3.3
* From (including) 2.4  Up to (excluding) 2.4.4

links:
* https://nvd.nist.gov/vuln/detail/CVE-2021-31684