### PR TITLE
Contribution to "Remote Code Execution in Spring Framework"

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-36p3-wjmg-h94x/GHSA-36p3-wjmg-h94x.json
+++ b/advisories/github-reviewed/2022/03/GHSA-36p3-wjmg-h94x/GHSA-36p3-wjmg-h94x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-36p3-wjmg-h94x",
-  "modified": "2022-03-31T18:30:50Z",
+  "modified": "2022-04-01T12:23:35Z",
   "published": "2022-03-31T18:30:50Z",
   "aliases": [
     "CVE-2022-22965"
@@ -12,82 +12,6 @@
 
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.springframework:spring-core"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "5.2.20"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.springframework:spring-core"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "5.3.0"
-            },
-            {
-              "fixed": "5.3.18"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.springframework:spring-beans"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "5.2.20"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.springframework:spring-beans"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "5.3.0"
-            },
-            {
-              "fixed": "5.3.18"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "Maven",


### PR DESCRIPTION
**Updates**
- Affected products

Marking `spring-beans` and `spring-core` as affected results in pretty much every Spring application being vulnerable to CVE-2022-22965 which is not accurate as per https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement. Keeping `spring-beans` and `spring-core` in this advisory will lead to a lot of churn and false positives. 