### PR TITLE
Fix affected versions for GHSA-99wh-973f-779p

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-99wh-973f-779p/GHSA-99wh-973f-779p.json
+++ b/advisories/github-reviewed/2022/03/GHSA-99wh-973f-779p/GHSA-99wh-973f-779p.json
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "5.1-beta"
+              "introduced": "5.1-beta1"
             },
             {
               "fixed": "5.1"

--- a/advisories/github-reviewed/2022/03/GHSA-99wh-973f-779p/GHSA-99wh-973f-779p.json
+++ b/advisories/github-reviewed/2022/03/GHSA-99wh-973f-779p/GHSA-99wh-973f-779p.json
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "5.1-beta"
             },
             {
               "fixed": "5.1"


### PR DESCRIPTION
As per the reference docs, the bug was introduced in 5.1-beta1 and fixed in 5.1
https://huntr.dev/bounties/d63972a2-b910-480a-a86b-d1f75d24d563/

https://nvd.nist.gov/vuln/detail/CVE-2022-0265

<img width="834" alt="image" src="https://user-images.githubusercontent.com/4360246/161328342-204cf077-82a4-48e6-96db-0762f555ef4f.png">
