### PR TITLE
Contribution to "Remote Code Execution in Spring Framework"

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-36p3-wjmg-h94x/GHSA-36p3-wjmg-h94x.json
+++ b/advisories/github-reviewed/2022/03/GHSA-36p3-wjmg-h94x/GHSA-36p3-wjmg-h94x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-36p3-wjmg-h94x",
-  "modified": "2022-03-31T18:30:50Z",
+  "modified": "2022-04-04T09:51:40Z",
   "published": "2022-03-31T18:30:50Z",
   "aliases": [
     "CVE-2022-22965"
@@ -12,44 +12,6 @@
 
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.springframework:spring-beans"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "5.2.20"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.springframework:spring-beans"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "5.3.0"
-            },
-            {
-              "fixed": "5.3.18"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "Maven",


### PR DESCRIPTION
**Updates**
- Affected products

As per the Spring framework core contributor @rstoyanchev in https://github.com/github/advisory-database/pull/169#issuecomment-1086127921 `spring-beans` alone is _not_ vulnerable and _should_ not be included in this advisory. 

Keeping `spring-beans` in this advisory will flag every Spring application to be vulnerable to CVE-2022-22965 aka Spring4Shell when it is commonly agreed the vulnerability can only be exploited via `spring-webmvc` and/or `spring-webflux` as described in https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement#am-i-impacted.

Please consider removing `spring-beans` from the advisory by merging this PR. Thanks.