### PR TITLE
[GHSA-25mp-g6fv-mqxx] Unexpected server crash in Next.js.

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-25mp-g6fv-mqxx/GHSA-25mp-g6fv-mqxx.json
+++ b/advisories/github-reviewed/2021/12/GHSA-25mp-g6fv-mqxx/GHSA-25mp-g6fv-mqxx.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-25mp-g6fv-mqxx",
-  "modified": "2021-12-16T14:10:33Z",
+  "modified": "2022-04-05T08:23:36Z",
   "published": "2021-12-07T21:12:09Z",
   "aliases": [
     "CVE-2021-43803"
   ],
   "summary": "Unexpected server crash in Next.js.",
-  "details": "Next.js is a React framework. In versions of Next.js prior to 12.0.5 or 11.1.3, invalid or malformed URLs could lead to a server crash. In order to be affected by this issue, the deployment must use Next.js versions above 11.1.0 and below 12.0.5, Node.js above 15.0.0, and next start or a custom server. Deployments on Vercel are not affected, along with similar environments where invalid requests are filtered before reaching Next.js. Versions 12.0.5 and 11.1.3 contain patches for this issue.",
+  "details": "Next.js is a React framework. In versions of Next.js prior to 12.0.5 or 11.1.3, invalid or malformed URLs could lead to a server crash. In order to be affected by this issue, the deployment must use Next.js versions above 11.1.0 and below 12.0.5, Node.js above 15.0.0, and next start or a custom server. Deployments on Vercel are not affected, along with similar environments where invalid requests are filtered before reaching Next.js. Versions 12.0.5 and 11.1.3 contain patches for this issue.\n\nNote that prior version 0.9.9 package `next` hosted a very different utility (0.4.1 being the latest version), and this advisory does not apply to those versions.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.9.9"
             },
             {
               "fixed": "11.1.3"
@@ -60,10 +60,6 @@
       "url": "https://github.com/vercel/next.js/security/advisories/GHSA-25mp-g6fv-mqxx"
     },
     {
-      "type": "ADVISORY",
-      "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43803"
-    },
-    {
       "type": "WEB",
       "url": "https://github.com/vercel/next.js/pull/32080"
     },
@@ -73,11 +69,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/vercel/next.js/releases/tag/v11.1.3"
+      "url": "https://github.com/vercel/next.js/releases/v12.0.5"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43803"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/vercel/next.js/releases/v12.0.5"
+      "url": "https://github.com/vercel/next.js/releases/tag/v11.1.3"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
Problem is that security vulnerability is incorrectly applied to v0.4 version of `next`, when it was totally different product, and that affects some of my packages which still depend on `next@0.4`

**Updates**
- Affected products
- Description

