### PR TITLE
[GHSA-cf66-xwfp-gvc4] Missing Origin Validation in webpack-dev-server

### DIFF
--- a/advisories/github-reviewed/2019/01/GHSA-cf66-xwfp-gvc4/GHSA-cf66-xwfp-gvc4.json
+++ b/advisories/github-reviewed/2019/01/GHSA-cf66-xwfp-gvc4/GHSA-cf66-xwfp-gvc4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-cf66-xwfp-gvc4",
-  "modified": "2021-09-09T17:01:16Z",
+  "modified": "2022-04-05T20:44:05Z",
   "published": "2019-01-04T17:40:59Z",
   "aliases": [
     "CVE-2018-14732"
@@ -33,16 +33,31 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "webpack-dev-server"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.11.4"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-14732"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/webpack/webpack-dev-server/issues/1445"
     },
     {
       "type": "WEB",
@@ -59,6 +74,10 @@
     {
       "type": "WEB",
       "url": "https://www.npmjs.com/advisories/725"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/webpack/webpack-dev-server/issues/1445"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- Description

Hello, the recommendation section says the following:
```
For webpack-dev-server 2.x update to version 2.11.4 or later.
For webpack-dev-server 3.x update to version 3.1.11 or later.
```

But dependabot only considers the upgrade to >= 3.1.11 as a fix, but does not consider an upgrade to >=2.11.4 as a fix for webpack 2.x.

Thank you for the amazing work with dependabot so far!