### PR TITLE
[GHSA-q62h-jw38-24vh] Uncaught Exception in zip4j

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-q62h-jw38-24vh/GHSA-q62h-jw38-24vh.json
+++ b/advisories/github-reviewed/2022/02/GHSA-q62h-jw38-24vh/GHSA-q62h-jw38-24vh.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-q62h-jw38-24vh",
-  "modified": "2022-03-03T22:07:14Z",
+  "modified": "2022-04-09T09:37:53Z",
   "published": "2022-02-25T00:01:04Z",
   "aliases": [
     "CVE-2022-24615"
   ],
   "summary": "Uncaught Exception in zip4j",
-  "details": "zip4j up to 2.9.0 can throw various uncaught exceptions while parsing a specially crafted ZIP file, which could result in an application crash. This could be used to mount a denial of service attack against services that use zip4j library.",
+  "details": "zip4j up to 2.9.1 can throw various uncaught exceptions while parsing a specially crafted ZIP file, which could result in an application crash. This could be used to mount a denial of service attack against services that use zip4j library.",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**

Issue related to the CVE was fixed in v2.10.0 and all previous versions of until then were affected by this issue. The one prior to v2.10.0 is 2.9.1.