### PR TITLE
[GHSA-p979-4mfw-53vg] HTTP Request Smuggling in Netty

### DIFF
--- a/advisories/github-reviewed/2019/10/GHSA-p979-4mfw-53vg/GHSA-p979-4mfw-53vg.json
+++ b/advisories/github-reviewed/2019/10/GHSA-p979-4mfw-53vg/GHSA-p979-4mfw-53vg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-p979-4mfw-53vg",
-  "modified": "2022-04-01T18:11:58Z",
+  "modified": "2022-04-10T00:47:01Z",
   "published": "2019-10-11T18:41:23Z",
   "aliases": [
     "CVE-2019-16869"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.1.42"
+              "fixed": "4.1.42.Final"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.1.42"
+      }
     }
   ],
   "references": [
@@ -42,11 +45,107 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/netty/netty/compare/netty-4.1.41.Final...netty-4.1.42.Final"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/netty/netty/issues/9571"
     },
     {
       "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/2494a2ac7f66af6e4646a4937b17972a4ec7cd3c7333c66ffd6c639d@%3Cdev.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/2e1cf538b502713c2c42ffa46d81f4688edb5676eb55bd9fc4b4fed7@%3Cissues.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/37ed432b8eb35d8bd757f53783ec3e334bd51f514534432bea7f1c3d@%3Cissues.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/380f6d2730603a2cd6b0a8bea9bcb21a86c199147e77e448c5f7390b@%3Ccommits.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/3e6d7aae1cca10257e3caf2d69b22f74c875f12a1314155af422569d@%3Cdev.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/6e1e34c0d5635a987d595df9e532edac212307243bb1b49eead6d55b@%3Cissues.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/76540c8b0ed761bfa6c81fa28c13057f13a5448aed079d656f6a3c79@%3Cissues.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/9128111213b7b734ffc85db08d8f789b00a85a7f241b708e55debbd0@%3Cissues.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/a0f77c73af32cbe4ff0968bfcbbe80ae6361f3dccdd46f3177547266@%3Cissues.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/b2cd51795f938632c6f60a4c59d9e587fbacd7f7d0e0a3684850a30f@%3Cissues.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/bdf7a5e597346a75d2d884ca48c767525e35137ad59d8f10b8fc943c@%3Cdev.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/cbf6e6a04cb37e9320ad20e437df63beeab1755fc0761918ed5c5a6e@%3Ccommits.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/cf5aa087632ead838f8ac3a42e9837684e7afe6e0fcb7704e0c73bc0@%3Ccommits.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/d14f721e0099b914daebe29bca199fde85d8354253be9d6d3d46507a@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/d3eb0dbea75ef5c400bd49dfa1901ad50be606cca3cb29e0d01b6a54@%3Cissues.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/e192fe8797c192679759ffa6b15e4d0806546945a41d8ebfbc6ee3ac@%3Ccommits.tinkerpop.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/e39931d7cdd17241e69a0a09a89d99d7435bcc59afee8a9628d67769@%3Cdev.zookeeper.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/f6c5ebfb018787c764f000362d59e4b231c0a36b6253aa866de8c64e@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2019/09/msg00035.html"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2019:3892"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/9317fd092b257a0815434b116a8af8daea6e920b6673f4fd5583d5fe@%3Ccommits.druid.apache.org%3E"
     },
     {
       "type": "WEB",
@@ -74,10 +173,6 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/netty/netty/compare/netty-4.1.41.Final...netty-4.1.42.Final"
-    },
-    {
-      "type": "WEB",
       "url": "https://lists.apache.org/thread.html/0acadfb96176768caac79b404110df62d14d30aa9d53b6dbdb1407ac@%3Cissues.spark.apache.org%3E"
     },
     {
@@ -86,35 +181,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/2494a2ac7f66af6e4646a4937b17972a4ec7cd3c7333c66ffd6c639d@%3Cdev.zookeeper.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/2e1cf538b502713c2c42ffa46d81f4688edb5676eb55bd9fc4b4fed7@%3Cissues.zookeeper.apache.org%3E"
-    },
-    {
-      "type": "WEB",
       "url": "https://lists.apache.org/thread.html/35961d1ae00849974353a932b4fef12ebce074541552eceefa04f1fd@%3Cdev.olingo.apache.org%3E"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/37ed432b8eb35d8bd757f53783ec3e334bd51f514534432bea7f1c3d@%3Cissues.zookeeper.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/380f6d2730603a2cd6b0a8bea9bcb21a86c199147e77e448c5f7390b@%3Ccommits.zookeeper.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/3e6d7aae1cca10257e3caf2d69b22f74c875f12a1314155af422569d@%3Cdev.zookeeper.apache.org%3E"
-    },
-    {
-      "type": "WEB",
       "url": "https://lists.apache.org/thread.html/51923a9ba513b2e816e02a9d1fd8aa6f12e3e4e99bbd9dc884bccbbe@%3Cissues.spark.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
     },
     {
       "type": "WEB",
@@ -130,14 +201,6 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/6e1e34c0d5635a987d595df9e532edac212307243bb1b49eead6d55b@%3Cissues.zookeeper.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/76540c8b0ed761bfa6c81fa28c13057f13a5448aed079d656f6a3c79@%3Cissues.zookeeper.apache.org%3E"
-    },
-    {
-      "type": "WEB",
       "url": "https://lists.apache.org/thread.html/799eb85d67cbddc1851a3e63a07b55e95b2f44f1685225d38570ce89@%3Cissues.spark.apache.org%3E"
     },
     {
@@ -146,31 +209,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/9128111213b7b734ffc85db08d8f789b00a85a7f241b708e55debbd0@%3Cissues.zookeeper.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/9317fd092b257a0815434b116a8af8daea6e920b6673f4fd5583d5fe@%3Ccommits.druid.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/a0f77c73af32cbe4ff0968bfcbbe80ae6361f3dccdd46f3177547266@%3Cissues.zookeeper.apache.org%3E"
-    },
-    {
-      "type": "WEB",
       "url": "https://lists.apache.org/thread.html/af6e9c2d716868606523857a4cd7a5ee506e6d1710f5fb0d567ec030@%3Cdev.olingo.apache.org%3E"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
-    },
-    {
-      "type": "WEB",
       "url": "https://lists.apache.org/thread.html/b264fa5801e87698e9f43f2b5585fbc5ebdc26c6f4aad861b258fb69@%3Cdev.olingo.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/b2cd51795f938632c6f60a4c59d9e587fbacd7f7d0e0a3684850a30f@%3Cissues.zookeeper.apache.org%3E"
     },
     {
       "type": "WEB",
@@ -182,35 +225,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/bdf7a5e597346a75d2d884ca48c767525e35137ad59d8f10b8fc943c@%3Cdev.zookeeper.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/cbf6e6a04cb37e9320ad20e437df63beeab1755fc0761918ed5c5a6e@%3Ccommits.zookeeper.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/cf5aa087632ead838f8ac3a42e9837684e7afe6e0fcb7704e0c73bc0@%3Ccommits.zookeeper.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/d14f721e0099b914daebe29bca199fde85d8354253be9d6d3d46507a@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/d3eb0dbea75ef5c400bd49dfa1901ad50be606cca3cb29e0d01b6a54@%3Cissues.zookeeper.apache.org%3E"
-    },
-    {
-      "type": "WEB",
       "url": "https://lists.apache.org/thread.html/d7d530599dc7813056c712213e367b68cdf56fb5c9b73f864870bc4c@%3Cdev.olingo.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/e192fe8797c192679759ffa6b15e4d0806546945a41d8ebfbc6ee3ac@%3Ccommits.tinkerpop.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/e39931d7cdd17241e69a0a09a89d99d7435bcc59afee8a9628d67769@%3Cdev.zookeeper.apache.org%3E"
     },
     {
       "type": "WEB",
@@ -218,47 +233,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/f6c5ebfb018787c764f000362d59e4b231c0a36b6253aa866de8c64e@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r0aa8b28e76ec01c697b15e161e6797e88fc8d406ed762e253401106e@%3Ccommits.camel.apache.org%3E"
-    },
-    {
-      "type": "WEB",
       "url": "https://lists.apache.org/thread.html/r0c3d49bfdbc62fd3915676433cc5899c5506d06da1c552ef1b7923a5@%3Ccommon-issues.hadoop.apache.org%3E"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r131e572d003914843552fa45c4398b9903fb74144986e8b107c0a3a7@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r3225f7dfe6b8a37e800ecb8e31abd7ac6c4312dbd3223dd8139c37bb@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
       "url": "https://lists.apache.org/thread.html/r4d3f1d3e333d9c2b2f6e6ae8ed8750d4de03410ac294bcd12c7eefa3@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r73c400ab66d79821dec9e3472f0e2c048d528672bdb0f8bf44d7cb1f@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r7790b9d99696d9eddce8a8c96f13bb68460984294ea6fea3800143e4@%3Ccommits.pulsar.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r831e0548fad736a98140d0b3b7dc575af0c50faea0b266434ba813cc@%3Cdev.rocketmq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r832724df393a7ef25ca4c7c2eb83ad2d6c21c74569acda5233f9f1ec@%3Ccommits.pulsar.apache.org%3E"
     },
     {
       "type": "WEB",
@@ -278,14 +257,6 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/raaac04b7567c554786132144bea3dcb72568edd410c1e6f0101742e7@%3Cissues.flink.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rb25b42f666d2cac5e6e6b3f771faf60d1f1aa58073dcdd8db14edf8a@%3Cdev.rocketmq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
       "url": "https://lists.apache.org/thread.html/rb3361f6c6a5f834ad3db5e998c352760d393c0891b8d3bea90baa836@%3Ccommon-issues.hadoop.apache.org%3E"
     },
     {
@@ -294,23 +265,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rc8d554aad889d12b140d9fd7d2d6fc2e8716e9792f6f4e4b2cdc2d05@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
       "url": "https://lists.apache.org/thread.html/rcb2c59428f34d4757702f9ae739a8795bda7bea97b857e708a9c62c6@%3Ccommon-commits.hadoop.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rcddf723a4b4117f8ed6042e9ac25e8c5110a617bab77694b61b14833@%3Cdev.rocketmq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rdb69125652311d0c41f6066ff44072a3642cf33a4b5e3c4f9c1ec9c2@%3Ccommits.pulsar.apache.org%3E"
     },
     {
       "type": "WEB",
@@ -334,19 +289,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rf5b2dfb7401666a19915f8eaef3ba9f5c3386e2066fcd2ae66e16a2f@%3Cdev.flink.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2019/09/msg00035.html"
-    },
-    {
-      "type": "WEB",
       "url": "https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2020/09/msg00004.html"
     },
     {
       "type": "WEB",
@@ -354,11 +297,71 @@
     },
     {
       "type": "WEB",
+      "url": "https://www.debian.org/security/2020/dsa-4597"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r0aa8b28e76ec01c697b15e161e6797e88fc8d406ed762e253401106e@%3Ccommits.camel.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r7790b9d99696d9eddce8a8c96f13bb68460984294ea6fea3800143e4@%3Ccommits.pulsar.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r831e0548fad736a98140d0b3b7dc575af0c50faea0b266434ba813cc@%3Cdev.rocketmq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r832724df393a7ef25ca4c7c2eb83ad2d6c21c74569acda5233f9f1ec@%3Ccommits.pulsar.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/raaac04b7567c554786132144bea3dcb72568edd410c1e6f0101742e7@%3Cissues.flink.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rb25b42f666d2cac5e6e6b3f771faf60d1f1aa58073dcdd8db14edf8a@%3Cdev.rocketmq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rcddf723a4b4117f8ed6042e9ac25e8c5110a617bab77694b61b14833@%3Cdev.rocketmq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rdb69125652311d0c41f6066ff44072a3642cf33a4b5e3c4f9c1ec9c2@%3Ccommits.pulsar.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rf5b2dfb7401666a19915f8eaef3ba9f5c3386e2066fcd2ae66e16a2f@%3Cdev.flink.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2020/09/msg00004.html"
+    },
+    {
+      "type": "WEB",
       "url": "https://usn.ubuntu.com/4532-1/"
     },
     {
       "type": "WEB",
-      "url": "https://www.debian.org/security/2020/dsa-4597"
+      "url": "https://lists.apache.org/thread.html/r131e572d003914843552fa45c4398b9903fb74144986e8b107c0a3a7@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rc8d554aad889d12b140d9fd7d2d6fc2e8716e9792f6f4e4b2cdc2d05@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r3225f7dfe6b8a37e800ecb8e31abd7ac6c4312dbd3223dd8139c37bb@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r73c400ab66d79821dec9e3472f0e2c048d528672bdb0f8bf44d7cb1f@%3Ccommits.cassandra.apache.org%3E"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products

----

The description says:

> Netty before 4.1.42.Final mishandles whitespace

`4.1.42.Final` is technically a different version than `4.1.42`, since `Final` is a build component.