### PR TITLE
[GHSA-r7c9-c69m-rph8] Code injection in PHPUnit

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-r7c9-c69m-rph8/GHSA-r7c9-c69m-rph8.json
+++ b/advisories/github-reviewed/2022/03/GHSA-r7c9-c69m-rph8/GHSA-r7c9-c69m-rph8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-r7c9-c69m-rph8",
-  "modified": "2022-03-26T00:19:30Z",
+  "modified": "2022-04-13T05:05:28Z",
   "published": "2022-03-26T00:19:30Z",
   "aliases": [
     "CVE-2017-9841"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.8.19"
             },
             {
               "fixed": "4.8.28"


### PR DESCRIPTION
**Updates**
- Affected products

---

The vulnerability was added with this commit - https://github.com/sebastianbergmann/phpunit/commit/3aaddb1c5bd9b9b8d070b4cf120e71c36fd08412

You can see from the tags on that commit that it was added in 4.8.19 and no earlier.

<img width="1226" alt="image" src="https://user-images.githubusercontent.com/133747/163104294-2f257364-0b9d-4f6e-8bea-606a5166102f.png">
