### PR TITLE
[GHSA-72cx-5ff9-4hhc] python-markdown2 before 1.0.1.14 has multiple cross-site...

### DIFF
--- a/advisories/unreviewed/2022/04/GHSA-72cx-5ff9-4hhc/GHSA-72cx-5ff9-4hhc.json
+++ b/advisories/unreviewed/2022/04/GHSA-72cx-5ff9-4hhc/GHSA-72cx-5ff9-4hhc.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-72cx-5ff9-4hhc",
-  "modified": "2022-04-21T01:54:03Z",
+  "modified": "2022-04-22T20:06:59Z",
   "published": "2022-04-21T01:54:03Z",
   "aliases": [
     "CVE-2009-3724"
   ],
+  "summary": "Cross-site scripting in markdown2 for python",
   "details": "python-markdown2 before 1.0.1.14 has multiple cross-site scripting (XSS) issues.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "markdown2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.0.1.14"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -20,16 +39,16 @@
     },
     {
       "type": "WEB",
-      "url": "https://snyk.io/vuln/SNYK-PYTHON-PYRAD-40000"
+      "url": "https://www.openwall.com/lists/oss-security/2009/10/29/5"
     },
     {
-      "type": "WEB",
-      "url": "https://www.openwall.com/lists/oss-security/2009/10/29/5"
+      "type": "PACKAGE",
+      "url": "https://github.com/trentm/python-markdown2"
     }
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- References
- Source code location
- Summary