### PR TITLE
[GHSA-fmx4-26r3-wxpf] Integer overflow in cmark-gfm table parsing extension leads to heap memory corruption

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-fmx4-26r3-wxpf/GHSA-fmx4-26r3-wxpf.json
+++ b/advisories/github-reviewed/2022/03/GHSA-fmx4-26r3-wxpf/GHSA-fmx4-26r3-wxpf.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-fmx4-26r3-wxpf",
-  "modified": "2022-03-03T20:28:47Z",
+  "modified": "2022-04-25T00:01:18Z",
   "published": "2022-03-03T20:28:47Z",
   "aliases": [
 
   ],
-  "summary": "Integer overflow in cmark-gfm table parsing extension leads to heap memory corruption",
+  "summary": "Integer overflow in cmark-gm's table parsing extension leads to heap memory corruption",
   "details": "### Impact\n\nCommonMarker uses `cmark-gfm` for rendering [Github Flavored Markdown](https://github.github.com/gfm/). An [integer overflow in `cmark-gfm`'s table row parsing](https://github.com/github/cmark-gfm/security/advisories/GHSA-mc3g-88wq-6f4x) may lead to heap memory corruption when parsing tables who's marker rows contain more than UINT16_MAX columns. The impact of this heap corruption ranges from Information Leak to Arbitrary Code Execution.\n\nIf affected versions of CommonMarker are used for rendering remote user controlled markdown, this vulnerability may lead to Remote Code Execution (RCE).\n\n### Patches\n\nThis vulnerability has been patched in the following CommonMarker release:\n\n- v0.23.4\n\n### Workarounds\n\nThe vulnerability exists in the table markdown extensions of `cmark-gfm`. Disabling any use of the table extension will prevent this vulnerability from being triggered.\n\n### References\n\n- https://github.com/github/cmark-gfm/security/advisories/GHSA-mc3g-88wq-6f4x\n\n### Acknowledgements\n\nWe would like to thank Felix Wilhelm of Google's Project Zero for reporting this vulnerability\n\n### For more information\n\nIf you have any questions or comments about this advisory:\n\n* Open an issue in [CommonMarker](http://github.com/gjtorikian/commonmarker)",
   "severity": [
     {


### PR DESCRIPTION
**Updates**
- Description
- Summary