### PR TITLE
[GHSA-mmc9-pwm7-qj5w] Unaligned memory access in rand_core

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-mmc9-pwm7-qj5w/GHSA-mmc9-pwm7-qj5w.json
+++ b/advisories/github-reviewed/2021/08/GHSA-mmc9-pwm7-qj5w/GHSA-mmc9-pwm7-qj5w.json
@@ -20,6 +20,12 @@
         "ecosystem": "crates.io",
         "name": "rand_core"
       },
+      "ecosystem_specific": {
+        "affected_functions": [
+          "rand_core::BlockRng::fill_bytes",
+          "rand_core::BlockRng::next_u64"
+        ]
+      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -38,6 +44,12 @@
       "package": {
         "ecosystem": "crates.io",
         "name": "rand_core"
+      },
+      "ecosystem_specific": {
+        "affected_functions": [
+          "rand_core::BlockRng::fill_bytes",
+          "rand_core::BlockRng::next_u64"
+        ]
       },
       "ranges": [
         {

--- a/advisories/github-reviewed/2021/08/GHSA-mmc9-pwm7-qj5w/GHSA-mmc9-pwm7-qj5w.json
+++ b/advisories/github-reviewed/2021/08/GHSA-mmc9-pwm7-qj5w/GHSA-mmc9-pwm7-qj5w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-mmc9-pwm7-qj5w",
-  "modified": "2021-08-18T20:45:24Z",
+  "modified": "2022-04-26T21:16:05Z",
   "published": "2021-08-25T20:56:50Z",
   "aliases": [
     "CVE-2020-25576"
@@ -19,12 +19,6 @@
       "package": {
         "ecosystem": "crates.io",
         "name": "rand_core"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "rand_core::BlockRng::fill_bytes",
-          "rand_core::BlockRng::next_u64"
-        ]
       },
       "ranges": [
         {
@@ -45,12 +39,6 @@
         "ecosystem": "crates.io",
         "name": "rand_core"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "rand_core::BlockRng::fill_bytes",
-          "rand_core::BlockRng::next_u64"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -59,7 +47,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.3.2"
+              "fixed": "0.3.1"
             }
           ]
         }

--- a/advisories/github-reviewed/2021/08/GHSA-mmc9-pwm7-qj5w/GHSA-mmc9-pwm7-qj5w.json
+++ b/advisories/github-reviewed/2021/08/GHSA-mmc9-pwm7-qj5w/GHSA-mmc9-pwm7-qj5w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-mmc9-pwm7-qj5w",
-  "modified": "2022-04-26T21:16:05Z",
+  "modified": "2022-04-28T15:00:34Z",
   "published": "2021-08-25T20:56:50Z",
   "aliases": [
     "CVE-2020-25576"


### PR DESCRIPTION
[RUSTSEC-2019-0035](https://rustsec.org/advisories/RUSTSEC-2019-0035.html) says the patched version is `^0.3.1`. There is [no published 0.3.2 release](https://crates.io/crates/rand_core/versions).