### PR TITLE
[GHSA-27rq-4943-qcwp] The Hashicorp go-getter library before 1.5.11 could write...

### DIFF
--- a/advisories/unreviewed/2022/04/GHSA-27rq-4943-qcwp/GHSA-27rq-4943-qcwp.json
+++ b/advisories/unreviewed/2022/04/GHSA-27rq-4943-qcwp/GHSA-27rq-4943-qcwp.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-27rq-4943-qcwp",
-  "modified": "2022-04-28T00:00:35Z",
+  "modified": "2022-04-28T15:25:23Z",
   "published": "2022-04-28T00:00:35Z",
   "aliases": [
     "CVE-2022-29810"
   ],
+  "summary": "Hashicorp go-getter ",
   "details": "The Hashicorp go-getter library before 1.5.11 could write SSH credentials into its logfile, exposing sensitive credentials to local users able to read the logfile.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/go-getter"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.5.11"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -35,7 +54,7 @@
     "cwe_ids": [
 
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Summary