### PR TITLE
[GHSA-mwm4-5qwr-g9pf] Keycloak is vulnerable to IDN homograph attack

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-mwm4-5qwr-g9pf/GHSA-mwm4-5qwr-g9pf.json
+++ b/advisories/github-reviewed/2022/04/GHSA-mwm4-5qwr-g9pf/GHSA-mwm4-5qwr-g9pf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-mwm4-5qwr-g9pf",
-  "modified": "2022-04-28T21:00:31Z",
+  "modified": "2022-04-29T22:17:21Z",
   "published": "2022-04-28T21:00:31Z",
   "aliases": [
 
@@ -36,6 +36,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/keycloak/keycloak/security/advisories/GHSA-mwm4-5qwr-g9pf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/keycloak/keycloak/commit/ac79fd0c23c6947a04073afc61e30d341498438e"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References