### PR TITLE
[GHSA-ghq2-m3pq-qf3p] Jenkins CVS Plugin 2.19 and earlier does not escape the...

### DIFF
--- a/advisories/unreviewed/2022/04/GHSA-ghq2-m3pq-qf3p/GHSA-ghq2-m3pq-qf3p.json
+++ b/advisories/unreviewed/2022/04/GHSA-ghq2-m3pq-qf3p/GHSA-ghq2-m3pq-qf3p.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-ghq2-m3pq-qf3p",
-  "modified": "2022-04-21T00:00:42Z",
+  "modified": "2022-04-30T00:17:14Z",
   "published": "2022-04-13T00:00:18Z",
   "aliases": [
     "CVE-2022-29037"
   ],
+  "summary": "Stored XSS in Jenkins CVS Plugin",
   "details": "Jenkins CVS Plugin 2.19 and earlier does not escape the name and description of CVS Symbolic Name parameters on views displaying parameters, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:cvs"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.19.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -24,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://www.jenkins.io/security/advisory/2022-04-12/#SECURITY-2617"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/cvs-plugin"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Source code location
- Summary