### PR TITLE
[GHSA-52j8-p7r3-733m] cmd/go in Go before 1.16.14 and 1.17.x before 1.17.7 can...

### DIFF
--- a/advisories/unreviewed/2022/02/GHSA-52j8-p7r3-733m/GHSA-52j8-p7r3-733m.json
+++ b/advisories/unreviewed/2022/02/GHSA-52j8-p7r3-733m/GHSA-52j8-p7r3-733m.json
@@ -1,20 +1,36 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-52j8-p7r3-733m",
-  "modified": "2022-03-30T00:01:42Z",
+  "modified": "2022-05-06T21:56:13Z",
   "published": "2022-02-12T00:00:50Z",
   "aliases": [
     "CVE-2022-23773"
   ],
+  "summary": "",
   "details": "cmd/go in Go before 1.16.14 and 1.17.x before 1.17.7 can misinterpret branch names that falsely appear to be version tags. This can lead to incorrect access control if an actor is supposed to be able to create branches but not tags.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
-    }
+
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "cmd/go"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.17.7"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -28,6 +44,14 @@
     {
       "type": "WEB",
       "url": "https://security.netapp.com/advisory/ntap-20220225-0006/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://kb.prohacktive.io/index.php?action=detail&id=CVE-2022-23773&lang=en"
+    },
+    {
+      "type": "WEB",
+      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2053541"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- References
- Summary