### PR TITLE
[GHSA-vwmq-9gjc-2jjj] Certificate.Verify in crypto/x509 in Go 1.18.x before 1...

### DIFF
--- a/advisories/unreviewed/2022/04/GHSA-vwmq-9gjc-2jjj/GHSA-vwmq-9gjc-2jjj.json
+++ b/advisories/unreviewed/2022/04/GHSA-vwmq-9gjc-2jjj/GHSA-vwmq-9gjc-2jjj.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-vwmq-9gjc-2jjj",
-  "modified": "2022-05-01T00:00:38Z",
+  "modified": "2022-05-07T10:35:32Z",
   "published": "2022-04-21T00:00:25Z",
   "aliases": [
     "CVE-2022-27536"
   ],
+  "summary": "",
   "details": "Certificate.Verify in crypto/x509 in Go 1.18.x before 1.18.1 can be caused to panic on macOS when presented with certain malformed certificates. This allows a remote TLS server to cause a TLS client to panic.",
   "severity": [
     {
@@ -14,12 +15,34 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "crypto/x509"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.18.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-27536"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/golang/go/issues/51759"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Summary