### PR TITLE
[GHSA-7jvx-f994-rfw2] materialize-css vulnerable to cross-site Scripting (XSS) due to improper escape of user input

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-7jvx-f994-rfw2/GHSA-7jvx-f994-rfw2.json
+++ b/advisories/github-reviewed/2022/05/GHSA-7jvx-f994-rfw2/GHSA-7jvx-f994-rfw2.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-7jvx-f994-rfw2",
-  "modified": "2022-05-03T21:09:12Z",
+  "modified": "2022-05-09T11:32:55Z",
   "published": "2022-05-03T00:00:45Z",
   "aliases": [
     "CVE-2022-25349"
   ],
   "summary": "materialize-css vulnerable to cross-site Scripting (XSS) due to improper escape of user input",
-  "details": "All versions of package materialize-css are vulnerable to Cross-site Scripting (XSS) due to improper escape of user input (such as &lt;not-a-tag /&gt;) that is being parsed as HTML/JavaScript, and inserted into the Document Object Model (DOM). This vulnerability can be exploited when the user-input is provided to the autocomplete component.",
+  "details": "All versions before 1.1.0 materialize-css are vulnerable to Cross-site Scripting (XSS) due to improper escape of user input (such as &lt;not-a-tag /&gt;) that is being parsed as HTML/JavaScript, and inserted into the Document Object Model (DOM). This vulnerability can be exploited when the user-input is provided to the autocomplete component.\n\n## Recommendation\n\nUpdate to 1.1.0.  \nThe repository and package names have moved.  \nThe new npm package is `@materializecss/materialize`, and the new repo is https://github.com/materializecss/materialize.  \n\nThis CVE is a duplicate of CVE-2019-11003. ",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "npm",
-        "name": "materialize-css"
+        "name": "@materializecss/materialize"
       },
       "ranges": [
         {
@@ -26,6 +26,9 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "1.1.0"
             }
           ]
         }
@@ -54,7 +57,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/Dogfalo/materialize"
+      "url": "https://github.com/materializecss/materialize"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location

--- 

Development has moved to https://github.com/materializecss/materialize 

Also, this CVE is a duplicate of CVE-2019-11003.  