### PR TITLE
[GHSA-h236-g5gh-vq6c] Cross-site scripting in Froala Editor

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-h236-g5gh-vq6c/GHSA-h236-g5gh-vq6c.json
+++ b/advisories/github-reviewed/2022/02/GHSA-h236-g5gh-vq6c/GHSA-h236-g5gh-vq6c.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-h236-g5gh-vq6c",
-  "modified": "2022-02-10T23:32:51Z",
+  "modified": "2022-05-18T11:52:29Z",
   "published": "2022-02-10T23:32:51Z",
   "aliases": [
     "CVE-2019-19935"
   ],
   "summary": "Cross-site scripting in Froala Editor",
-  "details": "Froala Editor before 3.0.6 allows XSS.",
+  "details": "Froala Editor before [3.2.3](https://github.com/froala/wysiwyg-editor/releases/tag/v3.2.3) allows XSS through copy-pasted content. ",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "3.0.6"
+              "fixed": "3.2.3"
             }
           ]
         }


### PR DESCRIPTION
I didn't find anything that looked like a XSS fix in the 3.0.6 release, so I tried out the PoC described in https://blog.compass-security.com/2020/07/yet-another-froala-0-day-xss/ until I found the version that fixed it.  
That version was 3.2.3.  
That same version also includes a "Fixed XSS Vulnerability in WYSIWYG HTML Editor" in the change-notes.  

**Updates**
- Affected products
- Description