### PR TITLE
[GHSA-9236-8w7q-rmrv] archivy is vulnerable to Cross-Site Request Forgery (CSRF)

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-9236-8w7q-rmrv/GHSA-9236-8w7q-rmrv.json
+++ b/advisories/github-reviewed/2022/01/GHSA-9236-8w7q-rmrv/GHSA-9236-8w7q-rmrv.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-9236-8w7q-rmrv",
-  "modified": "2022-01-05T20:41:25Z",
+  "modified": "2022-05-22T22:37:35Z",
   "published": "2022-01-06T21:59:50Z",
   "aliases": [
     "CVE-2021-4162"
   ],
   "summary": "archivy is vulnerable to Cross-Site Request Forgery (CSRF)",
-  "details": "archivy is vulnerable to Cross-Site Request Forgery (CSRF). There is [a fix](https://github.com/archivy/archivy/commit/796c3ae318eea183fc88c87ec5a27355b0f6a99d) available in the master branch.",
+  "details": "archivy is vulnerable to Cross-Site Request Forgery (CSRF) prior to version 1.6.2",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -26,13 +26,13 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "1.6.2"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 1.6.1"
-      }
+      ]
     }
   ],
   "references": [
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://huntr.dev/bounties/e204a768-2129-4b6f-abad-e436309c7c32"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/archivy/archivy/releases/tag/v1.6.2"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References