### PR TITLE
[GHSA-6h5x-7c5m-7cr7] Exposure of Sensitive Information in eventsource

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-6h5x-7c5m-7cr7/GHSA-6h5x-7c5m-7cr7.json
+++ b/advisories/github-reviewed/2022/05/GHSA-6h5x-7c5m-7cr7/GHSA-6h5x-7c5m-7cr7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-6h5x-7c5m-7cr7",
-  "modified": "2022-05-25T19:28:43Z",
+  "modified": "2022-05-27T18:06:56Z",
   "published": "2022-05-13T00:01:12Z",
   "aliases": [
     "CVE-2022-1650"
@@ -33,6 +33,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "eventsource"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.1.1"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
@@ -47,6 +66,10 @@
     {
       "type": "WEB",
       "url": "https://huntr.dev/bounties/dc9e467f-be5d-4945-867d-1044d27e9b8e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.mend.io/vulnerability-database/CVE-2022-1650"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

Additional reference about 1.1.1 being fixed: https://github.com/EventSource/eventsource/pull/273#issuecomment-1127624508