### PR TITLE
[GHSA-h8pj-cxx2-jfg2] Improper Input Validation in httpx

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-h8pj-cxx2-jfg2/GHSA-h8pj-cxx2-jfg2.json
+++ b/advisories/github-reviewed/2022/04/GHSA-h8pj-cxx2-jfg2/GHSA-h8pj-cxx2-jfg2.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-h8pj-cxx2-jfg2",
-  "modified": "2022-05-10T14:08:21Z",
+  "modified": "2022-05-28T17:57:51Z",
   "published": "2022-04-29T00:00:25Z",
   "aliases": [
     "CVE-2021-41945"
   ],
   "summary": "Improper Input Validation in httpx",
-  "details": "Encode OSS httpx <=1.0.0.beta0 is affected by improper input validation in `httpx.URL`, `httpx.Client` and some functions using `httpx.URL.copy_with`.",
+  "details": "Encode OSS httpx < 0.23.0 is affected by improper input validation in `httpx.URL`, `httpx.Client` and some functions using `httpx.URL.copy_with`.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -26,13 +26,13 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "0.23.0"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 1.0.0b0"
-      }
+      ]
     }
   ],
   "references": [
@@ -46,19 +46,23 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/encode/httpx/pull/2185"
-    },
-    {
-      "type": "WEB",
       "url": "https://gist.github.com/lebr0nli/4edb76bbd3b5ff993cf44f2fbce5e571"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/encode/httpx"
+      "url": "https://github.com/encode/httpx/discussions/1831"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/encode/httpx/discussions/1831"
+      "url": "https://github.com/encode/httpx/pull/2185"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/encode/httpx/pull/2214"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/encode/httpx"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**

- Affected products
- Description
- References

I'm one of the @encode maintainers. We have (hopefully) remediated GHSA-h8pj-cxx2-jfg2 in [v0.23.0](https://github.com/encode/httpx/releases/tag/0.23.0), and would appreciate a review of the fix.

Not sure if/how you want to keep the 1.0.0.beta0 release in the advisory. I guess we would need to do another beta release with the fix.

Thanks for your consideration.
