### PR TITLE
DO NOT MERGE but please fix [GHSA-hp87-p4gw-j4gq] Unhandled exception in gopkg.in/yaml.v3

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-hp87-p4gw-j4gq/GHSA-hp87-p4gw-j4gq.json
+++ b/advisories/github-reviewed/2022/05/GHSA-hp87-p4gw-j4gq/GHSA-hp87-p4gw-j4gq.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-hp87-p4gw-j4gq",
-  "modified": "2022-05-25T20:17:24Z",
+  "modified": "2022-05-31T15:28:12Z",
   "published": "2022-05-20T00:00:17Z",
   "aliases": [
     "CVE-2022-28948"
   ],
   "summary": "Unhandled exception in gopkg.in/yaml.v3",
-  "details": "An issue in the Unmarshal function in Go-Yaml v3 causes the program to crash when attempting to deserialize invalid input.",
+  "details": "As there seems to be no other way to deal with a totally broken GitHub CVE, I'm afraid I need to give notice via an improvement request in the hope something hooman notices how messed up this GitHub CVE is ... albeit admittedly based on upstream.\n\n- The affected versions data is wrong, as it does not concern the widely used yaml.v2. This now causes an enormous number of false positives. See https://github.com/go-yaml/yaml/issues/666#issuecomment-1133337993.\n- yaml.v3 has (not only) incompatible unmarshalling changes that can silently break a lot of applications trying to upgrade from yaml.v2 to yaml.v3. For instance, at least in some situations the keys of unmarshalled maps change from interface{} to string. This and other API changes require lots of downstream changes, albeit yaml.v2 isn't vulnerable to the DoS attack that makes v3 panic'king.\n\nAn issue in the Unmarshal function in Go-Yaml v3 causes the program to crash when attempting to deserialize invalid input.",
   "severity": [
 
   ],


### PR DESCRIPTION
**This is not an improvement PR, do NOT merge it**

**This is a request to fix the broken GHSA**

As there seems to be no other way to deal with a totally broken GitHub CVE, I'm afraid I need to give notice via an improvement request in the hope something hooman notices how messed up this GitHub CVE is ... albeit admittedly based on upstream.

- The affected versions data is wrong, as it does not concern the widely used yaml.v2. This now causes an enormous number of false positives. See https://github.com/go-yaml/yaml/issues/666#issuecomment-1133337993.
- yaml.v3 has (not only) incompatible unmarshalling changes that can silently break a lot of applications trying to upgrade from yaml.v2 to yaml.v3. For instance, at least in some situations the keys of unmarshalled maps change from interface{} to string. This and other API changes require lots of downstream changes, albeit yaml.v2 isn't vulnerable to the DoS attack that makes v3 panic'king.