### PR TITLE
GHSA-hj57-j5cw-2mwp: add CVE ID; fix Go package name

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-hj57-j5cw-2mwp/GHSA-hj57-j5cw-2mwp.json
+++ b/advisories/github-reviewed/2022/05/GHSA-hj57-j5cw-2mwp/GHSA-hj57-j5cw-2mwp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-hj57-j5cw-2mwp",
-  "modified": "2022-05-26T20:19:44Z",
+  "modified": "2022-06-03T04:23:35Z",
   "published": "2022-05-25T19:37:37Z",
   "aliases": [
     "CVE-2022-1706"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/coreos/ignition"
+        "name": "github.com/coreos/ignition/v2"
       },
       "ranges": [
         {

--- a/advisories/github-reviewed/2022/05/GHSA-hj57-j5cw-2mwp/GHSA-hj57-j5cw-2mwp.json
+++ b/advisories/github-reviewed/2022/05/GHSA-hj57-j5cw-2mwp/GHSA-hj57-j5cw-2mwp.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-hj57-j5cw-2mwp",
-  "modified": "2022-05-25T19:37:37Z",
+  "modified": "2022-05-26T20:19:44Z",
   "published": "2022-05-25T19:37:37Z",
   "aliases": [
-
+    "CVE-2022-1706"
   ],
   "summary": "Ignition config accessible to unprivileged software on VMware",
   "details": "### Impact\nUnprivileged software in VMware VMs, including software running in unprivileged containers, can retrieve an Ignition config stored in a hypervisor guestinfo variable or OVF environment.  If the Ignition config contains secrets, this can result in the compromise of sensitive information.\n\n### Patches\nIgnition 2.14.0 and later [adds](https://github.com/coreos/ignition/pull/1350) a new systemd service, `ignition-delete-config.service`, that deletes the Ignition config from supported hypervisors (currently VMware and VirtualBox) during the first boot.  This ensures that unprivileged software cannot retrieve the Ignition config from the hypervisor.\n\nIf you have external tooling that requires the Ignition config to remain accessible in VM metadata after provisioning, and your Ignition config does not include sensitive information, you can prevent Ignition 2.14.0 and later from deleting the config by masking `ignition-delete-config.service`.  For example:\n\n```json\n{\n  \"ignition\": {\n    \"version\": \"3.0.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"name\": \"ignition-delete-config.service\",\n        \"mask\": true\n      }\n    ]\n  }\n}\n```\n\n### Workarounds\n[Avoid storing secrets](https://coreos.github.io/ignition/operator-notes/#secrets) in Ignition configs. In addition to VMware, many cloud platforms allow unprivileged software in a VM to retrieve the Ignition config from a networked cloud metadata service. While platform-specific mitigation is possible, such as firewall rules that prevent access to the metadata service, it's best to store secrets in a dedicated platform such as [Hashicorp Vault](https://www.vaultproject.io/).\n\n### Advice to Linux distributions\nLinux distributions that ship Ignition should ensure the new `ignition-delete-config.service` is installed and enabled by default.\n\nIn addition, we recommend shipping a service similar to `ignition-delete-config.service` that runs when existing machines are upgraded, similar to the one in https://github.com/coreos/fedora-coreos-config/pull/1738. Consider giving your users advance notice of this change, and providing instructions for masking `ignition-delete-config.service` on existing nodes if users have tooling that requires the Ignition config to remain accessible in VM metadata.\n\n### References\nFor more information, see #1300 and #1350.\n\n### For more information\nIf you have any questions or comments about this advisory, [open an issue in Ignition](https://github.com/coreos/ignition/issues/new/choose) or email the CoreOS [development mailing list](https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/).",
@@ -36,6 +36,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/coreos/ignition/security/advisories/GHSA-hj57-j5cw-2mwp"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1706"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
Add omitted CVE ID to GHSA-hj57-j5cw-2mwp; it seems to have been taken by GHSA-mjqc-5c9x-xfcc (see #361).  Fix the Go package name.

Followup to #335, which was closed automatically.  Incorporates fix from #344 (thanks @dghubble!).