### PR TITLE
[GHSA-566x-hhrf-qf8m] Use after free in ordered-float

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-566x-hhrf-qf8m/GHSA-566x-hhrf-qf8m.json
+++ b/advisories/github-reviewed/2021/08/GHSA-566x-hhrf-qf8m/GHSA-566x-hhrf-qf8m.json
@@ -1,18 +1,15 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-566x-hhrf-qf8m",
-  "modified": "2021-08-19T18:54:34Z",
+  "modified": "2022-06-08T14:49:28Z",
   "published": "2021-08-25T20:50:30Z",
   "aliases": [
     "CVE-2020-35923"
   ],
-  "summary": "Use after free in ordered-float",
-  "details": "An issue was discovered in the ordered-float crate before 1.1.1 and 2.x before 2.0.1 for Rust. A NotNan value can contain a NaN.",
+  "summary": "ordered_float:NotNan may contain NaN after panic in assignment operators",
+  "details": "After using an assignment operators such as `NotNan::add_assign`, `NotNan::mul_assign`, etc., it was possible for the resulting `NotNan` value to contain a `NaN`.  This could cause undefined behavior in safe code, because the safe `NotNan::cmp` method contains internal unsafe code that assumes the value is never `NaN`.  (It could also cause undefined behavior in third-party unsafe code that makes the same assumption, as well as logic errors in safe code.)",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
-    }
+
   ],
   "affected": [
     {
@@ -28,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.0.1"
+              "fixed": "^1.1.1 >=2.0.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.0.1"
+      }
     }
   ],
   "references": [
@@ -55,9 +55,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-416"
+
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Summary

It looks like this was mostly drawn from the CWE assignment in CVE-2020-35923 which is completely wrong. I've sent an email to NVD to correct it on that end, but things should also be updated here. Reviewers can see the linked RustSec advisory for a more complete explanation. Most importantly, version 1.1.1 of ordered-float is patched against this issue. It's entirely unclear to me if I've expressed that properly in the advisory here, I can't find documentation for how you express versions in this.

I think this should be assigned Low severity because it requires a rather esoteric code pattern (catching a panic then using some piece of state from the panic site) to even cause a problem.