### PR TITLE
[GHSA-frgw-fgh6-9g52] The numpy.pad function in Numpy 1.13.1 and older versions...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-frgw-fgh6-9g52/GHSA-frgw-fgh6-9g52.json
+++ b/advisories/unreviewed/2022/05/GHSA-frgw-fgh6-9g52/GHSA-frgw-fgh6-9g52.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-frgw-fgh6-9g52",
-  "modified": "2022-05-13T01:42:46Z",
+  "modified": "2022-06-11T02:33:27Z",
   "published": "2022-05-13T01:42:46Z",
   "aliases": [
     "CVE-2017-12852"
   ],
+  "summary": "Numpy missing input validation",
   "details": "The numpy.pad function in Numpy 1.13.1 and older versions is missing input validation. An empty list or ndarray will stick into an infinite loop, which can allow attackers to cause a DoS attack.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "numpy"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.13.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.13.1"
+      }
+    }
   ],
   "references": [
     {
@@ -28,6 +50,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/BT123/testcasesForMyRequest/tree/master/CVE-2017-12852"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/numpy/numpy/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary