### PR TITLE
[GHSA-q3cj-2r34-2cwc] HKDF in cryptography before 1.5.2 returns an empty byte...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-q3cj-2r34-2cwc/GHSA-q3cj-2r34-2cwc.json
+++ b/advisories/unreviewed/2022/05/GHSA-q3cj-2r34-2cwc/GHSA-q3cj-2r34-2cwc.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-q3cj-2r34-2cwc",
-  "modified": "2022-05-17T02:51:56Z",
+  "modified": "2022-06-11T03:15:50Z",
   "published": "2022-05-17T02:51:56Z",
   "aliases": [
     "CVE-2016-9243"
   ],
+  "summary": "Improper input validation in cryptography",
   "details": "HKDF in cryptography before 1.5.2 returns an empty byte-string if used with a length less than algorithm.digest_size.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "cryptography"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.5.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary