### PR TITLE
[GHSA-wf5p-c75w-w3wh] Null pointer dereference in TFLite MLIR optimizations

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-wf5p-c75w-w3wh/GHSA-wf5p-c75w-w3wh.json
+++ b/advisories/github-reviewed/2021/08/GHSA-wf5p-c75w-w3wh/GHSA-wf5p-c75w-w3wh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-wf5p-c75w-w3wh",
-  "modified": "2021-08-24T17:58:35Z",
+  "modified": "2022-06-14T18:01:44Z",
   "published": "2021-08-25T14:39:36Z",
   "aliases": [
     "CVE-2021-37689"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "PyPI",
-        "name": "tensorflow-lite"
+        "name": "tflite"
       },
       "ranges": [
         {


### PR DESCRIPTION
Tensorflow-lite doesn't seem to be a package name on https://pypi.org/search/?q=tensorflow-lite

Checking this link though: https://github.com/tensorflow/tensorflow/commit/d6b57f461b39fd1aa8c1b870f1b974aac3554955

...I think they may be referring to https://pypi.org/project/tflite/ ? 

**Updates**
- Affected products