### PR TITLE
[GHSA-rxhx-9fj6-6h2m] enum_map macro can cause UB when `Enum` trait is incorrectly implemented

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-rxhx-9fj6-6h2m/GHSA-rxhx-9fj6-6h2m.json
+++ b/advisories/github-reviewed/2022/06/GHSA-rxhx-9fj6-6h2m/GHSA-rxhx-9fj6-6h2m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-rxhx-9fj6-6h2m",
-  "modified": "2022-06-17T03:04:41Z",
+  "modified": "2022-06-17T03:23:19Z",
   "published": "2022-06-16T23:53:32Z",
   "aliases": [
 
@@ -9,7 +9,10 @@
   "summary": "enum_map macro can cause UB when `Enum` trait is incorrectly implemented",
   "details": "Affected versions of this crate did not properly check the length of an enum when using `enum_map!` macro, trusting user-provided length.\n\nWhen the `LENGTH` in the `Enum` trait does not match the array length in the `EnumArray` trait, this can result in the initialization of the enum map with uninitialized types, which in turn can allow an attacker to execute arbitrary code.\n\nThis problem can only occur with a manual implementation of the Enum trait, it will never occur for enums that use `#[derive(Enum)]`.\n\nExample code that triggers this vulnerability looks like this:\n\n```rust\nenum E {\n    A,\n    B,\n    C,\n}\n\nimpl Enum for E {\n    const LENGTH: usize = 2;\n\n    fn from_usize(value: usize) -> E {\n        match value {\n            0 => E::A,\n            1 => E::B,\n            2 => E::C,\n            _ => unimplemented!(),\n        }\n    }\n\n    fn into_usize(self) -> usize {\n        self as usize\n    }\n}\n\nimpl<V> EnumArray<V> for E {\n    type Array = [V; 3];\n}\n\nlet _map: EnumMap<E, String> = enum_map! { _ => \"Hello, world!\".into() };\n```\n\nThe flaw was corrected in commit [b824e23](https://github.com/xfix/enum-map/commit/b824e232f2fb47837740070096ac253df8e80dfc) by putting `LENGTH` property on sealed trait for macro to read.\n",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+    }
   ],
   "affected": [
     {
@@ -58,7 +61,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "HIGH",
+    "severity": "CRITICAL",
     "github_reviewed": true
   }
 }

--- a/advisories/github-reviewed/2022/06/GHSA-rxhx-9fj6-6h2m/GHSA-rxhx-9fj6-6h2m.json
+++ b/advisories/github-reviewed/2022/06/GHSA-rxhx-9fj6-6h2m/GHSA-rxhx-9fj6-6h2m.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-rxhx-9fj6-6h2m",
-  "modified": "2022-06-17T02:58:20Z",
+  "modified": "2022-06-17T03:01:53Z",
   "published": "2022-06-16T23:53:32Z",
   "aliases": [
 
   ],
   "summary": "enum_map macro can cause UB when `Enum` trait is incorrectly implemented",
-  "details": "Affected versions of this crate did not properly check the length of an enum when using `enum_map!` macro, trusting user-provided length.\n\nWhen the `LENGTH` in the `Enum` trait does not match the array length in the `EnumArray` trait, this can result in the initialization of the enum map with uninitialized types, which in turn can allow an attacker to execute arbitrary code.\n\nThis problem can only occur with a manual implementation of the Enum trait, it will never occur for enums that use `#[derive(Enum)]`.\n\nExample code that triggers this vulnerability looks like this:\n\n```rust\nenum E {\n    A,\n    B,\n    C,\n}\n\nimpl Enum for E {\n    const LENGTH: usize = 2;\n\n    fn from_usize(value: usize) -> E {\n        match value {\n            0 => E::A,\n            1 => E::B,\n            2 => E::C,\n            _ => unimplemented!(),\n        }\n    }\n\n    fn into_usize(self) -> usize {\n        self as usize\n    }\n}\n\nimpl<V> EnumArray<V> for E {\n    type Array = [V; 3];\n}\n\nlet _map: EnumMap<E, String> = enum_map! { _ => \"Hello, world!\".into() };\n```\n\nThe flaw was corrected in commit [b824e23](https://github.com/xfix/enum-map/commit/b824e232f2fb47837740070096ac253df8e80dfc) by putting `LENGTH` property on sealed trait for macro to read.\n",
+  "details": "Affected versions of this crate did not properly check the length of an enum when using `enum_map!` macro, trusting user-provided length.\n\nWhen the `LENGTH` in the `Enum` trait does not match the array length in the `EnumArray` trait, this can result in the initialization of the enum map with uninitialized types, which in turn can allow an attacker to execute arbitrary code.\n\nThis problem can only occur with a manual implementation of the Enum trait, it will never occur for enums that use `#[derive(Enum)]`.\n\nExample code that triggers this vulnerability looks like this:\n\n```rust\nenum E {\n    A,\n    B,\n    C,\n}\n\nimpl Enum for E {\n    const LENGTH: usize = 2;\n\n    fn from_usize(value: usize) -> E {\n        match value {\n            0 => E::A,\n            1 => E::B,\n            2 => E::C,\n            _ => unimplemented!(),\n        }\n    }\n\n    fn into_usize(self) -> usize {\n        self as usize\n    }\n}\n\nimpl<V> EnumArray<V> for E {\n    type Array = [V; 3];\n}\n\nlet _map: EnumMap<E, String> = enum_map! { _ => \"Hello, world!\".into() };\n```\n\nThe flaw was corrected in commit [b824e23](https://gitlab.com/KonradBorowski/enum-map/-/commit/b824e232f2fb47837740070096ac253df8e80dfc) by putting `LENGTH` property on sealed trait for macro to read.\n",
   "severity": [
 
   ],
@@ -51,7 +51,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/xfix/enum-map/"
+      "url": "https://github.com/xfix/enum-map"
     }
   ],
   "database_specific": {

--- a/advisories/github-reviewed/2022/06/GHSA-rxhx-9fj6-6h2m/GHSA-rxhx-9fj6-6h2m.json
+++ b/advisories/github-reviewed/2022/06/GHSA-rxhx-9fj6-6h2m/GHSA-rxhx-9fj6-6h2m.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-rxhx-9fj6-6h2m",
-  "modified": "2022-06-16T23:53:32Z",
+  "modified": "2022-06-17T02:58:20Z",
   "published": "2022-06-16T23:53:32Z",
   "aliases": [
 
   ],
   "summary": "enum_map macro can cause UB when `Enum` trait is incorrectly implemented",
-  "details": "Affected versions of this crate did not properly check the length of an enum when using `enum_map!` macro, trusting user-provided length.\n\nWhen the `LENGTH` in the `Enum` trait does not match the array length in the `EnumArray` trait, this can result in the initialization of the enum map with uninitialized types, which in turn can allow an attacker to execute arbitrary code.\n\nThis problem can only occur with a manual implementation of the Enum trait, it will never occur for enums that use `#[derive(Enum)]`.\n\nExample code that triggers this vulnerability looks like this:\n\n```rust\nenum E {\n    A,\n    B,\n    C,\n}\n\nimpl Enum for E {\n    const LENGTH: usize = 2;\n\n    fn from_usize(value: usize) -> E {\n        match value {\n            0 => E::A,\n            1 => E::B,\n            2 => E::C,\n            _ => unimplemented!(),\n        }\n    }\n\n    fn into_usize(self) -> usize {\n        self as usize\n    }\n}\n\nimpl<V> EnumArray<V> for E {\n    type Array = [V; 3];\n}\n\nlet _map: EnumMap<E, String> = enum_map! { _ => \"Hello, world!\".into() };\n```\n\nThe flaw was corrected in commit [b824e23](https://gitlab.com/KonradBorowski/enum-map/-/commit/b824e232f2fb47837740070096ac253df8e80dfc) by putting `LENGTH` property on sealed trait for macro to read.\n",
+  "details": "Affected versions of this crate did not properly check the length of an enum when using `enum_map!` macro, trusting user-provided length.\n\nWhen the `LENGTH` in the `Enum` trait does not match the array length in the `EnumArray` trait, this can result in the initialization of the enum map with uninitialized types, which in turn can allow an attacker to execute arbitrary code.\n\nThis problem can only occur with a manual implementation of the Enum trait, it will never occur for enums that use `#[derive(Enum)]`.\n\nExample code that triggers this vulnerability looks like this:\n\n```rust\nenum E {\n    A,\n    B,\n    C,\n}\n\nimpl Enum for E {\n    const LENGTH: usize = 2;\n\n    fn from_usize(value: usize) -> E {\n        match value {\n            0 => E::A,\n            1 => E::B,\n            2 => E::C,\n            _ => unimplemented!(),\n        }\n    }\n\n    fn into_usize(self) -> usize {\n        self as usize\n    }\n}\n\nimpl<V> EnumArray<V> for E {\n    type Array = [V; 3];\n}\n\nlet _map: EnumMap<E, String> = enum_map! { _ => \"Hello, world!\".into() };\n```\n\nThe flaw was corrected in commit [b824e23](https://github.com/xfix/enum-map/commit/b824e232f2fb47837740070096ac253df8e80dfc) by putting `LENGTH` property on sealed trait for macro to read.\n",
   "severity": [
 
   ],
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0.0-2"
             },
             {
               "fixed": "2.0.2"
@@ -39,11 +39,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://gitlab.com/KonradBorowski/enum-map/-/blob/master/CHANGELOG.md#version-202"
+      "url": "https://github.com/xfix/enum-map/blob/master/CHANGELOG.md#version-202"
     },
     {
       "type": "WEB",
-      "url": "https://gitlab.com/KonradBorowski/enum-map/-/commit/b824e232f2fb47837740070096ac253df8e80dfc"
+      "url": "https://github.com/xfix/enum-map/commit/b824e232f2fb47837740070096ac253df8e80dfc"
     },
     {
       "type": "WEB",
@@ -51,7 +51,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://gitlab.com/KonradBorowski/enum-map"
+      "url": "https://github.com/xfix/enum-map/"
     }
   ],
   "database_specific": {

--- a/advisories/github-reviewed/2022/06/GHSA-rxhx-9fj6-6h2m/GHSA-rxhx-9fj6-6h2m.json
+++ b/advisories/github-reviewed/2022/06/GHSA-rxhx-9fj6-6h2m/GHSA-rxhx-9fj6-6h2m.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-rxhx-9fj6-6h2m",
-  "modified": "2022-06-17T03:01:53Z",
+  "modified": "2022-06-17T03:04:41Z",
   "published": "2022-06-16T23:53:32Z",
   "aliases": [
 
   ],
   "summary": "enum_map macro can cause UB when `Enum` trait is incorrectly implemented",
-  "details": "Affected versions of this crate did not properly check the length of an enum when using `enum_map!` macro, trusting user-provided length.\n\nWhen the `LENGTH` in the `Enum` trait does not match the array length in the `EnumArray` trait, this can result in the initialization of the enum map with uninitialized types, which in turn can allow an attacker to execute arbitrary code.\n\nThis problem can only occur with a manual implementation of the Enum trait, it will never occur for enums that use `#[derive(Enum)]`.\n\nExample code that triggers this vulnerability looks like this:\n\n```rust\nenum E {\n    A,\n    B,\n    C,\n}\n\nimpl Enum for E {\n    const LENGTH: usize = 2;\n\n    fn from_usize(value: usize) -> E {\n        match value {\n            0 => E::A,\n            1 => E::B,\n            2 => E::C,\n            _ => unimplemented!(),\n        }\n    }\n\n    fn into_usize(self) -> usize {\n        self as usize\n    }\n}\n\nimpl<V> EnumArray<V> for E {\n    type Array = [V; 3];\n}\n\nlet _map: EnumMap<E, String> = enum_map! { _ => \"Hello, world!\".into() };\n```\n\nThe flaw was corrected in commit [b824e23](https://gitlab.com/KonradBorowski/enum-map/-/commit/b824e232f2fb47837740070096ac253df8e80dfc) by putting `LENGTH` property on sealed trait for macro to read.\n",
+  "details": "Affected versions of this crate did not properly check the length of an enum when using `enum_map!` macro, trusting user-provided length.\n\nWhen the `LENGTH` in the `Enum` trait does not match the array length in the `EnumArray` trait, this can result in the initialization of the enum map with uninitialized types, which in turn can allow an attacker to execute arbitrary code.\n\nThis problem can only occur with a manual implementation of the Enum trait, it will never occur for enums that use `#[derive(Enum)]`.\n\nExample code that triggers this vulnerability looks like this:\n\n```rust\nenum E {\n    A,\n    B,\n    C,\n}\n\nimpl Enum for E {\n    const LENGTH: usize = 2;\n\n    fn from_usize(value: usize) -> E {\n        match value {\n            0 => E::A,\n            1 => E::B,\n            2 => E::C,\n            _ => unimplemented!(),\n        }\n    }\n\n    fn into_usize(self) -> usize {\n        self as usize\n    }\n}\n\nimpl<V> EnumArray<V> for E {\n    type Array = [V; 3];\n}\n\nlet _map: EnumMap<E, String> = enum_map! { _ => \"Hello, world!\".into() };\n```\n\nThe flaw was corrected in commit [b824e23](https://github.com/xfix/enum-map/commit/b824e232f2fb47837740070096ac253df8e80dfc) by putting `LENGTH` property on sealed trait for macro to read.\n",
   "severity": [
 
   ],


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Source code location