### PR TITLE
[GHSA-7v4j-8wvr-v55r] `array!` macro is unsound when its length is impure constant

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-7v4j-8wvr-v55r/GHSA-7v4j-8wvr-v55r.json
+++ b/advisories/github-reviewed/2022/06/GHSA-7v4j-8wvr-v55r/GHSA-7v4j-8wvr-v55r.json
@@ -1,15 +1,18 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-7v4j-8wvr-v55r",
-  "modified": "2022-06-16T23:40:38Z",
+  "modified": "2022-06-17T03:56:21Z",
   "published": "2022-06-16T23:40:38Z",
   "aliases": [
 
   ],
   "summary": "`array!` macro is unsound when its length is impure constant",
-  "details": "Affected versions of this crate did substitute the array length provided by an user at compile-time multiple times.\n\nWhen an impure constant expression is passed as an array length (such as a result of an impure procedural macro), this can result in the initialization of an array with uninitialized types, which in turn can allow an attacker to execute arbitrary code.\n\nThe flaw was corrected in commit [d5b63f72](https://gitlab.com/KonradBorowski/array-macro/-/commit/d5b63f72090f3809c21ac28f9cfd84f12559bf7d) by making sure that array length is substituted just once.\n",
+  "details": "Affected versions of this crate did substitute the array length provided by an user at compile-time multiple times.\n\nWhen an impure constant expression is passed as an array length (such as a result of an impure procedural macro), this can result in the initialization of an array with uninitialized types, which in turn can allow an attacker to execute arbitrary code.\n\nThe flaw was corrected in commit [d5b63f72](https://github.com/xfix/array-macro/commit/d5b63f72090f3809c21ac28f9cfd84f12559bf7d) by making sure that array length is substituted just once.\n",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+    }
   ],
   "affected": [
     {
@@ -22,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.1.0"
             },
             {
               "fixed": "2.1.2"
@@ -47,14 +50,14 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://gitlab.com/KonradBorowski/array-macro"
+      "url": "https://github.com/xfix/array-macro"
     }
   ],
   "database_specific": {
     "cwe_ids": [
 
     ],
-    "severity": "MODERATE",
+    "severity": "CRITICAL",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location