### PR TITLE
[GHSA-mmjf-f5jw-w72q] openssl-src 111 stream is not affected

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-mmjf-f5jw-w72q/GHSA-mmjf-f5jw-w72q.json
+++ b/advisories/github-reviewed/2021/12/GHSA-mmjf-f5jw-w72q/GHSA-mmjf-f5jw-w72q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-mmjf-f5jw-w72q",
-  "modified": "2022-06-17T00:01:23Z",
+  "modified": "2022-06-17T12:31:00Z",
   "published": "2021-12-15T00:00:42Z",
   "aliases": [
     "CVE-2021-4044"

--- a/advisories/github-reviewed/2021/12/GHSA-mmjf-f5jw-w72q/GHSA-mmjf-f5jw-w72q.json
+++ b/advisories/github-reviewed/2021/12/GHSA-mmjf-f5jw-w72q/GHSA-mmjf-f5jw-w72q.json
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "300.0.0"
             },
             {
               "fixed": "300.0.4"


### PR DESCRIPTION
Addresses #405 
- openssl-src 111 release stream is not supposed to be affected by this advisory
- openssl-src has two release streams - 111 for 1.1.1 and 300 for 3.0 vendored OpenSSL
- openssl-src release stream 111 brings vendored openssl 1.1.1 and
- openssl-src release stream 300 brings vendored openssl 3.0
- I've fixed the advisory to make sure only 300 release stream is advised to upgrade as 111 is unaffected
- This is pinging a lot of people as this widely used vendored openssl uses 111 release stream