### PR TITLE
[GHSA-mpg5-fvwp-42m2] Unsoundness in `dashmap` references

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-mpg5-fvwp-42m2/GHSA-mpg5-fvwp-42m2.json
+++ b/advisories/github-reviewed/2022/06/GHSA-mpg5-fvwp-42m2/GHSA-mpg5-fvwp-42m2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-mpg5-fvwp-42m2",
-  "modified": "2022-06-16T23:52:24Z",
+  "modified": "2022-06-17T15:29:21Z",
   "published": "2022-06-16T23:52:24Z",
   "aliases": [
 
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "5.0.0"
             },
             {
               "fixed": "5.1.0"


### PR DESCRIPTION
**Updates**
- Affected products
- Description

This advisory only affects dashmap 5.0.0, nothing before that version. I tried to list affected versions as just 5.0.0, but the form wouldn't let me.

Source: The cited RustSec advisory: https://rustsec.org/advisories/RUSTSEC-2022-0002.html