### PR TITLE
[GHSA-r45x-ghr2-qjxc] `#[zeroize(drop)]` doesn't implement `Drop` for `enum`s

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-r45x-ghr2-qjxc/GHSA-r45x-ghr2-qjxc.json
+++ b/advisories/github-reviewed/2022/06/GHSA-r45x-ghr2-qjxc/GHSA-r45x-ghr2-qjxc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-r45x-ghr2-qjxc",
-  "modified": "2022-06-17T00:30:52Z",
+  "modified": "2022-06-17T15:42:44Z",
   "published": "2022-06-17T00:30:52Z",
   "aliases": [
 
@@ -9,7 +9,10 @@
   "summary": "`#[zeroize(drop)]` doesn't implement `Drop` for `enum`s",
   "details": "Affected versions of this crate did not implement `Drop` when `#[zeroize(drop)]` was used on an `enum`.\n\nThis can result in memory not being zeroed out after dropping it, which is exactly what is intended when adding this attribute.\n\nThe flaw was corrected in version 1.2 and `#[zeroize(drop)]` on `enum`s now properly implements `Drop`.\n",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+    }
   ],
   "affected": [
     {
@@ -44,9 +47,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-226"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- CWEs
- Description
- Severity