### PR TITLE
[GHSA-mfm6-r9g2-q4r7.json] 111.20.0 fixed version for openssl-src 111

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-mfm6-r9g2-q4r7/GHSA-mfm6-r9g2-q4r7.json
+++ b/advisories/github-reviewed/2022/05/GHSA-mfm6-r9g2-q4r7/GHSA-mfm6-r9g2-q4r7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-mfm6-r9g2-q4r7",
-  "modified": "2022-06-17T00:05:49Z",
+  "modified": "2022-06-17T16:05:00Z",
   "published": "2022-05-04T00:00:23Z",
   "aliases": [
     "CVE-2022-1343"
@@ -25,10 +25,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "300.0.0"
             },
             {
               "fixed": "300.0.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "crates.io",
+        "name": "openssl-src"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "111.20.0"
             }
           ]
         }


### PR DESCRIPTION
Further to #405 

We today updated RUSTSEC-2022-0025,26,27 to reflect the reality for openssl-src :
https://github.com/rustsec/advisory-db/pull/1263

This advisory was missing release path fixed version for openssl-src 111 release stream
Currently dependabot is asking to switch 300 release stream which is incorrect advice as there are two separate streams