### PR TITLE
[GHSA-mfm6-r9g2-q4r7] openssl-src 111 stream is not affected

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-mfm6-r9g2-q4r7/GHSA-mfm6-r9g2-q4r7.json
+++ b/advisories/github-reviewed/2022/05/GHSA-mfm6-r9g2-q4r7/GHSA-mfm6-r9g2-q4r7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-mfm6-r9g2-q4r7",
-  "modified": "2022-06-17T00:05:49Z",
+  "modified": "2022-06-20T15:20:00Z",
   "published": "2022-05-04T00:00:23Z",
   "aliases": [
     "CVE-2022-1343"
@@ -29,25 +29,6 @@
             },
             {
               "fixed": "300.0.6"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "crates.io",
-        "name": "openssl-src"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "111.20.0"
             }
           ]
         }


### PR DESCRIPTION
#405 

**Correction**
- openssl-src 111 stream is not affected
- only 300 stream is affected and affected should be marked only 300.0.0 => && <  300.0.6

We've adjusted the associated RustSec