### PR TITLE
[GHSA-g323-fr93-4j3c] openssl-src 111 stream is not affected

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-g323-fr93-4j3c/GHSA-g323-fr93-4j3c.json
+++ b/advisories/github-reviewed/2022/05/GHSA-g323-fr93-4j3c/GHSA-g323-fr93-4j3c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-g323-fr93-4j3c",
-  "modified": "2022-06-17T00:05:28Z",
+  "modified": "2022-06-20T15:20:00Z",
   "published": "2022-05-04T00:00:22Z",
   "aliases": [
     "CVE-2022-1473"
@@ -29,25 +29,6 @@
             },
             {
               "fixed": "300.0.6"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "crates.io",
-        "name": "openssl-src"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "111.20.0"
             }
           ]
         }


### PR DESCRIPTION
#405 

**Correction**
- openssl-src 111 stream is not affected
- only 300 stream is affected and affected should be marked only 300.0.0 => && <  300.0.6

We've adjusted the associated RustSec