### PR TITLE
[GHSA-rvp4-r3g6-8hxq] Insufficiently Protected Credentials via Insecure Temporary File in org.apache.nifi:nifi-single-user-utils

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-rvp4-r3g6-8hxq/GHSA-rvp4-r3g6-8hxq.json
+++ b/advisories/github-reviewed/2022/06/GHSA-rvp4-r3g6-8hxq/GHSA-rvp4-r3g6-8hxq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-rvp4-r3g6-8hxq",
-  "modified": "2022-06-20T22:33:41Z",
+  "modified": "2022-06-21T02:34:18Z",
   "published": "2022-06-20T22:33:41Z",
   "aliases": [
     "CVE-2022-26850"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:C/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -60,7 +60,7 @@
     "cwe_ids": [
       "CWE-522"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Severity