### PR TITLE
[GHSA-c5hx-w945-j4pq] Memory flaw in zeroize_derive

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-c5hx-w945-j4pq/GHSA-c5hx-w945-j4pq.json
+++ b/advisories/github-reviewed/2022/01/GHSA-c5hx-w945-j4pq/GHSA-c5hx-w945-j4pq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-c5hx-w945-j4pq",
-  "modified": "2022-01-07T18:29:04Z",
+  "modified": "2022-06-22T19:46:01Z",
   "published": "2022-01-06T22:08:33Z",
   "aliases": [
     "CVE-2021-45706"
@@ -42,15 +42,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/iqlusioninc/crates/issues/876"
-    },
-    {
-      "type": "WEB",
       "url": "https://raw.githubusercontent.com/rustsec/advisory-db/main/crates/zeroize_derive/RUSTSEC-2021-0115.md"
     },
     {
       "type": "WEB",
       "url": "https://rustsec.org/advisories/RUSTSEC-2021-0115.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/iqlusioninc/crates/issues/876"
     },
     {
       "type": "PACKAGE",
@@ -59,7 +59,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-459"
     ],
     "severity": "CRITICAL",
     "github_reviewed": true


### PR DESCRIPTION
Updating with the CWE from https://nvd.nist.gov/vuln/detail/CVE-2021-45706.

**Updates**
- CWEs