### PR TITLE
[GHSA-pfrx-2q88-qq97] Got allows a redirect to a UNIX socket

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-pfrx-2q88-qq97/GHSA-pfrx-2q88-qq97.json
+++ b/advisories/github-reviewed/2022/06/GHSA-pfrx-2q88-qq97/GHSA-pfrx-2q88-qq97.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-pfrx-2q88-qq97",
-  "modified": "2022-06-21T20:05:25Z",
+  "modified": "2022-06-24T13:28:58Z",
   "published": "2022-06-19T00:00:21Z",
   "aliases": [
     "CVE-2022-33987"
   ],
   "summary": "Got allows a redirect to a UNIX socket",
-  "details": "The got package before 12.1.0 for Node.js allows a redirect to a UNIX socket.",
+  "details": "The got package before 11.8.5 and before 12.1.0 for Node.js allows a redirect to a UNIX socket.",
   "severity": [
 
   ],
@@ -62,11 +62,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/sindresorhus/got/commit/861ccd9ac2237df762a9e2beed7edd88c60782dc"
+      "url": "https://github.com/sindresorhus/got/compare/v12.0.3...v12.1.0"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/sindresorhus/got/compare/v12.0.3...v12.1.0"
+      "url": "https://github.com/sindresorhus/got/commit/861ccd9ac2237df762a9e2beed7edd88c60782dc"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Description

My intention is to make it clearer that got v11 has been patched as well and not all versions “before 12.1.0” are vulnerable.