### PR TITLE
[GHSA-mh2h-6j8q-x246] Improper Neutralization of Special Elements in Output Used by a Downstream Component in Codecov

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-mh2h-6j8q-x246/GHSA-mh2h-6j8q-x246.json
+++ b/advisories/github-reviewed/2022/05/GHSA-mh2h-6j8q-x246/GHSA-mh2h-6j8q-x246.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-mh2h-6j8q-x246",
-  "modified": "2022-06-23T17:49:55Z",
+  "modified": "2022-06-24T16:59:29Z",
   "published": "2022-05-24T17:07:19Z",
   "aliases": [
     "CVE-2020-7596"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "3.62"
+              "fixed": "3.6.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products