### PR TITLE
[GHSA-x4cf-6jr3-3qvp] Out-of-bounds Read in Facebook Hermes

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-x4cf-6jr3-3qvp/GHSA-x4cf-6jr3-3qvp.json
+++ b/advisories/github-reviewed/2022/05/GHSA-x4cf-6jr3-3qvp/GHSA-x4cf-6jr3-3qvp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-x4cf-6jr3-3qvp",
-  "modified": "2022-06-24T01:00:13Z",
+  "modified": "2022-06-27T03:19:41Z",
   "published": "2022-05-24T17:32:10Z",
   "aliases": [
     "CVE-2020-1915"
@@ -28,13 +28,13 @@
               "introduced": "0"
             },
             {
-              "fixed": "7.2"
+              "fixed": "0.7.2"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 7.1"
+        "last_known_affected_version_range": "<= 0.7.1"
       }
     }
   ],
@@ -50,6 +50,10 @@
     {
       "type": "WEB",
       "url": "https://www.facebook.com/security/advisories/cve-2020-1915"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/facebook/hermes/releases/tag/v0.7.2"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

There is no version 7.2 of hermes-engine, so far the latest version is 0.11.0, the patched version supposed to be 0.7.2