### PR TITLE
[GHSA-3m6f-3gfg-4x56] Panic on incorrect date input to `simple_asn1`

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-3m6f-3gfg-4x56/GHSA-3m6f-3gfg-4x56.json
+++ b/advisories/github-reviewed/2022/06/GHSA-3m6f-3gfg-4x56/GHSA-3m6f-3gfg-4x56.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-3m6f-3gfg-4x56",
-  "modified": "2022-06-17T00:19:49Z",
+  "modified": "2022-06-27T14:49:18Z",
   "published": "2022-06-17T00:19:49Z",
   "aliases": [
 
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.6.0"
             },
             {
               "fixed": "0.6.1"


### PR DESCRIPTION
See the originating RustSec advisory; this only affects version 0.6.0: https://rustsec.org/advisories/RUSTSEC-2021-0125.html

**Updates**
- Affected products