### PR TITLE
Add Erlang as a supported ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Our supported ecosystems are:
 - pip (registry: https://pypi.org/)
 - RubyGems (registry: https://rubygems.org/)
 - Rust (registry: https://crates.io/)
+- Erlang (registry: https://hex.pm/)
 
 If you have a suggestion for a new ecosystem we should support, please open an [issue](https://github.com/github/advisory-database/issues) for discussion.
 


### PR DESCRIPTION
This PR adds Erlang to the supported ecosystems list.