### PR TITLE
Keep supported ecosystem list alphabetized

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Generally speaking, our ecosystems are the namespace used by a package registry.
 Our supported ecosystems are:
 
 - Composer (registry: https://packagist.org)
+- Erlang (registry: https://hex.pm/)
 - Go (registry: https://pkg.go.dev/)
 - Maven (registry: https://repo1.maven.org/maven2/org/)
 - npm (registry: https://www.npmjs.com/)
@@ -46,7 +47,6 @@ Our supported ecosystems are:
 - pip (registry: https://pypi.org/)
 - RubyGems (registry: https://rubygems.org/)
 - Rust (registry: https://crates.io/)
-- Erlang (registry: https://hex.pm/)
 
 If you have a suggestion for a new ecosystem we should support, please open an [issue](https://github.com/github/advisory-database/issues) for discussion.
 


### PR DESCRIPTION
Small update to move Erlang entry into alphabetized position in list of supported ecosystems