### PR TITLE
[GHSA-735f-pg76-fxc4] The OpenSSL 3.0.4 release introduced a serious bug in the...

### DIFF
--- a/advisories/unreviewed/2022/07/GHSA-735f-pg76-fxc4/GHSA-735f-pg76-fxc4.json
+++ b/advisories/unreviewed/2022/07/GHSA-735f-pg76-fxc4/GHSA-735f-pg76-fxc4.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-735f-pg76-fxc4",
-  "modified": "2022-07-02T00:00:29Z",
+  "modified": "2022-07-06T11:27:20Z",
   "published": "2022-07-02T00:00:29Z",
   "aliases": [
     "CVE-2022-2274"
   ],
+  "summary": "",
   "details": "The OpenSSL 3.0.4 release introduced a serious bug in the RSA implementation for X86_64 CPUs supporting the AVX512IFMA instructions. This issue makes the RSA implementation with 2048 bit private keys incorrect on such machines and memory corruption will happen during the computation. As a consequence of the memory corruption an attacker may be able to trigger a remote code execution on the machine performing the computation. SSL/TLS servers or other servers using 2048 bit RSA private keys running on machines supporting AVX512IFMA instructions of the X86_64 architecture are affected by this issue.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "crates.io",
+        "name": "openssl-src"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "300.0.8+3.0.4"
+            },
+            {
+              "fixed": "300.0.9+3.0.5"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -25,6 +44,10 @@
     {
       "type": "WEB",
       "url": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=4d8a88c134df634ba610ff8db1eb8478ac5fd345"
+    },
+    {
+      "type": "WEB",
+      "url": "https://rustsec.org/advisories/RUSTSEC-2022-0033.html"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Summary