### PR TITLE
[GHSA-h9cw-7g8j-h66h] The package link-preview-js before 2.1.16 are vulnerable...

### DIFF
--- a/advisories/unreviewed/2022/07/GHSA-h9cw-7g8j-h66h/GHSA-h9cw-7g8j-h66h.json
+++ b/advisories/unreviewed/2022/07/GHSA-h9cw-7g8j-h66h/GHSA-h9cw-7g8j-h66h.json
@@ -1,17 +1,39 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-h9cw-7g8j-h66h",
-  "modified": "2022-07-02T00:00:19Z",
+  "modified": "2022-07-06T17:19:47Z",
   "published": "2022-07-02T00:00:19Z",
   "aliases": [
     "CVE-2022-25876"
   ],
+  "summary": "link-preview-js vulnerable to server-side request forgery attacks",
   "details": "The package link-preview-js before 2.1.16 are vulnerable to Server-side Request Forgery (SSRF) which allows attackers to send arbitrary requests to the local network and read the response. This is due to flawed DNS rebinding protection.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "link-preview-js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.1.17"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.1.16"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary