### PR TITLE
Fixed link to Maven package registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Our supported ecosystems are:
 - Composer (registry: https://packagist.org)
 - Erlang (registry: https://hex.pm/)
 - Go (registry: https://pkg.go.dev/)
-- Maven (registry: https://repo1.maven.org/maven2/org/)
+- Maven (registry: https://repo1.maven.org/maven2/)
 - npm (registry: https://www.npmjs.com/)
 - NuGet (registry: https://www.nuget.org/)
 - pip (registry: https://pypi.org/)


### PR DESCRIPTION
The last segment of the previous URL is already part of the package group.