### PR TITLE
[GHSA-rpr3-cw39-3pxh] jackson-databind before 2.9.10.4 vulnerable to unsafe deserialization

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-rpr3-cw39-3pxh/GHSA-rpr3-cw39-3pxh.json
+++ b/advisories/github-reviewed/2022/07/GHSA-rpr3-cw39-3pxh/GHSA-rpr3-cw39-3pxh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-rpr3-cw39-3pxh",
-  "modified": "2022-07-15T19:41:47Z",
+  "modified": "2022-07-16T05:34:53Z",
   "published": "2022-07-15T19:41:47Z",
   "aliases": [
     "CVE-2020-10650"
@@ -33,6 +33,38 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 2.9.10.3"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.fasterxml.jackson.core:jackson-databind"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.fasterxml.jackson.core:jackson-databind"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products