### PR TITLE
[GHSA-533q-88rf-cgxx] Heap-based Buffer Overflow in NPM radare2.js prior to 5.6.2.

### DIFF
--- a/advisories/unreviewed/2022/02/GHSA-533q-88rf-cgxx/GHSA-533q-88rf-cgxx.json
+++ b/advisories/unreviewed/2022/02/GHSA-533q-88rf-cgxx/GHSA-533q-88rf-cgxx.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-533q-88rf-cgxx",
-  "modified": "2022-03-17T00:05:53Z",
+  "modified": "2022-07-18T09:27:38Z",
   "published": "2022-02-09T00:00:28Z",
   "aliases": [
     "CVE-2022-0518"
   ],
+  "summary": "Heap-based Buffer Overflow in NPM radare2.js prior to 5.6.2.",
   "details": "Heap-based Buffer Overflow in NPM radare2.js prior to 5.6.2.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "radare2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.6.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -31,11 +50,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/BZTIMAS53YT66FUS4QHQAFRJOBMUFG6D/"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/E6YBRQ3UCFWJVSOYIKPVUDASZ544TFND/"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/E6YBRQ3UCFWJVSOYIKPVUDASZ544TFND/"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/BZTIMAS53YT66FUS4QHQAFRJOBMUFG6D/"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/radareorg/radare2"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary