### PR TITLE
[GHSA-cj88-88mr-972w] glob-parent before 6.0.1 vulnerable to Regular Expression Denial of Service (ReDoS)

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-cj88-88mr-972w/GHSA-cj88-88mr-972w.json
+++ b/advisories/github-reviewed/2022/07/GHSA-cj88-88mr-972w/GHSA-cj88-88mr-972w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-cj88-88mr-972w",
-  "modified": "2022-07-18T17:03:23Z",
+  "modified": "2022-07-19T11:44:37Z",
   "published": "2022-07-18T17:03:23Z",
   "aliases": [
     "CVE-2021-35065"
@@ -22,13 +22,16 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "6.0.0"
             },
             {
               "fixed": "6.0.1"
             }
           ]
         }
+      ],
+      "versions": [
+        "6.0.0"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

Dependabot / github harasses open source maintainers by including bogus & false vulnerability reports, which makes people create 1000s of issues all over GitHub. Can you stop this?

https://github.com/paulmillr/chokidar/issues/1191