### PR TITLE
[GHSA-mhxj-85r3-2x55] file-type vulnerable to Infinite Loop via malformed MKV file

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-mhxj-85r3-2x55/GHSA-mhxj-85r3-2x55.json
+++ b/advisories/github-reviewed/2022/07/GHSA-mhxj-85r3-2x55/GHSA-mhxj-85r3-2x55.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-mhxj-85r3-2x55",
-  "modified": "2022-07-22T20:26:05Z",
+  "modified": "2022-07-26T08:29:32Z",
   "published": "2022-07-22T00:00:38Z",
   "aliases": [
     "CVE-2022-36313"
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "13.0.0"
             },
             {
               "fixed": "16.5.4"
@@ -58,14 +58,6 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/sindresorhus/file-type/commit/2c4d1200c99dffb7d515b9b9951ef43c22bf7e47"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/sindresorhus/file-type/commit/d86835680f4cccbee1a60628783c36700ec9e254"
-    },
-    {
-      "type": "WEB",
       "url": "https://github.com/sindresorhus/file-type/releases/tag/v16.5.4"
     },
     {
@@ -75,6 +67,14 @@
     {
       "type": "WEB",
       "url": "https://www.npmjs.com/package/file-type"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/sindresorhus/file-type/commit/2c4d1200c99dffb7d515b9b9951ef43c22bf7e47"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/sindresorhus/file-type/commit/d86835680f4cccbee1a60628783c36700ec9e254"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products

**Resons**

If you check the [diff between 12.4.2 and 13.0.0](https://github.com/sindresorhus/file-type/compare/v12.4.2...v13.0.0#diff-c853b2249e99790d8725774cf63c90c5ab17112067df6e267f3701d7bf591d12R611-R613), you can see that the vulnerable code was introduced between these two versions, so v13.0.0 is the first vulnerable version.