### PR TITLE
[GHSA-chqf-hx79-gxc6] Improper Restriction of XML External Entity Reference in Openpyxl

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-chqf-hx79-gxc6/GHSA-chqf-hx79-gxc6.json
+++ b/advisories/github-reviewed/2022/05/GHSA-chqf-hx79-gxc6/GHSA-chqf-hx79-gxc6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-chqf-hx79-gxc6",
-  "modified": "2022-07-01T11:49:57Z",
+  "modified": "2022-07-26T13:54:15Z",
   "published": "2022-05-17T02:58:54Z",
   "aliases": [
     "CVE-2017-5992"
@@ -50,6 +50,14 @@
     {
       "type": "WEB",
       "url": "https://bitbucket.org/openpyxl/openpyxl/issues/749"
+    },
+    {
+      "type": "WEB",
+      "url": "https://foss.heptapod.net/openpyxl/openpyxl/-/commit/7fe678fd89fd"
+    },
+    {
+      "type": "WEB",
+      "url": "https://foss.heptapod.net/openpyxl/openpyxl/-/issues/749"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References: added links to current upstream repository and issue tracker