### PR TITLE
[GHSA-6qq8-5wq3-86rp] Traefik vulnerable to Open Redirect via handling of X-Forwarded-Prefix header

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-6qq8-5wq3-86rp/GHSA-6qq8-5wq3-86rp.json
+++ b/advisories/github-reviewed/2022/02/GHSA-6qq8-5wq3-86rp/GHSA-6qq8-5wq3-86rp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-6qq8-5wq3-86rp",
-  "modified": "2022-07-29T12:29:35Z",
+  "modified": "2022-08-02T06:28:42Z",
   "published": "2022-02-11T23:19:21Z",
   "aliases": [
     "CVE-2020-15129"
@@ -47,16 +47,19 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.3.0"
+              "fixed": "2.2.8"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.3.0"
+      }
     },
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/containous/traefik"
+        "name": "github.com/traefik/traefik/api"
       },
       "ranges": [
         {
@@ -75,7 +78,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/containous/traefik/v2"
+        "name": "github.com/traefik/traefik/v2/api"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products