### PR TITLE
Add GitHub Actions to list of supported ecosystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Our supported ecosystems are:
 
 - Composer (registry: https://packagist.org)
 - Erlang (registry: https://hex.pm/)
+- GitHub Actions (registry: https://github.com/marketplace?type=actions)
 - Go (registry: https://pkg.go.dev/)
 - Maven (registry: https://repo.maven.apache.org/maven2)
 - npm (registry: https://www.npmjs.com/)


### PR DESCRIPTION
Updates the list of supported ecosystems to now include `GitHub Actions`