### PR TITLE
Add stale Action to repo to handle PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,22 @@
+name: Close stale PRs
+
+on:
+  schedule:
+  - cron: "00 0 * * *" # runs at 00:00 daily
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v5.1.1
+      name: Clean up stale PRs
+      with:
+        repo-token: ${{ secrets.stale_bot }}
+        stale-pr-message: "👋 This pull request has been marked as stale because it has been open with no activity. You can: comment on the issue or remove the stale label to hold stale off for a while, add the `Keep` label to hold stale off permanently, or do nothing. If you do nothing this pull request will be closed eventually by the stale bot. Please see CONTRIBUTING.md for more polocy details."
+        stale-pr-label: "Stale"
+        exempt-pr-labels: "Keep" # a "Keep" label will keep the PR from being closed as stale
+        days-before-pr-stale: 15 # when the PR is considered stale
+        days-before-pr-close: 30 # when the PR is closed by the bot
+        ascending: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,7 +14,7 @@ jobs:
       name: Clean up stale PRs
       with:
         repo-token: ${{ secrets.stale_bot }}
-        stale-pr-message: "👋 This pull request has been marked as stale because it has been open with no activity. You can: comment on the issue or remove the stale label to hold stale off for a while, add the `Keep` label to hold stale off permanently, or do nothing. If you do nothing this pull request will be closed eventually by the stale bot. Please see CONTRIBUTING.md for more polocy details."
+        stale-pr-message: "👋 This pull request has been marked as stale because it has been open with no activity. You can: comment on the issue or remove the stale label to hold stale off for a while, add the `Keep` label to hold stale off permanently, or do nothing. If you do nothing this pull request will be closed eventually by the stale bot. Please see CONTRIBUTING.md for more policy details."
         stale-pr-label: "Stale"
         exempt-pr-labels: "Keep" # a "Keep" label will keep the PR from being closed as stale
         days-before-pr-stale: 15 # when the PR is considered stale

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/stale@v5.1.1
       name: Clean up stale PRs
       with:
-        repo-token: ${{ secrets.stale_bot }}
+        repo-token: ${{ secrets.STALE_BOT }}
         stale-pr-message: "👋 This pull request has been marked as stale because it has been open with no activity. You can: comment on the issue or remove the stale label to hold stale off for a while, add the `Keep` label to hold stale off permanently, or do nothing. If you do nothing this pull request will be closed eventually by the stale bot. Please see CONTRIBUTING.md for more policy details."
         stale-pr-label: "Stale"
         exempt-pr-labels: "Keep" # a "Keep" label will keep the PR from being closed as stale

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,5 +18,7 @@ jobs:
         stale-pr-label: "Stale"
         exempt-pr-labels: "Keep" # a "Keep" label will keep the PR from being closed as stale
         days-before-pr-stale: 15 # when the PR is considered stale
-        days-before-pr-close: 30 # when the PR is closed by the bot
+        days-before-pr-close: 15 # when the PR is closed by the bot, 
+        days-before-issue-stale: -1 # prevents issues from being tagged by the bot
+        days-before-issue-close: -1 # prevents issues from being closed by the bot
         ascending: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Change one advisory per PR. If there are multiple advisories you would like to improve, submit them as separate pull requests.
 
 ## Stale advisory improvements
-Sometimes our curation team may need more information or clarification about your contribution. They will respond directly to your pull request with comments and questions. Once they have this information, they'll finish their review and process your PR! If your pull request has remained stale (no recent activity) for **30 days** then our team will close the request. Any PR closed due to staleness is welcome to be resubmitted or reopened.
+Sometimes our curation team may need more information or clarification about your contribution. They will respond directly to your pull request with comments and questions. Once they have this information, they'll finish their review and process your PR! If your pull request has has no activity for 15 days, the `stale` label will be added. If there continues to be no activity, then after another 15 days (30 days in total) the request will automatically be closed. Any PR closed due to staleness is welcome to be resubmitted or reopened.
 
 ## Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Change one advisory per PR. If there are multiple advisories you would like to improve, submit them as separate pull requests.
 
 ## Stale advisory improvements
-Sometimes our curation team may need more information or clarification about your contribution. They will respond directly to your pull request with comments and questions. Once they have this information, they'll finish their review and process your PR! If your pull request has has no activity for 15 days, the `stale` label will be added. If there continues to be no activity, then after another 15 days (30 days in total) the request will automatically be closed. Any PR closed due to staleness is welcome to be resubmitted or reopened.
+Sometimes our curation team may need more information or clarification about your contribution. They will respond directly to your pull request with comments and questions. Once they have this information, they'll finish their review and process your PR! If your pull request has has no activity for 30 consecutive days it will automatically be closed. After 15 days of no activity, the `stale` label will be added. If there continues to be no activity, then after another 15 days the request will be closed. Any PR closed due to staleness is welcome to be resubmitted or reopened.
 
 ## Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Change one advisory per PR. If there are multiple advisories you would like to improve, submit them as separate pull requests.
 
 ## Stale advisory improvements
-Sometimes our curation team may need more information or clarification about your contribution. They will respond directly to your pull request with comments and questions. Once they have this information, they'll finish their review and process your PR! If your pull request has has no activity for 30 consecutive days it will automatically be closed. After 15 days of no activity, the `stale` label will be added. If there continues to be no activity, then after another 15 days the request will be closed. Any PR closed due to staleness is welcome to be resubmitted or reopened.
+Sometimes our curation team may need more information or clarification about your contribution. They will respond directly to your pull request with comments and questions. Once they have this information, they'll finish their review and process your PR! If your pull request has no activity for 30 consecutive days it will automatically be closed. After 15 days of no activity, the `stale` label will be added. If there continues to be no activity, then after another 15 days the request will be closed. Any PR closed due to staleness is welcome to be resubmitted or reopened.
 
 ## Resources
 


### PR DESCRIPTION
This PR adds the [stale](https://github.com/marketplace/actions/close-stale-issues) Action to the repository to automatically mark and close stale pull requests after 30 days of inactivity. It additionally updates the contributing.md to better reflect the actions that the workflow will take.