### PR TITLE
[GHSA-g954-5hwp-pp24] Prototype Pollution in protobufjs

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-g954-5hwp-pp24/GHSA-g954-5hwp-pp24.json
+++ b/advisories/github-reviewed/2022/05/GHSA-g954-5hwp-pp24/GHSA-g954-5hwp-pp24.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-g954-5hwp-pp24",
-  "modified": "2022-06-27T21:05:26Z",
+  "modified": "2022-08-16T22:16:54Z",
   "published": "2022-05-28T00:00:20Z",
   "aliases": [
     "CVE-2022-25878"
   ],
   "summary": "Prototype Pollution in protobufjs",
-  "details": "The package protobufjs before 6.11.3 and 6.10.3 is vulnerable to Prototype Pollution, which can allow an attacker to add/modify properties of the Object.prototype.\n\nThis vulnerability can occur in multiple ways:\n1. by providing untrusted user input to util.setProperty or to ReflectionObject.setParsedOption functions\n2. by parsing/loading .proto files\n\n\n",
+  "details": "The package protobufjs after 6.9.0, until 6.11.3 and 6.10.3 is vulnerable to Prototype Pollution, which can allow an attacker to add/modify properties of the Object.prototype.\n\nThis vulnerability can occur in multiple ways:\n1. by providing untrusted user input to util.setProperty or to ReflectionObject.setParsedOption functions\n2. by parsing/loading .proto files\n\n\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "6.9.1"
             },
             {
               "fixed": "6.10.3"


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
The vulnerable code was not introduced yet in 6.9.0 (no util.setProperty in https://github.com/protobufjs/protobuf.js/blob/v6.10.0/src/util.js).
Version 6.10.0 is the first vulnerable release (https://github.com/protobufjs/protobuf.js/blob/07e8185379d6ca6235b71685566c3ce4f594ed34/src/util.js#L176).