### PR TITLE
[GHSA-fw3v-x4f2-v673] Mistune v2.0.2 vulnerable to catastrophic backtracking

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-fw3v-x4f2-v673/GHSA-fw3v-x4f2-v673.json
+++ b/advisories/github-reviewed/2022/07/GHSA-fw3v-x4f2-v673/GHSA-fw3v-x4f2-v673.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-fw3v-x4f2-v673",
-  "modified": "2022-08-11T00:18:47Z",
+  "modified": "2022-08-20T12:30:22Z",
   "published": "2022-07-26T00:00:27Z",
   "aliases": [
     "CVE-2022-34749"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
     }
   ],
   "affected": [
@@ -59,9 +59,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-697"
+      "CWE-400"
     ],
-    "severity": "CRITICAL",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- CWEs
- Severity

**Comments**
This is a ReDoS, and I don't think that can reasonably be assumed to have either a confidentiality or integrity impact.