### PR TITLE
[GHSA-jq4p-mq33-w375] Cross-site Scripting when rendering error messages in laminas-form

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-jq4p-mq33-w375/GHSA-jq4p-mq33-w375.json
+++ b/advisories/github-reviewed/2022/01/GHSA-jq4p-mq33-w375/GHSA-jq4p-mq33-w375.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-jq4p-mq33-w375",
-  "modified": "2022-02-07T21:16:31Z",
+  "modified": "2022-08-22T10:03:42Z",
   "published": "2022-01-28T23:08:29Z",
   "aliases": [
     "CVE-2022-23598"
@@ -66,7 +66,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.17.2"
+              "fixed": "2.17.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Mitigation was released as 2.17.1. There is no 2.17.2 release.
https://github.com/laminas/laminas-form/releases/tag/2.17.1