### PR TITLE
[GHSA-fw3v-x4f2-v673] Mistune v2.0.2 vulnerable to catastrophic backtracking

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-fw3v-x4f2-v673/GHSA-fw3v-x4f2-v673.json
+++ b/advisories/github-reviewed/2022/07/GHSA-fw3v-x4f2-v673/GHSA-fw3v-x4f2-v673.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-fw3v-x4f2-v673",
-  "modified": "2022-08-22T18:27:17Z",
+  "modified": "2022-08-23T13:09:41Z",
   "published": "2022-07-26T00:00:27Z",
   "aliases": [
     "CVE-2022-34749"
   ],
   "summary": "Mistune v2.0.2 vulnerable to catastrophic backtracking",
-  "details": "In Mistune through 2.0.2, support of inline markup is implemented by using regular expressions that can involve a high amount of backtracking on certain edge cases. This behavior is commonly named catastrophic backtracking.",
+  "details": "In Mistune 2.x through 2.0.2, support of inline markup is implemented by using regular expressions that can involve a high amount of backtracking on certain edge cases. This behavior is commonly named catastrophic backtracking.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0.0a1"
             },
             {
               "fixed": "2.0.3"


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Per https://github.com/lepture/mistune/issues/314#issuecomment-1223972386, only 2.x versions of mistune are vulnerable to this CVE. The vulnerable regex was added in https://github.com/lepture/mistune/commit/ca1e7b506850f4e488823fc7338b49a8f9852718, first released in 2.0.0a1.