### PR TITLE
[GHSA-mxcc-7h5m-x57r] Jenkins GitHub Plugin 1.34.4 and earlier uses a non...

### DIFF
--- a/advisories/unreviewed/2022/07/GHSA-mxcc-7h5m-x57r/GHSA-mxcc-7h5m-x57r.json
+++ b/advisories/unreviewed/2022/07/GHSA-mxcc-7h5m-x57r/GHSA-mxcc-7h5m-x57r.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-mxcc-7h5m-x57r",
-  "modified": "2022-08-04T00:00:22Z",
+  "modified": "2022-08-23T19:29:38Z",
   "published": "2022-07-28T00:00:43Z",
   "aliases": [
     "CVE-2022-36885"
   ],
-  "details": "Jenkins GitHub Plugin 1.34.4 and earlier uses a non-constant time comparison function when checking whether the provided and computed webhook signatures are equal, allowing attackers to use statistical methods to obtain a valid webhook signature.",
+  "summary": "Observable timing discrepancy in Jenkins GitHub Plugin",
+  "details": "Jenkins GitHub Plugin prior to 1.34.5 uses a non-constant time comparison function when checking whether the provided and computed webhook signatures are equal, allowing attackers to use statistical methods to obtain a valid webhook signature.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,12 +15,34 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.coravy.hudson.plugins.github:github"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.34.5"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36885"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/github-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location
- Summary

**Comments**
https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-1849

Maven groupId and artifactId information taken from https://plugins.jenkins.io/github/#dependencies