### PR TITLE
[GHSA-jc8g-xhw5-6x46] Improper Certificate Validation in Microsoft .NET Framework components

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-jc8g-xhw5-6x46/GHSA-jc8g-xhw5-6x46.json
+++ b/advisories/github-reviewed/2018/10/GHSA-jc8g-xhw5-6x46/GHSA-jc8g-xhw5-6x46.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-jc8g-xhw5-6x46",
-  "modified": "2022-07-07T21:42:15Z",
+  "modified": "2022-08-23T20:40:57Z",
   "published": "2018-10-16T19:59:05Z",
   "aliases": [
     "CVE-2018-0786"
@@ -343,16 +343,16 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.1.0"
+              "introduced": "4.0.1"
             },
             {
-              "fixed": "4.1.1"
+              "fixed": "4.0.2"
             }
           ]
         }
       ],
       "versions": [
-        "4.1.0"
+        "4.0.1"
       ]
     },
     {
@@ -397,6 +397,72 @@
       ],
       "versions": [
         "4.3.0"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "System.Private.ServiceModel"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.4.0"
+            },
+            {
+              "fixed": "4.4.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "4.4.0"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "System.Private.ServiceModel"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.3.0"
+            },
+            {
+              "fixed": "4.3.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "4.3.0"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "System.Private.ServiceModel"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.1.0"
+            },
+            {
+              "fixed": "4.1.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "4.1.0"
       ]
     },
     {
@@ -419,72 +485,6 @@
       ],
       "versions": [
         "4.0.1"
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "NuGet",
-        "name": "System.Private.ServiceModel"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "4.4.0"
-            },
-            {
-              "fixed": "4.4.1"
-            }
-          ]
-        }
-      ],
-      "versions": [
-        "4.4.0"
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "NuGet",
-        "name": "System.Private.ServiceModel"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "4.3.0"
-            },
-            {
-              "fixed": "4.3.1"
-            }
-          ]
-        }
-      ],
-      "versions": [
-        "4.3.0"
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "NuGet",
-        "name": "System.Private.ServiceModel"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "4.1.0"
-            },
-            {
-              "fixed": "4.1.1"
-            }
-          ]
-        }
-      ],
-      "versions": [
-        "4.1.0"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Package id System.ServiceModel.Duplex 4.1.0 doesn't exist. Should be 4.0.1. The patched version is 4.0.2.