### PR TITLE
[GHSA-f2jv-r9rf-7988] Remote code execution in handlebars when compiling templates

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-f2jv-r9rf-7988/GHSA-f2jv-r9rf-7988.json
+++ b/advisories/github-reviewed/2021/05/GHSA-f2jv-r9rf-7988/GHSA-f2jv-r9rf-7988.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-f2jv-r9rf-7988",
-  "modified": "2021-04-23T18:55:25Z",
+  "modified": "2022-08-23T21:51:10Z",
   "published": "2021-05-06T15:57:44Z",
   "aliases": [
     "CVE-2021-23369"
@@ -33,6 +33,82 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.webjars:handlebars"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.7.6"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.webjars.npm:handlebars"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.7.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.webjars.bower:handlebars"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.7.6"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.webjars.bowergithub.wycats:handlebars.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.7.2"
+      }
     }
   ],
   "references": [
@@ -47,6 +123,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/handlebars-lang/handlebars.js/commit/f0589701698268578199be25285b2ebea1c1e427"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/wycats/handlebars.js"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
Including the [webjars](https://www.webjars.org/) which package up the handlebars javascript as a Java artifact and are available on Maven

https://search.maven.org/artifact/org.webjars.bowergithub.wycats/handlebars.js/4.7.2/jar
https://search.maven.org/artifact/org.webjars.npm/handlebars/4.7.7/jar
https://search.maven.org/artifact/org.webjars/handlebars/4.7.6/jar
https://search.maven.org/artifact/org.webjars.bower/handlebars/4.7.6/jar 