### PR TITLE
[GHSA-f825-f98c-gj3g] automattic/mongoose vulnerable to Prototype pollution via Schema.path

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-f825-f98c-gj3g/GHSA-f825-f98c-gj3g.json
+++ b/advisories/github-reviewed/2022/07/GHSA-f825-f98c-gj3g/GHSA-f825-f98c-gj3g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-f825-f98c-gj3g",
-  "modified": "2022-08-11T22:11:23Z",
+  "modified": "2022-08-24T07:35:55Z",
   "published": "2022-07-29T00:00:18Z",
   "aliases": [
     "CVE-2022-2564"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "6.4.6"
+              "fixed": "6.4.6, 5.13.15"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 6.4.6"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
new patch has been released to fix this in version 5