### PR TITLE
[GHSA-j32j-2hxv-rqf7] Uncontrolled Resource Consumption in pg-native and libpq

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-j32j-2hxv-rqf7/GHSA-j32j-2hxv-rqf7.json
+++ b/advisories/github-reviewed/2022/06/GHSA-j32j-2hxv-rqf7/GHSA-j32j-2hxv-rqf7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-j32j-2hxv-rqf7",
-  "modified": "2022-06-20T22:28:59Z",
+  "modified": "2022-08-24T19:08:23Z",
   "published": "2022-06-18T00:00:20Z",
   "aliases": [
     "CVE-2022-25852"
@@ -26,6 +26,9 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "1.8.10"
             }
           ]
         }
@@ -45,6 +48,9 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "3.0.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The Snyk references show the fixed versions. These can also be verified by checking the two project github repos (which I did)