### PR TITLE
[GHSA-hfxp-p695-629x] abomonation transmutes &T to and from &[u8] without sufficient constraints

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-hfxp-p695-629x/GHSA-hfxp-p695-629x.json
+++ b/advisories/github-reviewed/2022/06/GHSA-hfxp-p695-629x/GHSA-hfxp-p695-629x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-hfxp-p695-629x",
-  "modified": "2022-06-16T23:24:29Z",
+  "modified": "2022-08-25T11:47:08Z",
   "published": "2022-06-16T23:24:29Z",
   "aliases": [
 


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
this advisory is a duplicate of https://github.com/advisories/GHSA-5vwc-r48g-wj6c