### PR TITLE
[GHSA-98j2-hfxp-8h8r] Apache Doris, prior to 1.0.0, used a hardcoded key and IV...

### DIFF
--- a/advisories/unreviewed/2022/04/GHSA-98j2-hfxp-8h8r/GHSA-98j2-hfxp-8h8r.json
+++ b/advisories/unreviewed/2022/04/GHSA-98j2-hfxp-8h8r/GHSA-98j2-hfxp-8h8r.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-98j2-hfxp-8h8r",
-  "modified": "2022-05-07T00:01:11Z",
+  "modified": "2022-08-31T05:46:23Z",
   "published": "2022-04-27T00:00:20Z",
   "aliases": [
     "CVE-2022-23942"
   ],
+  "summary": "Hard-coded Key & IV in Apache Doris",
   "details": "Apache Doris, prior to 1.0.0, used a hardcoded key and IV to initialize the cipher used for ldap password, which may lead to information disclosure.",
   "severity": [
     {
@@ -14,12 +15,42 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.doris"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.0.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23942"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/incubator-doris/pull/7862"
+    },
+    {
+      "type": "WEB",
+      "url": "https://advisory.dw1.io/53"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/doris/blob/9ca369aa58ef6215e2c79b14fc1b4edfc2e2d720/fe/fe-core/src/main/java/org/apache/doris/common/util/SymmetricEncryption.java#L38-L48"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Update product metadata, title & references.