### PR TITLE
[GHSA-5q2v-6j86-5h9v] Security Update for the OPC UA .NET Standard Stack

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-5q2v-6j86-5h9v/GHSA-5q2v-6j86-5h9v.json
+++ b/advisories/github-reviewed/2022/06/GHSA-5q2v-6j86-5h9v/GHSA-5q2v-6j86-5h9v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-5q2v-6j86-5h9v",
-  "modified": "2022-06-17T21:44:01Z",
+  "modified": "2022-08-31T10:15:35Z",
   "published": "2022-06-17T21:44:01Z",
   "aliases": [
     "CVE-2022-29862"
@@ -9,13 +9,38 @@
   "summary": "Security Update for the OPC UA .NET Standard Stack",
   "details": "A vulnerability was discovered in OPC UA .NET Standard Stack that allows a malicious client or server to cause a peer to hang with a carefully crafted message sent during secure channel creation.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
   ],
   "affected": [
     {
       "package": {
         "ecosystem": "NuGet",
         "name": "OPCFoundation.NetStandard.Opc.Ua"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.4.368.58"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.4.368.53"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "OPCFoundation.NetStandard.Opc.Ua.Core"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS

**Comments**
provide CVSS string and the Core package which contains the vulnerability. It has been changed on the github project itself, but has not been picked up here yet