### PR TITLE
[GHSA-3rq8-h3gj-r5c6]  .NET Denial of Service Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-3rq8-h3gj-r5c6/GHSA-3rq8-h3gj-r5c6.json
+++ b/advisories/github-reviewed/2022/08/GHSA-3rq8-h3gj-r5c6/GHSA-3rq8-h3gj-r5c6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-3rq8-h3gj-r5c6",
-  "modified": "2022-08-30T19:32:29Z",
+  "modified": "2022-08-31T15:45:05Z",
   "published": "2022-08-30T19:32:29Z",
   "aliases": [
     "CVE-2022-29117"
@@ -50,13 +50,13 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.22"
+              "fixed": "4.2.2"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 4.21"
+        "last_known_affected_version_range": "<= 4.2.1"
       }
     },
     {
@@ -94,13 +94,13 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.22"
+              "fixed": "4.2.2"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 4.21"
+        "last_known_affected_version_range": "<= 4.2.1"
       }
     },
     {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Incorrect versions listed for Microsoft.Owin.Security.Cookies and Microsoft.Owin (e.g. 4.21 rather than 4.2.1).