### PR TITLE
[GHSA-2m65-m22p-9wjw] .NET Information Disclosure Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-2m65-m22p-9wjw/GHSA-2m65-m22p-9wjw.json
+++ b/advisories/github-reviewed/2022/08/GHSA-2m65-m22p-9wjw/GHSA-2m65-m22p-9wjw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-2m65-m22p-9wjw",
-  "modified": "2022-08-11T21:17:41Z",
+  "modified": "2022-08-31T15:48:22Z",
   "published": "2022-08-10T00:00:18Z",
   "aliases": [
     "CVE-2022-34716"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.6.0"
             },
             {
               "fixed": "4.7.1"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
System.Security.Cryptography.Xml 4.5.0 is only supported by the .NET Framework and is not supported or vulnerable in the .NET Core context.