### PR TITLE
[GHSA-rprw-h62v-c2w7] PyYAML insecurely deserializes YAML strings leading to arbitrary code execution

### DIFF
--- a/advisories/github-reviewed/2019/01/GHSA-rprw-h62v-c2w7/GHSA-rprw-h62v-c2w7.json
+++ b/advisories/github-reviewed/2019/01/GHSA-rprw-h62v-c2w7/GHSA-rprw-h62v-c2w7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-rprw-h62v-c2w7",
-  "modified": "2022-07-18T19:40:16Z",
+  "modified": "2022-09-04T16:03:24Z",
   "published": "2019-01-04T17:45:26Z",
   "aliases": [
     "CVE-2017-18342"
@@ -9,32 +9,13 @@
   "summary": "PyYAML insecurely deserializes YAML strings leading to arbitrary code execution",
   "details": "In PyYAML before 4.1, the yaml.load() API could execute arbitrary code. In other words, yaml.safe_load is not used.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-    }
+
   ],
   "affected": [
     {
       "package": {
         "ecosystem": "PyPI",
-        "name": "PyYAML"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "yaml.load",
-          "yaml.dump",
-          "safe_dump_all",
-          "safe_dump",
-          "yaml.CSafeLoader",
-          "yaml.CLoader",
-          "yaml.CSafeDumper",
-          "yaml.CDumper",
-          "yaml.SafeDumper",
-          "yaml.Dumper",
-          "yaml.SafeLoader",
-          "yaml.Loader"
-        ]
+        "name": ""
       },
       "ranges": [
         {
@@ -42,9 +23,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "4.1"
             }
           ]
         }
@@ -101,7 +79,7 @@
     "cwe_ids": [
       "CWE-502"
     ],
-    "severity": "CRITICAL",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
https://nvd.nist.gov/vuln/detail/CVE-2017-18342
https://github.com/marshmallow-code/apispec/issues/278
https://github.com/yaml/pyyaml/issues/193
https://github.com/yaml/pyyaml/pull/74
https://github.com/yaml/pyyaml/blob/master/CHANGES
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/JEX7IPV5P2QJITAMA5Z63GQCZA5I6NVZ/
https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KSQQMRUQSXBSUXLCRD3TSZYQ7SEZRKCE/
https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/M6JCFGEIEOFMWWIXGHSELMKQDD4CV2BA/
https://security.gentoo.org/glsa/202003-45