### PR TITLE
[GHSA-cppw-2mf8-qpm5] Matrix Synapse before 1.5.0 mishandles signature checking...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-cppw-2mf8-qpm5/GHSA-cppw-2mf8-qpm5.json
+++ b/advisories/unreviewed/2022/05/GHSA-cppw-2mf8-qpm5/GHSA-cppw-2mf8-qpm5.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-cppw-2mf8-qpm5",
-  "modified": "2022-05-24T22:01:05Z",
+  "modified": "2022-09-05T15:15:40Z",
   "published": "2022-05-24T22:01:05Z",
   "aliases": [
     "CVE-2019-18835"
   ],
+  "summary": "Improper Verification of Cryptographic Signature in matrix-synapse",
   "details": "Matrix Synapse before 1.5.0 mishandles signature checking on some federation APIs. Events sent over /send_join, /send_leave, and /invite may not be correctly signed, or may not come from the expected servers.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "matrix-synapse"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.5.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,13 +42,17 @@
       "url": "https://github.com/matrix-org/synapse/pull/6262"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/matrix-org/synapse"
+    },
+    {
       "type": "WEB",
       "url": "https://github.com/matrix-org/synapse/releases/tag/v1.5.0"
     }
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-347"
     ],
     "severity": "HIGH",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- Source code location
- Summary

**Comments**
PR providing fix: https://github.com/matrix-org/synapse/pull/6262
Release Notes for fixed version: https://github.com/matrix-org/synapse/releases/tag/v1.5.0
