### PR TITLE
[GHSA-8wcw-cw2f-h4g2] Jenkins Active Directory Plugin 2.19 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-8wcw-cw2f-h4g2/GHSA-8wcw-cw2f-h4g2.json
+++ b/advisories/unreviewed/2022/05/GHSA-8wcw-cw2f-h4g2/GHSA-8wcw-cw2f-h4g2.json
@@ -1,22 +1,45 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-8wcw-cw2f-h4g2",
-  "modified": "2022-05-24T17:33:07Z",
+  "modified": "2022-09-05T18:39:12Z",
   "published": "2022-05-24T17:33:07Z",
   "aliases": [
     "CVE-2020-2300"
   ],
-  "details": "Jenkins Active Directory Plugin 2.19 and earlier does not prohibit the use of an empty password in Windows/ADSI mode, which allows attackers to log in to Jenkins as any user depending on the configuration of the Active Directory server.",
+  "summary": "Login allowed with empty password by Active Directory Jenkins Plugin ",
+  "details": "Jenkins Active Directory Plugin prior to 2.20 does not prohibit the use of an empty password in Windows/ADSI mode, which allows attackers to log in to Jenkins as any user depending on the configuration of the Active Directory server.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:active-directory"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.20"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2300"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/active-directory-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location
- Summary

**Comments**
Jenkins Security Advisory: https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2099
GroupId and ArtifactId from https://plugins.jenkins.io/active-directory/#dependencies