### PR TITLE
[GHSA-ppxp-px5q-gwqm] The npm ci command in npm 7.x and 8.x through 8.1.3...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-ppxp-px5q-gwqm/GHSA-ppxp-px5q-gwqm.json
+++ b/advisories/unreviewed/2022/05/GHSA-ppxp-px5q-gwqm/GHSA-ppxp-px5q-gwqm.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-ppxp-px5q-gwqm",
-  "modified": "2022-05-24T19:20:36Z",
+  "modified": "2022-09-09T08:38:31Z",
   "published": "2022-05-24T19:20:36Z",
   "aliases": [
     "CVE-2021-43616"
   ],
+  "summary": "",
   "details": "The npm ci command in npm 7.x and 8.x through 8.1.3 proceeds with an installation even if dependency information in package-lock.json differs from package.json. This behavior is inconsistent with the documentation, and makes it easier for attackers to install malware that was supposed to have been blocked by an exact version match requirement in package-lock.json.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "npm"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "7.0.0"
+            },
+            {
+              "fixed": "8.1.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 8.1.3"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Updated package repo and package name and affected versions as in the description. Also tested that all versions of 7.x were vulnerable manually.