### PR TITLE
[GHSA-r9jw-mwhq-wp62] In PyJWT 1.5.0 and below the `invalid_strings` check in ...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-r9jw-mwhq-wp62/GHSA-r9jw-mwhq-wp62.json
+++ b/advisories/unreviewed/2022/05/GHSA-r9jw-mwhq-wp62/GHSA-r9jw-mwhq-wp62.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-r9jw-mwhq-wp62",
-  "modified": "2022-05-13T01:42:19Z",
+  "modified": "2022-09-10T23:35:26Z",
   "published": "2022-05-13T01:42:19Z",
   "aliases": [
     "CVE-2017-11424"
   ],
+  "summary": "PyJWT vulnerable to key confusion attacks",
   "details": "In PyJWT 1.5.0 and below the `invalid_strings` check in `HMACAlgorithm.prepare_key` does not account for all PEM encoded public keys. Specifically, the PKCS1 PEM encoded format would be allowed because it is prefaced with the string `-----BEGIN RSA PUBLIC KEY-----` which is not accounted for. This enables symmetric/asymmetric key confusion attacks against users using the PKCS1 PEM encoded public keys, which would allow an attacker to craft JWTs from scratch.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "pyjwt"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.5.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.5.0"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Advisory was not yet mapped to a product