### PR TITLE
[GHSA-7v44-75jf-22gj] Kimai v2 before 1.1 has XSS via a timesheet description.

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-7v44-75jf-22gj/GHSA-7v44-75jf-22gj.json
+++ b/advisories/unreviewed/2022/05/GHSA-7v44-75jf-22gj/GHSA-7v44-75jf-22gj.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-7v44-75jf-22gj",
-  "modified": "2022-05-24T16:54:38Z",
+  "modified": "2022-09-10T23:45:53Z",
   "published": "2022-05-24T16:54:38Z",
   "aliases": [
     "CVE-2019-15481"
   ],
+  "summary": "",
   "details": "Kimai v2 before 1.1 has XSS via a timesheet description.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "kevinpapst/kimai2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Not mapped to a package. Dependency graph says kevinpapst/kimai2 is a composer package