### PR TITLE
[GHSA-6wj9-77wq-jq7p] Nokogiri before 1.5.4 is vulnerable to XXE attacks

### DIFF
--- a/advisories/unreviewed/2022/04/GHSA-6wj9-77wq-jq7p/GHSA-6wj9-77wq-jq7p.json
+++ b/advisories/unreviewed/2022/04/GHSA-6wj9-77wq-jq7p/GHSA-6wj9-77wq-jq7p.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-6wj9-77wq-jq7p",
-  "modified": "2022-04-23T00:40:45Z",
+  "modified": "2022-09-11T00:05:56Z",
   "published": "2022-04-23T00:40:45Z",
   "aliases": [
     "CVE-2012-6685"
   ],
+  "summary": "",
   "details": "Nokogiri before 1.5.4 is vulnerable to XXE attacks",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "nokogiri"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.5.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Not mapped