### PR TITLE
[GHSA-6h98-cf9g-vmg2] Github Electron version 1.6.4 - 1.6.11 and 1.7.0 - 1.7.5...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-6h98-cf9g-vmg2/GHSA-6h98-cf9g-vmg2.json
+++ b/advisories/unreviewed/2022/05/GHSA-6h98-cf9g-vmg2/GHSA-6h98-cf9g-vmg2.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-6h98-cf9g-vmg2",
-  "modified": "2022-05-13T01:41:15Z",
+  "modified": "2022-09-11T00:53:03Z",
   "published": "2022-05-13T01:41:15Z",
   "aliases": [
     "CVE-2017-1000424"
   ],
+  "summary": "",
   "details": "Github Electron version 1.6.4 - 1.6.11 and 1.7.0 - 1.7.5 is vulnerable to a URL Spoofing problem when opening PDFs in PDFium resulting loading arbitrary PDFs that a hacker can control.",
   "severity": [
     {
@@ -14,7 +15,50 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "Electron"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.6.4"
+            },
+            {
+              "fixed": "1.6.12"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.6.11"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "Electron"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.7.0"
+            },
+            {
+              "fixed": "1.7.6"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.7.5"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Not mapped