### PR TITLE
[GHSA-rwx9-wqj8-vr77] secure-store in Expo through 2.16.1 on iOS provides the...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-rwx9-wqj8-vr77/GHSA-rwx9-wqj8-vr77.json
+++ b/advisories/unreviewed/2022/05/GHSA-rwx9-wqj8-vr77/GHSA-rwx9-wqj8-vr77.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-rwx9-wqj8-vr77",
-  "modified": "2022-05-24T17:26:43Z",
+  "modified": "2022-09-11T01:43:50Z",
   "published": "2022-05-24T17:26:43Z",
   "aliases": [
     "CVE-2020-24653"
   ],
+  "summary": "",
   "details": "secure-store in Expo through 2.16.1 on iOS provides the insecure kSecAttrAccessibleAlwaysThisDeviceOnly policy when WHEN_UNLOCKED_THIS_DEVICE_ONLY is used.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "expo"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.16.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Not mapped