### PR TITLE
[GHSA-69fv-gw6g-8ccg] Potential memory corruption in arrayfire

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-69fv-gw6g-8ccg/GHSA-69fv-gw6g-8ccg.json
+++ b/advisories/github-reviewed/2021/08/GHSA-69fv-gw6g-8ccg/GHSA-69fv-gw6g-8ccg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-69fv-gw6g-8ccg",
-  "modified": "2021-08-19T21:24:28Z",
+  "modified": "2022-09-12T13:27:04Z",
   "published": "2021-08-25T20:43:26Z",
   "aliases": [
     "CVE-2018-20998"
@@ -18,25 +18,6 @@
     {
       "package": {
         "ecosystem": "crates.io",
-        "name": "arrayfire"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "3.6.0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "PyPI",
         "name": "arrayfire"
       },
       "ranges": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
We withdrew [PYSEC-2019-144](https://github.com/pypa/advisory-database/blob/c141d734181d6cfe02a72db3a50008b9a464362e/vulns/arrayfire/PYSEC-2019-144.yaml) in https://github.com/pypa/advisory-database/pull/99 as this specifically affected the rust bindings only