### PR TITLE
[GHSA-9w3m-gqgf-c4p9] Using snakeYAML to parse untrusted YAML files may be...

### DIFF
--- a/advisories/unreviewed/2022/09/GHSA-9w3m-gqgf-c4p9/GHSA-9w3m-gqgf-c4p9.json
+++ b/advisories/unreviewed/2022/09/GHSA-9w3m-gqgf-c4p9/GHSA-9w3m-gqgf-c4p9.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.2.0",
   "id": "GHSA-9w3m-gqgf-c4p9",
-  "modified": "2022-09-06T00:00:27Z",
+  "modified": "2022-09-13T07:39:21Z",
   "published": "2022-09-06T00:00:27Z",
   "aliases": [
     "CVE-2022-38752"
   ],
+  "summary": "Parsing crafted YAML input could lead to stack-overflow",
   "details": "Using snakeYAML to parse untrusted YAML files may be vulnerable to Denial of Service attacks (DOS). If the parser is running on user supplied input, an attacker may supply content that causes the parser to crash by stack-overflow.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.yaml:snakeyaml"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.32"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,13 +42,18 @@
       "url": "https://bitbucket.org/snakeyaml/snakeyaml/issues/531/stackoverflow-oss-fuzz-47081"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://bitbucket.org/snakeyaml/snakeyaml/src"
+    },
+    {
       "type": "WEB",
       "url": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47081"
     }
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-121",
+      "CWE-787"
     ],
     "severity": null,
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- Source code location
- Summary

**Comments**
This vulnerability has been fixed in 1.32; see https://bitbucket.org/snakeyaml/snakeyaml/issues/531/stackoverflow-oss-fuzz-47081