### PR TITLE
[GHSA-rhwx-hjx2-x4qr] PDFKit vulnerable to Command Injection

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-rhwx-hjx2-x4qr/GHSA-rhwx-hjx2-x4qr.json
+++ b/advisories/github-reviewed/2022/09/GHSA-rhwx-hjx2-x4qr/GHSA-rhwx-hjx2-x4qr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-rhwx-hjx2-x4qr",
-  "modified": "2022-09-15T03:30:40Z",
+  "modified": "2022-09-15T05:14:41Z",
   "published": "2022-09-10T00:00:32Z",
   "aliases": [
     "CVE-2022-25765"
@@ -50,7 +50,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/pdfkit/pdfkit/blob/master/lib/pdfkit/source.rb%23L44-L50"
+      "url": "https://github.com/pdfkit/pdfkit/blob/master/lib/pdfkit/source.rb#L44-L50"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Because the referring URL is broken