### PR TITLE
[GHSA-935h-fp8w-9vph] Double free vulnerability in the j2k_read_ppm_v3 function...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-935h-fp8w-9vph/GHSA-935h-fp8w-9vph.json
+++ b/advisories/unreviewed/2022/05/GHSA-935h-fp8w-9vph/GHSA-935h-fp8w-9vph.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-935h-fp8w-9vph",
-  "modified": "2022-05-13T01:05:18Z",
+  "modified": "2022-09-16T20:00:26Z",
   "published": "2022-05-13T01:05:18Z",
   "aliases": [
     "CVE-2015-1239"
   ],
+  "summary": "",
   "details": "Double free vulnerability in the j2k_read_ppm_v3 function in OpenJPEG before r2997, as used in PDFium in Google Chrome, allows remote attackers to cause a denial of service (process crash) via a crafted PDF.",
   "severity": [
     {
@@ -14,12 +15,31 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "openjpeg"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-1239"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/uclouvain/openjpeg/issues/477"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Summary

**Comments**
openjpeg issue page needs to be linked