### PR TITLE
[GHSA-74w3-p89x-ffgh] ansi_term is Unmaintained

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-74w3-p89x-ffgh/GHSA-74w3-p89x-ffgh.json
+++ b/advisories/github-reviewed/2022/09/GHSA-74w3-p89x-ffgh/GHSA-74w3-p89x-ffgh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-74w3-p89x-ffgh",
-  "modified": "2022-09-16T21:03:19Z",
+  "modified": "2022-09-17T10:05:50Z",
   "published": "2022-09-16T21:03:19Z",
   "aliases": [
 
@@ -47,7 +47,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "CRITICAL",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- Severity

**Comments**
Severity of this case is incredibly inflated. There's no vulnerability here, and a risk of one is very low: this package has been stable for years, and has a perfect security track record.

Calling everything "Critical" undermines my trust in your whole security advisory program. This advisory has also been marked as "GitHub reviewed", and the review did not catch how absurd this advisory is.

