### PR TITLE
[GHSA-74w3-p89x-ffgh] ansi_term is Unmaintained

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-74w3-p89x-ffgh/GHSA-74w3-p89x-ffgh.json
+++ b/advisories/github-reviewed/2022/09/GHSA-74w3-p89x-ffgh/GHSA-74w3-p89x-ffgh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-74w3-p89x-ffgh",
-  "modified": "2022-09-16T21:03:19Z",
+  "modified": "2022-09-18T06:15:26Z",
   "published": "2022-09-16T21:03:19Z",
   "aliases": [
 
@@ -45,9 +45,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-1104"
     ],
-    "severity": "CRITICAL",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- Severity

**Comments**
Massively misstated severity. Critical should be reserved for "Your app is on fire and everyone can read your memory contents" and such. This seems like a Low severity, since there is no exploit and not even any specific bug in the library, it's just a notification of deprecation and lack of maintenance.