### PR TITLE
[GHSA-74w3-p89x-ffgh] ansi_term is Unmaintained

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-74w3-p89x-ffgh/GHSA-74w3-p89x-ffgh.json
+++ b/advisories/github-reviewed/2022/09/GHSA-74w3-p89x-ffgh/GHSA-74w3-p89x-ffgh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-74w3-p89x-ffgh",
-  "modified": "2022-09-16T21:03:19Z",
+  "modified": "2022-09-19T10:38:04Z",
   "published": "2022-09-16T21:03:19Z",
   "aliases": [
 
@@ -47,7 +47,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "CRITICAL",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- Severity

**Comments**
RUSTSEC classifies this as "info". This crate just produces ansi console output, it doesn't even parse any trusted or untrusted input. So there's no reason to mark this as "critical".