### PR TITLE
[GHSA-74w3-p89x-ffgh] ansi_term is Unmaintained

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-74w3-p89x-ffgh/GHSA-74w3-p89x-ffgh.json
+++ b/advisories/github-reviewed/2022/09/GHSA-74w3-p89x-ffgh/GHSA-74w3-p89x-ffgh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-74w3-p89x-ffgh",
-  "modified": "2022-09-16T21:03:19Z",
+  "modified": "2022-09-19T13:18:31Z",
   "published": "2022-09-16T21:03:19Z",
   "aliases": [
 


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
I don't think unmaintained projects should be considered vulnerabilties.

1. It's not a specific vulnerability. It may be the root cause of future vulnerabilities. It may not.
1. There's no patch. No future version which is asserted to be unaffected. No past version which is sensibly considered to be effective. The action is not clearly given.
1. What score or severity are you meant to give? On what basis? How does this prioritise vs other vulnerabilities, and why?