### PR TITLE
[GHSA-q2q7-5pp4-w6pg] Catastrophic backtracking in URL authority parser when passed URL containing many @ characters

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-q2q7-5pp4-w6pg/GHSA-q2q7-5pp4-w6pg.json
+++ b/advisories/github-reviewed/2021/06/GHSA-q2q7-5pp4-w6pg/GHSA-q2q7-5pp4-w6pg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-q2q7-5pp4-w6pg",
-  "modified": "2021-10-21T16:39:49Z",
+  "modified": "2022-09-20T12:25:48Z",
   "published": "2021-06-01T21:19:32Z",
   "aliases": [
     "CVE-2021-33503"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.25.4"
             },
             {
               "fixed": "1.26.5"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
* `docker run -it --rm debian:buster bash -c 'apt update && apt install python3-pip -y && pip3 install urllib3==1.25.3 && time python3 -c "import urllib3; urllib3.util.parse_url(\"http://\"+  (\"@\"*10000) + \"[\")"'` gives a runtime of 0.064s for the test on my system
* `docker run -it --rm debian:buster bash -c 'apt update && apt install python3-pip -y && pip3 install urllib3==1.25.4 && time python3 -c "import urllib3; urllib3.util.parse_url(\"http://\"+  (\"@\"*10000) + \"[\")"'` gives a runtime of 4.531s for the test  on my system
* `docker run -it --rm debian:buster bash -c 'apt update && apt install python3-pip -y && pip3 install urllib3==1.26.4 && time python3 -c "import urllib3; urllib3.util.parse_url(\"http://\"+  (\"@\"*10000) + \"[\")"'` gives a runtime of 4.295s for the test  on my system
* `docker run -it --rm debian:buster bash -c 'apt update && apt install python3-pip -y && pip3 install urllib3==1.26.5 && time python3 -c "import urllib3; urllib3.util.parse_url(\"http://\"+  (\"@\"*10000) + \"[\")"'` gives a runtime of 0.047s for the test on my system