### PR TITLE
[GHSA-rfj2-q3h3-hm5j] Cargo extracting malicious crates can corrupt arbitrary files

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-rfj2-q3h3-hm5j/GHSA-rfj2-q3h3-hm5j.json
+++ b/advisories/github-reviewed/2022/09/GHSA-rfj2-q3h3-hm5j/GHSA-rfj2-q3h3-hm5j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-rfj2-q3h3-hm5j",
-  "modified": "2022-09-16T17:12:30Z",
+  "modified": "2022-09-21T08:30:13Z",
   "published": "2022-09-16T17:12:30Z",
   "aliases": [
     "CVE-2022-36113"
@@ -9,10 +9,7 @@
   "summary": "Cargo extracting malicious crates can corrupt arbitrary files",
   "details": "The Rust Security Response WG was notified that Cargo did not prevent extracting some malformed packages downloaded from alternate registries. An attacker able to upload packages to an alternate registry could corrupt arbitary files when Cargo downloaded the package.\n\nThe severity of this vulnerability is \"low\" for users of alternate registries. Users relying on crates.io are not affected.\n\nNote that **by design** Cargo allows code execution at build time, due to build scripts and procedural macros. The vulnerabilities in this advisory allow performing a subset of the possible damage in a harder to track down way. Your dependencies must still be trusted if you want to be protected from attacks, as it's possible to perform the same attacks with build scripts and procedural macros.\n\n## Arbitrary file corruption\n\nAfter a package is downloaded, Cargo extracts its source code in the `~/.cargo` folder on disk, making it available to the Rust projects it builds. To record when an extraction is successfull, Cargo writes \"ok\" to the `.cargo-ok` file at the root of the extracted source code once it extracted all the files.\n\nIt was discovered that Cargo allowed packages to contain a `.cargo-ok` *symbolic link*, which Cargo would extract. Then, when Cargo attempted to write \"ok\" into `.cargo-ok`, it would actually replace the first two bytes of the file the symlink pointed to with `ok`. This would allow an attacker to corrupt one file on the machine using Cargo to extract the package.\n\n## Affected versions\n\nThe vulnerability is present in all versions of Cargo. Rust 1.64, to be released on September 22nd, will include a fix for it.\n\nSince the vulnerability is just a more limited way to accomplish what a malicious build scripts or procedural macros can do, we decided not to publish Rust point releases backporting the security fix. Patch files are available for Rust 1.63.0 are available [in the wg-security-response repository][patches] for people building their own toolchain.\n\n## Mitigations\n\nWe recommend users of alternate registries to excercise care in which package they download, by only including trusted dependencies in their projects. Please note that even with these vulnerabilities fixed, by design Cargo allows arbitrary code execution at build time thanks to build scripts and procedural macros: a malicious dependency will be able to cause damage regardless of these vulnerabilities.\n\ncrates.io implemented server-side checks to reject these kinds of packages years ago, and there are no packages on crates.io exploiting these vulnerabilities. crates.io users still need to excercise care in choosing their dependencies though, as remote code execution is allowed by design there as well.\n\n## Acknowledgements\n\nWe want to thank Ori Hollander from JFrog Security Research for responsibly disclosing this to us according to the [Rust security policy][policy].\n\nWe also want to thank Josh Triplett for developing the fixes, Weihang Lo for developing the tests, and Pietro Albini for writing this advisory. The disclosure was coordinated by Pietro Albini and Josh Stone.\n\n[policy]: https://www.rust-lang.org/policies/security\n[patches]: https://github.com/rust-lang/wg-security-response/tree/master/patches",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L"
-    }
+
   ],
   "affected": [
     {
@@ -61,7 +58,7 @@
     "cwe_ids": [
       "CWE-22"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
The Security Response WG intentionally marked this vulnerability as "low" severity rather than going with the CVSS assessment, with the following reasoning:

> Note that **by design** Cargo allows code execution at build time, due to build scripts and procedural macros. The vulnerabilities in this advisory allow performing a subset of the possible damage in a harder to track down way. Your dependencies must still be trusted if you want to be protected from attacks, as it's possible to perform the same attacks with build scripts and procedural macros.

This updates the severity of this advisory to reflect the text of the advisory.