### PR TITLE
[GHSA-mw37-wx8p-gp45] Craft CMS vulnerable to Cross-site Scripting via Drafts

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-mw37-wx8p-gp45/GHSA-mw37-wx8p-gp45.json
+++ b/advisories/github-reviewed/2022/09/GHSA-mw37-wx8p-gp45/GHSA-mw37-wx8p-gp45.json
@@ -1,17 +1,39 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-mw37-wx8p-gp45",
-  "modified": "2022-09-21T15:20:42Z",
+  "modified": "2022-09-22T14:55:56Z",
   "published": "2022-09-17T00:00:30Z",
   "aliases": [
     "CVE-2022-37251"
   ],
   "summary": "Craft CMS vulnerable to Cross-site Scripting via Drafts",
-  "details": "Craft CMS 4.2.0.1 is vulnerable to Cross Site Scripting (XSS) via Drafts. Version 4.2.1 contains a patch for this issue.",
+  "details": "Craft CMS `3.70-RC1`–`3.7.55.1` and `4.0.0-RC1`–`4.2.0.1` are vulnerable to Cross Site Scripting (XSS) via entry revisions and drafts. Versions `3.7.55.2` and `4.2.1` contain patches for this issue.",
   "severity": [
 
   ],
   "affected": [
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "craftcms/cms"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.7.0-beta.1"
+            },
+            {
+              "fixed": "4.2.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 3.7.55.2"
+      }
+    },
     {
       "package": {
         "ecosystem": "Packagist",

--- a/advisories/github-reviewed/2022/09/GHSA-mw37-wx8p-gp45/GHSA-mw37-wx8p-gp45.json
+++ b/advisories/github-reviewed/2022/09/GHSA-mw37-wx8p-gp45/GHSA-mw37-wx8p-gp45.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-mw37-wx8p-gp45",
-  "modified": "2022-09-22T14:55:56Z",
+  "modified": "2022-09-22T14:59:05Z",
   "published": "2022-09-17T00:00:30Z",
   "aliases": [
     "CVE-2022-37251"
   ],
-  "summary": "Craft CMS vulnerable to Cross-site Scripting via Drafts",
+  "summary": "Craft CMS vulnerable to Cross-site Scripting via entry revisions and drafts",
   "details": "Craft CMS `3.70-RC1`–`3.7.55.1` and `4.0.0-RC1`–`4.2.0.1` are vulnerable to Cross Site Scripting (XSS) via entry revisions and drafts. Versions `3.7.55.2` and `4.2.1` contain patches for this issue.",
   "severity": [
 
@@ -25,14 +25,11 @@
               "introduced": "3.7.0-beta.1"
             },
             {
-              "fixed": "4.2.1"
+              "fixed": "3.7.55.2"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 3.7.55.2"
-      }
+      ]
     },
     {
       "package": {

--- a/advisories/github-reviewed/2022/09/GHSA-mw37-wx8p-gp45/GHSA-mw37-wx8p-gp45.json
+++ b/advisories/github-reviewed/2022/09/GHSA-mw37-wx8p-gp45/GHSA-mw37-wx8p-gp45.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-mw37-wx8p-gp45",
-  "modified": "2022-09-20T17:14:36Z",
+  "modified": "2022-09-21T15:20:42Z",
   "published": "2022-09-17T00:00:30Z",
   "aliases": [
     "CVE-2022-37251"
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.0.0-RC1"
             },
             {
               "fixed": "4.2.1"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The vulnerability did not affect versions prior to 4.0.0