### PR TITLE
[GHSA-9339-86wc-4qgf] Apache Xalan Java XSLT library integer truncation issue when processing malicious XSLT stylesheets

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-9339-86wc-4qgf/GHSA-9339-86wc-4qgf.json
+++ b/advisories/github-reviewed/2022/07/GHSA-9339-86wc-4qgf/GHSA-9339-86wc-4qgf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9339-86wc-4qgf",
-  "modified": "2022-07-29T13:02:22Z",
+  "modified": "2022-09-22T11:27:18Z",
   "published": "2022-07-20T00:00:18Z",
   "aliases": [
     "CVE-2022-34169"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.7.2"
+              "fixed": "2.7.3"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.7.2"
+      }
     }
   ],
   "references": [
@@ -51,6 +54,10 @@
     {
       "type": "WEB",
       "url": "https://lists.apache.org/thread/2qvl7r43wb4t8p9dd9om1bnkssk07sn8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread/x3f7xv3p1g32qj2hlg8wd57pwcpld471"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Xalan 2.7.3 release candidate is under review, and can soon be expected :)
https://lists.apache.org/thread/x3f7xv3p1g32qj2hlg8wd57pwcpld471