### PR TITLE
[GHSA-f7gc-6hcj-wc42] Malicious Package in path-to-regxep

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-f7gc-6hcj-wc42/GHSA-f7gc-6hcj-wc42.json
+++ b/advisories/github-reviewed/2020/09/GHSA-f7gc-6hcj-wc42/GHSA-f7gc-6hcj-wc42.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-f7gc-6hcj-wc42",
-  "modified": "2021-10-01T21:03:55Z",
+  "modified": "2022-09-26T07:08:53Z",
   "published": "2020-09-03T17:05:06Z",
   "aliases": [
 
@@ -18,14 +18,14 @@
     {
       "package": {
         "ecosystem": "npm",
-        "name": "path-to-regxep"
+        "name": ""
       },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0.0.0"
+              "introduced": "0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Package already not in npmjs.com,  this advisory should be removed.