### PR TITLE
[GHSA-r4r9-mgjc-g6q3] Path Traversal in 626

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-r4r9-mgjc-g6q3/GHSA-r4r9-mgjc-g6q3.json
+++ b/advisories/github-reviewed/2020/09/GHSA-r4r9-mgjc-g6q3/GHSA-r4r9-mgjc-g6q3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-r4r9-mgjc-g6q3",
-  "modified": "2020-08-31T18:28:44Z",
+  "modified": "2022-09-26T07:10:53Z",
   "published": "2020-09-01T19:06:15Z",
   "aliases": [
     "CVE-2018-3727"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This package no longer exists in npmjs.com, and this advisory should be removed.