### PR TITLE
[GHSA-8qv5-68g4-248j] Scala subject to file deletion, code execution due to Java deserialization chain with LazyList object deserialization

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-8qv5-68g4-248j/GHSA-8qv5-68g4-248j.json
+++ b/advisories/github-reviewed/2022/09/GHSA-8qv5-68g4-248j/GHSA-8qv5-68g4-248j.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1.3.0",
+  "id": "GHSA-8qv5-68g4-248j",
+  "modified": "2022-09-28T14:20:48Z",
+  "published": "2022-09-25T00:00:20Z",
+  "aliases": [
+    "CVE-2022-36944"
+  ],
+  "summary": "Scala subject to file deletion, code execution due to Java deserialization chain with LazyList object deserialization",
+  "details": "Scala 2.13.x before 2.13.9 has a Java deserialization chain in its JAR file. On its own, it cannot be exploited. There is only a risk in conjunction with LazyList object deserialization within an application. In such situations, it allows attackers to erase contents of arbitrary files, make network connections, or possibly run arbitrary code (specifically, Function0 functions) via a gadget chain.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.scala-lang:scala-library"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.13.0"
+            },
+            {
+              "fixed": "2.13.9"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36944"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/scala/scala/pull/10118"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/scala/scala"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.scala-lang.org/download/"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-502"
+    ],
+    "severity": "CRITICAL",
+    "github_reviewed": true
+  }
+}


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
There's no version 2.19.0 and the CVE was fixed in 2.13.9: https://github.com/scala/scala/releases/tag/v2.13.9, https://nvd.nist.gov/vuln/detail/CVE-2022-36944