### PR TITLE
[GHSA-8qv5-68g4-248j] Scala subject to file deletion, code execution due to Java deserialization chain with LazyList object deserialization

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-8qv5-68g4-248j/GHSA-8qv5-68g4-248j.json
+++ b/advisories/github-reviewed/2022/09/GHSA-8qv5-68g4-248j/GHSA-8qv5-68g4-248j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8qv5-68g4-248j",
-  "modified": "2022-09-28T14:10:01Z",
+  "modified": "2022-09-29T07:35:08Z",
   "published": "2022-09-25T00:00:20Z",
   "aliases": [
     "CVE-2022-36944"
@@ -28,7 +28,7 @@
               "introduced": "2.13.0"
             },
             {
-              "fixed": "2.19.0"
+              "fixed": "2.13.9"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Wrong patched version — 2.19.0. The correct is 2.13.9