### PR TITLE
[GHSA-w95h-2gj2-x2p4] A OS Command Injection vulnerability exists in Node.js...

### DIFF
--- a/advisories/unreviewed/2022/07/GHSA-w95h-2gj2-x2p4/GHSA-w95h-2gj2-x2p4.json
+++ b/advisories/unreviewed/2022/07/GHSA-w95h-2gj2-x2p4/GHSA-w95h-2gj2-x2p4.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-w95h-2gj2-x2p4",
-  "modified": "2022-07-22T00:00:38Z",
+  "modified": "2022-09-29T10:27:09Z",
   "published": "2022-07-15T00:00:18Z",
   "aliases": [
     "CVE-2022-32212"
   ],
+  "summary": "",
   "details": "A OS Command Injection vulnerability exists in Node.js versions <14.20.0, <16.20.0, <18.5.0 due to an insufficient IsAllowedHost check that can easily be bypassed because IsIPAddress does not properly check if an IP address is invalid before making DBS requests allowing rebinding attacks.",
   "severity": [
     {
@@ -14,7 +15,22 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
As 16.20.0 in description is not released now, is this correct?
We find it has been fixed 16.17.1 from here: https://github.com/nodejs/node/commit/77fe2f32e427d6d66163f73474c22391341a216e