### PR TITLE
[GHSA-rgv9-q543-rqg4] In FasterXML jackson-databind before 2.13.4, resource...

### DIFF
--- a/advisories/unreviewed/2022/10/GHSA-rgv9-q543-rqg4/GHSA-rgv9-q543-rqg4.json
+++ b/advisories/unreviewed/2022/10/GHSA-rgv9-q543-rqg4/GHSA-rgv9-q543-rqg4.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-rgv9-q543-rqg4",
-  "modified": "2022-10-03T00:00:31Z",
+  "modified": "2022-10-03T09:33:48Z",
   "published": "2022-10-03T00:00:31Z",
   "aliases": [
     "CVE-2022-42004"
   ],
+  "summary": "",
   "details": "In FasterXML jackson-databind before 2.13.4, resource exhaustion can occur because of a lack of a check in BeanDeserializer._deserializeFromArray to prevent use of deeply nested arrays. An application is vulnerable only with certain customized choices for deserialization.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "Jackson-databind"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.13.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -29,13 +48,17 @@
     {
       "type": "WEB",
       "url": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50490"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/FasterXML/jackson-databind"
     }
   ],
   "database_specific": {
     "cwe_ids": [
 
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Source code location
- Summary

**Comments**
I found and requested this CVE with Mitre. Some details were left out from the CVE description.

Adding eco system and package name.