### PR TITLE
[GHSA-f36p-42jv-8rh2] Lithium vulnerable to Cross Site Scripting in provided Swagger-UI

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-f36p-42jv-8rh2/GHSA-f36p-42jv-8rh2.json
+++ b/advisories/github-reviewed/2022/09/GHSA-f36p-42jv-8rh2/GHSA-f36p-42jv-8rh2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-f36p-42jv-8rh2",
-  "modified": "2022-09-30T04:53:37Z",
+  "modified": "2022-10-05T11:54:36Z",
   "published": "2022-09-30T04:53:37Z",
   "aliases": [
 
@@ -33,6 +33,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.wire.bots:lithium"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 3.4.2"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The project namespace was renamed from `com.wire.bots` to `com.wire` in the past, this change adds the old name to the affected products