### PR TITLE
update CVE record to correct identifier

### DIFF
--- a/advisories/github-reviewed/2019/04/GHSA-wv67-q8rr-grjp/GHSA-wv67-q8rr-grjp.json
+++ b/advisories/github-reviewed/2019/04/GHSA-wv67-q8rr-grjp/GHSA-wv67-q8rr-grjp.json
@@ -5,7 +5,7 @@
   "published": "2019-04-23T15:59:10Z",
   "withdrawn": "2019-04-26T14:50:56Z",
   "aliases": [
-    "CVE-2019-5428"
+    "CVE-2019-11358"
   ],
   "summary": "Prototype Pollution in jquery",
   "details": "Versions of `jquery`  prior to 3.4.0 are vulnerable to Prototype Pollution. The extend() method allows an attacker to modify the prototype for `Object` causing changes in properties that will exist on all objects.\n\n\n## Recommendation\n\nUpgrade to version 3.4.0 or later.",
@@ -36,7 +36,7 @@
   "references": [
     {
       "type": "ADVISORY",
-      "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-5428"
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-11358"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
The CVE identifier for GHSA-wv67-q8rr-grjp is incorrect. CVE-2019-5428 was rejected as a duplicate of CVE-2019-11358 per the NVD database

https://nvd.nist.gov/vuln/detail/CVE-2019-5428