### PR TITLE
[GHSA-77xx-rxvh-q682] HyperSQL DataBase vulnerable to remote code execution when processing untrusted input

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-77xx-rxvh-q682/GHSA-77xx-rxvh-q682.json
+++ b/advisories/github-reviewed/2022/10/GHSA-77xx-rxvh-q682/GHSA-77xx-rxvh-q682.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-77xx-rxvh-q682",
-  "modified": "2022-10-06T21:16:51Z",
+  "modified": "2022-10-07T08:32:23Z",
   "published": "2022-10-06T18:52:05Z",
   "aliases": [
     "CVE-2022-41853"
@@ -43,7 +43,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/myxof/hypersql"
+      "url": "https://sourceforge.net/projects/hsqldb"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Source code location

**Comments**
HSQLDB is not hosted on github let alone here https://github.com/myxof/hypersql, and there is no such thing as a release 2.7.1, neither on sourceforge: https://sourceforge.net/projects/hsqldb/files/, nor on maven central: https://repo1.maven.org/maven2/org/hsqldb/hsqldb/

~Is this CVE a legitimate?~ (it seems to be, but maybe published prematurely as no release is available yet)