### PR TITLE
[GHSA-99v3-9x35-c5vf] Improper Authentication in Apache WSS4J

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-99v3-9x35-c5vf/GHSA-99v3-9x35-c5vf.json
+++ b/advisories/github-reviewed/2022/05/GHSA-99v3-9x35-c5vf/GHSA-99v3-9x35-c5vf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-99v3-9x35-c5vf",
-  "modified": "2022-07-07T22:34:04Z",
+  "modified": "2022-10-12T13:44:48Z",
   "published": "2022-05-13T01:09:20Z",
   "aliases": [
     "CVE-2014-3623"
@@ -45,25 +45,6 @@
             },
             {
               "fixed": "2.0.2"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.apache.wss4j:wss4j-ws-security-dom"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.0.0"
-            },
-            {
-              "fixed": "3.0.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
WSS4J 3.0.0 is not impacted. "as used in Apache CXF 2.7.x before 2.7.13 and 3.0.x before 3.0.2" -> This refers to Apache CXF, which embeds WSS4J.