### PR TITLE
[GHSA-28xr-mwxg-3qc8] Command injection in simple-git

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-28xr-mwxg-3qc8/GHSA-28xr-mwxg-3qc8.json
+++ b/advisories/github-reviewed/2022/04/GHSA-28xr-mwxg-3qc8/GHSA-28xr-mwxg-3qc8.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-28xr-mwxg-3qc8",
-  "modified": "2022-05-03T22:29:53Z",
+  "modified": "2022-10-13T14:48:25Z",
   "published": "2022-04-02T00:00:13Z",
   "aliases": [
     "CVE-2022-24066"
   ],
   "summary": "Command injection in simple-git",
-  "details": "`simple-git` (maintained as [git-js](https://github.com/steveukx/git-js) named repository on GitHub) is a light weight interface for running git commands in any node.js application.The package simple-git before 3.5.0 are vulnerable to Command Injection due to an incomplete fix of [CVE-2022-24433](https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-2421199) which only patches against the git fetch attack vector. A similar use of the --upload-pack feature of git is also supported for git clone, which the prior fix didn't cover. A fix was released in simple-git@3.6.0.",
+  "details": "`simple-git` (maintained as [git-js](https://github.com/steveukx/git-js) named repository on GitHub) is a light weight interface for running git commands in any node.js application.The package simple-git before 3.5.0 are vulnerable to Command Injection due to an incomplete fix of [CVE-2022-24433](https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-2421199) which only patches against the git fetch attack vector. A similar use of the --upload-pack feature of git is also supported for git clone, which the prior fix didn't cover. A fix was released in simple-git@3.5.0.",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Description

**Comments**
Affected products said 3.5.0, but the text said 3.6.0. Both of these indicate that 3.5.0 is correct: https://github.com/steveukx/git-js/releases/tag/simple-git%403.5.0

https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-2434306