### PR TITLE
[GHSA-wrx5-rp7m-mm49] JXPath vulnerable to remote code execution when interpreting untrusted XPath expressions

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-wrx5-rp7m-mm49/GHSA-wrx5-rp7m-mm49.json
+++ b/advisories/github-reviewed/2022/10/GHSA-wrx5-rp7m-mm49/GHSA-wrx5-rp7m-mm49.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-wrx5-rp7m-mm49",
-  "modified": "2022-10-10T16:55:26Z",
+  "modified": "2022-10-14T16:39:35Z",
   "published": "2022-10-06T18:52:05Z",
   "aliases": [
     "CVE-2022-41852"
   ],
   "summary": "JXPath vulnerable to remote code execution when interpreting untrusted XPath expressions",
-  "details": "Those using JXPath to interpret untrusted XPath expressions may be vulnerable to a remote code execution attack. All JXPathContext class functions processing a XPath string are vulnerable except `compile()` and `compilePath()` function. The XPath expression can be used by an attacker to load any Java class from the classpath resulting in code execution.",
+  "details": "Those using JXPath to interpret untrusted XPath expressions may be vulnerable to a remote code execution attack. All JXPathContext class functions processing a XPath string are vulnerable except `compile()` and `compilePath()` function. The XPath expression can be used by an attacker to load any Java class from the classpath resulting in code execution.\n\n## Example vulnerable code\nFollowing code will execute the RCE in `pathWithUserInput` variable:\n- `new JXPathContext(someObject).getValue(pathWithUserInput);`\n- `new JXPathContext(someObject).iterate(pathWithUserInput);`\n\n## Proof of concept\nSpring application with vulnerable endpoint:\n- [CVE-2022-41852 Proof of Concept](https://github.com/Warxim/CVE-2022-41852)\n\n## Solutions and workarounds\n1. Do not allow use of untrusted input in XPath parameters.\n2. Disable functions in JXPathContext by replacing functions with empty function library:\n`context.setFunctions(new FunctionLibrary());`",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -45,8 +45,20 @@
       "url": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47133"
     },
     {
+      "type": "WEB",
+      "url": "https://commons.apache.org/proper/commons-jxpath/users-guide.html#Standard_Extension_Functions"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/Warxim/CVE-2022-41852"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/apache/commons-jxpath"
+    },
+    {
+      "type": "WEB",
+      "url": "https://hackinglab.cz/en/blog/remote-code-execution-in-jxpath-library-cve-2022-41852/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
Adding more technical information about the issue and link to working proof of concept and possible solutions. (More details about the issue can be found in the added references.)