### PR TITLE
[GHSA-9pgh-qqpf-7wqj] Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution') in @xmldom/xmldom and xmldom

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-9pgh-qqpf-7wqj/GHSA-9pgh-qqpf-7wqj.json
+++ b/advisories/github-reviewed/2022/10/GHSA-9pgh-qqpf-7wqj/GHSA-9pgh-qqpf-7wqj.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9pgh-qqpf-7wqj",
-  "modified": "2022-10-16T21:48:24Z",
+  "modified": "2022-10-17T11:03:29Z",
   "published": "2022-10-11T20:42:57Z",
   "aliases": [
     "CVE-2022-37616"
   ],
   "summary": "Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution') in @xmldom/xmldom and xmldom",
-  "details": "### Impact\nA prototype pollution vulnerability exists in the function copy in dom.js in the xmldom (published as @xmldom/xmldom) package before 0.8.3.\n\n### Patches\nUpdate to `@xmldom/xmldom@0.8.3` or higher or to `@xmldom/xmldom@0.9.0-beta.2` or higher if you are on the dist-tag `next`.\n\n### Workarounds\nNo, if you can not update to v0.8.3, please let us know, we would be able to also provide a patch update for version 0.7.x if required.\n\n### References\nhttps://github.com/xmldom/xmldom/pull/437\n\n### For more information\nIf you have any questions or comments about this advisory:\n* Email us at security@xmldom.org\n* Add information to https://github.com/xmldom/xmldom/issue/436",
+  "details": "### Impact\nA prototype pollution vulnerability exists in the function copy in dom.js in the xmldom (published as @xmldom/xmldom) package before 0.8.3 on 0.8.x and 0.7.6 on 0.7.x.\n\n### Patches\nUpdate to `@xmldom/xmldom@0.7.6` on 0.7.x,`@xmldom/xmldom@0.8.3` or higher or to `@xmldom/xmldom@0.9.0-beta.2` or higher if you are on the dist-tag `next`.\n\n### Workarounds\n\n### References\nhttps://github.com/xmldom/xmldom/pull/437\n\n### For more information\nIf you have any questions or comments about this advisory:\n* Email us at security@xmldom.org\n* Add information to https://github.com/xmldom/xmldom/issue/436",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.8.0"
             },
             {
               "fixed": "0.8.3"
@@ -47,7 +47,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.6.0"
+              "fixed": "0.7.6"
             }
           ]
         }
@@ -73,25 +73,6 @@
       ],
       "versions": [
         "0.9.0-beta.1"
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "@xmldom/xmldom"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "0.7.6"
-            }
-          ]
-        }
       ]
     }
   ],

--- a/advisories/github-reviewed/2022/10/GHSA-9pgh-qqpf-7wqj/GHSA-9pgh-qqpf-7wqj.json
+++ b/advisories/github-reviewed/2022/10/GHSA-9pgh-qqpf-7wqj/GHSA-9pgh-qqpf-7wqj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9pgh-qqpf-7wqj",
-  "modified": "2022-10-11T20:42:57Z",
+  "modified": "2022-10-16T21:48:24Z",
   "published": "2022-10-11T20:42:57Z",
   "aliases": [
     "CVE-2022-37616"
@@ -73,6 +73,25 @@
       ],
       "versions": [
         "0.9.0-beta.1"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@xmldom/xmldom"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.7.6"
+            }
+          ]
+        }
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Maintainer has merged https://github.com/xmldom/xmldom/pull/441 which backports the fix to 0.7.x branch and released as 0.7.6.

Updated changelog: https://github.com/xmldom/xmldom/blob/master/CHANGELOG.md#076

Hopefully this would resolve the dependabot alert generated for this to allow for 0.7.6 to be considered as a fixed version as well, thanks.