### PR TITLE
[GHSA-prp9-9gxw-38j8] A deserialization flaw was found in Apache Chainsaw...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-prp9-9gxw-38j8/GHSA-prp9-9gxw-38j8.json
+++ b/advisories/unreviewed/2022/05/GHSA-prp9-9gxw-38j8/GHSA-prp9-9gxw-38j8.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-prp9-9gxw-38j8",
-  "modified": "2022-05-24T19:05:32Z",
+  "modified": "2022-10-17T13:35:48Z",
   "published": "2022-05-24T19:05:32Z",
   "aliases": [
     "CVE-2020-9493"
   ],
+  "summary": "Critical vulnerability for package chainsaw",
   "details": "A deserialization flaw was found in Apache Chainsaw versions prior to 2.1.0 which could lead to malicious code execution.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "0.1.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
security scan provided by grype software tool, reveals the vulnerability