### PR TITLE
[GHSA-9pgh-qqpf-7wqj] Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution') in @xmldom/xmldom and xmldom

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-9pgh-qqpf-7wqj/GHSA-9pgh-qqpf-7wqj.json
+++ b/advisories/github-reviewed/2022/10/GHSA-9pgh-qqpf-7wqj/GHSA-9pgh-qqpf-7wqj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9pgh-qqpf-7wqj",
-  "modified": "2022-10-11T20:42:57Z",
+  "modified": "2022-10-17T15:17:53Z",
   "published": "2022-10-11T20:42:57Z",
   "aliases": [
     "CVE-2022-37616"
@@ -73,6 +73,25 @@
       ],
       "versions": [
         "0.9.0-beta.1"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@xmldom/xmldom"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.7.6"
+            }
+          ]
+        }
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The fix for this CVE has been backported to the 0.7 branch as of v 0.7.6 as can be seen here:
https://github.com/xmldom/xmldom/pull/441
https://github.com/xmldom/xmldom/releases/tag/0.7.6
