### PR TITLE
[GHSA-jjjh-jjxp-wpff] Uncontrolled Resource Consumption in Jackson-databind

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-jjjh-jjxp-wpff/GHSA-jjjh-jjxp-wpff.json
+++ b/advisories/github-reviewed/2022/10/GHSA-jjjh-jjxp-wpff/GHSA-jjjh-jjxp-wpff.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-jjjh-jjxp-wpff",
-  "modified": "2022-10-05T22:24:22Z",
+  "modified": "2022-10-18T07:57:34Z",
   "published": "2022-10-03T00:00:31Z",
   "aliases": [
     "CVE-2022-42003"
   ],
   "summary": "Uncontrolled Resource Consumption in Jackson-databind",
-  "details": "In FasterXML jackson-databind before 2.14.0-rc1, resource exhaustion can occur because of a lack of a check in primitive value deserializers to avoid deep wrapper array nesting, when the UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled.",
+  "details": "In FasterXML jackson-databind before 2.14.0-rc1 and 2.13.4.1, resource exhaustion can occur because of a lack of a check in primitive value deserializers to avoid deep wrapper array nesting, when the UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.14.0-rc1"
+              "fixed": "2.13.4.1"
             }
           ]
         }
@@ -55,6 +55,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/FasterXML/jackson-databind"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/blob/2.13/release-notes/VERSION-2.x"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
This CVE is also fixed in Jackson Databind 2.13.4.1. I think it makes more sense to use this version than a release candidate (2.14.0-rc1).