### PR TITLE
[GHSA-56h3-78gp-v83r] Jettison parser crash by stackoverflow

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-56h3-78gp-v83r/GHSA-56h3-78gp-v83r.json
+++ b/advisories/github-reviewed/2022/09/GHSA-56h3-78gp-v83r/GHSA-56h3-78gp-v83r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-56h3-78gp-v83r",
-  "modified": "2022-09-20T21:22:04Z",
+  "modified": "2022-10-18T16:14:05Z",
   "published": "2022-09-17T00:00:41Z",
   "aliases": [
     "CVE-2022-40149"
@@ -25,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.5.0"
+              "fixed": "1.5.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.5.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The fix is in 1.5.1