### PR TITLE
GHSA-w596-4wvx-j9j6: mark as withdrawn

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-w596-4wvx-j9j6/GHSA-w596-4wvx-j9j6.json
+++ b/advisories/github-reviewed/2022/10/GHSA-w596-4wvx-j9j6/GHSA-w596-4wvx-j9j6.json
@@ -7,7 +7,7 @@
     "CVE-2022-42969"
   ],
   "summary": "ReDoS in py library when used with subversion ",
-  "details": "The py library through 1.11.0 for Python allows remote attackers to conduct a ReDoS (Regular expression Denial of Service) attack via a Subversion repository with crafted info data, because the InfoSvnCommand argument is mishandled.\n\nThe particular codepath in question is the regular expression at `py._path.svnurl.InfoSvnCommand.lspattern` and is only relevant when dealing with subversion (svn) projects. Notablely the codepath is not used in the popular pytest project.",
+  "details": "The py library through 1.11.0 for Python allows remote attackers to conduct a ReDoS (Regular expression Denial of Service) attack via a Subversion repository with crafted info data, because the InfoSvnCommand argument is mishandled.\n\nThe particular codepath in question is the regular expression at `py._path.svnurl.InfoSvnCommand.lspattern` and is only relevant when dealing with subversion (svn) projects. Notablely the codepath is not used in the popular pytest project.\n\nThis report is believed to be spam, and is not considered exploitable in any depending codebases.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -73,5 +73,6 @@
     ],
     "severity": "MODERATE",
     "github_reviewed": true
-  }
+  },
+  "withdrawn": "2022-10-20T00:33:53Z"
 }


### PR DESCRIPTION
This is believed to be CVE spam: it's a low-value ReDoS report on an 18 year old code snippet that doesn't affect its primary dependent, and is not known to be used by any other significant codebases.

See: https://github.com/pytest-dev/py/issues/287

Signed-off-by: William Woodruff <william@trailofbits.com>