### PR TITLE
[GHSA-3f7h-mf4q-vrm4] XStream Denial of Service due to parser crash

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-3f7h-mf4q-vrm4/GHSA-3f7h-mf4q-vrm4.json
+++ b/advisories/github-reviewed/2022/09/GHSA-3f7h-mf4q-vrm4/GHSA-3f7h-mf4q-vrm4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-3f7h-mf4q-vrm4",
-  "modified": "2022-09-20T21:21:07Z",
+  "modified": "2022-10-20T11:41:30Z",
   "published": "2022-09-17T00:00:41Z",
   "aliases": [
     "CVE-2022-40152"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This appears to be incorrect and this whole advisory needs to be updated and identify the correct library. I am not familiar enough with this vul to confidently update this whole advisory to be correct.

Link to the issue in woodstox: https://github.com/FasterXML/woodstox/issues/157#issuecomment-1274221678