### PR TITLE
[GHSA-2j79-8pqc-r7x6] react-native-reanimated vulnerable to ReDoS

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-2j79-8pqc-r7x6/GHSA-2j79-8pqc-r7x6.json
+++ b/advisories/github-reviewed/2022/10/GHSA-2j79-8pqc-r7x6/GHSA-2j79-8pqc-r7x6.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-2j79-8pqc-r7x6",
-  "modified": "2022-10-04T21:16:38Z",
+  "modified": "2022-10-20T16:42:55Z",
   "published": "2022-10-01T00:00:24Z",
   "aliases": [
     "CVE-2022-24373"
   ],
-  "summary": "react-native-reanimated vulnerable to ReDoS",
-  "details": "The package react-native-reanimated before 3.0.0-rc.1 is vulnerable to Regular Expression Denial of Service (ReDoS) due to improper usage of regular expression in the parser of Colors.js.",
+  "summary": "react-native-reanimated: parsing colors vulnerable to ReDoS",
+  "details": "The package react-native-reanimated before 2.10.0 or 3.0.0-rc.1 is vulnerable to Regular Expression Denial of Service (ReDoS) due to improper usage of regular expression in the parser of Colors.js.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -33,6 +33,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "react-native-reanimated"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.10.0"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
@@ -46,11 +65,19 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/software-mansion/react-native-reanimated/pull/3382/commits/7adf06d0c59382d884a04be86a96eede3d0432fa"
+      "url": "https://github.com/software-mansion/react-native-reanimated/pull/3382/commits/7adf06d0c59382d884a04be86a96eede3d0432fa="
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/software-mansion/react-native-reanimated/commit/8a927904366fa2d02df7a11553f8b0aa93471279"
     },
     {
       "type": "PACKAGE",
       "url": "https://github.com/software-mansion/react-native-reanimated"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/software-mansion/react-native-reanimated/blob/2.10.0/src/reanimated2/Colors.ts#L26"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Summary

**Comments**
This vulnerability was also fixed for 2.x releases by cherry-picking the commit to the v2 branch:
https://github.com/software-mansion/react-native-reanimated/blob/2.10.0/src/reanimated2/Colors.ts#L26