### PR TITLE
[GHSA-g4rg-993r-mgx7] Improper Neutralization of Special Elements used in a Command in Shell-quote

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-g4rg-993r-mgx7/GHSA-g4rg-993r-mgx7.json
+++ b/advisories/github-reviewed/2022/05/GHSA-g4rg-993r-mgx7/GHSA-g4rg-993r-mgx7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-g4rg-993r-mgx7",
-  "modified": "2022-06-21T20:08:10Z",
+  "modified": "2022-10-21T19:24:54Z",
   "published": "2022-05-24T19:18:27Z",
   "aliases": [
     "CVE-2021-42740"
@@ -45,15 +45,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/substack/node-shell-quote/commit/5799416ed454aa4ec9afafc895b4e31760ea1abe"
+      "url": "https://github.com/ljharb/shell-quote/commit/5799416ed454aa4ec9afafc895b4e31760ea1abe"
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/substack/node-shell-quote"
+      "url": "https://github.com/ljharb/shell-quote"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/substack/node-shell-quote/blob/master/CHANGELOG.md#173"
+      "url": "https://github.com/ljharb/shell-quote/blob/master/CHANGELOG.md#173"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Original GitHub project is gone - links 404. NPM registry points to updated project (https://github.com/ljharb/shell-quote). Replacing the target(s) seem to point to relevant commits.