### PR TITLE
[GHSA-crxj-hrmp-4rwf] Labstack Echo Open Redirect vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-crxj-hrmp-4rwf/GHSA-crxj-hrmp-4rwf.json
+++ b/advisories/github-reviewed/2022/09/GHSA-crxj-hrmp-4rwf/GHSA-crxj-hrmp-4rwf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-crxj-hrmp-4rwf",
-  "modified": "2022-09-30T06:31:20Z",
+  "modified": "2022-10-21T21:56:37Z",
   "published": "2022-09-29T00:00:26Z",
   "aliases": [
     "CVE-2022-40083"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:N/I:N/A:L"
     }
   ],
   "affected": [
@@ -61,7 +61,7 @@
     "cwe_ids": [
       "CWE-601"
     ],
-    "severity": "CRITICAL",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
CVSS score is too high. The score is calculated on how the vulnerability itself should be scored, not what might happen afterwards, such as clicking on an open redirect link -> redirect to a phishing page.