### PR TITLE
[GHSA-3mq5-fq9h-gj7j] XStream Denial of Service due to parser crash

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-3mq5-fq9h-gj7j/GHSA-3mq5-fq9h-gj7j.json
+++ b/advisories/github-reviewed/2022/09/GHSA-3mq5-fq9h-gj7j/GHSA-3mq5-fq9h-gj7j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-3mq5-fq9h-gj7j",
-  "modified": "2022-09-20T21:21:26Z",
+  "modified": "2022-10-26T12:49:21Z",
   "published": "2022-09-17T00:00:41Z",
   "aliases": [
     "CVE-2022-40151"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "com.thoughtworks.xstream:xstream"
+        "name": "com.fasterxml.woodstox:woodstox-core"
       },
       "ranges": [
         {
@@ -23,19 +23,42 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "1.5.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 6.4.0"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.fasterxml.woodstox:woodstox-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 5.4.0"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-40151"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/woodstox/issues/160"
     },
     {
       "type": "WEB",
@@ -51,7 +74,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/x-stream/xstream"
+      "url": "https://github.com/FasterXML/woodstox"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Clearly, the issue is not in XStream but in Woodstox. https://github.com/FasterXML/woodstox/issues/160