### PR TITLE
[GHSA-rrc9-gqf8-8rwg] Prototype Pollution via file load in aws-sdk and @aws-sdk/shared-ini-file-loader

### DIFF
--- a/advisories/github-reviewed/2021/11/GHSA-rrc9-gqf8-8rwg/GHSA-rrc9-gqf8-8rwg.json
+++ b/advisories/github-reviewed/2021/11/GHSA-rrc9-gqf8-8rwg/GHSA-rrc9-gqf8-8rwg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-rrc9-gqf8-8rwg",
-  "modified": "2021-04-06T20:37:10Z",
+  "modified": "2022-10-26T20:48:21Z",
   "published": "2021-11-16T21:26:43Z",
   "aliases": [
     "CVE-2020-28472"
@@ -89,7 +89,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-400"
+      "CWE-1321"
     ],
     "severity": "HIGH",
     "github_reviewed": true


### PR DESCRIPTION
**Updates**
- CWEs

**Comments**
CWE is wrong - the vulnerability is prototype pollution, which can have varied effects depending on context.