### PR TITLE
[GHSA-98g7-rxmf-rrxm] fabric8 kubernetes-client vulnerable 

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-98g7-rxmf-rrxm/GHSA-98g7-rxmf-rrxm.json
+++ b/advisories/github-reviewed/2022/07/GHSA-98g7-rxmf-rrxm/GHSA-98g7-rxmf-rrxm.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-98g7-rxmf-rrxm",
-  "modified": "2022-09-08T14:19:24Z",
+  "modified": "2022-11-02T17:09:46Z",
   "published": "2022-07-15T05:17:35Z",
   "aliases": [
     "CVE-2021-4178"
   ],
   "summary": "fabric8 kubernetes-client vulnerable ",
-  "details": "fabric8 Kubernetes client had an arbitrary code execution flaw in versions 5.0.0-beta-1 and higher. Attackers could potentially insert malicious YAMLs due to misconfigured YAML parsing.",
+  "details": "fabric8 Kubernetes client had an arbitrary code execution flaw in versions 5.0.0-beta-1 and higher. Attackers could potentially insert malicious YAMLs due to misconfigured YAML parsing.\n\n",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- CVE-2021-4178 Incorrect affected version range

The affected versions that mentioned in the Vulnerability details:

>= 5.0.0-beta-1, < 5.0.3
>= 5.1.0, < 5.1.2
>= 5.2.0, < 5.3.2
>= 5.5.0, < 5.7.4
>= 5.8.0, < 5.8.1
>= 5.9.0, < 5.11.2

According to [5.10.2 release](https://github.com/fabric8io/kubernetes-client/releases/tag/v5.10.2),  5.10.2 is a patched version and not affected.

Please add this patch to the affected version.

Thanks,

Shaul