### PR TITLE
[GHSA-rhwx-hjx2-x4qr] PDFKit vulnerable to Command Injection

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-rhwx-hjx2-x4qr/GHSA-rhwx-hjx2-x4qr.json
+++ b/advisories/github-reviewed/2022/09/GHSA-rhwx-hjx2-x4qr/GHSA-rhwx-hjx2-x4qr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-rhwx-hjx2-x4qr",
-  "modified": "2022-09-15T03:30:40Z",
+  "modified": "2022-11-02T17:11:33Z",
   "published": "2022-09-10T00:00:32Z",
   "aliases": [
     "CVE-2022-25765"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.8.7"
+              "fixed": "0.8.7.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 0.8.7"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The changes in 0.8.7 was insufficient to fix command injection. It only partially fixed a specific case of it, but command injection and environment reading was still possible: https://github.com/pdfkit/pdfkit/issues/517