### PR TITLE
[GHSA-crh6-fp67-6883] xmldom allows multiple root nodes in a DOM

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-crh6-fp67-6883/GHSA-crh6-fp67-6883.json
+++ b/advisories/github-reviewed/2022/11/GHSA-crh6-fp67-6883/GHSA-crh6-fp67-6883.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-crh6-fp67-6883",
-  "modified": "2022-11-01T17:29:11Z",
+  "modified": "2022-11-02T19:09:47Z",
   "published": "2022-11-01T17:29:11Z",
   "aliases": [
     "CVE-2022-39353"
@@ -113,7 +113,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-112"
     ],
     "severity": "CRITICAL",
     "github_reviewed": true


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs

**Comments**
add 	CWE-112: Missing XML Validation to advisory - the root cause is that malformed XML (multiple root nodes) is not rejected by the parser