### PR TITLE
[GHSA-2m4x-4q9j-w97g] Denial of service in Open Policy Agent 

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-2m4x-4q9j-w97g/GHSA-2m4x-4q9j-w97g.json
+++ b/advisories/github-reviewed/2022/06/GHSA-2m4x-4q9j-w97g/GHSA-2m4x-4q9j-w97g.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "1.3.0",
+  "id": "GHSA-2m4x-4q9j-w97g",
+  "modified": "2022-11-02T19:18:51Z",
+  "published": "2022-07-01T00:01:03Z",
+  "aliases": [
+    "CVE-2022-33082"
+  ],
+  "summary": "Denial of service in Open Policy Agent ",
+  "details": "An issue in the AST parser (ast/compile.go) of Open Policy Agent v0.10.2 allows attackers to cause a Denial of Service (DoS) via a crafted input.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/open-policy-agent/opa"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.42.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-33082"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/open-policy-agent/opa/issues/4761"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/open-policy-agent/opa/issues/4762"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/open-policy-agent/opa/commit/064f6168a8dfebdeb2ea147f7882bb9f5d2b7f67"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/open-policy-agent/opa"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/open-policy-agent/opa/blob/598176de326025451025225aca53e85708d5f1db/ast/compile.go#L1224"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-703"
+    ],
+    "severity": "HIGH",
+    "github_reviewed": true
+  }
+}


### PR DESCRIPTION
**Updates**
- CWEs

**Comments**
DOS is caused by an unhandled runtime panic case on compiling bad input