### PR TITLE
[GHSA-76p3-8jx3-jpfq] Prototype pollution vulnerability in function parseQuery...

### DIFF
--- a/advisories/unreviewed/2022/10/GHSA-76p3-8jx3-jpfq/GHSA-76p3-8jx3-jpfq.json
+++ b/advisories/unreviewed/2022/10/GHSA-76p3-8jx3-jpfq/GHSA-76p3-8jx3-jpfq.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-76p3-8jx3-jpfq",
-  "modified": "2022-10-13T19:00:17Z",
+  "modified": "2022-11-04T17:54:52Z",
   "published": "2022-10-13T12:00:28Z",
   "aliases": [
     "CVE-2022-37601"
   ],
-  "details": "Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.",
+  "summary": "Prototype pollution in webpack loader-utils",
+  "details": "Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils prior to version 2.0.3 via the name variable in parseQuery.js.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "loader-utils"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.0.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -32,6 +51,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/webpack/loader-utils/blob/d9f4e23cf411d8556f8bac2d3bf05a6e0103b568/lib/parseQuery.js#L47"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/webpack/loader-utils/releases/tag/v2.0.3"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Summary

**Comments**
Release notes for patched version: https://github.com/webpack/loader-utils/releases/tag/v2.0.3