### PR TITLE
[GHSA-vg46-2rrj-3647] Twisted vulnerable to NameVirtualHost Host header injection

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-vg46-2rrj-3647/GHSA-vg46-2rrj-3647.json
+++ b/advisories/github-reviewed/2022/10/GHSA-vg46-2rrj-3647/GHSA-vg46-2rrj-3647.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-vg46-2rrj-3647",
-  "modified": "2022-10-31T16:01:30Z",
+  "modified": "2022-11-04T18:09:13Z",
   "published": "2022-10-26T22:08:39Z",
   "aliases": [
     "CVE-2022-39348"
@@ -28,7 +28,7 @@
               "introduced": "0.9.4"
             },
             {
-              "fixed": "22.10.0.rc1"
+              "fixed": "22.10.0rc1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It looks like the version on PyPI is https://pypi.org/project/Twisted/22.10.0rc1/ without the extra . 