### PR TITLE
[GHSA-9339-86wc-4qgf] Apache Xalan Java XSLT library integer truncation issue when processing malicious XSLT stylesheets

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-9339-86wc-4qgf/GHSA-9339-86wc-4qgf.json
+++ b/advisories/github-reviewed/2022/07/GHSA-9339-86wc-4qgf/GHSA-9339-86wc-4qgf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9339-86wc-4qgf",
-  "modified": "2022-09-22T19:16:28Z",
+  "modified": "2022-11-07T15:33:13Z",
   "published": "2022-07-20T00:00:18Z",
   "aliases": [
     "CVE-2022-34169"
@@ -28,14 +28,11 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.7.3"
+              "last_affected": "2.7.2"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 2.7.2"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Version 2.7.3 has not been published yet (currently 2.7.3 RC5). 
Dependabot will fail to create patch when an "affected product" does not have a released patched version.