### PR TITLE
[GHSA-4pcg-wr6c-h9cq] fastify/websocket vulnerable to uncaught exception via crash on malformed packet

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-4pcg-wr6c-h9cq/GHSA-4pcg-wr6c-h9cq.json
+++ b/advisories/github-reviewed/2022/11/GHSA-4pcg-wr6c-h9cq/GHSA-4pcg-wr6c-h9cq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4pcg-wr6c-h9cq",
-  "modified": "2022-11-07T21:13:57Z",
+  "modified": "2022-11-07T21:35:26Z",
   "published": "2022-11-07T21:13:57Z",
   "aliases": [
     "CVE-2022-39386"
@@ -25,14 +25,17 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "5.0.0"
+              "introduced": "0"
             },
             {
-              "fixed": "5.1.1"
+              "fixed": "5.0.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 5.0.0"
+      }
     },
     {
       "package": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Typo in the original vulnerability range: The patch for 5.x.x is in 5.0.1, not 5.1.1 which doesn't exist.