### PR TITLE
[GHSA-v57x-gxfj-484q] Security Advisory for "Log4Shell"

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-v57x-gxfj-484q/GHSA-v57x-gxfj-484q.json
+++ b/advisories/github-reviewed/2022/01/GHSA-v57x-gxfj-484q/GHSA-v57x-gxfj-484q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-v57x-gxfj-484q",
-  "modified": "2022-01-19T16:11:28Z",
+  "modified": "2022-11-08T10:58:23Z",
   "published": "2022-01-21T23:25:04Z",
   "aliases": [
 
@@ -29,82 +29,6 @@
             },
             {
               "fixed": "4.5.3"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "com.hazelcast:hazelcast"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "5.0"
-            },
-            {
-              "fixed": "5.0.2"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "com.hazelcast:hazelcast"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "4.0.0"
-            },
-            {
-              "fixed": "4.0.5"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "com.hazelcast:hazelcast"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "4.1.1"
-            },
-            {
-              "fixed": "4.1.8"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "com.hazelcast:hazelcast"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "4.2"
-            },
-            {
-              "fixed": "4.2.4"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Not the maven package com.hazelcast:hazelcast is affected, but its transitive log4j dependency.

If software X uses a hazelcast as a maven dependency then the pom.xml file of software X can bump the log4j dependency to a fixed version without the need to also bump the hazelcast version. Security advisories for log4j already exists, for example CVE-2021-44228 = https://github.com/advisories/GHSA-jfh8-c2jp-5v3q

No change has been made to com.hazelcast:hazelcast source code when the log4 version was bumped:
https://github.com/hazelcast/hazelcast/pulls?q=is%3Apr+%22Bump+log4j2.version%22

Therefore com.hazelcast:hazelcast should not be listed in the "Affected products" section.

The description of this advisory already correctly explains that not the com.hazelcast:hazelcast maven package but Hazelcast Management Center, Hazelcast IMDG, Hazelcast IMDG Enterprise, Hazelcast Jet and Hazelcast Platform are effected.