### PR TITLE
[GHSA-76p3-8jx3-jpfq] Prototype pollution in webpack loader-utils

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-76p3-8jx3-jpfq/GHSA-76p3-8jx3-jpfq.json
+++ b/advisories/github-reviewed/2022/10/GHSA-76p3-8jx3-jpfq/GHSA-76p3-8jx3-jpfq.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-76p3-8jx3-jpfq",
-  "modified": "2022-11-04T20:29:12Z",
+  "modified": "2022-11-09T11:20:56Z",
   "published": "2022-10-13T12:00:28Z",
   "aliases": [
     "CVE-2022-37601"
   ],
   "summary": "Prototype pollution in webpack loader-utils",
-  "details": "Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils prior to version 2.0.3 via the name variable in parseQuery.js.",
+  "details": "This alert is getting raised for a file and folder in our repository that was deleted a long time ago. Please could you feedback to the feature team. The specific alert in our case is: https://github.com/edfenergy/wmo-se-master-market-prices/security/dependabot/149",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Description

**Comments**
This alert is getting raised for a file and folder in our repository that was deleted a long time ago. Please could you feedback to the feature team. The specific alert in our case is: https://github.com/edfenergy/wmo-se-master-market-prices/security/dependabot/149