### PR TITLE
[GHSA-8g2p-5pqh-5jmc] .NET Information Disclosure Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-8g2p-5pqh-5jmc/GHSA-8g2p-5pqh-5jmc.json
+++ b/advisories/github-reviewed/2022/11/GHSA-8g2p-5pqh-5jmc/GHSA-8g2p-5pqh-5jmc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8g2p-5pqh-5jmc",
-  "modified": "2022-11-08T23:00:22Z",
+  "modified": "2022-11-09T11:53:59Z",
   "published": "2022-11-08T23:00:22Z",
   "aliases": [
 
@@ -86,8 +86,16 @@
       "url": "https://github.com/dotnet/runtime/issues/78042"
     },
     {
+      "type": "WEB",
+      "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41064"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/dotnet/corefx"
+    },
+    {
+      "type": "WEB",
+      "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2022-41064"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41064 seems just reserved, but I think it's also the same as https://msrc.microsoft.com/update-guide/vulnerability/CVE-2022-41064