### PR TITLE
[GHSA-8cw2-jv5c-c825] Missing Initialization of Resource in Apache Arrow

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-8cw2-jv5c-c825/GHSA-8cw2-jv5c-c825.json
+++ b/advisories/github-reviewed/2022/05/GHSA-8cw2-jv5c-c825/GHSA-8cw2-jv5c-c825.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8cw2-jv5c-c825",
-  "modified": "2022-06-28T14:36:34Z",
+  "modified": "2022-11-09T20:18:54Z",
   "published": "2022-05-24T17:00:40Z",
   "aliases": [
     "CVE-2019-12408"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "PyPI",
-        "name": "arrow"
+        "name": "pyarrow"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
For Python, Apache Arrow's library is called `pyarrow` in PyPI. (https://pypi.org/project/pyarrow/)
The `arrow` package is an unrelated datetime package with no dependencies on the vulnerable version of `pyarrow`. (https://pypi.org/project/arrow/)