### PR TITLE
[GHSA-r74q-gxcg-73hx] Improper Input Validation in simple_form

### DIFF
--- a/advisories/github-reviewed/2019/09/GHSA-r74q-gxcg-73hx/GHSA-r74q-gxcg-73hx.json
+++ b/advisories/github-reviewed/2019/09/GHSA-r74q-gxcg-73hx/GHSA-r74q-gxcg-73hx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-r74q-gxcg-73hx",
-  "modified": "2022-09-17T00:23:57Z",
+  "modified": "2022-11-11T19:47:22Z",
   "published": "2019-09-30T19:41:15Z",
   "aliases": [
     "CVE-2019-16676"
@@ -45,12 +45,12 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-16676"
     },
     {
-      "type": "ADVISORY",
-      "url": "https://github.com/advisories/GHSA-r74q-gxcg-73hx"
+      "type": "WEB",
+      "url": "https://github.com/heartcombo/simple_form/commit/8c91bd76a5052ddf3e3ab9fd8333f9aa7b2e2dd6"
     },
     {
-      "type": "WEB",
-      "url": "https://github.com/plataformatec/simple_form/commits/master"
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-r74q-gxcg-73hx"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
The old commit link was the entire commit history of the `master` branch which is not helpful when diving into changes related to the vulnerability. The updated link is the patch commit that fixes the issue.