### PR TITLE
[GHSA-653v-rqx9-j85p] deep-object-diff vulnerable to Prototype Pollution

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-653v-rqx9-j85p/GHSA-653v-rqx9-j85p.json
+++ b/advisories/github-reviewed/2022/11/GHSA-653v-rqx9-j85p/GHSA-653v-rqx9-j85p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-653v-rqx9-j85p",
-  "modified": "2022-11-08T14:48:51Z",
+  "modified": "2022-11-12T20:31:55Z",
   "published": "2022-11-04T12:00:25Z",
   "aliases": [
     "CVE-2022-41713"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.1.0"
+              "fixed": "1.1.9"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.1.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The vulnerabilty has been fixed by 1.1.9: https://github.com/mattphillips/deep-object-diff/pull/87