### PR TITLE
[GHSA-jjjh-jjxp-wpff] Uncontrolled Resource Consumption in Jackson-databind

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-jjjh-jjxp-wpff/GHSA-jjjh-jjxp-wpff.json
+++ b/advisories/github-reviewed/2022/10/GHSA-jjjh-jjxp-wpff/GHSA-jjjh-jjxp-wpff.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-jjjh-jjxp-wpff",
-  "modified": "2022-10-18T17:24:11Z",
+  "modified": "2022-11-14T12:03:00Z",
   "published": "2022-10-03T00:00:31Z",
   "aliases": [
     "CVE-2022-42003"
   ],
   "summary": "Uncontrolled Resource Consumption in Jackson-databind",
-  "details": "In FasterXML jackson-databind before 2.14.0-rc1 and 2.13.4.1, resource exhaustion can occur because of a lack of a check in primitive value deserializers to avoid deep wrapper array nesting, when the UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled.",
+  "details": "In FasterXML jackson-databind before 2.14.0-rc1 and 2.13.4.1 and 2.12.7.1, resource exhaustion can occur because of a lack of a check in primitive value deserializers to avoid deep wrapper array nesting, when the UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -29,6 +29,25 @@
             },
             {
               "fixed": "2.13.4.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.fasterxml.jackson.core:jackson-databind"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.12.7.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
As claimed in https://github.com/FasterXML/jackson-databind/issues/3590, `jackson-databind:2.12.7.1` also has fixed this CVE