### PR TITLE
[GHSA-76p3-8jx3-jpfq] Prototype pollution in webpack loader-utils

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-76p3-8jx3-jpfq/GHSA-76p3-8jx3-jpfq.json
+++ b/advisories/github-reviewed/2022/10/GHSA-76p3-8jx3-jpfq/GHSA-76p3-8jx3-jpfq.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-76p3-8jx3-jpfq",
-  "modified": "2022-11-04T20:29:12Z",
+  "modified": "2022-11-15T05:01:01Z",
   "published": "2022-10-13T12:00:28Z",
   "aliases": [
     "CVE-2022-37601"
   ],
   "summary": "Prototype pollution in webpack loader-utils",
-  "details": "Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils prior to version 2.0.3 via the name variable in parseQuery.js.",
+  "details": "CVE Description\nPrototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils prior to version 2.0.3 via the name variable in parseQuery.js.\n\nImpact\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as __proto__, constructor and prototype. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nPatches\nupdated the empty result to be set as a null object through the object assignment rather than empty object literal\n\nWorkarounds\nNone.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,11 +28,14 @@
               "introduced": "2.0.0"
             },
             {
-              "fixed": "2.0.3"
+              "fixed": "> 2.0.3"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.0.3"
+      }
     },
     {
       "package": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
The Owners of the library have addressed this issue in https://github.com/webpack/loader-utils/issues/212, in commit https://github.com/webpack/loader-utils/commit/a93cf6f4702012030f6b5ee8340d5c95ec1c7d4c, released in 2.0.3 and this has a resolution that has been backported for upstream fixes to all packages utilizing this one.