### PR TITLE
[GHSA-rgv9-q543-rqg4] Uncontrolled Resource Consumption in FasterXML jackson-databind

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-rgv9-q543-rqg4/GHSA-rgv9-q543-rqg4.json
+++ b/advisories/github-reviewed/2022/10/GHSA-rgv9-q543-rqg4/GHSA-rgv9-q543-rqg4.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-rgv9-q543-rqg4",
-  "modified": "2022-10-05T22:25:35Z",
+  "modified": "2022-11-15T14:06:46Z",
   "published": "2022-10-03T00:00:31Z",
   "aliases": [
     "CVE-2022-42004"
   ],
   "summary": "Uncontrolled Resource Consumption in FasterXML jackson-databind",
-  "details": "In FasterXML jackson-databind before 2.13.4, resource exhaustion can occur because of a lack of a check in BeanDeserializer._deserializeFromArray to prevent use of deeply nested arrays. An application is vulnerable only with certain customized choices for deserialization.",
+  "details": "In FasterXML jackson-databind before 2.12.7.1 and in 2.13.x before 2.13.4, resource exhaustion can occur because of a lack of a check in BeanDeserializer._deserializeFromArray to prevent use of deeply nested arrays. An application is vulnerable only with certain customized choices for deserialization.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -29,6 +29,25 @@
             },
             {
               "fixed": "2.13.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.fasterxml.jackson.core:jackson-databind"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.12.7.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
As claimed in https://github.com/FasterXML/jackson-databind/issues/3582, `jackson-databind:2.12.7.1` also has fixed this CVE