### PR TITLE
[GHSA-g3q9-xf95-8hp5] NuGet Elevation of Privilege Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-g3q9-xf95-8hp5/GHSA-g3q9-xf95-8hp5.json
+++ b/advisories/github-reviewed/2022/10/GHSA-g3q9-xf95-8hp5/GHSA-g3q9-xf95-8hp5.json
@@ -1,0 +1,455 @@
+{
+  "schema_version": "1.3.0",
+  "id": "GHSA-g3q9-xf95-8hp5",
+  "modified": "2022-11-16T01:16:12Z",
+  "published": "2022-10-11T20:48:52Z",
+  "aliases": [
+    "CVE-2022-41032"
+  ],
+  "summary": "NuGet Elevation of Privilege Vulnerability",
+  "details": "## Description\n\nMicrosoft is releasing this security advisory to provide information about a vulnerability in .NET 7.0.0-rc, .NET 6.0, .NET Core 3.1, and NuGet (NuGet.exe, NuGet.Commands, NuGet.CommandLine, NuGet.Protocol). This advisory also provides guidance on what developers can do to update their applications to remove this vulnerability.\n\nA vulnerability exists in .NET 7.0.0-rc.1, .NET 6.0, .NET Core 3.1, and NuGet clients (NuGet.exe, NuGet.Commands, NuGet.CommandLine, NuGet.Protocol) where a malicious actor could cause a user to execute arbitrary code.\n\n## Affected software\n\n### NuGet & NuGet Packages\n\n- Any NuGet.exe, NuGet.Commands, NuGet.CommandLine, NuGet.Protocol 6.3.0 version or earlier.\n- Any NuGet.exe, NuGet.Commands, NuGet.CommandLine, NuGet.Protocol 6.2.1 version or earlier.\n- Any NuGet.exe, NuGet.Commands, NuGet.CommandLine, NuGet.Protocol 6.0.2 version or earlier.\n- Any NuGet.exe, NuGet.Commands, NuGet.CommandLine, NuGet.Protocol 5.11.2 version or earlier.\n- Any NuGet.exe, NuGet.Commands, NuGet.CommandLine, NuGet.Protocol 5.9.2 version or earlier.\n- Any NuGet.exe, NuGet.Commands, NuGet.CommandLine, NuGet.Protocol 5.7.2 version or earlier.\n- Any NuGet.exe, NuGet.Commands, NuGet.CommandLine, NuGet.Protocol 4.9.5 version or earlier.\n\n### .NET SDK(s)\n\n- Any .NET 6.0 application running on .NET 6.0.9 or earlier.\n- Any .NET 3.1 application running on .NET Core 3.1.29 or earlier.\n\n## Patches\n\nTo fix the issue, please install the latest version of .NET 6.0 or .NET Core 3.1 and NuGet (NuGet.exe, NuGet.Commands, NuGet.CommandLine, NuGet.Protocol versions). If you have installed one or more .NET SDKs through Visual Studio, Visual Studio will prompt you to update Visual Studio, which will also update your .NET SDKs.\n\n- If you're using NuGet.exe 6.3.0 or lower, you should download and install 6.3.1 from https://dist.nuget.org/win-x86-commandline/v6.3.1/nuget.exe .\n\n- If you're using NuGet.exe 6.2.1 or lower, you should download and install 6.2.2 from https://dist.nuget.org/win-x86-commandline/v6.2.2/nuget.exe .\n\n- If you're using NuGet.exe 6.0.2 or lower, you should download and install 6.0.3 from https://dist.nuget.org/win-x86-commandline/v6.0.3/nuget.exe .\n\n- If you're using NuGet.exe 5.11.2 or lower, you should download and install 5.11.3 from https://dist.nuget.org/win-x86-commandline/v5.11.3/nuget.exe .\n\n- If you're using NuGet.exe 5.9.2 or lower, you should download and install 5.9.3 from https://dist.nuget.org/win-x86-commandline/v5.9.3/nuget.exe .\n\n- If you're using NuGet.exe 5.7.2 or lower, you should download and install 5.7.3 from https://dist.nuget.org/win-x86-commandline/v5.7.3/nuget.exe .\n\n- If you're using NuGet.exe 4.9.5 or lower, you should download and install 4.9.6 from https://dist.nuget.org/win-x86-commandline/v4.9.6/nuget.exe .\n\n- If you're using .NET Core 6.0, you should download and install Runtime 6.0.10 or SDK 6.0.110 (for Visual Studio 2022 v17.0) or SDK 6.0.402 (for Visual Studio 2022 v17.3) from https://dotnet.microsoft.com/download/dotnet-core/6.0.\n\n- If you're using .NET Core 3.1, you should download and install Runtime 3.1.30 or SDK 3.1.424 (for Visual Studio 2019 v16.9 or Visual Studio 2019 v16.11 or Visual Studio 2022 v17.0 or Visual Studio 2022 v17.1) from https://dotnet.microsoft.com/download/dotnet-core/3.1.\n\n.NET 6.0 and .NET Core 3.1 updates are also available from Microsoft Update. To access this either type \"Check for updates\" in your Windows search, or open Settings, choose Update & Security and then click Check for Updates.\n\n## Other details\n\nAnnouncement for this issue can be found at https://github.com/NuGet/Announcements/issues/65\n\nMSRC details for this can be found at https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2022-41032\n",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Commands"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.6.0"
+            },
+            {
+              "fixed": "4.9.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Commands"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.0.0"
+            },
+            {
+              "fixed": "5.7.3-rtm.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Commands"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.8.0"
+            },
+            {
+              "fixed": "5.9.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Commands"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.10.0"
+            },
+            {
+              "fixed": "5.11.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Commands"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.0.3-rc.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Commands"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.1.0"
+            },
+            {
+              "fixed": "6.2.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Commands"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.3.0"
+            },
+            {
+              "fixed": "6.3.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.CommandLine"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.6.0"
+            },
+            {
+              "fixed": "4.9.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.CommandLine"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.0.0"
+            },
+            {
+              "fixed": "5.7.3-rtm.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.CommandLine"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.8.0"
+            },
+            {
+              "fixed": "5.9.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.CommandLine"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.10.0"
+            },
+            {
+              "fixed": "5.11.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.CommandLine"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.0.3-rc.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.CommandLine"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.1.0"
+            },
+            {
+              "fixed": "6.2.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.CommandLine"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.3.0"
+            },
+            {
+              "fixed": "6.3.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Protocol"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.6.0"
+            },
+            {
+              "fixed": "4.9.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Protocol"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.0.0"
+            },
+            {
+              "fixed": "5.7.3-rtm.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Protocol"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.8.0"
+            },
+            {
+              "fixed": "5.9.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Protocol"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.10.0"
+            },
+            {
+              "fixed": "5.11.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Protocol"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.0.3-rc.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Protocol"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.1.0"
+            },
+            {
+              "fixed": "6.2.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Protocol"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.3.0"
+            },
+            {
+              "fixed": "6.3.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/NuGet/NuGet.Client/security/advisories/GHSA-g3q9-xf95-8hp5"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41032"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/NuGet/Announcements/issues/65"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/NuGet/NuGet.Client"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HDPT2MJC3HD7HYZGASOOX6MTDR4ASBL5/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/X7BMHO5ITRBZREVTEKHQRGSFRPDMALV3/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41032"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+
+    ],
+    "severity": "HIGH",
+    "github_reviewed": true
+  }
+}


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
I work on the NuGet team at Microsoft and a contributor to https://github.com/NuGet/NuGet.Client repository. I mentioned versions incorrectly when I created the security advisory on our repository https://github.com/NuGet/NuGet.Client/security/advisories/GHSA-g3q9-xf95-8hp5. I later updated the content of the advisory in the repo. However, I noticed that nuget.org is still displaying NuGet.Protocol package 6.0.3-rc1 version as vulnerable https://www.nuget.org/packages/NuGet.Protocol/6.0.3-rc.1 which is truly not the case. Hence suggesting the improvements again here. Happy to answer any further questions you may have.