### PR TITLE
[GHSA-653v-rqx9-j85p] deep-object-diff vulnerable to Prototype Pollution

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-653v-rqx9-j85p/GHSA-653v-rqx9-j85p.json
+++ b/advisories/github-reviewed/2022/11/GHSA-653v-rqx9-j85p/GHSA-653v-rqx9-j85p.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-653v-rqx9-j85p",
-  "modified": "2022-11-15T23:52:40Z",
+  "modified": "2022-11-16T01:32:39Z",
   "published": "2022-11-04T12:00:25Z",
   "aliases": [
     "CVE-2022-41713"
   ],
   "summary": "deep-object-diff vulnerable to Prototype Pollution",
-  "details": "deep-object-diff before version 1.1.6 allows an external attacker to edit or add new properties to an object. This is possible because the application does not properly validate incoming JSON keys, thus allowing the `__proto__` property to be edited. This issue was fixed in version 1.1.19.",
+  "details": "deep-object-diff before version 1.1.6 allows an external attacker to edit or add new properties to an object. This is possible because the application does not properly validate incoming JSON keys, thus allowing the `__proto__` property to be edited. This issue was fixed in version 1.1.9.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,7 +28,7 @@
               "introduced": "1.1.6"
             },
             {
-              "fixed": "1.1.19"
+              "fixed": "1.1.9"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Looks like the vulnerability accidentally was set to resolved in 1.1.19 instead of 1.1.9 where it was actually resolved in: https://github.com/mattphillips/deep-object-diff/releases/tag/v1.19

(Note the tag is weird there, but it's the latest version)