### PR TITLE
[GHSA-gcqq-w6gr-h9j9] Directory traversal vulnerability in RubyZip

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-gcqq-w6gr-h9j9/GHSA-gcqq-w6gr-h9j9.json
+++ b/advisories/github-reviewed/2017/10/GHSA-gcqq-w6gr-h9j9/GHSA-gcqq-w6gr-h9j9.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-gcqq-w6gr-h9j9",
-  "modified": "2022-04-25T16:33:02Z",
+  "modified": "2022-11-16T06:16:42Z",
   "published": "2017-10-24T18:33:35Z",
   "aliases": [
     "CVE-2017-5946"
   ],
   "summary": "Directory traversal vulnerability in RubyZip",
-  "details": "The Zip::File component in the rubyzip gem before 1.2.1 for Ruby has a directory traversal vulnerability. If a site allows uploading of .zip files, an attacker can upload a malicious file that uses \"../\" pathname substrings to write arbitrary files to the filesystem.",
+  "details": "The Zip::File component in the rubyzip gem with the exception of 1.2.1 for Ruby has a directory traversal vulnerability. If a site allows uploading of .zip files, an attacker can upload a malicious file that uses \"../\" pathname substrings to write arbitrary files to the filesystem.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -26,13 +26,13 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "1.2.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.2.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
This gem now leaves input validation to the user as of the v1.2.2 modification.
https://github.com/rubyzip/rubyzip/compare/v1.2.1...v1.2.2#diff-8ef701a2c36ea4d1c722990985d508e866a5144c825004ebb03d3c875483a59fR161-R162
Therefore, it is again vulnerable starting from v1.2.2.