### PR TITLE
[GHSA-gcqq-w6gr-h9j9] Directory traversal vulnerability in RubyZip

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-gcqq-w6gr-h9j9/GHSA-gcqq-w6gr-h9j9.json
+++ b/advisories/github-reviewed/2017/10/GHSA-gcqq-w6gr-h9j9/GHSA-gcqq-w6gr-h9j9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-gcqq-w6gr-h9j9",
-  "modified": "2022-11-16T06:16:42Z",
+  "modified": "2022-11-16T06:25:10Z",
   "published": "2017-10-24T18:33:35Z",
   "aliases": [
     "CVE-2017-5946"
@@ -26,13 +26,32 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "1.2.1"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 1.2.1"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "rubyzip"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.3.2"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [

--- a/advisories/github-reviewed/2017/10/GHSA-gcqq-w6gr-h9j9/GHSA-gcqq-w6gr-h9j9.json
+++ b/advisories/github-reviewed/2017/10/GHSA-gcqq-w6gr-h9j9/GHSA-gcqq-w6gr-h9j9.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-gcqq-w6gr-h9j9",
-  "modified": "2022-04-25T16:33:02Z",
+  "modified": "2022-11-16T06:16:42Z",
   "published": "2017-10-24T18:33:35Z",
   "aliases": [
     "CVE-2017-5946"
   ],
   "summary": "Directory traversal vulnerability in RubyZip",
-  "details": "The Zip::File component in the rubyzip gem before 1.2.1 for Ruby has a directory traversal vulnerability. If a site allows uploading of .zip files, an attacker can upload a malicious file that uses \"../\" pathname substrings to write arbitrary files to the filesystem.",
+  "details": "The Zip::File component in the rubyzip gem with the exception of 1.2.1 for Ruby has a directory traversal vulnerability. If a site allows uploading of .zip files, an attacker can upload a malicious file that uses \"../\" pathname substrings to write arbitrary files to the filesystem.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -26,13 +26,13 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "1.2.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.2.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
This gem now leaves input validation to the user as of the v1.2.2 modification.
Therefore, it is again vulnerable starting from v1.2.2.