### PR TITLE
[GHSA-653v-rqx9-j85p] deep-object-diff vulnerable to Prototype Pollution

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-653v-rqx9-j85p/GHSA-653v-rqx9-j85p.json
+++ b/advisories/github-reviewed/2022/11/GHSA-653v-rqx9-j85p/GHSA-653v-rqx9-j85p.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-653v-rqx9-j85p",
-  "modified": "2022-11-08T14:48:51Z",
+  "modified": "2022-11-16T07:39:42Z",
   "published": "2022-11-04T12:00:25Z",
   "aliases": [
     "CVE-2022-41713"
   ],
   "summary": "deep-object-diff vulnerable to Prototype Pollution",
-  "details": "deep-object-diff version 1.1.0 allows an external attacker to edit or add new properties to an object. This is possible because the application does not properly validate incoming JSON keys, thus allowing the `__proto__` property to be edited.",
+  "details": "deep-object-diff before version 1.1.6 allows an external attacker to edit or add new properties to an object. This is possible because the application does not properly validate incoming JSON keys, thus allowing the `__proto__` property to be edited. This issue was fixed in version 1.1.9.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -25,10 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.1.6"
             },
             {
-              "last_affected": "1.1.0"
+              "fixed": "1.1.9"
             }
           ]
         }
@@ -43,6 +43,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/mattphillips/deep-object-diff/issues/85"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mattphillips/deep-object-diff/issues/85#issuecomment-1312450353"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mattphillips/deep-object-diff/pull/87/commits/55f9c3c70cf0d54cb30291e949fb8682fa3c5d9f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mattphillips/deep-object-diff/pull/87/commits/9576963b68b955e88610aa4f0c696a1aafc1119d"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
The fixed version is 1.1.9, not 1.1.19. There isn't any released version 1.1.19. 1.1.9 is the latest version.