### PR TITLE
[GHSA-4696-g7jj-xg2h] An integer overflow exists in Mapbox's closed source gl...

### DIFF
--- a/advisories/unreviewed/2022/08/GHSA-4696-g7jj-xg2h/GHSA-4696-g7jj-xg2h.json
+++ b/advisories/unreviewed/2022/08/GHSA-4696-g7jj-xg2h/GHSA-4696-g7jj-xg2h.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4696-g7jj-xg2h",
-  "modified": "2022-08-18T00:00:18Z",
+  "modified": "2022-11-17T17:28:00Z",
   "published": "2022-08-17T00:00:33Z",
   "aliases": [
     "CVE-2022-38216"
   ],
+  "summary": "Integer Overflow in gl-native",
   "details": "An integer overflow exists in Mapbox's closed source gl-native library prior to version 10.6.1, which is bundled with multiple Mapbox products including open source libraries. The overflow is caused by large image height and width values when creating a new Image and allows for out of bounds writes, potentially crashing the Mapbox process.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@mapbox/mapbox-maps-android"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "10.6.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -24,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.6.1"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/mapbox/mapbox-maps-android/tree/main"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
Providing evidence for resolution in a patched version of the source. This was fixed on July 7th with the release of 10.6.1