### PR TITLE
[GHSA-rhrf-w5v6-jgp3] Vulnerability in the MySQL Connectors product of Oracle...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-rhrf-w5v6-jgp3/GHSA-rhrf-w5v6-jgp3.json
+++ b/advisories/unreviewed/2022/05/GHSA-rhrf-w5v6-jgp3/GHSA-rhrf-w5v6-jgp3.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-rhrf-w5v6-jgp3",
-  "modified": "2022-05-24T17:15:10Z",
+  "modified": "2022-11-21T16:23:21Z",
   "published": "2022-05-24T17:15:10Z",
   "aliases": [
     "CVE-2020-2934"
   ],
-  "details": "Vulnerability in the MySQL Connectors product of Oracle MySQL (component: Connector/J). Supported versions that are affected are 8.0.19 and prior and 5.1.48 and prior. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise MySQL Connectors. Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in unauthorized update, insert or delete access to some of MySQL Connectors accessible data as well as unauthorized read access to a subset of MySQL Connectors accessible data and unauthorized ability to cause a partial denial of service (partial DOS) of MySQL Connectors. CVSS 3.0 Base Score 5.0 (Confidentiality, Integrity and Availability impacts). CVSS Vector: (CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L).",
+  "summary": "Vulnerability in the MySQL Connectors product of Oracle MySQL",
+  "details": "Vulnerability in the MySQL Connectors product of Oracle MySQL (component: Connector/J).\n\nSupported versions that are affected are 8.0.19 and prior and 5.1.48 and prior.\n\nDifficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise MySQL Connectors.\n\nSuccessful attacks require human interaction from a person other than the attacker.\n\nSuccessful attacks of this vulnerability can result in unauthorized update, insert or delete access to some of MySQL Connectors accessible data as well as unauthorized read access to a subset of MySQL Connectors accessible data and unauthorized ability to cause a partial denial of service (partial DOS) of MySQL Connectors.\n\nCVSS 3.0 Base Score 5.0 (Confidentiality, Integrity and Availability impacts).\nCVSS Vector: (CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L).",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,7 +15,44 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "mysql:mysql-connector-java"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "8.0.21"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "mysql:mysql-connector-java"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.1.49"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Summary

**Comments**
Example by GitHub Field Security Services to show a customer that it is possible to amend advisory information for missing CVEs to add to the GHSA database, based on a vulnerable code base they were using for comparison