### PR TITLE
[GHSA-qm95-pgcg-qqfq] Insufficient validation when decoding a Socket.IO packet

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-qm95-pgcg-qqfq/GHSA-qm95-pgcg-qqfq.json
+++ b/advisories/github-reviewed/2022/10/GHSA-qm95-pgcg-qqfq/GHSA-qm95-pgcg-qqfq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-qm95-pgcg-qqfq",
-  "modified": "2022-11-14T20:01:32Z",
+  "modified": "2022-11-21T23:46:41Z",
   "published": "2022-10-26T12:00:28Z",
   "aliases": [
     "CVE-2022-2421"
@@ -25,10 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.0.0"
+              "introduced": "4.1.0"
             },
             {
-              "fixed": "4.0.5"
+              "fixed": "4.2.1"
             }
           ]
         }
@@ -44,10 +44,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.1.0"
+              "introduced": "4.0.0"
             },
             {
-              "fixed": "4.2.1"
+              "fixed": "4.0.5"
             }
           ]
         }
@@ -128,7 +128,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-1287"
     ],
     "severity": "CRITICAL",
     "github_reviewed": true


### PR DESCRIPTION
**Updates**
- CWEs

**Comments**
proposal - attach CWE-1287 (improper validation of specified type of input) to this advisory. Root cause is library fails to enforce that packets are `Buffer` objects - see also workaround