### PR TITLE
[GHSA-4vrc-q7m6-vq7w] Lin CMS vulnerable to Improper Authentication

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-4vrc-q7m6-vq7w/GHSA-4vrc-q7m6-vq7w.json
+++ b/advisories/github-reviewed/2022/11/GHSA-4vrc-q7m6-vq7w/GHSA-4vrc-q7m6-vq7w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4vrc-q7m6-vq7w",
-  "modified": "2022-11-22T00:18:48Z",
+  "modified": "2022-11-22T05:29:21Z",
   "published": "2022-11-10T12:01:09Z",
   "aliases": [
     "CVE-2022-44244"
@@ -17,8 +17,8 @@
   "affected": [
     {
       "package": {
-        "ecosystem": "PyPI",
-        "name": "Lin-CMS"
+        "ecosystem": "Maven",
+        "name": "io.github.talelin:lin-cms-core"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The package is wrong. Actually, the lin-cms for python 0.2.1 has not been released. I think the actual package is for Java.