### PR TITLE
[GHSA-4696-g7jj-xg2h] Mapbox is vulnerable to Integer Overflow

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-4696-g7jj-xg2h/GHSA-4696-g7jj-xg2h.json
+++ b/advisories/github-reviewed/2022/08/GHSA-4696-g7jj-xg2h/GHSA-4696-g7jj-xg2h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4696-g7jj-xg2h",
-  "modified": "2022-11-22T00:03:50Z",
+  "modified": "2022-11-22T05:42:23Z",
   "published": "2022-08-17T00:00:33Z",
   "aliases": [
     "CVE-2022-38216"
@@ -19,25 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "com.mapbox.mapboxsdk:mapbox-android-core"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "10.6.1"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "@mapbox/mapbox-maps-android"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The package is for Android developer. It should not be a npm package.