### PR TITLE
[GHSA-vc47-6rqg-c7f5] cgi.rb in Ruby through 2.6.x, through 3.0x, and through 3...

### DIFF
--- a/advisories/unreviewed/2022/11/GHSA-vc47-6rqg-c7f5/GHSA-vc47-6rqg-c7f5.json
+++ b/advisories/unreviewed/2022/11/GHSA-vc47-6rqg-c7f5/GHSA-vc47-6rqg-c7f5.json
@@ -1,17 +1,80 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-vc47-6rqg-c7f5",
-  "modified": "2022-11-19T00:30:55Z",
+  "modified": "2022-11-22T18:19:59Z",
   "published": "2022-11-19T00:30:55Z",
   "aliases": [
     "CVE-2021-33621"
   ],
+  "summary": "HTTP response splitting in CGI",
   "details": "cgi.rb in Ruby through 2.6.x, through 3.0x, and through 3.1.x allows HTTP header injection. If a CGI application using the CGI library inserts untrusted input into the HTTP response header, an attacker can exploit it to insert a newline character to split a header, and inject malicious content to deceive clients.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "cgi"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.1.0.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "cgi"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.2.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.2.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "cgi"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.3.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.3.3"
+      }
+    }
   ],
   "references": [
     {
@@ -21,6 +84,10 @@
     {
       "type": "WEB",
       "url": "https://hackerone.com/reports/1204695"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/ruby/cgi"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Public announcement at https://www.ruby-lang.org/en/news/2022/11/22/http-response-splitting-in-cgi-cve-2021-33621/