### PR TITLE
[GHSA-vfpx-fww4-ggcq] Use after free in Skia in Google Chrome prior to 106.0...

### DIFF
--- a/advisories/unreviewed/2022/11/GHSA-vfpx-fww4-ggcq/GHSA-vfpx-fww4-ggcq.json
+++ b/advisories/unreviewed/2022/11/GHSA-vfpx-fww4-ggcq/GHSA-vfpx-fww4-ggcq.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-vfpx-fww4-ggcq",
-  "modified": "2022-11-10T19:01:09Z",
+  "modified": "2022-11-24T08:19:26Z",
   "published": "2022-11-10T12:01:17Z",
   "aliases": [
     "CVE-2022-3445"
   ],
+  "summary": "Use after free in Skia in Google Chrome prior to 106.0.5249.119",
   "details": "Use after free in Skia in Google Chrome prior to 106.0.5249.119 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page. (Chromium security severity: High)",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "puppeteer"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "18.1.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Adding puppeteer which has Chromium inside. Chromium versions are listed in https://github.com/puppeteer/puppeteer/blob/main/versions.js