### PR TITLE
[GHSA-w37g-rhq8-7m4j] Snakeyaml vulnerbale to Stack overflow leading to denial of service

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-w37g-rhq8-7m4j/GHSA-w37g-rhq8-7m4j.json
+++ b/advisories/github-reviewed/2022/11/GHSA-w37g-rhq8-7m4j/GHSA-w37g-rhq8-7m4j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-w37g-rhq8-7m4j",
-  "modified": "2022-11-21T22:27:27Z",
+  "modified": "2022-11-24T14:30:51Z",
   "published": "2022-11-11T19:00:31Z",
   "aliases": [
     "CVE-2022-41854"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.33"
+              "fixed": "1.32"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It seems like the affected versions are incorrect. When reviewing the referenced links it seems this has been fixed in version 1.32. Also see https://security.snyk.io/package/maven/org.yaml:snakeyaml