### PR TITLE
[GHSA-f7vh-qwp3-x37m] Deserialization of Untrusted Data in Apache Log4j

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-f7vh-qwp3-x37m/GHSA-f7vh-qwp3-x37m.json
+++ b/advisories/github-reviewed/2022/01/GHSA-f7vh-qwp3-x37m/GHSA-f7vh-qwp3-x37m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-f7vh-qwp3-x37m",
-  "modified": "2022-06-20T22:48:35Z",
+  "modified": "2022-11-25T10:44:24Z",
   "published": "2022-01-19T00:01:15Z",
   "aliases": [
     "CVE-2022-23307"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.logging.log4j:log4j"
+        "name": "log4j:log4j"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The artifact's name was not correct. The artifact org.apache.logging.log4j:log4j does not exist in version 1.2.x, only for versions >=2.0. The correct artifact name for the given version is log4j:log4j