### PR TITLE
[GHSA-w37g-rhq8-7m4j] Snakeyaml vulnerbale to Stack overflow leading to denial of service

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-w37g-rhq8-7m4j/GHSA-w37g-rhq8-7m4j.json
+++ b/advisories/github-reviewed/2022/11/GHSA-w37g-rhq8-7m4j/GHSA-w37g-rhq8-7m4j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-w37g-rhq8-7m4j",
-  "modified": "2022-11-25T15:13:15Z",
+  "modified": "2022-11-25T15:14:46Z",
   "published": "2022-11-11T19:00:31Z",
   "aliases": [
     "CVE-2022-41854"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.33"
+              "fixed": "1.32"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.31"
+      }
     }
   ],
   "references": [

--- a/advisories/github-reviewed/2022/11/GHSA-w37g-rhq8-7m4j/GHSA-w37g-rhq8-7m4j.json
+++ b/advisories/github-reviewed/2022/11/GHSA-w37g-rhq8-7m4j/GHSA-w37g-rhq8-7m4j.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-w37g-rhq8-7m4j",
-  "modified": "2022-11-25T15:09:40Z",
+  "modified": "2022-11-25T15:13:15Z",
   "published": "2022-11-11T19:00:31Z",
   "aliases": [
     "CVE-2022-41854"
   ],
-  "summary": "Snakeyaml vulnerbale to Stack overflow leading to denial of service",
+  "summary": "Snakeyaml vulnerable to Stack overflow leading to denial of service",
   "details": "Those using Snakeyaml to parse untrusted YAML files may be vulnerable to Denial of Service attacks (DOS). If the parser is running on user supplied input, an attacker may supply content that causes the parser to crash by stack overflow. This effect may support a denial of service attack.",
   "severity": [
     {
@@ -28,14 +28,11 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.32"
+              "last_affected": "1.33"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 1.31"
-      }
+      ]
     }
   ],
   "references": [

--- a/advisories/github-reviewed/2022/11/GHSA-w37g-rhq8-7m4j/GHSA-w37g-rhq8-7m4j.json
+++ b/advisories/github-reviewed/2022/11/GHSA-w37g-rhq8-7m4j/GHSA-w37g-rhq8-7m4j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-w37g-rhq8-7m4j",
-  "modified": "2022-11-21T22:27:27Z",
+  "modified": "2022-11-25T15:09:40Z",
   "published": "2022-11-11T19:00:31Z",
   "aliases": [
     "CVE-2022-41854"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.33"
+              "fixed": "1.32"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.31"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Vulnerable version range was redacted by NVD on Nov 15, 2022: https://nvd.nist.gov/vuln/detail/CVE-2022-41854