### PR TITLE
[GHSA-2p9h-ccw7-33gf] cleo is vulnerable to Regular Expression Denial of Service (ReDoS)

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-2p9h-ccw7-33gf/GHSA-2p9h-ccw7-33gf.json
+++ b/advisories/github-reviewed/2022/11/GHSA-2p9h-ccw7-33gf/GHSA-2p9h-ccw7-33gf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-2p9h-ccw7-33gf",
-  "modified": "2022-11-10T18:52:40Z",
+  "modified": "2022-11-25T21:01:43Z",
   "published": "2022-11-10T12:01:17Z",
   "aliases": [
     "CVE-2022-42966"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.0.0a5"
+              "fixed": "1.0.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.0.0a5"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Cleo 1.0.0 (yanked) and >= 2.0.0 include a fix for this regular expression.