### PR TITLE
[GHSA-28w4-h56g-grg7] Jenkins Job Configuration History Plugin 1165...

### DIFF
--- a/advisories/unreviewed/2022/08/GHSA-28w4-h56g-grg7/GHSA-28w4-h56g-grg7.json
+++ b/advisories/unreviewed/2022/08/GHSA-28w4-h56g-grg7/GHSA-28w4-h56g-grg7.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-28w4-h56g-grg7",
-  "modified": "2022-08-26T00:03:35Z",
+  "modified": "2022-11-26T22:41:22Z",
   "published": "2022-08-24T00:00:28Z",
   "aliases": [
     "CVE-2022-38664"
   ],
+  "summary": "Jenkins Job Configuration History Plugin does not escape the job name on the System Configuration History page",
   "details": "Jenkins Job Configuration History Plugin 1165.v8cc9fd1f4597 and earlier does not escape the job name on the System Configuration History page, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to configure job names.",
   "severity": [
     {
@@ -14,12 +15,37 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:jobConfigHistory"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1166.vc9f255f45b_8a"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1165.v8cc9fd1f4597"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-38664"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/job-config-history-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
The change proposed updates the affected versions this security vulnerability applies to and the version it has been fixed in, according to the information of the CVE: https://nvd.nist.gov/vuln/detail/CVE-2022-38664
The patched version has been disclosed by the Jenkins CERT team: https://www.jenkins.io/security/advisory/2022-08-23/#SECURITY-2765