### PR TITLE
[GHSA-995f-9x5r-2rcj] Heap buffer overflow in GPU in Google Chrome prior to 107...

### DIFF
--- a/advisories/unreviewed/2022/11/GHSA-995f-9x5r-2rcj/GHSA-995f-9x5r-2rcj.json
+++ b/advisories/unreviewed/2022/11/GHSA-995f-9x5r-2rcj/GHSA-995f-9x5r-2rcj.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-995f-9x5r-2rcj",
-  "modified": "2022-11-28T15:30:24Z",
+  "modified": "2022-11-28T21:35:43Z",
   "published": "2022-11-25T03:30:19Z",
   "aliases": [
     "CVE-2022-4135"
   ],
+  "summary": "Heap buffer overflow in GPU",
   "details": "Heap buffer overflow in GPU in Google Chrome prior to 107.0.5304.121 allowed a remote attacker who had compromised the renderer process to potentially perform a sandbox escape via a crafted HTML page. (Chromium security severity: High)",
   "severity": [
     {
@@ -14,12 +15,38 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "electron"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "19.0.0"
+            },
+            {
+              "fixed": "19.1.8"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-4135"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/electron/electron/pull/36444"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/electron/electron/pull/36447"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- References
- Severity
- Summary

**Comments**
Added electron 19.x as an affected product