### PR TITLE
[GHSA-gqm2-2gcx-p88w] Incorrect Permission Assignment for Critical Resource in Jenkins Credentials Binding Plugin

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-gqm2-2gcx-p88w/GHSA-gqm2-2gcx-p88w.json
+++ b/advisories/github-reviewed/2022/01/GHSA-gqm2-2gcx-p88w/GHSA-gqm2-2gcx-p88w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-gqm2-2gcx-p88w",
-  "modified": "2022-06-20T22:49:42Z",
+  "modified": "2022-11-29T08:16:11Z",
   "published": "2022-01-13T00:01:03Z",
   "aliases": [
     "CVE-2022-20616"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.28"
+              "fixed": "1.27.1"
             }
           ]
         }
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-20616"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/credentials-binding-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
Updating first version including a fix according to https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-2342