### PR TITLE
[GHSA-c8cc-hj57-vm65] Jenkins Active Directory Plugin 2.25 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/01/GHSA-c8cc-hj57-vm65/GHSA-c8cc-hj57-vm65.json
+++ b/advisories/unreviewed/2022/01/GHSA-c8cc-hj57-vm65/GHSA-c8cc-hj57-vm65.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-c8cc-hj57-vm65",
-  "modified": "2022-01-19T00:01:34Z",
+  "modified": "2022-11-29T08:27:01Z",
   "published": "2022-01-13T00:00:55Z",
   "aliases": [
     "CVE-2022-23105"
   ],
+  "summary": "User passwords transmitted in plain text by Jenkins Active Directory Plugin ",
   "details": "Jenkins Active Directory Plugin 2.25 and earlier does not encrypt the transmission of data between the Jenkins controller and Active Directory servers in most configurations.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:A/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:active-directory"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.25.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.25"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23105"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/active-directory-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-1389