### PR TITLE
[GHSA-h6x7-jq46-fp33] Jenkins HashiCorp Vault Plugin 3.7.0 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/01/GHSA-h6x7-jq46-fp33/GHSA-h6x7-jq46-fp33.json
+++ b/advisories/unreviewed/2022/01/GHSA-h6x7-jq46-fp33/GHSA-h6x7-jq46-fp33.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-h6x7-jq46-fp33",
-  "modified": "2022-01-19T00:01:34Z",
+  "modified": "2022-11-29T08:32:00Z",
   "published": "2022-01-13T00:00:54Z",
   "aliases": [
     "CVE-2022-23109"
   ],
+  "summary": "Improper credentials masking in Jenkins HashiCorp Vault Plugin ",
   "details": "Jenkins HashiCorp Vault Plugin 3.7.0 and earlier does not mask Vault credentials in Pipeline build logs or in Pipeline step descriptions when Pipeline: Groovy Plugin 2.85 or later is installed.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.datapipe.jenkins.plugins:hashicorp-vault-plugin"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.8.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.7.0"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23109"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/hashicorp-vault-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-2213