### PR TITLE
[GHSA-fjpm-hf7c-xgc2] Jenkins Publish Over SSH Plugin 1.22 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/01/GHSA-fjpm-hf7c-xgc2/GHSA-fjpm-hf7c-xgc2.json
+++ b/advisories/unreviewed/2022/01/GHSA-fjpm-hf7c-xgc2/GHSA-fjpm-hf7c-xgc2.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-fjpm-hf7c-xgc2",
-  "modified": "2022-01-19T00:01:33Z",
+  "modified": "2022-11-29T08:34:32Z",
   "published": "2022-01-13T00:00:54Z",
   "aliases": [
     "CVE-2022-23110"
   ],
+  "summary": "Stored XSS vulnerability in Jenkins Publish Over SSH Plugin ",
   "details": "Jenkins Publish Over SSH Plugin 1.22 and earlier does not escape the SSH server name, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Overall/Administer permission.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:publish-over-ssh"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.23"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.22"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23110"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/publish-over-ssh-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-2287

The patched version is noted in https://github.com/jenkinsci/publish-over-ssh-plugin/releases/tag/publish-over-ssh-1.23 (SECURITY-2287)