### PR TITLE
[GHSA-884c-9wwh-9p6v] A cross-site request forgery (CSRF) vulnerability in...

### DIFF
--- a/advisories/unreviewed/2022/01/GHSA-884c-9wwh-9p6v/GHSA-884c-9wwh-9p6v.json
+++ b/advisories/unreviewed/2022/01/GHSA-884c-9wwh-9p6v/GHSA-884c-9wwh-9p6v.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-884c-9wwh-9p6v",
-  "modified": "2022-01-19T00:01:33Z",
+  "modified": "2022-11-29T08:36:30Z",
   "published": "2022-01-13T00:00:53Z",
   "aliases": [
     "CVE-2022-23111"
   ],
+  "summary": "CSRF vulnerability and missing permission checks in Jenkins Publish Over SSH Plugin",
   "details": "A cross-site request forgery (CSRF) vulnerability in Jenkins Publish Over SSH Plugin 1.22 and earlier allows attackers to connect to an attacker-specified SSH server using attacker-specified credentials.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:publish-over-ssh"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.23"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.22"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23111"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/publish-over-ssh-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Source code location
- Summary

**Comments**
Fill in details, according to https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-2290

The fix has been delivered in https://github.com/jenkinsci/publish-over-ssh-plugin/releases/tag/publish-over-ssh-1.23 (SECURITY-2290)