### PR TITLE
[GHSA-j8rg-4hjm-8r95] Jenkins Publish Over SSH Plugin 1.22 and earlier performs...

### DIFF
--- a/advisories/unreviewed/2022/01/GHSA-j8rg-4hjm-8r95/GHSA-j8rg-4hjm-8r95.json
+++ b/advisories/unreviewed/2022/01/GHSA-j8rg-4hjm-8r95/GHSA-j8rg-4hjm-8r95.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-j8rg-4hjm-8r95",
-  "modified": "2022-01-20T00:02:19Z",
+  "modified": "2022-11-29T08:39:56Z",
   "published": "2022-01-13T00:00:53Z",
   "aliases": [
     "CVE-2022-23113"
   ],
+  "summary": "Path traversal vulnerability in Jenkins Publish Over SSH Plugin ",
   "details": "Jenkins Publish Over SSH Plugin 1.22 and earlier performs a validation of the file name specifying whether it is present or not, resulting in a path traversal vulnerability allowing attackers with Item/Configure permission to discover the name of the Jenkins controller files.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:publish-over-ssh"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.23"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.22"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23113"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/publish-over-ssh-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-2307

The fix has been delivered in https://github.com/jenkinsci/publish-over-ssh-plugin/releases/tag/publish-over-ssh-1.23 (SECURITY-2307)