### PR TITLE
[GHSA-r3rr-wph6-9638] Jenkins Publish Over SSH Plugin 1.22 and earlier stores...

### DIFF
--- a/advisories/unreviewed/2022/01/GHSA-r3rr-wph6-9638/GHSA-r3rr-wph6-9638.json
+++ b/advisories/unreviewed/2022/01/GHSA-r3rr-wph6-9638/GHSA-r3rr-wph6-9638.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-r3rr-wph6-9638",
-  "modified": "2022-01-19T00:01:32Z",
+  "modified": "2022-11-29T08:41:14Z",
   "published": "2022-01-13T00:00:53Z",
   "aliases": [
     "CVE-2022-23114"
   ],
+  "summary": "Password stored in plain text by Jenkins Publish Over SSH Plugin ",
   "details": "Jenkins Publish Over SSH Plugin 1.22 and earlier stores password unencrypted in its global configuration file on the Jenkins controller where it can be viewed by users with access to the Jenkins controller file system.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:publish-over-ssh"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.23"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.22"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23114"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/publish-over-ssh-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-2291

The fix has been delivered in https://github.com/jenkinsci/publish-over-ssh-plugin/releases/tag/publish-over-ssh-1.23 (SECURITY-2291)