### PR TITLE
[GHSA-cw68-xmm4-c83r] Jenkins Conjur Secrets Plugin 1.0.9 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/01/GHSA-cw68-xmm4-c83r/GHSA-cw68-xmm4-c83r.json
+++ b/advisories/unreviewed/2022/01/GHSA-cw68-xmm4-c83r/GHSA-cw68-xmm4-c83r.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-cw68-xmm4-c83r",
-  "modified": "2022-01-20T00:02:18Z",
+  "modified": "2022-11-29T08:54:28Z",
   "published": "2022-01-13T00:00:53Z",
   "aliases": [
     "CVE-2022-23117"
   ],
+  "summary": "Agent-to-controller security bypass in Jenkins Conjur Secrets Plugin allows retrieving all credentials ",
   "details": "Jenkins Conjur Secrets Plugin 1.0.9 and earlier implements functionality that allows attackers able to control agent processes to retrieve all username/password credentials stored on the Jenkins controller.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.conjur.jenkins:conjur-credentials"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.0.10"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.0.9"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23117"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/conjur-credentials-plugin"
     },
     {
       "type": "WEB",
@@ -31,7 +60,7 @@
     "cwe_ids": [
       "CWE-269"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory data according to https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-2522%20(2)

The fix has been integrated in https://github.com/jenkinsci/conjur-credentials-plugin/pull/19 and has been published in https://github.com/jenkinsci/conjur-credentials-plugin/releases/tag/conjur-credentials-1.0.10