### PR TITLE
[GHSA-qh87-2qvh-5jf8] Jenkins CollabNet Plugins Plugin 2.0.8 and earlier stores...

### DIFF
--- a/advisories/unreviewed/2022/08/GHSA-qh87-2qvh-5jf8/GHSA-qh87-2qvh-5jf8.json
+++ b/advisories/unreviewed/2022/08/GHSA-qh87-2qvh-5jf8/GHSA-qh87-2qvh-5jf8.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-qh87-2qvh-5jf8",
-  "modified": "2022-08-24T00:00:28Z",
+  "modified": "2022-11-29T09:16:57Z",
   "published": "2022-08-24T00:00:28Z",
   "aliases": [
     "CVE-2022-38665"
   ],
+  "summary": "RabbitMQ password stored in plain text by Jenkins CollabNet Plugins Plugin ",
   "details": "Jenkins CollabNet Plugins Plugin 2.0.8 and earlier stores a RabbitMQ password unencrypted in its global configuration file on the Jenkins controller where it can be viewed by users with access to the Jenkins controller file system.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:collabnet"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.0.9"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.0.8"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-38665"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/collabnet-plugin"
     },
     {
       "type": "WEB",
@@ -31,7 +60,7 @@
     "cwe_ids": [
       "CWE-256"
     ],
-    "severity": null,
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Source code location
- Summary

**Comments**
Provide advisory details according to https://www.jenkins.io/security/advisory/2022-08-23/#SECURITY-2157