### PR TITLE
[GHSA-4p8f-2fwv-6xcw] A missing permission check in Jenkins RocketChat Notifier...

### DIFF
--- a/advisories/unreviewed/2022/03/GHSA-4p8f-2fwv-6xcw/GHSA-4p8f-2fwv-6xcw.json
+++ b/advisories/unreviewed/2022/03/GHSA-4p8f-2fwv-6xcw/GHSA-4p8f-2fwv-6xcw.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4p8f-2fwv-6xcw",
-  "modified": "2022-04-05T00:00:39Z",
+  "modified": "2022-11-29T10:02:14Z",
   "published": "2022-03-30T00:00:25Z",
   "aliases": [
     "CVE-2022-28139"
   ],
-  "details": "A missing permission check in Jenkins RocketChat Notifier Plugin 1.4.10 and earlier allows attackers with Overall/Read permission to connect to an attacker-specified URL using attacker-specified credentials.",
+  "summary": "Missing permission check in Jenkins RocketChat Notifier Plugin ",
+  "details": "RocketChat Notifier Plugin 1.4.10 and earlier does not perform a permission check in a method implementing form validation.\nThis allows attackers with Overall/Read permission to connect to an attacker-specified URL using attacker-specified username and password.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,12 +15,37 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:rocketchatnotifier"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.5.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.4.10"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-28139"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/rocketchatnotifier-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location
- Summary

**Comments**
Update version range affected according to https://www.jenkins.io/security/advisory/2022-03-29/#SECURITY-2241

Also updates the description matching the CVE record.