### PR TITLE
[GHSA-w97x-j6rg-55v5] Jenkins Proxmox Plugin 0.5.0 and earlier stores the...

### DIFF
--- a/advisories/unreviewed/2022/03/GHSA-w97x-j6rg-55v5/GHSA-w97x-j6rg-55v5.json
+++ b/advisories/unreviewed/2022/03/GHSA-w97x-j6rg-55v5/GHSA-w97x-j6rg-55v5.json
@@ -1,25 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-w97x-j6rg-55v5",
-  "modified": "2022-04-05T00:00:39Z",
+  "modified": "2022-11-29T10:04:43Z",
   "published": "2022-03-30T00:00:25Z",
   "aliases": [
     "CVE-2022-28141"
   ],
+  "summary": "Password stored in plain text by Jenkins Proxmox Plugin ",
   "details": "Jenkins Proxmox Plugin 0.5.0 and earlier stores the Proxmox Datacenter password unencrypted in the global config.xml file on the Jenkins controller where it can be viewed by users with access to the Jenkins controller file system.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:proxmox"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.6.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.5.0"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-28141"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/proxmox-plugin"
     },
     {
       "type": "WEB",
@@ -34,7 +60,7 @@
     "cwe_ids": [
       "CWE-522"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Source code location
- Summary

**Comments**
Update versions affected according to https://www.jenkins.io/security/advisory/2022-03-29/#SECURITY-2079