### PR TITLE
[GHSA-fhhx-r983-44xc] Jenkins Proxmox Plugin 0.6.0 and earlier disables SSL/TLS...

### DIFF
--- a/advisories/unreviewed/2022/03/GHSA-fhhx-r983-44xc/GHSA-fhhx-r983-44xc.json
+++ b/advisories/unreviewed/2022/03/GHSA-fhhx-r983-44xc/GHSA-fhhx-r983-44xc.json
@@ -1,25 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-fhhx-r983-44xc",
-  "modified": "2022-04-05T00:00:39Z",
+  "modified": "2022-11-29T10:06:30Z",
   "published": "2022-03-30T00:00:27Z",
   "aliases": [
     "CVE-2022-28142"
   ],
+  "summary": "SSL/TLS certificate validation globally disabled by Jenkins Proxmox Plugin ",
   "details": "Jenkins Proxmox Plugin 0.6.0 and earlier disables SSL/TLS certificate validation globally for the Jenkins controller JVM when configured to ignore SSL/TLS issues.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:proxmox"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.7.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.6.0"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-28142"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/proxmox-plugin"
     },
     {
       "type": "WEB",
@@ -34,7 +60,7 @@
     "cwe_ids": [
       "CWE-295"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Source code location
- Summary

**Comments**
Update versions affected according to https://www.jenkins.io/security/advisory/2022-03-29/#SECURITY-2081