### PR TITLE
[GHSA-85f9-w9cx-h363] Cross site request forgery in Jenkins Job and Node ownership Plugin

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-85f9-w9cx-h363/GHSA-85f9-w9cx-h363.json
+++ b/advisories/github-reviewed/2022/03/GHSA-85f9-w9cx-h363/GHSA-85f9-w9cx-h363.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-85f9-w9cx-h363",
-  "modified": "2022-04-07T15:35:41Z",
+  "modified": "2022-11-29T10:28:14Z",
   "published": "2022-03-30T00:00:23Z",
   "aliases": [
     "CVE-2022-28150"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
     }
   ],
   "affected": [
@@ -28,14 +28,11 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.13.1"
+              "last_affected": "0.13.0"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 0.13.0"
-      }
+      ]
     }
   ],
   "references": [
@@ -60,7 +57,7 @@
     "cwe_ids": [
       "CWE-352"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
Update details according to https://www.jenkins.io/security/advisory/2022-03-29/#SECURITY-2062%20(1)

This CSRF vulnerability is not yet fixed.