### PR TITLE
[GHSA-q787-qgw2-j2qf] Jenkins Tests Selector Plugin 1.3.3 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/03/GHSA-q787-qgw2-j2qf/GHSA-q787-qgw2-j2qf.json
+++ b/advisories/unreviewed/2022/03/GHSA-q787-qgw2-j2qf/GHSA-q787-qgw2-j2qf.json
@@ -1,25 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-q787-qgw2-j2qf",
-  "modified": "2022-04-05T00:00:37Z",
+  "modified": "2022-11-29T10:35:15Z",
   "published": "2022-03-30T00:00:21Z",
   "aliases": [
     "CVE-2022-28159"
   ],
+  "summary": "Stored XSS vulnerability in Jenkins Tests Selector Plugin",
   "details": "Jenkins Tests Selector Plugin 1.3.3 and earlier does not escape the Properties File Path option for Choosing Tests parameters, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:selected-tests-executor"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.3.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-28159"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/selected-tests-executor-plugin"
     },
     {
       "type": "WEB",
@@ -34,7 +57,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Source code location
- Summary

**Comments**
Fill in versions affected according to https://www.jenkins.io/security/advisory/2022-03-29/#SECURITY-2262