### PR TITLE
[GHSA-3r5x-x6xf-m8fv] Jenkins Tests Selector Plugin 1.3.3 and earlier allows...

### DIFF
--- a/advisories/unreviewed/2022/03/GHSA-3r5x-x6xf-m8fv/GHSA-3r5x-x6xf-m8fv.json
+++ b/advisories/unreviewed/2022/03/GHSA-3r5x-x6xf-m8fv/GHSA-3r5x-x6xf-m8fv.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-3r5x-x6xf-m8fv",
-  "modified": "2022-04-05T00:00:37Z",
+  "modified": "2022-11-29T10:37:05Z",
   "published": "2022-03-30T00:00:21Z",
   "aliases": [
     "CVE-2022-28160"
   ],
-  "details": "Jenkins Tests Selector Plugin 1.3.3 and earlier allows users with Item/Configure permission to read arbitrary files on the Jenkins controller.",
+  "summary": "Arbitrary file read vulnerability in Jenkins Tests Selector Plugin",
+  "details": "Jenkins Tests Selector Plugin 1.3.3 and earlier allows users with Item/Configure permission to read arbitrary files on the Jenkins controller using the Choosing Tests parameter.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,12 +15,34 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:selected-tests-executor"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.3.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-28160"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/selected-tests-executor-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location
- Summary

**Comments**
Fill in versions affected according to https://www.jenkins.io/security/advisory/2022-03-29/#SECURITY-2338