### PR TITLE
[GHSA-qrmm-w75w-3wpx] Server side request forgery in SwaggerUI

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-qrmm-w75w-3wpx/GHSA-qrmm-w75w-3wpx.json
+++ b/advisories/github-reviewed/2021/12/GHSA-qrmm-w75w-3wpx/GHSA-qrmm-w75w-3wpx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-qrmm-w75w-3wpx",
-  "modified": "2022-05-26T20:08:34Z",
+  "modified": "2022-11-29T18:16:09Z",
   "published": "2021-12-09T19:08:38Z",
   "aliases": [
 
@@ -64,6 +64,25 @@
             },
             {
               "fixed": "4.1.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Swashbuckle.AspNetCore.SwaggerUI"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "6.4"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Swashbuckle repackages the swagger-ui-dist npm package and thus inherits the vulnerability. Fixed in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/commit/401c7cb81e5efe835ceb8aae23e82057d57c7d29 and released in 6.4.