### PR TITLE
[GHSA-874r-46c6-7p4r] Jenkins Favorite Plugin 2.4.0 and earlier does not escape...

### DIFF
--- a/advisories/unreviewed/2022/03/GHSA-874r-46c6-7p4r/GHSA-874r-46c6-7p4r.json
+++ b/advisories/unreviewed/2022/03/GHSA-874r-46c6-7p4r/GHSA-874r-46c6-7p4r.json
@@ -1,25 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-874r-46c6-7p4r",
-  "modified": "2022-03-24T00:00:48Z",
+  "modified": "2022-11-30T08:10:08Z",
   "published": "2022-03-16T00:00:45Z",
   "aliases": [
     "CVE-2022-27196"
   ],
+  "summary": "Stored XSS vulnerability in Jenkins Favorite Plugin",
   "details": "Jenkins Favorite Plugin 2.4.0 and earlier does not escape the names of jobs in the favorite column, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure or Item/Create permissions.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jvnet.hudson.plugins:favorite"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.4.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.4.0"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-27196"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/favorite-plugin"
     },
     {
       "type": "WEB",
@@ -34,7 +60,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-03-15/#SECURITY-2557