### PR TITLE
[GHSA-6fg4-36v7-xv32] Jenkins Dashboard View Plugin 2.18 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/03/GHSA-6fg4-36v7-xv32/GHSA-6fg4-36v7-xv32.json
+++ b/advisories/unreviewed/2022/03/GHSA-6fg4-36v7-xv32/GHSA-6fg4-36v7-xv32.json
@@ -1,25 +1,45 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-6fg4-36v7-xv32",
-  "modified": "2022-03-24T00:00:48Z",
+  "modified": "2022-11-30T08:13:24Z",
   "published": "2022-03-16T00:00:45Z",
   "aliases": [
     "CVE-2022-27197"
   ],
-  "details": "Jenkins Dashboard View Plugin 2.18 and earlier does not perform URL validation for the Iframe Portlet's Iframe source URL, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to configure views.",
+  "summary": "Stored XSS vulnerability in Jenkins Dashboard View Plugin",
+  "details": "Jenkins Dashboard View Plugin 2.18 and earlier does not perform URL validation for the Iframe Portlet's Iframe source URL, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to configure views.\n\nDashboard View Plugin 2.18.1 performs URL validation for the Iframe Portlet’s Iframe source URL.\nAdditionally, Dashboard View Plugin 2.18.1 sets the sandbox attribute for the iframe to restrict the included page.\n\nIn case of problems, the [Java system property](https://www.jenkins.io/doc/book/managing/system-properties/) `hudson.plugins.view.dashboard.core.IframePortlet.sandboxAttributeValue` can be used to customize the sandbox attribute value. The Java system property `hudson.plugins.view.dashboard.core.IframePortlet.doNotUseSandbox` can be used to disable the sandbox completely.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:dashboard-view"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-27197"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/dashboard-view-plugin"
     },
     {
       "type": "WEB",
@@ -34,7 +54,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-03-15/#SECURITY-2559

Also provide more information if the fixed version causes potential issues.