### PR TITLE
[GHSA-x3m3-g8w6-mf28] Jenkins Semantic Versioning Plugin 1.13 and earlier does...

### DIFF
--- a/advisories/unreviewed/2022/03/GHSA-x3m3-g8w6-mf28/GHSA-x3m3-g8w6-mf28.json
+++ b/advisories/unreviewed/2022/03/GHSA-x3m3-g8w6-mf28/GHSA-x3m3-g8w6-mf28.json
@@ -1,25 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-x3m3-g8w6-mf28",
-  "modified": "2022-03-23T00:00:43Z",
+  "modified": "2022-11-30T08:22:47Z",
   "published": "2022-03-16T00:00:45Z",
   "aliases": [
     "CVE-2022-27201"
   ],
-  "details": "Jenkins Semantic Versioning Plugin 1.13 and earlier does not restrict execution of an controller/agent message to agents, and implements no limitations about the file path that can be parsed, allowing attackers able to control agent processes to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.",
+  "summary": "Agent-to-controller security bypass in Jenkins Semantic Versioning Plugin",
+  "details": "Jenkins Semantic Versioning Plugin defines a controller/agent message that processes a given file as XML and returns version information. The XML parser is not configured to prevent XML external entity (XXE) attacks, which is only a problem if XML documents are parsed on the Jenkins controller.\n\nJenkins Semantic Versioning Plugin 1.13 and earlier does not restrict execution of a controller/agent message to agents, and implements no limitations about the file path that can be parsed, allowing attackers able to control agent processes to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.\n\nThis vulnerability is only exploitable in Jenkins 2.318 and earlier, LTS 2.303.2 and earlier. See the [LTS upgrade guide](https://www.jenkins.io/doc/upgrade-guide/2.303/#upgrading-to-jenkins-lts-2-303-3).",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:semantic-versioning-plugin"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.14"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.13"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-27201"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/semantic-versioning-plugin"
     },
     {
       "type": "WEB",
@@ -35,7 +61,7 @@
       "CWE-611",
       "CWE-918"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-03-15/#SECURITY-2124 and clarify which Jenkins versions are actually affected by it.