### PR TITLE
[GHSA-hx3r-qwxv-5jw9] Jenkins GitLab Authentication Plugin 1.13 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/03/GHSA-hx3r-qwxv-5jw9/GHSA-hx3r-qwxv-5jw9.json
+++ b/advisories/unreviewed/2022/03/GHSA-hx3r-qwxv-5jw9/GHSA-hx3r-qwxv-5jw9.json
@@ -1,25 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-hx3r-qwxv-5jw9",
-  "modified": "2022-03-24T00:00:46Z",
+  "modified": "2022-11-30T08:31:59Z",
   "published": "2022-03-16T00:00:43Z",
   "aliases": [
     "CVE-2022-27206"
   ],
-  "details": "Jenkins GitLab Authentication Plugin 1.13 and earlier stores the GitLab client secret unencrypted in the global config.xml file on the Jenkins controller where it can be viewed by users with access to the Jenkins controller file system.",
+  "summary": "Client Secret stored in plain text by Jenkins GitLab Authentication Plugin",
+  "details": "Jenkins GitLab Authentication Plugin 1.13 and earlier stores the GitLab client secret unencrypted in the global `config.xml` file on the Jenkins controller where it can be viewed by users with access to the Jenkins controller file system.\n\nThis client secret can be viewed by users with access to the Jenkins controller file system.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:gitlab-oauth"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.14"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.13"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-27206"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/gitlab-oauth-plugin"
     },
     {
       "type": "WEB",
@@ -35,7 +61,7 @@
       "CWE-311",
       "CWE-522"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-03-15/#SECURITY-1891

The vulnerability has been fixed in 1.14, according to https://github.com/jenkinsci/gitlab-oauth-plugin/releases/tag/gitlab-oauth-1.14 (SECURITY-1891)