### PR TITLE
[GHSA-x75r-g63m-82wj] Jenkins dbCharts Plugin 0.5.2 and earlier stores JDBC...

### DIFF
--- a/advisories/unreviewed/2022/03/GHSA-x75r-g63m-82wj/GHSA-x75r-g63m-82wj.json
+++ b/advisories/unreviewed/2022/03/GHSA-x75r-g63m-82wj/GHSA-x75r-g63m-82wj.json
@@ -1,25 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-x75r-g63m-82wj",
-  "modified": "2022-03-26T00:00:51Z",
+  "modified": "2022-11-30T08:49:44Z",
   "published": "2022-03-16T00:00:43Z",
   "aliases": [
     "CVE-2022-27216"
   ],
-  "details": "Jenkins dbCharts Plugin 0.5.2 and earlier stores JDBC connection passwords unencrypted in its global configuration file on the Jenkins controller where they can be viewed by users with access to the Jenkins controller file system.",
+  "summary": "Passwords stored in plain text by Jenkins dbCharts Plugin",
+  "details": "Jenkins dbCharts Plugin 0.5.2 and earlier stores JDBC connection passwords unencrypted in its global configuration file `hudson.plugins.dbcharts.DbChartPublisher.xml` on the Jenkins controller as part of its configuration.\n\nThese passwords can be viewed by users with access to the Jenkins controller file system.\n",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:dbCharts"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "0.5.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-27216"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/dbCharts-plugin"
     },
     {
       "type": "WEB",
@@ -34,7 +57,7 @@
     "cwe_ids": [
       "CWE-522"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-03-15/#SECURITY-2159