### PR TITLE
[GHSA-455j-8hg5-8576] Jenkins Gerrit Trigger Plugin 2.35.2 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/04/GHSA-455j-8hg5-8576/GHSA-455j-8hg5-8576.json
+++ b/advisories/unreviewed/2022/04/GHSA-455j-8hg5-8576/GHSA-455j-8hg5-8576.json
@@ -1,25 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-455j-8hg5-8576",
-  "modified": "2022-04-21T00:00:42Z",
+  "modified": "2022-12-01T09:24:34Z",
   "published": "2022-04-13T00:00:19Z",
   "aliases": [
     "CVE-2022-29039"
   ],
-  "details": "Jenkins Gerrit Trigger Plugin 2.35.2 and earlier does not escape the name and description of Base64 Encoded String parameters on views displaying parameters, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.",
+  "summary": "Stored XSS vulnerability in Jenkins Gerrit Trigger Plugin",
+  "details": "Jenkins Gerrit Trigger Plugin 2.35.2 and earlier does not escape the name and description of parameters on views displaying parameters, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.\n\nExploitation of these vulnerabilities requires that parameters are listed on another page, like the \"Build With Parameters\" and \"Parameters\" pages provided by Jenkins (core), and that those pages are not hardened to prevent exploitation. Jenkins (core) has prevented exploitation of vulnerabilities of this kind on the \"Build With Parameters\" and \"Parameters\" pages since 2.44 and LTS 2.32.2 as part of the [SECURITY-353 / CVE-2017-2601](https://www.jenkins.io/security/advisory/2017-02-01/#persisted-cross-site-scripting-vulnerability-in-parameter-names-and-descriptions) fix.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.sonyericsson.hudson.plugins.gerrit:gerrit-trigger"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.35.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.35.2"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-29039"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/gerrit-trigger-plugin"
     },
     {
       "type": "WEB",
@@ -30,7 +56,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-04-12/#SECURITY-2617