### PR TITLE
[GHSA-f3jq-9c79-j65m] Jenkins Job Generator Plugin 1.22 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/04/GHSA-f3jq-9c79-j65m/GHSA-f3jq-9c79-j65m.json
+++ b/advisories/unreviewed/2022/04/GHSA-f3jq-9c79-j65m/GHSA-f3jq-9c79-j65m.json
@@ -1,25 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-f3jq-9c79-j65m",
-  "modified": "2022-04-21T00:00:41Z",
+  "modified": "2022-12-01T09:33:30Z",
   "published": "2022-04-13T00:00:17Z",
   "aliases": [
     "CVE-2022-29042"
   ],
-  "details": "Jenkins Job Generator Plugin 1.22 and earlier does not escape the name and description of Generator Parameter and Generator Choice parameters on Job Generator jobs' Build With Parameters views, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.",
+  "summary": "Stored XSS vulnerability in Jenkins Job Generator Plugin",
+  "details": "Jenkins Job Generator Plugin 1.22 and earlier does not escape the name and description of Generator Parameter and Generator Choice parameters on Job Generator jobs' Build With Parameters views, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.\n\nExploitation of this vulnerability requires that parameters are listed on another page, like the \"Build With Parameters\" and \"Parameters\" pages provided by Jenkins (core), and that those pages are not hardened to prevent exploitation. Jenkins (core) has prevented exploitation of vulnerabilities of this kind on the \"Build With Parameters\" and \"Parameters\" pages since 2.44 and LTS 2.32.2 as part of the [SECURITY-353 / CVE-2017-2601](https://www.jenkins.io/security/advisory/2017-02-01/#persisted-cross-site-scripting-vulnerability-in-parameter-names-and-descriptions) fix.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:jobgenerator"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.22"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-29042"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jobgenerator-plugin"
     },
     {
       "type": "WEB",
@@ -30,7 +53,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-04-12/#SECURITY-2617