### PR TITLE
[GHSA-vhxq-9mpv-gj87] Jenkins Google Compute Engine Plugin 4.3.8 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/04/GHSA-vhxq-9mpv-gj87/GHSA-vhxq-9mpv-gj87.json
+++ b/advisories/unreviewed/2022/04/GHSA-vhxq-9mpv-gj87/GHSA-vhxq-9mpv-gj87.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-vhxq-9mpv-gj87",
-  "modified": "2022-04-21T00:00:41Z",
+  "modified": "2022-12-01T09:55:40Z",
   "published": "2022-04-13T00:00:15Z",
   "aliases": [
     "CVE-2022-29052"
   ],
-  "details": "Jenkins Google Compute Engine Plugin 4.3.8 and earlier stores private keys unencrypted in cloud agent config.xml files on the Jenkins controller where they can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.",
+  "summary": "Private key stored in plain text by Jenkins Google Compute Engine Plugin",
+  "details": "Jenkins Google Compute Engine Plugin 4.3.8 and earlier stores private keys unencrypted in cloud agent `config.xml` files on the Jenkins controller where they can be viewed by users with Agent/Extended Read permission, or access to the Jenkins controller file system.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,12 +15,37 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:google-compute-engine"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.3.9"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.3.8"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-29052"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/google-compute-engine-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location
- Summary

**Comments**
Update details according to https://www.jenkins.io/security/advisory/2022-04-12/#SECURITY-2045