### PR TITLE
[GHSA-fm6q-97gw-c4wh] Secret exposure in Jenkins HashiCorp Vault Plugin

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-fm6q-97gw-c4wh/GHSA-fm6q-97gw-c4wh.json
+++ b/advisories/github-reviewed/2022/02/GHSA-fm6q-97gw-c4wh/GHSA-fm6q-97gw-c4wh.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-fm6q-97gw-c4wh",
-  "modified": "2022-02-24T13:55:23Z",
+  "modified": "2022-12-01T10:06:21Z",
   "published": "2022-02-16T00:01:28Z",
   "aliases": [
     "CVE-2022-25186"
   ],
-  "summary": "Secret exposure in Jenkins HashiCorp Vault Plugin",
+  "summary": "Agent-to-controller security bypass in Jenkins HashiCorp Vault Plugin",
   "details": "Jenkins HashiCorp Vault Plugin 3.8.0 and earlier implements functionality that allows agent processes to retrieve any Vault secrets for use on the agent, allowing attackers able to control agent processes to obtain Vault secrets for an attacker-specified path and key.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
@@ -28,17 +28,24 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.8.0"
+              "fixed": "336.v182c0fbaaeb7"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.8.0"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25186"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/hashicorp-vault-plugin"
     },
     {
       "type": "WEB",
@@ -49,7 +56,7 @@
     "cwe_ids": [
       "CWE-693"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Source code location
- Summary

**Comments**
Update fixed version and CVSS evaluation according to https://www.jenkins.io/security/advisory/2022-02-15/#SECURITY-2429