### PR TITLE
[GHSA-23h5-8ph6-7rfc] Jenkins Fortify Plugin 20.2.34 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/02/GHSA-23h5-8ph6-7rfc/GHSA-23h5-8ph6-7rfc.json
+++ b/advisories/unreviewed/2022/02/GHSA-23h5-8ph6-7rfc/GHSA-23h5-8ph6-7rfc.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-23h5-8ph6-7rfc",
-  "modified": "2022-02-24T00:01:05Z",
+  "modified": "2022-12-01T10:09:23Z",
   "published": "2022-02-16T00:01:27Z",
   "aliases": [
     "CVE-2022-25188"
   ],
-  "details": "Jenkins Fortify Plugin 20.2.34 and earlier does not sanitize the appName and appVersion parameters of its Pipeline steps, allowing attackers with Item/Configure permission to write or overwrite .xml files on the Jenkins controller file system with content not controllable by the attacker.",
+  "summary": "Path traversal vulnerability in Jenkins Fortify Plugin",
+  "details": "Fortify Plugin 20.2.34 and earlier does not sanitize the `appName` and `appVersion` parameters of its Pipeline steps, which are used to write to files inside build directories.\n\nThis allows attackers with Item/Configure permission to write or overwrite `.xml` files on the Jenkins controller file system with content not controllable by the attacker.\n\nFortify Plugin 20.2.35 sanitizes the `appName` and `appVersion` parameters of its Pipeline steps when determining the resulting filename.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:fortify"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "20.2.35"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 20.2.34"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25188"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/fortify-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Update entries according to https://www.jenkins.io/security/advisory/2022-02-15/#SECURITY-2214