### PR TITLE
[GHSA-2phq-ghf8-6586] Jenkins Snow Commander Plugin prior to 2.0 vulnerable to Missing Authorization

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-2phq-ghf8-6586/GHSA-2phq-ghf8-6586.json
+++ b/advisories/github-reviewed/2022/02/GHSA-2phq-ghf8-6586/GHSA-2phq-ghf8-6586.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-2phq-ghf8-6586",
-  "modified": "2022-07-15T18:26:21Z",
+  "modified": "2022-12-01T10:18:05Z",
   "published": "2022-02-16T00:01:24Z",
   "aliases": [
     "CVE-2022-25193"
   ],
   "summary": "Jenkins Snow Commander Plugin prior to 2.0 vulnerable to Missing Authorization",
-  "details": "Missing permission checks in Jenkins Snow Commander Plugin prior to 2.0 allow attackers with Overall/Read permission to connect to an attacker-specified webserver using attacker-specified credentials IDs obtained through another method, capturing credentials stored in Jenkins.",
+  "details": "Snow Commander Plugin 1.10 and earlier does not perform permission checks in methods implementing form validation.\n\nThis allows attackers with Overall/Read permission to connect to an attacker-specified webserver using attacker-specified credentials IDs obtained through another method, capturing credentials stored in Jenkins.\n\nAdditionally, these form validation methods do not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -32,7 +32,10 @@
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.10"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description

**Comments**
Update versions affected according to https://www.jenkins.io/security/advisory/2022-02-15/#SECURITY-2536