### PR TITLE
[GHSA-g5wh-fw4m-2v28] CSRF vulnerability in Jenkins autonomiq plugin

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-g5wh-fw4m-2v28/GHSA-g5wh-fw4m-2v28.json
+++ b/advisories/github-reviewed/2022/02/GHSA-g5wh-fw4m-2v28/GHSA-g5wh-fw4m-2v28.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-g5wh-fw4m-2v28",
-  "modified": "2022-05-04T20:57:40Z",
+  "modified": "2022-12-01T10:19:11Z",
   "published": "2022-02-16T00:01:23Z",
   "aliases": [
     "CVE-2022-25194"
   ],
   "summary": "CSRF vulnerability in Jenkins autonomiq plugin",
-  "details": "A cross-site request forgery (CSRF) vulnerability in Jenkins autonomiq Plugin 1.15 and earlier allows attackers to connect to an attacker-specified URL server using attacker-specified credentials.",
+  "details": "autonomiq Plugin 1.15 and earlier does not perform a permission check in an HTTP endpoint.\n\nThis allows attackers with Overall/Read permission to connect to an attacker-specified URL using attacker-specified username and password.\n\nAdditionally, this HTTP endpoint does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
     }
   ],
   "affected": [
@@ -57,7 +57,7 @@
     "cwe_ids": [
       "CWE-352"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Severity

**Comments**
Update CVSS evaluation according to https://www.jenkins.io/security/advisory/2022-02-15/#SECURITY-2545