### PR TITLE
[GHSA-mvq8-hgxh-4v2g] Jenkins GitLab Authentication Plugin 1.13 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/02/GHSA-mvq8-hgxh-4v2g/GHSA-mvq8-hgxh-4v2g.json
+++ b/advisories/unreviewed/2022/02/GHSA-mvq8-hgxh-4v2g/GHSA-mvq8-hgxh-4v2g.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-mvq8-hgxh-4v2g",
-  "modified": "2022-02-24T00:01:04Z",
+  "modified": "2022-12-01T10:21:04Z",
   "published": "2022-02-16T00:01:22Z",
   "aliases": [
     "CVE-2022-25196"
   ],
-  "details": "Jenkins GitLab Authentication Plugin 1.13 and earlier records the HTTP Referer header as part of the URL query parameters when the authentication process starts, allowing attackers with access to Jenkins to craft a URL that will redirect users to an attacker-specified URL after logging in.",
+  "summary": "Open redirect vulnerability in Jenkins GitLab Authentication Plugin",
+  "details": "Jenkins GitLab Authentication Plugin 1.13 and earlier records the HTTP `Referer` header as part of the URL query parameters when the authentication process starts, allowing attackers with access to Jenkins to craft a URL that will redirect users to an attacker-specified URL after logging in.\n\nThis issue is caused by an incomplete fix of [SECURITY-796](https://www.jenkins.io/security/advisory/2019-08-07/#SECURITY-796).",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:gitlab-oauth"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.13"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25196"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/gitlab-oauth-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Update details according to https://www.jenkins.io/security/advisory/2022-02-15/#SECURITY-1833