### PR TITLE
[GHSA-2587-w93g-63m2] Jenkins HashiCorp Vault Plugin 336.v182c0fbaaeb7 and...

### DIFF
--- a/advisories/unreviewed/2022/02/GHSA-2587-w93g-63m2/GHSA-2587-w93g-63m2.json
+++ b/advisories/unreviewed/2022/02/GHSA-2587-w93g-63m2/GHSA-2587-w93g-63m2.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-2587-w93g-63m2",
-  "modified": "2022-02-24T00:01:03Z",
+  "modified": "2022-12-01T10:23:38Z",
   "published": "2022-02-16T00:01:21Z",
   "aliases": [
     "CVE-2022-25197"
   ],
-  "details": "Jenkins HashiCorp Vault Plugin 336.v182c0fbaaeb7 and earlier implements functionality that allows agent processes to read arbitrary files on the Jenkins controller file system.",
+  "summary": "Agent-to-controller security bypass in Jenkins HashiCorp Vault Plugin allows reading arbitrary files",
+  "details": "Jenkins HashiCorp Vault Plugin 336.v182c0fbaaeb7 and earlier implements functionality that allows agent processes to read arbitrary files on the Jenkins controller file system.\n\nThis allows attackers able to control agent processes to read arbitrary files on the Jenkins controller file system.\n\nThis vulnerability is only exploitable in Jenkins 2.318 and earlier, LTS 2.303.2 and earlier. See the [LTS upgrade guide](https://www.jenkins.io/doc/upgrade-guide/2.303/#upgrading-to-jenkins-lts-2-303-3).",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.datapipe.jenkins.plugins:hashicorp-vault-plugin"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "351.vdb_f83a_1c6a_9d"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 336.v182c0fbaaeb7"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25197"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/hashicorp-vault-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Update details according to https://www.jenkins.io/security/advisory/2022-02-15/#SECURITY-2521

This has been fixed in https://github.com/jenkinsci/hashicorp-vault-plugin/releases/tag/351.vdb_f83a_1c6a_9d, SECURITY-2521