### PR TITLE
[GHSA-wwf6-x2rv-vxqh] Missing permission checks in Jenkins Checkmarx Plugin...

### DIFF
--- a/advisories/unreviewed/2022/02/GHSA-wwf6-x2rv-vxqh/GHSA-wwf6-x2rv-vxqh.json
+++ b/advisories/unreviewed/2022/02/GHSA-wwf6-x2rv-vxqh/GHSA-wwf6-x2rv-vxqh.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-wwf6-x2rv-vxqh",
-  "modified": "2022-02-24T00:01:03Z",
+  "modified": "2022-12-01T10:31:57Z",
   "published": "2022-02-16T00:01:19Z",
   "aliases": [
     "CVE-2022-25201"
   ],
-  "details": "Missing permission checks in Jenkins Checkmarx Plugin 2022.1.2 and earlier allow attackers with Overall/Read permission to connect to an attacker-specified webserver using attacker-specified credentials IDs obtained through another method, capturing credentials stored in Jenkins.",
+  "summary": "Missing permission checks in Jenkins Checkmarx Plugin allow capturing credentials",
+  "details": "Checkmarx Plugin 2022.1.2 and earlier does not perform permission checks in several HTTP endpoints.\n\nThis allows attackers with Overall/Read permission to connect to an attacker-specified webserver using attacker-specified credentials IDs obtained through another method, capturing credentials stored in Jenkins.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.checkmarx.jenkins:checkmarx"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2022.1.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2022.1.2"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25201"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/checkmarx-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-02-15/#SECURITY-1017

This has been fixed in https://github.com/jenkinsci/checkmarx-plugin/releases/tag/Release_2022.1.3