### PR TITLE
[GHSA-64q9-f38h-9mwx] Protection Mechanism Failure in Jenkins Doktor Plugin

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-64q9-f38h-9mwx/GHSA-64q9-f38h-9mwx.json
+++ b/advisories/github-reviewed/2022/02/GHSA-64q9-f38h-9mwx/GHSA-64q9-f38h-9mwx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-64q9-f38h-9mwx",
-  "modified": "2022-02-24T17:31:28Z",
+  "modified": "2022-12-01T10:37:22Z",
   "published": "2022-02-16T00:01:18Z",
   "aliases": [
     "CVE-2022-25204"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
@@ -42,7 +42,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/madhead/doktor"
+      "url": "https://github.com/jenkinsci/doktor-plugin"
     },
     {
       "type": "WEB",
@@ -53,7 +53,7 @@
     "cwe_ids": [
       "CWE-693"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Source code location

**Comments**
Update CVSS evaluation according to https://www.jenkins.io/security/advisory/2022-02-15/#SECURITY-2548

Also fixed the source code URL.