### PR TITLE
[GHSA-mvg9-xffr-p774] Out of bounds read in Pillow

### DIFF
--- a/advisories/github-reviewed/2021/03/GHSA-mvg9-xffr-p774/GHSA-mvg9-xffr-p774.json
+++ b/advisories/github-reviewed/2021/03/GHSA-mvg9-xffr-p774/GHSA-mvg9-xffr-p774.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-mvg9-xffr-p774",
-  "modified": "2021-12-02T15:31:14Z",
+  "modified": "2022-12-01T16:30:58Z",
   "published": "2021-03-29T16:35:57Z",
   "aliases": [
     "CVE-2021-25291"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "8.1.1"
+              "fixed": "8.2.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The patch version occurred in version 8.2.0, not 8.1.1. The vulnerability was first discovered in 8.1.1. https://security.gentoo.org/glsa/202107-33 has the correct affected package range. 

Additionally, we can see that the vulnerability fixing commit (cbdce6c5d054fccaf4af34b47f212355c64ace7a) didn't appear until tag 8.2.0:

~/Pillow$ git tag --contains cbdce6c5d054fccaf4af34b47f212355c64ace7a
8.2.0
8.3.0
8.3.1
8.3.2
8.4.0
9.0.0
9.0.1
9.1.0
9.1.1
9.2.0
9.3.0