### PR TITLE
[GHSA-wcg3-cvx6-7396] Segmentation fault in time

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-wcg3-cvx6-7396/GHSA-wcg3-cvx6-7396.json
+++ b/advisories/github-reviewed/2021/08/GHSA-wcg3-cvx6-7396/GHSA-wcg3-cvx6-7396.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-wcg3-cvx6-7396",
-  "modified": "2022-09-08T14:21:31Z",
+  "modified": "2022-12-01T22:54:34Z",
   "published": "2021-08-25T20:56:46Z",
   "aliases": [
     "CVE-2020-26235"
@@ -33,6 +33,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "crates.io",
+        "name": "time"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 0.2"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
All versions of `0.1.x` are listed as vulnerable in the advisory description.