### PR TITLE
[GHSA-7h2j-h5xp-h3gh] Missing Authorization in Jenkins SSH plugin

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-7h2j-h5xp-h3gh/GHSA-7h2j-h5xp-h3gh.json
+++ b/advisories/github-reviewed/2022/05/GHSA-7h2j-h5xp-h3gh/GHSA-7h2j-h5xp-h3gh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-7h2j-h5xp-h3gh",
-  "modified": "2022-06-01T20:54:49Z",
+  "modified": "2022-12-02T08:38:47Z",
   "published": "2022-05-18T00:00:40Z",
   "aliases": [
     "CVE-2022-30959"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
     }
   ],
   "affected": [
@@ -26,13 +26,13 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "2.6.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.6.1"
+      }
     }
   ],
   "references": [
@@ -53,7 +53,7 @@
     "cwe_ids": [
       "CWE-862"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
Update CVSS scoring to https://www.jenkins.io/security/advisory/2022-05-17/#SECURITY-2093 and remove fixed version.

This vulnerability is not addressed yet.