### PR TITLE
[GHSA-w37g-rhq8-7m4j] Snakeyaml vulnerable to Stack overflow leading to denial of service

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-w37g-rhq8-7m4j/GHSA-w37g-rhq8-7m4j.json
+++ b/advisories/github-reviewed/2022/11/GHSA-w37g-rhq8-7m4j/GHSA-w37g-rhq8-7m4j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-w37g-rhq8-7m4j",
-  "modified": "2022-11-28T22:17:31Z",
+  "modified": "2022-12-02T13:06:03Z",
   "published": "2022-11-11T19:00:31Z",
   "aliases": [
     "CVE-2022-41854"
@@ -26,13 +26,13 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "1.33"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.32"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
CVE-2022-41854 affects SnakeYAML up to v1.32 (excluding).

Github advisory report shows the vulnerability affecting versions 1.32 and 1.33 of this library.

I suggest the Github advisory report be updated to set the "Affected versions" field to `< 1.32`