### PR TITLE
[GHSA-22wj-vf5f-wrvj] Password exposure in H2 Database 

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-22wj-vf5f-wrvj/GHSA-22wj-vf5f-wrvj.json
+++ b/advisories/github-reviewed/2022/11/GHSA-22wj-vf5f-wrvj/GHSA-22wj-vf5f-wrvj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-22wj-vf5f-wrvj",
-  "modified": "2022-11-30T23:34:15Z",
+  "modified": "2022-12-02T16:01:52Z",
   "published": "2022-11-23T21:30:31Z",
   "aliases": [
     "CVE-2022-45868"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "com.h2database:h2"
+        "name": ""
       },
       "ranges": [
         {
@@ -26,9 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "2.1.214"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Removing the affected product so dependabot doesn't flag it - given that it doesn't seem like it should be a CVE - see https://github.com/h2database/h2database/issues/3686#issuecomment-1333917904