### PR TITLE
[GHSA-xpvp-h73c-m9rq] Jenkins 2.367 through 2.369 (both inclusive) does not...

### DIFF
--- a/advisories/unreviewed/2022/09/GHSA-xpvp-h73c-m9rq/GHSA-xpvp-h73c-m9rq.json
+++ b/advisories/unreviewed/2022/09/GHSA-xpvp-h73c-m9rq/GHSA-xpvp-h73c-m9rq.json
@@ -1,25 +1,70 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-xpvp-h73c-m9rq",
-  "modified": "2022-09-23T00:00:41Z",
+  "modified": "2022-12-03T08:45:55Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41224"
   ],
-  "details": "Jenkins 2.367 through 2.369 (both inclusive) does not escape tooltips of the l:helpIcon UI component used for some help icons on the Jenkins web UI, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to control tooltips for this component.",
+  "summary": "Jenkins XSS vulnerability",
+  "details": "Jenkins 2.367 through 2.369 (both inclusive) does not escape tooltips of the `l:helpIcon` UI component used for some help icons on the Jenkins web UI, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to control tooltips for this component.\n\nAs of publication, the Jenkins security team is unaware of any exploitable help icon/tooltip in Jenkins core or plugins published by the Jenkins project. The vast majority of help icons use the `l:help` component instead of `l:helpIcon`. The few known instances of `l:helpIcon` do not have user-controllable tooltip contents.\n\nJenkins 2.370 escapes tooltips of the `l:helpIcon` UI component.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.367"
+            },
+            {
+              "fixed": "2.370"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.370"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.369"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41224"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",
@@ -30,7 +75,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in details according to https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-2886

I've had to use two clauses for affected versions, because `>= 2.367, <=2.369` is not accepted.
Is there a specific syntax I need to use to define a small range of versions?