### PR TITLE
[GHSA-g43x-pcc9-f472] Jenkins Compuware Common Configuration Plugin vulnerable to Improper Restriction of XML External Entity Reference

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-g43x-pcc9-f472/GHSA-g43x-pcc9-f472.json
+++ b/advisories/github-reviewed/2022/09/GHSA-g43x-pcc9-f472/GHSA-g43x-pcc9-f472.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-g43x-pcc9-f472",
-  "modified": "2022-09-23T13:29:17Z",
+  "modified": "2022-12-03T08:48:17Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41226"
   ],
   "summary": "Jenkins Compuware Common Configuration Plugin vulnerable to Improper Restriction of XML External Entity Reference",
-  "details": "Jenkins Compuware Common Configuration Plugin 1.0.14 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks. Version 1.0.15 contains a patch.",
+  "details": "Jenkins Compuware Common Configuration Plugin 1.0.14 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers able to change the contents of the Topaz Workbench CLI home directory on agents to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
     }
   ],
   "affected": [
@@ -68,7 +68,7 @@
     "cwe_ids": [
       "CWE-611"
     ],
-    "severity": "CRITICAL",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Severity

**Comments**
Adjust CVSS scoring according to https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-2832