### PR TITLE
[GHSA-jjch-7g85-4m72] Jenkins NS-ND Integration Performance Publisher Plugin vulnerable to Cross-Site Request Forgery

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-jjch-7g85-4m72/GHSA-jjch-7g85-4m72.json
+++ b/advisories/github-reviewed/2022/09/GHSA-jjch-7g85-4m72/GHSA-jjch-7g85-4m72.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-jjch-7g85-4m72",
-  "modified": "2022-09-23T13:44:21Z",
+  "modified": "2022-12-03T08:49:13Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41227"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
     }
   ],
   "affected": [
@@ -56,7 +56,7 @@
     "cwe_ids": [
       "CWE-352"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
Correct CVSS scoring according to https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-2737