### PR TITLE
[GHSA-j2mj-g8jp-gjfm] Jenkins NS-ND Integration Performance Publisher Plugin vulnerable to Missing Authorization

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-j2mj-g8jp-gjfm/GHSA-j2mj-g8jp-gjfm.json
+++ b/advisories/github-reviewed/2022/09/GHSA-j2mj-g8jp-gjfm/GHSA-j2mj-g8jp-gjfm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-j2mj-g8jp-gjfm",
-  "modified": "2022-09-23T13:43:08Z",
+  "modified": "2022-12-03T08:50:03Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41228"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
     }
   ],
   "affected": [
@@ -56,7 +56,7 @@
     "cwe_ids": [
       "CWE-862"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
Correct CVSS scoring according to https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-2737