### PR TITLE
[GHSA-fq2h-r2h9-pj8r] Jenkins NS-ND Integration Performance Publisher Plugin vulnerable to Cross-site Scripting

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-fq2h-r2h9-pj8r/GHSA-fq2h-r2h9-pj8r.json
+++ b/advisories/github-reviewed/2022/09/GHSA-fq2h-r2h9-pj8r/GHSA-fq2h-r2h9-pj8r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-fq2h-r2h9-pj8r",
-  "modified": "2022-09-23T13:40:49Z",
+  "modified": "2022-12-03T08:53:22Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41229"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "4.8.0.134"
+              "fixed": "4.8.0.147"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.8.0.134"
+      }
     }
   ],
   "references": [
@@ -53,7 +56,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
Fill in details according to https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-2858

The vulnerability has been fixed in https://github.com/jenkinsci/cavisson-ns-nd-integration-plugin/commit/d77c6c7a279da002178f8244f37093773dd6aee5