### PR TITLE
[GHSA-3jp6-q9cg-rvgj] Jenkins Build-Publisher Plugin 1.22 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/09/GHSA-3jp6-q9cg-rvgj/GHSA-3jp6-q9cg-rvgj.json
+++ b/advisories/unreviewed/2022/09/GHSA-3jp6-q9cg-rvgj/GHSA-3jp6-q9cg-rvgj.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-3jp6-q9cg-rvgj",
-  "modified": "2022-09-23T00:00:41Z",
+  "modified": "2022-12-03T08:55:04Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41230"
   ],
-  "details": "Jenkins Build-Publisher Plugin 1.22 and earlier does not perform a permission check in an HTTP endpoint, allowing attackers with Overall/Read permission to obtain names and URLs of Jenkins servers that the plugin is configured to publish builds to, as well as builds pending for publication to those Jenkins servers.",
+  "summary": "Missing permission check in Jenkins build-publisher Plugin",
+  "details": "build-publisher Plugin 1.22 and earlier does not perform a permission check in an HTTP endpoint.\n\nThis allows attackers with Overall/Read permission to obtain names and URLs of Jenkins servers that the plugin is configured to publish builds to, as well as builds pending for publication to those Jenkins servers.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:build-publisher"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.22"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Summary

**Comments**
Fill in versions affected according to https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-1994