### PR TITLE
[GHSA-jrqh-c9v8-ccx9] Jenkins Build-Publisher Plugin 1.22 and earlier allows...

### DIFF
--- a/advisories/unreviewed/2022/09/GHSA-jrqh-c9v8-ccx9/GHSA-jrqh-c9v8-ccx9.json
+++ b/advisories/unreviewed/2022/09/GHSA-jrqh-c9v8-ccx9/GHSA-jrqh-c9v8-ccx9.json
@@ -1,20 +1,39 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-jrqh-c9v8-ccx9",
-  "modified": "2022-09-23T00:00:41Z",
+  "modified": "2022-12-03T08:56:15Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41231"
   ],
-  "details": "Jenkins Build-Publisher Plugin 1.22 and earlier allows attackers with Item/Configure permission to create or replace any config.xml file on the Jenkins controller file system by providing a crafted file name to an API endpoint.",
+  "summary": "Path traversal in Jenkins build-publisher Plugin",
+  "details": "Jenkins build-publisher Plugin 1.22 and earlier allows attackers with Item/Configure permission to create or replace any config.xml file on the Jenkins controller file system by providing a crafted file name to an API endpoint.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:build-publisher"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.22"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -30,7 +49,7 @@
     "cwe_ids": [
       "CWE-22"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Summary

**Comments**
Fill in details according to https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-2139