### PR TITLE
[GHSA-4jfq-4fqc-5j9c] Jenkins Rundeck Plugin Missing Authorization vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-4jfq-4fqc-5j9c/GHSA-4jfq-4fqc-5j9c.json
+++ b/advisories/github-reviewed/2022/09/GHSA-4jfq-4fqc-5j9c/GHSA-4jfq-4fqc-5j9c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4jfq-4fqc-5j9c",
-  "modified": "2022-09-23T13:39:39Z",
+  "modified": "2022-12-03T09:00:42Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41233"
@@ -28,17 +28,24 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.6.11"
+              "fixed": "3.6.12"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.6.11"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41233"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/rundeck-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
Fill in fixed version, this has been mitigated in 3.6.12, specifically https://github.com/jenkinsci/rundeck-plugin/commit/032b3bb9eafee5f83e3ddeb023eb34d0eeae19b7