### PR TITLE
[GHSA-qgv4-7jhx-c72q] Jenkins Rundeck Plugin Missing Authorization vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-qgv4-7jhx-c72q/GHSA-qgv4-7jhx-c72q.json
+++ b/advisories/github-reviewed/2022/09/GHSA-qgv4-7jhx-c72q/GHSA-qgv4-7jhx-c72q.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-qgv4-7jhx-c72q",
-  "modified": "2022-09-23T13:38:06Z",
+  "modified": "2022-12-03T09:04:13Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41234"
   ],
-  "summary": "Jenkins Rundeck Plugin Missing Authorization vulnerability",
-  "details": "Jenkins Rundeck Plugin 3.6.11 and earlier does not protect access to the /plugin/rundeck/webhook/ endpoint, allowing users with Overall/Read permission to trigger jobs that are configured to be triggerable via Rundeck.",
+  "summary": "Missing webhook endpoint authorization in Jenkins Rundeck Plugin",
+  "details": "Jenkins Rundeck Plugin 3.6.11 and earlier does not protect access to the `/plugin/rundeck/webhook/` endpoint, allowing users with Overall/Read permission to trigger jobs that are configured to be triggerable via Rundeck.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -28,17 +28,24 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.6.11"
+              "fixed": "3.6.12"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.6.11"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41234"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/rundeck-plugin"
     },
     {
       "type": "WEB",
@@ -49,7 +56,7 @@
     "cwe_ids": [
       "CWE-862"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
This has been fixed in https://github.com/jenkinsci/rundeck-plugin/commit/ab63fbeba11dac081078cd9acbf40d03b4f6f2a4, shipped in 3.6.12