### PR TITLE
[GHSA-f7fq-wp2x-jc25] Jenkins WildFly Deployer Plugin vulnerable to path traversal

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-f7fq-wp2x-jc25/GHSA-f7fq-wp2x-jc25.json
+++ b/advisories/github-reviewed/2022/09/GHSA-f7fq-wp2x-jc25/GHSA-f7fq-wp2x-jc25.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-f7fq-wp2x-jc25",
-  "modified": "2022-11-30T03:22:28Z",
+  "modified": "2022-12-03T09:05:18Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41235"
   ],
   "summary": "Jenkins WildFly Deployer Plugin vulnerable to path traversal",
-  "details": "Jenkins WildFly Deployer Plugin 1.0.2 and earlier implements functionality that allows agent processes to read arbitrary files on the Jenkins controller file system.",
+  "details": "Jenkins WildFly Deployer Plugin 1.0.2 and earlier implements functionality that allows agent processes to read arbitrary files on the Jenkins controller file system.\n\nThis vulnerability is only exploitable in Jenkins 2.318 and earlier, LTS 2.303.2 and earlier. See the [LTS upgrade guide](https://www.jenkins.io/doc/upgrade-guide/2.303/#upgrading-to-jenkins-lts-2-303-3).",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description

**Comments**
Fill in details according to https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-2645