### PR TITLE
[GHSA-x3jj-rgw9-7r5g] Jenkins DotCi Plugin 2.40.00 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/09/GHSA-x3jj-rgw9-7r5g/GHSA-x3jj-rgw9-7r5g.json
+++ b/advisories/unreviewed/2022/09/GHSA-x3jj-rgw9-7r5g/GHSA-x3jj-rgw9-7r5g.json
@@ -1,25 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-x3jj-rgw9-7r5g",
-  "modified": "2022-09-23T00:00:40Z",
+  "modified": "2022-12-03T09:08:56Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41237"
   ],
-  "details": "Jenkins DotCi Plugin 2.40.00 and earlier does not configure its YAML parser to prevent the instantiation of arbitrary types, resulting in a remote code execution vulnerability.",
+  "summary": "RCE vulnerability in Jenkins DotCi Plugin",
+  "details": "DotCi Plugin 2.40.00 and earlier does not configure its YAML parser to prevent the instantiation of arbitrary types.\n\nThis results in a remote code execution (RCE) vulnerability exploitable by attackers able to modify `.ci.yml` files in SCM.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.groupon.jenkins-ci.plugins:DotCi"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.40.00"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41237"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/DotCi"
     },
     {
       "type": "WEB",
@@ -30,7 +53,7 @@
     "cwe_ids": [
       "CWE-502"
     ],
-    "severity": "CRITICAL",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in details accordin to https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-1737