### PR TITLE
[GHSA-q9g4-9fx4-v533] Jenkins DotCi Plugin 2.40.00 and earlier does not escape...

### DIFF
--- a/advisories/unreviewed/2022/09/GHSA-q9g4-9fx4-v533/GHSA-q9g4-9fx4-v533.json
+++ b/advisories/unreviewed/2022/09/GHSA-q9g4-9fx4-v533/GHSA-q9g4-9fx4-v533.json
@@ -1,25 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-q9g4-9fx4-v533",
-  "modified": "2022-09-23T00:00:40Z",
+  "modified": "2022-12-03T09:11:35Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41239"
   ],
-  "details": "Jenkins DotCi Plugin 2.40.00 and earlier does not escape the GitHub user name parameter provided to commit notifications when displaying them in a build cause, resulting in a stored cross-site scripting (XSS) vulnerability.",
+  "summary": "Stored XSS vulnerability in Jenkins DotCi Plugin",
+  "details": "DotCi Plugin 2.40.00 and earlier does not escape the GitHub user name parameter provided to commit notifications when displaying them in a build cause.\n\nThis results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to submit crafted commit notifications to the `/githook/` endpoint (see also [SECURITY-2867](https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-2867)).\n\nThis vulnerability is only exploitable in Jenkins 2.314 and earlier, LTS 2.303.1 and earlier. See the [LTS upgrade guide](https://www.jenkins.io/doc/upgrade-guide/2.303/#SECURITY-2452).",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.groupon.jenkins-ci.plugins:DotCi"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.40.00"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41239"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/DotCi"
     },
     {
       "type": "WEB",
@@ -30,7 +53,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-2884