### PR TITLE
[GHSA-7qpm-vmwv-hq7h] Jenkins Walti Plugin 1.0.1 and earlier does not escape...

### DIFF
--- a/advisories/unreviewed/2022/09/GHSA-7qpm-vmwv-hq7h/GHSA-7qpm-vmwv-hq7h.json
+++ b/advisories/unreviewed/2022/09/GHSA-7qpm-vmwv-hq7h/GHSA-7qpm-vmwv-hq7h.json
@@ -1,25 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-7qpm-vmwv-hq7h",
-  "modified": "2022-09-23T00:00:40Z",
+  "modified": "2022-12-03T09:12:52Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41240"
   ],
+  "summary": "Stored XSS vulnerability in Jenkins Walti Plugin",
   "details": "Jenkins Walti Plugin 1.0.1 and earlier does not escape the information provided by the Walti API, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to provide malicious API responses from Walti.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:walti"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.0.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41240"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/walti-plugin"
     },
     {
       "type": "WEB",
@@ -30,7 +53,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Source code location
- Summary

**Comments**
Fill in details according to https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-1870