### PR TITLE
[GHSA-j8xr-2279-88qj] Jenkins RQM Plugin vulnerable to Improper Restriction of XML External Entity Reference

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-j8xr-2279-88qj/GHSA-j8xr-2279-88qj.json
+++ b/advisories/github-reviewed/2022/09/GHSA-j8xr-2279-88qj/GHSA-j8xr-2279-88qj.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-j8xr-2279-88qj",
-  "modified": "2022-09-23T13:36:52Z",
+  "modified": "2022-12-03T09:13:50Z",
   "published": "2022-09-22T00:00:28Z",
   "aliases": [
     "CVE-2022-41241"
   ],
   "summary": "Jenkins RQM Plugin vulnerable to Improper Restriction of XML External Entity Reference",
-  "details": "Jenkins RQM Plugin 2.8 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "details": "RQM Plugin 2.8 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers able to provide crafted API responses from Rational Quality Manager to have Jenkins parse a crafted XML document that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N"
     }
   ],
   "affected": [
@@ -41,6 +41,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41241"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/rqm-plugin"
+    },
+    {
       "type": "WEB",
       "url": "https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-2805"
     }
@@ -49,7 +53,7 @@
     "cwe_ids": [
       "CWE-611"
     ],
-    "severity": "CRITICAL",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location

**Comments**
Fix CVSS scoring according to https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-2805