### PR TITLE
[GHSA-pxp5-g66h-wpv2] Jenkins View26 Test-Reporting Plugin improperly validates hostname

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-pxp5-g66h-wpv2/GHSA-pxp5-g66h-wpv2.json
+++ b/advisories/github-reviewed/2022/09/GHSA-pxp5-g66h-wpv2/GHSA-pxp5-g66h-wpv2.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-pxp5-g66h-wpv2",
-  "modified": "2022-09-23T13:30:36Z",
+  "modified": "2022-12-03T09:15:59Z",
   "published": "2022-09-22T00:00:29Z",
   "aliases": [
     "CVE-2022-41244"
   ],
-  "summary": "Jenkins View26 Test-Reporting Plugin improperly validates hostname",
+  "summary": "Missing hostname validation in Jenkins View26 Test-Reporting Plugin",
   "details": "Jenkins View26 Test-Reporting Plugin 1.0.7 and earlier does not perform hostname validation when connecting to the configured View26 server that could be abused using a man-in-the-middle attack to intercept these connections.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -53,7 +53,7 @@
     "cwe_ids": [
       "CWE-297"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Summary

**Comments**
Fix CVSS scoring according to https://www.jenkins.io/security/advisory/2022-09-21/#SECURITY-2069