### PR TITLE
[GHSA-hgp8-w8fj-r4cm] ToolJet is vulnerable to Denial of Service (DoS)

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-hgp8-w8fj-r4cm/GHSA-hgp8-w8fj-r4cm.json
+++ b/advisories/github-reviewed/2022/11/GHSA-hgp8-w8fj-r4cm/GHSA-hgp8-w8fj-r4cm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-hgp8-w8fj-r4cm",
-  "modified": "2022-12-02T22:38:23Z",
+  "modified": "2022-12-05T01:19:34Z",
   "published": "2022-11-22T03:30:56Z",
   "aliases": [
     "CVE-2022-4111"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "npm",
-        "name": "tooljet"
+        "name": ""
       },
       "ranges": [
         {
@@ -26,9 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "1.27.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
There is no package just named `tooljet` on npmjs.com.