### PR TITLE
[GHSA-62wf-24c4-8r76] In Jenkins 2.320 through 2.355 (both inclusive) and LTS 2...

### DIFF
--- a/advisories/unreviewed/2022/06/GHSA-62wf-24c4-8r76/GHSA-62wf-24c4-8r76.json
+++ b/advisories/unreviewed/2022/06/GHSA-62wf-24c4-8r76/GHSA-62wf-24c4-8r76.json
@@ -1,25 +1,67 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-62wf-24c4-8r76",
-  "modified": "2022-06-30T00:00:37Z",
+  "modified": "2022-12-05T12:20:19Z",
   "published": "2022-06-24T00:00:31Z",
   "aliases": [
     "CVE-2022-34170"
   ],
-  "details": "In Jenkins 2.320 through 2.355 (both inclusive) and LTS 2.332.1 through LTS 2.332.3 (both inclusive) the help icon does not escape the feature name that is part of its tooltip, effectively undoing the fix for SECURITY-1955, resulting in a cross-site scripting (XSS) vulnerability exploitable by attackers with Job/Configure permission.",
+  "summary": "XSS vulnerability in Jenkins",
+  "details": "Since Jenkins 2.320 and LTS 2.332.1, help icon tooltips no longer escape the feature name, effectively undoing the fix for [SECURITY-1955](https://www.jenkins.io/security/advisory/2020-08-12/#SECURITY-1955).\n\nThis vulnerability is known to be exploitable by attackers with Job/Configure permission.\n\nJenkins 2.356, LTS 2.332.4 and LTS 2.346.1 addresses this vulnerability, the feature name in help icon tooltips is now escaped.\n\n",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.320"
+            },
+            {
+              "fixed": "2.356"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.332.1"
+            },
+            {
+              "fixed": "2.332.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-34170"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",
@@ -31,7 +73,7 @@
       "CWE-22",
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in details according to https://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2781

Hopefully, I selected the versions correctly. To clarify, versions 2.320 to 2.355 are affected. But also the LTS releases 2.332.1, 2.332.2 and 2.332.3 are impacted.
The vulnerability has been fixed in LTS 2.332.4, 2.346.1 and in the weekly 2.356