### PR TITLE
[GHSA-7f84-p6r5-jr6q] In Jenkins 2.321 through 2.355 (both inclusive) and LTS 2...

### DIFF
--- a/advisories/unreviewed/2022/06/GHSA-7f84-p6r5-jr6q/GHSA-7f84-p6r5-jr6q.json
+++ b/advisories/unreviewed/2022/06/GHSA-7f84-p6r5-jr6q/GHSA-7f84-p6r5-jr6q.json
@@ -1,25 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-7f84-p6r5-jr6q",
-  "modified": "2022-06-30T00:00:37Z",
+  "modified": "2022-12-05T12:32:28Z",
   "published": "2022-06-24T00:00:31Z",
   "aliases": [
     "CVE-2022-34171"
   ],
-  "details": "In Jenkins 2.321 through 2.355 (both inclusive) and LTS 2.332.1 through LTS 2.332.3 (both inclusive) the HTML output generated for new symbol-based SVG icons includes the 'title' attribute of 'l:ionicon' (until Jenkins 2.334) and 'alt' attribute of 'l:icon' (since Jenkins 2.335) without further escaping, resulting in a cross-site scripting (XSS) vulnerability.",
+  "summary": "XSS vulnerability in Jenkins",
+  "details": "Since Jenkins 2.321 and LTS 2.332.1, the HTML output generated for new symbol-based SVG icons includes the `title` attribute of `l:ionicon` until Jenkins 2.334 and `alt` attribute of `l:icon` since Jenkins 2.335 without further escaping.\n\nThis vulnerability is known to be exploitable by attackers with Job/Configure permission.\n\nJenkins 2.356, LTS 2.332.4 and LTS 2.346.1 addresses this vulnerability, the `title` attribute of `l:ionicon` (Jenkins LTS 2.332.4) and `alt` attribute of `l:icon` (Jenkins 2.356 and LTS 2.346.1) are escaped in the generated HTML output.\n\n",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.321"
+            },
+            {
+              "fixed": "2.356"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-34171"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",
@@ -31,7 +54,7 @@
       "CWE-22",
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in details according to https://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2781

Hopefully, I selected the versions correctly. To clarify, versions 2.321 to 2.355 are affected. But also the LTS releases 2.332.1, 2.332.2 and 2.332.3 are impacted.
The vulnerability has been fixed in LTS 2.332.4, 2.346.1 and in the weekly 2.356