### PR TITLE
[GHSA-mhp7-3393-pfqr] In Jenkins 2.340 through 2.355 (both inclusive) symbol...

### DIFF
--- a/advisories/unreviewed/2022/06/GHSA-mhp7-3393-pfqr/GHSA-mhp7-3393-pfqr.json
+++ b/advisories/unreviewed/2022/06/GHSA-mhp7-3393-pfqr/GHSA-mhp7-3393-pfqr.json
@@ -1,25 +1,73 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-mhp7-3393-pfqr",
-  "modified": "2022-06-30T00:00:37Z",
+  "modified": "2022-12-05T12:35:44Z",
   "published": "2022-06-24T00:00:31Z",
   "aliases": [
     "CVE-2022-34172"
   ],
-  "details": "In Jenkins 2.340 through 2.355 (both inclusive) symbol-based icons unescape previously escaped values of 'tooltip' parameters, resulting in a cross-site scripting (XSS) vulnerability.",
+  "summary": "XSS vulnerability in Jenkins",
+  "details": "Since Jenkins 2.340, symbol-based icons unescape previously escaped values of `tooltip` parameters.\n\nThis vulnerability is known to be exploitable by attackers with Job/Configure permission.\n\nJenkins 2.356, LTS 2.332.4 and LTS 2.346.1 addresses this vulnerability. Symbol-based icons no longer unescape values of `tooltip` parameters.\n\n",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.356"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.340"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.332.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.332.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-34172"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",
@@ -31,7 +79,7 @@
       "CWE-22",
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in details according to https://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2781

Hopefully, I selected the versions correctly. To clarify, versions 2.340 to 2.355 are affected. But also the LTS releases 2.332.1, 2.332.2 and 2.332.3 are impacted.
The vulnerability has been fixed in LTS 2.332.4, 2.346.1 and in the weekly 2.356