### PR TITLE
[GHSA-6g4r-q7qg-6qx6] In Jenkins 2.340 through 2.355 (both inclusive) the...

### DIFF
--- a/advisories/unreviewed/2022/06/GHSA-6g4r-q7qg-6qx6/GHSA-6g4r-q7qg-6qx6.json
+++ b/advisories/unreviewed/2022/06/GHSA-6g4r-q7qg-6qx6/GHSA-6g4r-q7qg-6qx6.json
@@ -1,25 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-6g4r-q7qg-6qx6",
-  "modified": "2022-06-30T00:00:37Z",
+  "modified": "2022-12-05T12:38:00Z",
   "published": "2022-06-24T00:00:31Z",
   "aliases": [
     "CVE-2022-34173"
   ],
-  "details": "In Jenkins 2.340 through 2.355 (both inclusive) the tooltip of the build button in list views supports HTML without escaping the job display name, resulting in a cross-site scripting (XSS) vulnerability exploitable by attackers with Job/Configure permission.",
+  "summary": "XSS vulnerability in Jenkins",
+  "details": "Since Jenkins 2.340, the tooltip of the build button in list views supports HTML without escaping the job display name.\n\nThis vulnerability is known to be exploitable by attackers with Job/Configure permission.\n\nJenkins 2.356 addresses this vulnerability. The tooltip of the build button in list views is now escaped.\n\nNo Jenkins LTS release is affected by SECURITY-2776 or SECURITY-2780, as these were not present in Jenkins 2.332.x and fixed in the 2.346.x line before 2.346.1.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.356"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.340"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-34173"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",
@@ -31,7 +57,7 @@
       "CWE-22",
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in details according to https://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2781

Hopefully, I selected the versions correctly. To clarify, versions 2.340 to 2.355 are affected, but no LTS releases.