### PR TITLE
[GHSA-9grj-j43m-mjqr] In Jenkins 2.355 and earlier, LTS 2.332.3 and earlier, an...

### DIFF
--- a/advisories/unreviewed/2022/06/GHSA-9grj-j43m-mjqr/GHSA-9grj-j43m-mjqr.json
+++ b/advisories/unreviewed/2022/06/GHSA-9grj-j43m-mjqr/GHSA-9grj-j43m-mjqr.json
@@ -1,25 +1,73 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9grj-j43m-mjqr",
-  "modified": "2022-06-30T00:00:37Z",
+  "modified": "2022-12-05T12:41:18Z",
   "published": "2022-06-24T00:00:31Z",
   "aliases": [
     "CVE-2022-34174"
   ],
-  "details": "In Jenkins 2.355 and earlier, LTS 2.332.3 and earlier, an observable timing discrepancy on the login form allows distinguishing between login attempts with an invalid username, and login attempts with a valid username and wrong password, when using the Jenkins user database security realm.",
+  "summary": "Observable timing discrepancy allows determining username validity in Jenkins",
+  "details": "In Jenkins 2.355 and earlier, LTS 2.332.3 and earlier, an observable timing discrepancy on the login form allows distinguishing between login attempts with an invalid username, and login attempts with a valid username and wrong password, when using the Jenkins user database security realm. This allows attackers to determine the validity of attacker-specified usernames.\n\nLogin attempts with an invalid username now validate a synthetic password to eliminate the timing discrepancy in Jenkins 2.356, LTS 2.332.4.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.356"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.355"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.332.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.332.3"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-34174"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",
@@ -31,7 +79,7 @@
       "CWE-203",
       "CWE-208"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in details according to https://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2566

To clarify, 2.355 and earlier are affected, 2.332.3, 2.332.2 and 2.332.1 are affected.
This has been fixed in 2.356 and 2.332.4