### PR TITLE
[GHSA-pv38-mqpp-v72h] Cross-site Scripting in Jenkins NS-ND Integration Performance Publisher Plugin

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-pv38-mqpp-v72h/GHSA-pv38-mqpp-v72h.json
+++ b/advisories/github-reviewed/2022/06/GHSA-pv38-mqpp-v72h/GHSA-pv38-mqpp-v72h.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-pv38-mqpp-v72h",
-  "modified": "2022-07-05T22:56:11Z",
+  "modified": "2022-12-05T13:05:32Z",
   "published": "2022-06-24T00:00:31Z",
   "aliases": [
     "CVE-2022-34191"
   ],
   "summary": "Cross-site Scripting in Jenkins NS-ND Integration Performance Publisher Plugin",
-  "details": "Jenkins NS-ND Integration Performance Publisher Plugin 4.8.0.77 and earlier does not escape the name of NetStorm Test parameters on views displaying parameters, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.",
+  "details": "Jenkins NS-ND Integration Performance Publisher Plugin 4.8.0.77 and earlier does not escape the name of NetStorm Test parameters on views displaying parameters, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.\n\nExploitation of this vulnerability requires that parameters are listed on another page, like the \"Build With Parameters\" and \"Parameters\" pages provided by Jenkins (core), and that those pages are not hardened to prevent exploitation. Jenkins (core) has prevented exploitation of vulnerabilities of this kind on the \"Build With Parameters\" and \"Parameters\" pages since 2.44 and LTS 2.32.2 as part of the [SECURITY-353 / CVE-2017-2601](https://www.jenkins.io/security/advisory/2017-02-01/#persisted-cross-site-scripting-vulnerability-in-parameter-names-and-descriptions) fix. Additionally, several plugins have previously been updated to list parameters in a way that prevents exploitation by default, see [SECURITY-2617 in the 2022-04-12 security advisory for a list](https://www.jenkins.io/security/advisory/2022-04-12/#SECURITY-2617).",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "4.8.0.77"
+              "fixed": "4.8.0.129"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.8.0.77"
+      }
     }
   ],
   "references": [
@@ -53,7 +56,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2784

This has been fixed in https://github.com/jenkinsci/cavisson-ns-nd-integration-plugin/commit/6321f09aa9518eeeaeaa2f81182e1eae079dbdf2 and https://github.com/jenkinsci/cavisson-ns-nd-integration-plugin/commit/5b6dc5957edc3eff1b7ef2c3b52264524161b734, released in 4.8.0.129