### PR TITLE
[GHSA-77vq-4j66-46m5] Missing Authorization in Jenkins ThreadFix Plugin

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-77vq-4j66-46m5/GHSA-77vq-4j66-46m5.json
+++ b/advisories/github-reviewed/2022/06/GHSA-77vq-4j66-46m5/GHSA-77vq-4j66-46m5.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-77vq-4j66-46m5",
-  "modified": "2022-07-05T22:17:02Z",
+  "modified": "2022-12-05T13:28:44Z",
   "published": "2022-06-24T00:00:32Z",
   "aliases": [
     "CVE-2022-34210"
   ],
-  "summary": "Missing Authorization in Jenkins ThreadFix Plugin",
+  "summary": "Missing permission check in Jenkins ThreadFix Plugin",
   "details": "A missing permission check in Jenkins ThreadFix Plugin 1.5.4 and earlier allows attackers with Overall/Read permission to connect to an attacker-specified URL.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Summary

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2249