### PR TITLE
[GHSA-35r9-gfqf-r6cw] Missing permission check in Jenkins vRealize Orchestrator Plugin

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-35r9-gfqf-r6cw/GHSA-35r9-gfqf-r6cw.json
+++ b/advisories/github-reviewed/2022/06/GHSA-35r9-gfqf-r6cw/GHSA-35r9-gfqf-r6cw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-35r9-gfqf-r6cw",
-  "modified": "2022-07-05T19:14:57Z",
+  "modified": "2022-12-05T13:30:33Z",
   "published": "2022-06-24T00:00:32Z",
   "aliases": [
     "CVE-2022-34212"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2279