### PR TITLE
[GHSA-q4mr-j6w9-r2mr] Missing Authorization in Jenkins Deployment Dashboard Plugin

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-q4mr-j6w9-r2mr/GHSA-q4mr-j6w9-r2mr.json
+++ b/advisories/github-reviewed/2022/07/GHSA-q4mr-j6w9-r2mr/GHSA-q4mr-j6w9-r2mr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-q4mr-j6w9-r2mr",
-  "modified": "2022-10-22T00:59:17Z",
+  "modified": "2022-12-06T08:30:44Z",
   "published": "2022-07-01T00:01:07Z",
   "aliases": [
     "CVE-2022-34798"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-06-30/#SECURITY-2798%20(2)