### PR TITLE
[GHSA-h5g3-v72x-hc6f] Plaintext Storage of a Password in Jenkins Jigomerge Plugin

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-h5g3-v72x-hc6f/GHSA-h5g3-v72x-hc6f.json
+++ b/advisories/github-reviewed/2022/07/GHSA-h5g3-v72x-hc6f/GHSA-h5g3-v72x-hc6f.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-h5g3-v72x-hc6f",
-  "modified": "2022-07-13T15:41:52Z",
+  "modified": "2022-12-06T08:37:25Z",
   "published": "2022-07-01T00:01:08Z",
   "aliases": [
     "CVE-2022-34806"
   ],
   "summary": "Plaintext Storage of a Password in Jenkins Jigomerge Plugin",
-  "details": "Jenkins Jigomerge Plugin 0.9 and earlier stores passwords unencrypted in job config.xml files on the Jenkins controller where they can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.",
+  "details": "Jenkins Jigomerge Plugin 0.9 and earlier stores passwords unencrypted in job `config.xml` files on the Jenkins controller where they can be viewed by users with Extended Read permission, or access to the Jenkins controller file system.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
@@ -53,7 +53,7 @@
     "cwe_ids": [
       "CWE-256"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-06-30/#SECURITY-2083