### PR TITLE
[GHSA-qm37-c4w6-h9v9] Missing Authorization in Jenkins XPath Configuration Viewer Plugin

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-qm37-c4w6-h9v9/GHSA-qm37-c4w6-h9v9.json
+++ b/advisories/github-reviewed/2022/07/GHSA-qm37-c4w6-h9v9/GHSA-qm37-c4w6-h9v9.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-qm37-c4w6-h9v9",
-  "modified": "2022-07-12T18:18:02Z",
+  "modified": "2022-12-06T08:43:14Z",
   "published": "2022-07-01T00:01:08Z",
   "aliases": [
     "CVE-2022-34811"
   ],
   "summary": "Missing Authorization in Jenkins XPath Configuration Viewer Plugin",
-  "details": "A missing permission check in Jenkins XPath Configuration Viewer Plugin 1.1.1 and earlier allows attackers with Overall/Read permission to access the XPath Configuration Viewer page.",
+  "details": "XPath Configuration Viewer Plugin 1.1.1 and earlier does not perform a permission check in an HTTP endpoint.\n\nThis allows attackers with Overall/Read permission to access the XPath Configuration Viewer page. Given appropriate XPath expressions, this page grants access to job configuration XML data to every user with Item/Read permission. The encrypted values of secrets stored in the job configuration are not redacted, as they would be by the config.xml API for users without Item/Configure permission.",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Update details to be more accurate according to https://www.jenkins.io/security/advisory/2022-06-30/#SECURITY-2002