### PR TITLE
[GHSA-562r-vg33-8x8h] TemporaryFolder on unix-like systems does not limit access to created files

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-562r-vg33-8x8h/GHSA-562r-vg33-8x8h.json
+++ b/advisories/github-reviewed/2022/11/GHSA-562r-vg33-8x8h/GHSA-562r-vg33-8x8h.json
@@ -1,0 +1,127 @@
+{
+  "schema_version": "1.3.0",
+  "id": "GHSA-562r-vg33-8x8h",
+  "modified": "2022-12-06T10:07:31Z",
+  "published": "2022-11-23T22:17:25Z",
+  "aliases": [
+    "CVE-2022-41946"
+  ],
+  "summary": "TemporaryFolder on unix-like systems does not limit access to created files",
+  "details": "**Vulnerability**\n\n`PreparedStatement.setText(int, InputStream)`\n\nand\n\n`PreparedStatemet.setBytea(int, InputStream)`\n\nwill create a temporary file if the InputStream is larger than 51k\n\n \nExample of vulnerable code:\n\n```java\nString s = \"some very large string greater than 51200 bytes\";\n\nPreparedStatement.setInputStream(1, new ByteArrayInputStream(s.getBytes()) );\n```\nThis will create a temporary file which is readable by other users on Unix like systems, but not MacOS.\n\nImpact\nOn Unix like systems, the system's temporary directory is shared between all users on that system. Because of this, when files and directories are written into this directory they are, by default, readable by other users on that same system.\n\nThis vulnerability does not allow other users to overwrite the contents of these directories or files. This is purely an information disclosure vulnerability.\n\nWhen analyzing the impact of this vulnerability, here are the important questions to ask:\n\nIs the driver running in an environment where the OS has other untrusted users.\nIf yes, and you answered 'yes' to question 1, this vulnerability impacts you.\nIf no, this vulnerability does not impact you.\nPatches\nBecause certain JDK file system APIs were only added in JDK 1.7, this this fix is dependent upon the version of the JDK you are using.\n\nJava 1.8 and higher users: this vulnerability is fixed in 42.2.27, 42.3.8, 42.4.3, 42.5.1\nJava 1.7 users: this vulnerability is fixed in 42.2.27.jre7\nJava 1.6 and lower users: no patch is available; you must use the workaround below.\nWorkarounds\nIf you are unable to patch, or are stuck running on Java 1.6, specifying the java.io.tmpdir system environment variable to a directory that is exclusively owned by the executing user will fix this vulnerability.\n\nReferences\n[CWE-200: Exposure of Sensitive Information to an Unauthorized Actor](https://cwe.mitre.org/data/definitions/200.html)\nFix commit https://github.com/pgjdbc/pgjdbc/commit/9008dc9aade6dbfe4efafcd6872ebc55f4699cf5\nSimilar Vulnerabilities\nGoogle Guava - https://github.com/google/guava/issues/4011\nApache Ant - https://nvd.nist.gov/vuln/detail/CVE-2020-1945\nJetBrains Kotlin Compiler - https://nvd.nist.gov/vuln/detail/CVE-2020-15824",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.postgresql:postgresql"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "42.2.27,42.2.27.jre7"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 42.2.27"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.postgresql:postgresql"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "42.3.0"
+            },
+            {
+              "fixed": "42.3.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.postgresql:postgresql"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "42.4.0"
+            },
+            {
+              "fixed": "42.4.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.postgresql:postgresql"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "42.5.0"
+            },
+            {
+              "fixed": "42.5.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-562r-vg33-8x8h"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41946"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pgjdbc/pgjdbc/commit/9008dc9aade6dbfe4efafcd6872ebc55f4699cf5"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/pgjdbc/pgjdbc"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2022/12/msg00003.html"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-200"
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true
+  }
+}


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
The wording in description was referring to a non-existing version 2.5.1, and there was a typo in the provided sample code.