### PR TITLE
[GHSA-wcg3-cvx6-7396] Segmentation fault in time

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-wcg3-cvx6-7396/GHSA-wcg3-cvx6-7396.json
+++ b/advisories/github-reviewed/2021/08/GHSA-wcg3-cvx6-7396/GHSA-wcg3-cvx6-7396.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-wcg3-cvx6-7396",
-  "modified": "2022-12-06T00:16:25Z",
+  "modified": "2022-12-06T11:41:22Z",
   "published": "2021-08-25T20:56:46Z",
   "aliases": [
     "CVE-2020-26235"
@@ -26,28 +26,18 @@
           "events": [
             {
               "introduced": "0.1"
-            },
-            {
-              "last_affected": "0.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 0.2"
+      }
     },
     {
       "package": {
         "ecosystem": "crates.io",
         "name": "time"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "time::UtcOffset::local_offset_at",
-          "time::UtcOffset::try_local_offset_at",
-          "time::UtcOffset::current_local_offset",
-          "time::UtcOffset::try_current_local_offset",
-          "time::OffsetDateTime::now_local",
-          "time::OffsetDateTime::try_now_local"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Fixing 0.1 version range to not cover 0.2 (probably meant to be < 0.2 considering issue description and https://rustsec.org/advisories/RUSTSEC-2020-0071.html).