### PR TITLE
[GHSA-cm7j-p8hc-97vj] Jenkins Git client plugin 3.11.0 does not perform SSH host key verification

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-cm7j-p8hc-97vj/GHSA-cm7j-p8hc-97vj.json
+++ b/advisories/github-reviewed/2022/07/GHSA-cm7j-p8hc-97vj/GHSA-cm7j-p8hc-97vj.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-cm7j-p8hc-97vj",
-  "modified": "2022-08-10T17:39:44Z",
+  "modified": "2022-12-07T08:52:50Z",
   "published": "2022-07-28T00:00:43Z",
   "aliases": [
     "CVE-2022-36881"
   ],
   "summary": "Jenkins Git client plugin 3.11.0 does not perform SSH host key verification",
-  "details": "Jenkins Git client plugin 3.11.0 and earlier does not perform SSH host key verification when connecting to Git repositories via SSH, enabling man-in-the-middle attacks. Git client plugin 3.11.1 provides strategies for performing host key verification for administrators to select the one that meets their security needs.",
+  "details": "Jenkins Git client plugin 3.11.0 and earlier does not perform SSH host key verification when connecting to Git repositories via SSH, enabling man-in-the-middle attacks. Git client Plugin 3.11.1 provides strategies for performing host key verification for administrators to select the one that meets their security needs. For more information see [the plugin documentation](https://github.com/jenkinsci/git-client-plugin#ssh-host-key-verification).",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -44,6 +44,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36881"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/git-client-plugin"
+    },
+    {
       "type": "WEB",
       "url": "https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-1468"
     },
@@ -56,7 +60,7 @@
     "cwe_ids": [
       "CWE-322"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Severity
- Source code location

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-1468