### PR TITLE
[GHSA-8xwj-2wgh-gprh] Jenkins Git Plugin before 4.11.4 allows attackers to trigger builds of jobs to use an attacker-specified Git repo

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-8xwj-2wgh-gprh/GHSA-8xwj-2wgh-gprh.json
+++ b/advisories/github-reviewed/2022/07/GHSA-8xwj-2wgh-gprh/GHSA-8xwj-2wgh-gprh.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8xwj-2wgh-gprh",
-  "modified": "2022-08-10T21:10:33Z",
+  "modified": "2022-12-07T08:55:31Z",
   "published": "2022-07-28T00:00:43Z",
   "aliases": [
     "CVE-2022-36882"
   ],
-  "summary": "Jenkins Git Plugin before 4.11.4 allows attackers to trigger builds of jobs to use an attacker-specified Git repo",
-  "details": "A cross-site request forgery (CSRF) vulnerability in Jenkins Git Plugin 4.11.3 and earlier allows attackers to trigger builds of jobs configured to use an attacker-specified Git repository and to cause them to check out an attacker-specified commit.",
+  "summary": "Lack of authentication mechanism in Jenkins Git Plugin webhook",
+  "details": "Git Plugin provides a webhook endpoint at `/git/notifyCommit` that can be used to notify Jenkins of changes to an SCM repository. For its most basic functionality, this endpoint receives a repository URL, and Jenkins will schedule polling for all jobs configured with the specified repository. In Git Plugin 4.11.3 and earlier, this endpoint can be accessed with GET requests and without authentication.\n\nThis webhook endpoint does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.\n\nGit Plugin 4.11.4 requires a `token` parameter which will act as an authentication for the webhook endpoint. While GET requests remain allowed, attackers would need to be able to provide a webhook token. For more information see [the plugin documentation](https://github.com/jenkinsci/git-plugin/#push-notification-from-repository).",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -56,7 +56,7 @@
     "cwe_ids": [
       "CWE-352"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Severity
- Summary

**Comments**
Enhance disclosure of details according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-284