### PR TITLE
[GHSA-v878-67xw-grw2] Jenkins Git Plugin before 4.11.4 is missing a permission check

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-v878-67xw-grw2/GHSA-v878-67xw-grw2.json
+++ b/advisories/github-reviewed/2022/07/GHSA-v878-67xw-grw2/GHSA-v878-67xw-grw2.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-v878-67xw-grw2",
-  "modified": "2022-08-10T18:25:32Z",
+  "modified": "2022-12-07T08:56:49Z",
   "published": "2022-07-28T00:00:43Z",
   "aliases": [
     "CVE-2022-36883"
   ],
-  "summary": "Jenkins Git Plugin before 4.11.4 is missing a permission check",
-  "details": "A missing permission check in Jenkins Git Plugin 4.11.3 and earlier allows unauthenticated attackers to trigger builds of jobs configured to use an attacker-specified Git repository and to cause them to check out an attacker-specified commit.",
+  "summary": "Lack of authentication mechanism in Jenkins Git Plugin webhook",
+  "details": "Git Plugin provides a webhook endpoint at `/git/notifyCommit` that can be used to notify Jenkins of changes to an SCM repository. For its most basic functionality, this endpoint receives a repository URL, and Jenkins will schedule polling for all jobs configured with the specified repository. In Git Plugin 4.11.3 and earlier, this endpoint can be accessed with GET requests and without authentication.\n\nIn addition to this basic functionality, the endpoint also accept a `sha1` parameter specifying a commit ID. If this parameter is specified, jobs configured with the specified repo will be triggered immediately, and the build will check out the specified commit.\n\nAdditionally, the output of the webhook endpoint will provide information about which jobs were triggered or scheduled for polling, including jobs the user has no permission to access.\n\nThis allows attackers with knowledge of Git repository URLs to trigger builds of jobs using a specified Git repository and to cause them to check out an attacker-specified commit, and to obtain information about the existence of jobs configured with this Git repository.\n\nGit Plugin 4.11.4 requires a `token` parameter which will act as an authentication for the webhook endpoint. While GET requests remain allowed, attackers would need to be able to provide a webhook token. For more information see [the plugin documentation](https://github.com/jenkinsci/git-plugin/#push-notification-from-repository).",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -44,6 +44,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36883"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/git-plugin"
+    },
+    {
       "type": "WEB",
       "url": "https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-284"
     },
@@ -56,7 +60,7 @@
     "cwe_ids": [
       "CWE-862"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Update advisory disclosure according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-284