### PR TITLE
[GHSA-449w-c77c-vmf6] Jenkins Git Plugin before 4.11.4 provides unauthenticated attackers information about the existence of jobs

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-449w-c77c-vmf6/GHSA-449w-c77c-vmf6.json
+++ b/advisories/github-reviewed/2022/07/GHSA-449w-c77c-vmf6/GHSA-449w-c77c-vmf6.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-449w-c77c-vmf6",
-  "modified": "2022-08-10T18:28:37Z",
+  "modified": "2022-12-07T08:58:40Z",
   "published": "2022-07-28T00:00:43Z",
   "aliases": [
     "CVE-2022-36884"
   ],
-  "summary": "Jenkins Git Plugin before 4.11.4 provides unauthenticated attackers information about the existence of jobs",
-  "details": "The webhook endpoint in Jenkins Git Plugin 4.11.3 and earlier provide unauthenticated attackers information about the existence of jobs configured to use an attacker-specified Git repository.",
+  "summary": "Lack of authentication mechanism in Jenkins Git Plugin webhook",
+  "details": "Git Plugin provides a webhook endpoint at `/git/notifyCommit` that can be used to notify Jenkins of changes to an SCM repository. For its most basic functionality, this endpoint receives a repository URL, and Jenkins will schedule polling for all jobs configured with the specified repository. In Git Plugin 4.11.3 and earlier, this endpoint can be accessed with GET requests and without authentication.\n\nIn addition to this basic functionality, the endpoint also accept a `sha1` parameter specifying a commit ID. If this parameter is specified, jobs configured with the specified repo will be triggered immediately, and the build will check out the specified commit.\n\nAdditionally, the output of the webhook endpoint will provide information about which jobs were triggered or scheduled for polling, including jobs the user has no permission to access.\n\nThis allows attackers with knowledge of Git repository URLs to trigger builds of jobs using a specified Git repository and to cause them to check out an attacker-specified commit, and to obtain information about the existence of jobs configured with this Git repository.\n\nAdditionally, this webhook endpoint does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.\n\nGit Plugin 4.11.4 requires a `token` parameter which will act as an authentication for the webhook endpoint. While GET requests remain allowed, attackers would need to be able to provide a webhook token. For more information see [the plugin documentation](https://github.com/jenkinsci/git-plugin/#push-notification-from-repository).",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36884"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/git-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Source code location
- Summary

**Comments**
Provide full advisory disclosure according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-284