### PR TITLE
[GHSA-mxcc-7h5m-x57r] Jenkins GitHub plugin 1.34.4 uses weak webhook signature function

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-mxcc-7h5m-x57r/GHSA-mxcc-7h5m-x57r.json
+++ b/advisories/github-reviewed/2022/07/GHSA-mxcc-7h5m-x57r/GHSA-mxcc-7h5m-x57r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-mxcc-7h5m-x57r",
-  "modified": "2022-08-24T20:44:20Z",
+  "modified": "2022-12-07T09:00:13Z",
   "published": "2022-07-28T00:00:43Z",
   "aliases": [
     "CVE-2022-36885"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
@@ -68,7 +68,7 @@
     "cwe_ids": [
       "CWE-208"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-1849