### PR TITLE
[GHSA-vpf7-q2rx-26mh] Jenkins HashiCorp Vault Plugin does not perform permission checks in several HTTP endpoints that perform Vault connection tests

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-vpf7-q2rx-26mh/GHSA-vpf7-q2rx-26mh.json
+++ b/advisories/github-reviewed/2022/07/GHSA-vpf7-q2rx-26mh/GHSA-vpf7-q2rx-26mh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-vpf7-q2rx-26mh",
-  "modified": "2022-08-11T15:16:00Z",
+  "modified": "2022-12-07T09:01:47Z",
   "published": "2022-07-28T00:00:43Z",
   "aliases": [
     "CVE-2022-36888"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36888"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/hashicorp-vault-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- CVSS
- Source code location

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2593