### PR TITLE
[GHSA-j5qq-6rpm-qjgh] Jenkins Deployer Framework Plugin does not restrict application path of applications when configuring a deployment

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-j5qq-6rpm-qjgh/GHSA-j5qq-6rpm-qjgh.json
+++ b/advisories/github-reviewed/2022/07/GHSA-j5qq-6rpm-qjgh/GHSA-j5qq-6rpm-qjgh.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-j5qq-6rpm-qjgh",
-  "modified": "2022-08-10T21:16:12Z",
+  "modified": "2022-12-07T09:02:48Z",
   "published": "2022-07-28T00:00:42Z",
   "aliases": [
     "CVE-2022-36889"
   ],
-  "summary": "Jenkins Deployer Framework Plugin does not restrict application path of applications when configuring a deployment",
+  "summary": "Path traversal vulnerability in Jenkins Deployer Framework Plugin allows reading arbitrary files",
   "details": "Jenkins Deployer Framework Plugin 85.v1d1888e8c021 and earlier does not restrict the application path of the applications when configuring a deployment, allowing attackers with Item/Configure permission to upload arbitrary files from the Jenkins controller file system to the selected service.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
     }
   ],
   "affected": [
@@ -44,6 +44,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36889"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/deployer-framework-plugin"
+    },
+    {
       "type": "WEB",
       "url": "https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2764"
     },
@@ -56,7 +60,7 @@
     "cwe_ids": [
       "CWE-22"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Severity
- Source code location
- Summary

**Comments**
Provide advisory details according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2764