### PR TITLE
[GHSA-75fc-fv3p-xh82] Jenkins Compuware Source Code Download is missing authorization

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-75fc-fv3p-xh82/GHSA-75fc-fv3p-xh82.json
+++ b/advisories/github-reviewed/2022/07/GHSA-75fc-fv3p-xh82/GHSA-75fc-fv3p-xh82.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-75fc-fv3p-xh82",
-  "modified": "2022-08-10T21:13:10Z",
+  "modified": "2022-12-07T09:05:53Z",
   "published": "2022-07-28T00:00:42Z",
   "aliases": [
     "CVE-2022-36896"
   ],
   "summary": "Jenkins Compuware Source Code Download is missing authorization",
-  "details": "A missing permission check in Jenkins Compuware Source Code Download for Endevor, PDS, and ISPW Plugin 2.0.12 and earlier allows attackers with Overall/Read permission to enumerate hosts and ports of Compuware configurations and credentials IDs of credentials stored in Jenkins.",
+  "details": "BMC Compuware Source Code Download for Endevor, PDS, and ISPW Plugin 2.0.12 and earlier does not perform permission checks in several HTTP endpoints.\n\nThis allows attackers with Overall/Read permission to enumerate hosts and ports of Compuware configurations and credentials IDs of credentials stored in Jenkins. Those credentials IDs can be used as part of an attack to capture the credentials using another vulnerability.\n\nBMC Compuware Source Code Download for Endevor, PDS, and ISPW Plugin 2.0.13 requires the appropriate permissions to enumerate hosts and ports of Compuware configurations and credentials IDs.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36896"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/compuware-scm-downloader-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Source code location

**Comments**
Update advisory details with more information according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2621