### PR TITLE
[GHSA-2qh6-hhvv-m2ww] Jenkins HTTP Request Plugin stores HTTP Request passwords unencrypted

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-2qh6-hhvv-m2ww/GHSA-2qh6-hhvv-m2ww.json
+++ b/advisories/github-reviewed/2022/07/GHSA-2qh6-hhvv-m2ww/GHSA-2qh6-hhvv-m2ww.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-2qh6-hhvv-m2ww",
-  "modified": "2022-08-10T18:30:41Z",
+  "modified": "2022-12-07T09:10:11Z",
   "published": "2022-07-28T00:00:42Z",
   "aliases": [
     "CVE-2022-36901"
   ],
   "summary": "Jenkins HTTP Request Plugin stores HTTP Request passwords unencrypted",
-  "details": "Jenkins HTTP Request Plugin 1.15 and earlier stores HTTP Request passwords unencrypted in its global configuration file on the Jenkins controller where they can be viewed by users with access to the Jenkins controller file system.",
+  "details": "HTTP Request Plugin 1.15 and earlier stores HTTP Request passwords unencrypted in its global configuration file `jenkins.plugins.http_request.HttpRequest.xml` on the Jenkins controller as part of its configuration when using (deprecated) Basic/Digest Authentication.\n\nThese passwords can be viewed by users with access to the Jenkins controller file system.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
@@ -28,17 +28,24 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.15"
+              "fixed": "1.16"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.15"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36901"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/http-request-plugin"
     },
     {
       "type": "WEB",
@@ -54,7 +61,7 @@
       "CWE-256",
       "CWE-668"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location

**Comments**
Update advisory details according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2053

The vulnerability has been addressed in 1.16: https://github.com/jenkinsci/http-request-plugin/releases/tag/http_request-1.16, SECURITY-2053