### PR TITLE
[GHSA-8528-c6m6-gppm] Jenkins OpenShift Deployer Plugin allows connection to attacker-specified URL using attacker-specified credentials

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-8528-c6m6-gppm/GHSA-8528-c6m6-gppm.json
+++ b/advisories/github-reviewed/2022/07/GHSA-8528-c6m6-gppm/GHSA-8528-c6m6-gppm.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8528-c6m6-gppm",
-  "modified": "2022-08-10T18:35:56Z",
+  "modified": "2022-12-07T09:15:09Z",
   "published": "2022-07-28T00:00:42Z",
   "aliases": [
     "CVE-2022-36906"
   ],
-  "summary": "Jenkins OpenShift Deployer Plugin allows connection to attacker-specified URL using attacker-specified credentials",
-  "details": "A cross-site request forgery (CSRF) vulnerability in Jenkins OpenShift Deployer Plugin 1.2.0 and earlier allows attackers to connect to an attacker-specified URL using attacker-specified username and password.",
+  "summary": "CSRF vulnerability and missing permission check in Jenkins OpenShift Deployer Plugin",
+  "details": "OpenShift Deployer Plugin 1.2.0 and earlier does not perform a permission check in a method implementing form validation.\n\nThis form validation method does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Summary

**Comments**
Update advisory details according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-1375%20(1)