### PR TITLE
[GHSA-jvjh-9r4q-8q5q] Jenkins OpenShift Deployer Plugin does not perform a permission check in a method implementing form validation

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-jvjh-9r4q-8q5q/GHSA-jvjh-9r4q-8q5q.json
+++ b/advisories/github-reviewed/2022/07/GHSA-jvjh-9r4q-8q5q/GHSA-jvjh-9r4q-8q5q.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-jvjh-9r4q-8q5q",
-  "modified": "2022-08-10T18:33:10Z",
+  "modified": "2022-12-07T09:16:14Z",
   "published": "2022-07-28T00:00:42Z",
   "aliases": [
     "CVE-2022-36907"
   ],
-  "summary": "Jenkins OpenShift Deployer Plugin does not perform a permission check in a method implementing form validation",
-  "details": "A missing permission check in Jenkins OpenShift Deployer Plugin 1.2.0 and earlier allows attackers with Overall/Read permission to connect to an attacker-specified URL using attacker-specified username and password.",
+  "summary": "Missing permission check in Jenkins OpenShift Deployer Plugin ",
+  "details": "OpenShift Deployer Plugin 1.2.0 and earlier does not perform a permission check in a method implementing form validation.\n\nThis allows attackers with Overall/Read permission to connect to an attacker-specified URL using attacker-specified username and password.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
     }
   ],
   "affected": [
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36907"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/openshift-deployer-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Update advisory details according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-1375%20(1)