### PR TITLE
[GHSA-5mv2-vqq7-mq5h] Jenkins OpenShift Deployer Plugin allows attackers to check for file path, upload SSH key file

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-5mv2-vqq7-mq5h/GHSA-5mv2-vqq7-mq5h.json
+++ b/advisories/github-reviewed/2022/07/GHSA-5mv2-vqq7-mq5h/GHSA-5mv2-vqq7-mq5h.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-5mv2-vqq7-mq5h",
-  "modified": "2022-08-10T18:36:35Z",
+  "modified": "2022-12-07T09:18:17Z",
   "published": "2022-07-28T00:00:42Z",
   "aliases": [
     "CVE-2022-36908"
   ],
-  "summary": "Jenkins OpenShift Deployer Plugin allows attackers to check for file path, upload SSH key file",
-  "details": "A cross-site request forgery (CSRF) vulnerability in Jenkins OpenShift Deployer Plugin 1.2.0 and earlier allows attackers to check for the existence of an attacker-specified file path on the Jenkins controller file system and to upload a SSH key file from the Jenkins controller file system to an attacker-specified URL.",
+  "summary": "CSRF vulnerability in Jenkins OpenShift Deployer Plugin",
+  "details": "OpenShift Deployer Plugin 1.2.0 and earlier does not perform permission checks in methods implementing form validation.\n\nThese form validation methods do not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36908"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/openshift-deployer-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Update advisory details according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-1375%20(2)