### PR TITLE
[GHSA-78fg-pvgg-6g3r] OpenShift Deployer Plugin does not perform permission checks in methods implementing form validation

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-78fg-pvgg-6g3r/GHSA-78fg-pvgg-6g3r.json
+++ b/advisories/github-reviewed/2022/07/GHSA-78fg-pvgg-6g3r/GHSA-78fg-pvgg-6g3r.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-78fg-pvgg-6g3r",
-  "modified": "2022-08-10T22:41:55Z",
+  "modified": "2022-12-07T09:19:25Z",
   "published": "2022-07-28T00:00:42Z",
   "aliases": [
     "CVE-2022-36909"
   ],
-  "summary": "OpenShift Deployer Plugin does not perform permission checks in methods implementing form validation",
-  "details": "A missing permission check in Jenkins OpenShift Deployer Plugin 1.2.0 and earlier allows attackers with Overall/Read permission to check for the existence of an attacker-specified file path on the Jenkins controller file system and to upload a SSH key file from the Jenkins controller file system to an attacker-specified URL.",
+  "summary": "Missing permission check in Jenkins OpenShift Deployer Plugin ",
+  "details": "OpenShift Deployer Plugin 1.2.0 and earlier does not perform permission checks in methods implementing form validation.\n\nThis allows attackers with Overall/Read permission to check for the existence of an attacker-specified file path on the Jenkins controller file system and to upload a SSH key file from the Jenkins controller file system to an attacker-specified URL.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36909"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/openshift-deployer-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Update advisory details according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-1375%20(2)