### PR TITLE
[GHSA-hm53-hrhh-gwfq] Openstack Heat Plugin does not perform permission checks in methods implementing form validation

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-hm53-hrhh-gwfq/GHSA-hm53-hrhh-gwfq.json
+++ b/advisories/github-reviewed/2022/07/GHSA-hm53-hrhh-gwfq/GHSA-hm53-hrhh-gwfq.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-hm53-hrhh-gwfq",
-  "modified": "2022-08-11T14:48:02Z",
+  "modified": "2022-12-07T09:22:59Z",
   "published": "2022-07-28T00:00:42Z",
   "aliases": [
     "CVE-2022-36912"
   ],
-  "summary": "Openstack Heat Plugin does not perform permission checks in methods implementing form validation",
-  "details": "A missing permission check in Jenkins Openstack Heat Plugin 1.5 and earlier allows attackers with Overall/Read permission to connect to an attacker-specified URL.",
+  "summary": "Missing permission checks in Jenkins openstack-heat Plugin",
+  "details": "openstack-heat Plugin 1.5 and earlier does not perform permission checks in methods implementing form validation.\n\nThis allows attackers with Overall/Read permission to connect to an attacker-specified URL.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36912"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/openstack-heat-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location
- Summary

**Comments**
Update CVE specific details according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2105%20(1)