### PR TITLE
[GHSA-m485-79jq-cxx7] Jenkins Google Cloud Backup Plugin allows attackers with Overall/Read permission to request a manual backup

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-m485-79jq-cxx7/GHSA-m485-79jq-cxx7.json
+++ b/advisories/github-reviewed/2022/07/GHSA-m485-79jq-cxx7/GHSA-m485-79jq-cxx7.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-m485-79jq-cxx7",
-  "modified": "2022-08-11T15:17:32Z",
+  "modified": "2022-12-07T09:25:22Z",
   "published": "2022-07-28T00:00:42Z",
   "aliases": [
     "CVE-2022-36916"
   ],
-  "summary": "Jenkins Google Cloud Backup Plugin allows attackers with Overall/Read permission to request a manual backup",
-  "details": "A cross-site request forgery (CSRF) vulnerability in Jenkins Google Cloud Backup Plugin 0.6 and earlier allows attackers to request a manual backup.",
+  "summary": "CSRF vulnerability in Jenkins Google Cloud Backup Plugin",
+  "details": "Google Cloud Backup Plugin 0.6 and earlier does not perform a permission check in an HTTP endpoint.\n\nAdditionally, this HTTP endpoint does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
     }
   ],
   "affected": [
@@ -41,6 +41,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36916"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/google-cloud-backup-plugin"
+    },
+    {
       "type": "WEB",
       "url": "https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2656"
     },
@@ -53,7 +57,7 @@
     "cwe_ids": [
       "CWE-352"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Update advisory details according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2656