### PR TITLE
[GHSA-5x3f-7m52-9cgf] Jenkins Coverity Plugin vulnerable to cross-site request forgery (CSRF)

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-5x3f-7m52-9cgf/GHSA-5x3f-7m52-9cgf.json
+++ b/advisories/github-reviewed/2022/07/GHSA-5x3f-7m52-9cgf/GHSA-5x3f-7m52-9cgf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-5x3f-7m52-9cgf",
-  "modified": "2022-08-10T18:22:18Z",
+  "modified": "2022-12-07T09:27:34Z",
   "published": "2022-07-28T00:00:42Z",
   "aliases": [
     "CVE-2022-36920"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
     }
   ],
   "affected": [
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36920"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/coverity-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Source code location

**Comments**
Update advisory details according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2790%20(2)