### PR TITLE
[GHSA-99mq-hw5m-gwjj] Jenkins Coverity Plugin is missing authorization, leading to Credential Capture

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-99mq-hw5m-gwjj/GHSA-99mq-hw5m-gwjj.json
+++ b/advisories/github-reviewed/2022/07/GHSA-99mq-hw5m-gwjj/GHSA-99mq-hw5m-gwjj.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-99mq-hw5m-gwjj",
-  "modified": "2022-08-10T18:24:43Z",
+  "modified": "2022-12-07T09:28:58Z",
   "published": "2022-07-28T00:00:42Z",
   "aliases": [
     "CVE-2022-36921"
   ],
-  "summary": "Jenkins Coverity Plugin is missing authorization, leading to Credential Capture",
-  "details": "A missing permission check in Jenkins Coverity Plugin 1.11.4 and earlier allows attackers with Overall/Read permission to connect to an attacker-specified URL using attacker-specified credentials IDs obtained through another method, capturing credentials stored in Jenkins.",
+  "summary": "Missing permission check in Coverity Plugin allows capturing credentials",
+  "details": "Coverity Plugin 1.11.4 and earlier does not perform a permission check in an HTTP endpoint.\n\nThis allows attackers with Overall/Read permission to connect to an attacker-specified URL using attacker-specified credentials IDs obtained through another method, capturing credentials stored in Jenkins.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
     }
   ],
   "affected": [
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36921"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/coverity-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Update advisory details according to https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2790%20(2)