### PR TITLE
[GHSA-q5j9-f95w-f4pr] TERASOLUNA Server Framework vulnerable to ClassLoader manipulation

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-q5j9-f95w-f4pr/GHSA-q5j9-f95w-f4pr.json
+++ b/advisories/github-reviewed/2022/12/GHSA-q5j9-f95w-f4pr/GHSA-q5j9-f95w-f4pr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-q5j9-f95w-f4pr",
-  "modified": "2022-12-06T21:53:44Z",
+  "modified": "2022-12-08T10:13:00Z",
   "published": "2022-12-05T06:30:21Z",
   "aliases": [
     "CVE-2022-43484"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "5.7.1.SP1.RELEASE"
+              "fixed": "1.0.1.RELEASE"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
"Affected versions" and "Patched versions" were wrong.

The vulnerability is due to Terasorna-gfw-common 1.0.0.RELEASE.
Therefore, upgrading to at least 1.0.1.RELEASE can avoid the vulnerability.