### PR TITLE
[GHSA-7qf3-c2q8-69m3] Improper Neutralization of Input During Web Page Generation in Jenkins

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-7qf3-c2q8-69m3/GHSA-7qf3-c2q8-69m3.json
+++ b/advisories/github-reviewed/2022/05/GHSA-7qf3-c2q8-69m3/GHSA-7qf3-c2q8-69m3.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-7qf3-c2q8-69m3",
-  "modified": "2022-06-24T00:51:20Z",
+  "modified": "2022-12-09T16:22:09Z",
   "published": "2022-05-24T17:39:13Z",
   "aliases": [
     "CVE-2021-21610"
   ],
-  "summary": "Improper Neutralization of Input During Web Page Generation in Jenkins",
-  "details": "Jenkins 2.274 and earlier, LTS 2.263.1 and earlier does not implement any restrictions for the URL rendering a formatted preview of markup passed as a query parameter, resulting in a reflected cross-site scripting (XSS) vulnerability if the configured markup formatter does not prohibit unsafe elements (JavaScript) in markup.",
+  "summary": "Reflected XSS vulnerability in Jenkins markup formatter preview",
+  "details": "Jenkins allows administrators to choose the markup formatter to use for descriptions of jobs, builds, views, etc. displayed in Jenkins. When editing such a description, users can choose to have Jenkins render a formatted preview of the description they entered.\n\nJenkins 2.274 and earlier, LTS 2.263.1 and earlier does not implement any restrictions for the URL rendering the formatted preview of markup passed as a query parameter. This results in a reflected cross-site scripting (XSS) vulnerability if the configured markup formatter does not prohibit unsafe elements (JavaScript) in markup, like [Anything Goes Formatter Plugin](https://plugins.jenkins.io/anything-goes-formatter/).\n\nJenkins 2.275, LTS 2.263.2 requires that preview URLs are accessed using POST and sets Content-Security-Policy headers that prevent execution of unsafe elements when the URL is accessed directly.\n\nIn case of problems with this change, these protections can be disabled by setting the [Java system properties](https://www.jenkins.io/doc/book/managing/system-properties/) `hudson.markup.MarkupFormatter.previewsAllowGET` to `true` and/or `hudson.markup.MarkupFormatter.previewsSetCSP` to `false`. Doing either is discouraged.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -66,6 +66,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21610"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
+    },
+    {
       "type": "WEB",
       "url": "https://www.jenkins.io/security/advisory/2021-01-13/#SECURITY-2153"
     }
@@ -74,7 +78,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Update CVSS scoring and details according to https://www.jenkins.io/security/advisory/2021-01-13/#SECURITY-2153