### PR TITLE
[GHSA-xmw5-45v9-pxqx] Jenkins TICS Plugin 2020.3.0.6 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-xmw5-45v9-pxqx/GHSA-xmw5-45v9-pxqx.json
+++ b/advisories/unreviewed/2022/05/GHSA-xmw5-45v9-pxqx/GHSA-xmw5-45v9-pxqx.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-xmw5-45v9-pxqx",
-  "modified": "2022-05-24T17:39:13Z",
+  "modified": "2022-12-09T16:40:53Z",
   "published": "2022-05-24T17:39:13Z",
   "aliases": [
     "CVE-2021-21613"
   ],
-  "details": "Jenkins TICS Plugin 2020.3.0.6 and earlier does not escape TICS service responses, resulting in a cross-site scripting (XSS) vulnerability exploitable by attackers able to control TICS service response content.",
+  "summary": "XSS vulnerability in Jenkins TICS Plugin",
+  "details": "TICS Plugin 2020.3.0.6 and earlier does not escape TICS service responses.\n\nThis results in a cross-site scripting (XSS) vulnerability exploitable by attackers able to control TICS service response content.\n\nTICS Plugin 2020.3.0.7 escapes TICS service responses, or strips HTML out, as appropriate.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.jenkins.plugins:tics"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2020.3.0.7"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2020.3.0.6"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21613"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/tics-plugin"
     },
     {
       "type": "WEB",
@@ -27,7 +56,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-01-13/#SECURITY-2098