### PR TITLE
[GHSA-4f6x-g5vh-8jm5] Jenkins Active Choices Plugin 2.5.2 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-4f6x-g5vh-8jm5/GHSA-4f6x-g5vh-8jm5.json
+++ b/advisories/unreviewed/2022/05/GHSA-4f6x-g5vh-8jm5/GHSA-4f6x-g5vh-8jm5.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4f6x-g5vh-8jm5",
-  "modified": "2022-05-24T17:43:01Z",
+  "modified": "2022-12-09T17:22:38Z",
   "published": "2022-05-24T17:43:01Z",
   "aliases": [
     "CVE-2021-21616"
   ],
-  "details": "Jenkins Active Choices Plugin 2.5.2 and earlier does not escape reference parameter values, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Job/Configure permission.",
+  "summary": "Stored XSS vulnerability in Jenkins Active Choices Plugin",
+  "details": "Active Choices Plugin 2.5.2 and earlier does not escape reference parameter values.\n\nThis results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Job/Configure permission.\n\nActive Choices Plugin 2.5.3 escapes reference parameter values.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.biouno:uno-choice"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.5.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.5.2"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21616"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/active-choices-plugin"
     },
     {
       "type": "WEB",
@@ -31,7 +60,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory according to https://www.jenkins.io/security/advisory/2021-02-24/#SECURITY-2192