### PR TITLE
[GHSA-48hr-jg4p-w4p4] Jenkins Claim Plugin 2.18.1 and earlier does not escape...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-48hr-jg4p-w4p4/GHSA-48hr-jg4p-w4p4.json
+++ b/advisories/unreviewed/2022/05/GHSA-48hr-jg4p-w4p4/GHSA-48hr-jg4p-w4p4.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-48hr-jg4p-w4p4",
-  "modified": "2022-05-24T17:43:01Z",
+  "modified": "2022-12-09T17:45:24Z",
   "published": "2022-05-24T17:43:01Z",
   "aliases": [
     "CVE-2021-21619"
   ],
-  "details": "Jenkins Claim Plugin 2.18.1 and earlier does not escape the user display name, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers who are able to control the display names of Jenkins users, either via the security realm, or directly inside Jenkins.",
+  "summary": "XSS vulnerability in Jenkins Claim Plugin",
+  "details": "Claim Plugin 2.18.1 and earlier does not escape the user display name shown in claims.\n\nThis results in a cross-site scripting (XSS) vulnerability exploitable by attackers who are able to control the display names of Jenkins users, either via the security realm, or directly inside Jenkins.\n\nEveryone with a Jenkins account can change their own display name.\n\nClaim Plugin 2.18.2 escapes the user display name shown in claims.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:claim"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.18.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.18.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21619"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/claim-plugin"
     },
     {
       "type": "WEB",
@@ -31,7 +60,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-02-24/#SECURITY-2188%20(1)