### PR TITLE
[GHSA-p6qc-37hq-wqr6] Jenkins Templating Engine Plugin 2.1 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-p6qc-37hq-wqr6/GHSA-p6qc-37hq-wqr6.json
+++ b/advisories/unreviewed/2022/05/GHSA-p6qc-37hq-wqr6/GHSA-p6qc-37hq-wqr6.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-p6qc-37hq-wqr6",
-  "modified": "2022-05-24T17:48:06Z",
+  "modified": "2022-12-09T18:40:34Z",
   "published": "2022-05-24T17:48:06Z",
   "aliases": [
     "CVE-2021-21646"
   ],
-  "details": "Jenkins Templating Engine Plugin 2.1 and earlier does not protect its pipeline configurations using Script Security Plugin, allowing attackers with Job/Configure permission to execute arbitrary code in the context of the Jenkins controller JVM.",
+  "summary": "Remote code execution vulnerability in Jenkins Templating Engine Plugin",
+  "details": "Templating Engine Plugin 2.1 and earlier does not protect its pipeline configurations using Script Security Plugin.\n\nThis vulnerability allows attackers with Job/Configure permission to execute arbitrary code in the context of the Jenkins controller JVM.\n\nTemplating Engine Plugin 2.2 integrates with Script Security Plugin to protect its pipeline configurations.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:templating-engine"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21646"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/templating-engine-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-04-21/#SECURITY-2311