### PR TITLE
[GHSA-732f-w585-gmpc] Jenkins Generic Webhook Trigger plugin 1.72 and earlier vulnerable to XML external entity (XXE) attacks

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-732f-w585-gmpc/GHSA-732f-w585-gmpc.json
+++ b/advisories/github-reviewed/2022/05/GHSA-732f-w585-gmpc/GHSA-732f-w585-gmpc.json
@@ -1,15 +1,18 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-732f-w585-gmpc",
-  "modified": "2022-08-26T16:28:18Z",
+  "modified": "2022-12-09T18:46:55Z",
   "published": "2022-05-24T19:05:40Z",
   "aliases": [
     "CVE-2021-21669"
   ],
-  "summary": "Jenkins Generic Webhook Trigger plugin 1.72 and earlier vulnerable to XML external entity (XXE) attacks",
-  "details": "Jenkins Generic Webhook Trigger Plugin 1.72 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability in Jenkins Generic Webhook Trigger Plugin",
+  "details": "Generic Webhook Trigger Plugin 1.72 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers with the ability to call webhooks configured to extract parameters using XPath to have Jenkins parse a crafted XML request body that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.\n\nGeneric Webhook Trigger Plugin 1.74 disables external entity resolution for its XML parser.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
+    }
   ],
   "affected": [
     {
@@ -61,7 +64,7 @@
     "cwe_ids": [
       "CWE-611"
     ],
-    "severity": "CRITICAL",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Severity
- Summary

**Comments**
Fix CVSS scoring according to https://www.jenkins.io/security/advisory/2021-06-18/#SECURITY-2330