### PR TITLE
[GHSA-rc7h-x6cq-988q] Improper Input Validation in JGroups

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-rc7h-x6cq-988q/GHSA-rc7h-x6cq-988q.json
+++ b/advisories/github-reviewed/2022/05/GHSA-rc7h-x6cq-988q/GHSA-rc7h-x6cq-988q.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-rc7h-x6cq-988q",
-  "modified": "2022-07-06T20:02:18Z",
+  "modified": "2022-12-11T10:45:17Z",
   "published": "2022-05-13T01:03:31Z",
   "aliases": [
     "CVE-2016-2141"
   ],
   "summary": "Improper Input Validation in JGroups",
-  "details": "JGroups before 4.0 does not require the proper headers for the ENCRYPT and AUTH protocols from nodes joining the cluster, which allows remote attackers to bypass security restrictions and send and receive messages within the cluster via unspecified vectors.",
+  "details": "JGroups before 4.0 does not require the proper headers for the ENCRYPT and AUTH protocols from nodes joining the cluster, which allows remote attackers to bypass security restrictions and send and receive messages within the cluster via unspecified vectors. The fix was also backported to 3.6.10.Final.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.0.0"
+              "fixed": "3.6.10, 4.0.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 3.6.10"
+      }
     }
   ],
   "references": [
@@ -79,6 +82,10 @@
     {
       "type": "WEB",
       "url": "https://issues.jboss.org/browse/JGRP-2021"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.redhat.com/browse/JGRP-2055"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
There is another fix in the 3.6 branch, with 3.6.10.Final - see https://issues.redhat.com/browse/JGRP-2055
3.6 is the branch prior to 4.0 branch, it was also fixed in 4.0.0.