### PR TITLE
[GHSA-47fc-vmwq-366v] PyTorch vulnerable to arbitrary code execution

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-47fc-vmwq-366v/GHSA-47fc-vmwq-366v.json
+++ b/advisories/github-reviewed/2022/11/GHSA-47fc-vmwq-366v/GHSA-47fc-vmwq-366v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-47fc-vmwq-366v",
-  "modified": "2022-12-02T22:28:40Z",
+  "modified": "2022-12-13T14:24:18Z",
   "published": "2022-11-26T03:30:27Z",
   "aliases": [
     "CVE-2022-45907"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
There should be a possibility (either directly or via an issue) to directly assign another person to such an alert. The owner of the repo is not necessarily the one to fix it.