### PR TITLE
[GHSA-w37g-rhq8-7m4j] Snakeyaml vulnerable to Stack overflow leading to denial of service

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-w37g-rhq8-7m4j/GHSA-w37g-rhq8-7m4j.json
+++ b/advisories/github-reviewed/2022/11/GHSA-w37g-rhq8-7m4j/GHSA-w37g-rhq8-7m4j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-w37g-rhq8-7m4j",
-  "modified": "2022-12-05T21:45:23Z",
+  "modified": "2022-12-13T16:33:29Z",
   "published": "2022-11-11T19:00:31Z",
   "aliases": [
     "CVE-2022-41854"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.33"
+              "fixed": "1.32"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.31"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Based on https://nvd.nist.gov/vuln/detail/CVE-2022-41854 (linked in description) "Up to (excluding) 1.32".  This would imply at least 1.33 is a fix if not also 1.32 as well.
