### PR TITLE
[GHSA-6q4g-84f3-mw74] Jenkins 2.314 and earlier, LTS 2.303.1 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-6q4g-84f3-mw74/GHSA-6q4g-84f3-mw74.json
+++ b/advisories/unreviewed/2022/05/GHSA-6q4g-84f3-mw74/GHSA-6q4g-84f3-mw74.json
@@ -1,17 +1,61 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-6q4g-84f3-mw74",
-  "modified": "2022-05-24T19:16:59Z",
+  "modified": "2022-12-13T18:31:29Z",
   "published": "2022-05-24T19:16:59Z",
   "aliases": [
     "CVE-2021-21682"
   ],
-  "details": "Jenkins 2.314 and earlier, LTS 2.303.1 and earlier accepts names of jobs and other entities with a trailing dot character, potentially replacing the configuration and data of other entities on Windows.",
+  "summary": "Improper handling of equivalent directory names on Windows in Jenkins",
+  "details": "Jenkins stores jobs and other entities on disk using their name shown on the UI as file and folder names.\n\nOn Windows, when specifying a file or folder with a trailing dot character (`example.`), the file or folder will be treated as if that character was not present (`example`). As both are legal names for jobs and other entities in Jenkins 2.314 and earlier, LTS 2.303.1 and earlier, this could allow users with the appropriate permissions to change or replace configurations of jobs and other entities.\n\nJenkins 2.315, LTS 2.303.2 does not allow names of jobs and other entities to end with a dot character.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.315"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.314"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.303.1"
+            },
+            {
+              "fixed": "2.303.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-10-06/#SECURITY-2424

Versions prior to 2.314 are affected, and 2.303.1
This vulnerability has been fixed in 2.315 onwards and 2.303.2 and 2.303.3