### PR TITLE
[GHSA-4pw5-r58h-fv24] The file browser in Jenkins 2.314 and earlier, LTS 2.303...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-4pw5-r58h-fv24/GHSA-4pw5-r58h-fv24.json
+++ b/advisories/unreviewed/2022/05/GHSA-4pw5-r58h-fv24/GHSA-4pw5-r58h-fv24.json
@@ -1,22 +1,73 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4pw5-r58h-fv24",
-  "modified": "2022-05-24T19:16:59Z",
+  "modified": "2022-12-13T18:33:38Z",
   "published": "2022-05-24T19:16:59Z",
   "aliases": [
     "CVE-2021-21683"
   ],
-  "details": "The file browser in Jenkins 2.314 and earlier, LTS 2.303.1 and earlier may interpret some paths to files as absolute on Windows, resulting in a path traversal vulnerability allowing attackers with Overall/Read permission (Windows controller) or Job/Workspace permission (Windows agents) to obtain the contents of arbitrary files.",
+  "summary": "Path traversal vulnerability on Windows in Jenkins",
+  "details": "The file browser for workspaces, archived artifacts, and `userContent/` in Jenkins 2.314 and earlier, LTS 2.303.1 and earlier may interpret some paths to files as absolute on Windows.\n\nThis results in a path traversal vulnerability allowing attackers with Overall/Read permission (Windows controller) or Job/Workspace permission (Windows agents) to obtain the contents of arbitrary files.\n\nThe file browser in Jenkins 2.315, LTS 2.303.2 refuses to serve files that would be considered absolute paths.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.315"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.314"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.303.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.303.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21683"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-10-06/#SECURITY-2481

This vulnerability affects 2.314 and earlier and 2.303.1 and has been fixed in 2.315 onwards, 2.303.2 and 2.303.3