### PR TITLE
[GHSA-gghc-g8cj-4vfv] Jenkins Git Plugin 4.8.2 and earlier does not escape the...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-gghc-g8cj-4vfv/GHSA-gghc-g8cj-4vfv.json
+++ b/advisories/unreviewed/2022/05/GHSA-gghc-g8cj-4vfv/GHSA-gghc-g8cj-4vfv.json
@@ -1,25 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-gghc-g8cj-4vfv",
-  "modified": "2022-10-25T19:00:33Z",
+  "modified": "2022-12-13T18:35:01Z",
   "published": "2022-05-24T19:16:59Z",
   "aliases": [
     "CVE-2021-21684"
   ],
-  "details": "Jenkins Git Plugin 4.8.2 and earlier does not escape the Git SHA-1 checksum parameters provided to commit notifications when displaying them in a build cause, resulting in a stored cross-site scripting (XSS) vulnerability.",
+  "summary": "Stored XSS vulnerability in Jenkins Git Plugin",
+  "details": "Git Plugin 4.8.2 and earlier does not escape the Git SHA-1 checksum parameters provided to commit notifications when displaying them in a build cause.\n\nThis results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to submit crafted commit notifications to the `/git/notifyCommit` endpoint.\n\nGit Plugin 4.8.3 rejects Git SHA-1 checksum parameters that do not match the expected format. Existing values are sanitized when displayed on the UI.\n\nThis vulnerability is only exploitable in Jenkins 2.314 and earlier, LTS 2.303.1 and earlier. See the [LTS upgrade guide](https://www.jenkins.io/doc/upgrade-guide/2.303/#SECURITY-2452).",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:git"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.8.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.8.2"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21684"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/git-plugin"
     },
     {
       "type": "WEB",
@@ -35,7 +61,7 @@
       "CWE-116",
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-10-06/#SECURITY-2499