### PR TITLE
[GHSA-34j5-c4cv-mmg5] Jenkins URLTrigger Plugin 0.48 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-34j5-c4cv-mmg5/GHSA-34j5-c4cv-mmg5.json
+++ b/advisories/unreviewed/2022/05/GHSA-34j5-c4cv-mmg5/GHSA-34j5-c4cv-mmg5.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-34j5-c4cv-mmg5",
-  "modified": "2022-05-24T19:03:11Z",
+  "modified": "2022-12-13T18:39:55Z",
   "published": "2022-05-24T19:03:11Z",
   "aliases": [
     "CVE-2021-21659"
   ],
-  "details": "Jenkins URLTrigger Plugin 0.48 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability in Jenkins URLTrigger Plugin",
+  "details": "URLTrigger Plugin 0.48 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers with Job/Configure permission or otherwise able to control the contents of an URL to an XML document being examined for changes to have Jenkins parse a crafted XML document that uses external entities for extraction of secrets from the polling Jenkins controller or agent, server-side request forgery, or denial-of-service attacks.\n\nURLTrigger Plugin 0.49 disables external entity resolution for its XML parser.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:urltrigger"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.49"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.48"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21659"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/urltrigger-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-05-25/#SECURITY-2341