### PR TITLE
[GHSA-xv69-6rf3-w5g2] Jenkins Cloud Statistics Plugin 0.26 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-xv69-6rf3-w5g2/GHSA-xv69-6rf3-w5g2.json
+++ b/advisories/unreviewed/2022/05/GHSA-xv69-6rf3-w5g2/GHSA-xv69-6rf3-w5g2.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-xv69-6rf3-w5g2",
-  "modified": "2022-05-24T17:45:45Z",
+  "modified": "2022-12-13T19:10:19Z",
   "published": "2022-05-24T17:45:45Z",
   "aliases": [
     "CVE-2021-21631"
   ],
-  "details": "Jenkins Cloud Statistics Plugin 0.26 and earlier does not perform a permission check in an HTTP endpoint, allowing attackers with Overall/Read permission and knowledge of random activity IDs to view related provisioning exception error messages.",
+  "summary": "Missing permission check in Jenkins Cloud Statistics Plugin",
+  "details": "Cloud Statistics Plugin 0.26 and earlier does not perform a permission check in an HTTP endpoint.\n\nThis allows attackers with Overall/Read permission and knowledge of random activity IDs to view related provisioning exception error messages.\n\nCloud Statistics Plugin 0.27 requires Overall/Administer permission to access provisioning exception error messages.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:cloud-stats"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.27"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.26"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21631"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/cloud-stats-plugin"
     },
     {
       "type": "WEB",
@@ -31,7 +60,7 @@
     "cwe_ids": [
       "CWE-862"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-03-30/#SECURITY-2246