### PR TITLE
[GHSA-f9gf-2q87-5m44] Jenkins Scriptler Plugin 3.3 and earlier does not escape...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-f9gf-2q87-5m44/GHSA-f9gf-2q87-5m44.json
+++ b/advisories/unreviewed/2022/05/GHSA-f9gf-2q87-5m44/GHSA-f9gf-2q87-5m44.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-f9gf-2q87-5m44",
-  "modified": "2022-05-24T19:20:33Z",
+  "modified": "2022-12-13T19:24:31Z",
   "published": "2022-05-24T19:20:33Z",
   "aliases": [
     "CVE-2021-21700"
   ],
-  "details": "Jenkins Scriptler Plugin 3.3 and earlier does not escape the name of scripts on the UI when asking to confirm their deletion, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by exploitable by attackers able to create Scriptler scripts.",
+  "summary": "Stored XSS vulnerability in Jenkins Scriptler Plugin",
+  "details": "Scriptler Plugin 3.3 and earlier does not escape the name of scripts on the UI when asking to confirm their deletion.\n\nThis results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to create Scriptler scripts.\n\nScriptler Plugin 3.4 escapes the name of scripts on the UI when asking to confirm their deletion.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:scriptler"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.3"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21700"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/scriptler-plugin"
     },
     {
       "type": "WEB",
@@ -31,7 +60,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-11-12/#SECURITY-2406