### PR TITLE
[GHSA-ppv9-v43c-xqpp] Jenkins pom2config Plugin 1.2 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-ppv9-v43c-xqpp/GHSA-ppv9-v43c-xqpp.json
+++ b/advisories/unreviewed/2022/05/GHSA-ppv9-v43c-xqpp/GHSA-ppv9-v43c-xqpp.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-ppv9-v43c-xqpp",
-  "modified": "2022-05-24T19:20:33Z",
+  "modified": "2022-12-13T19:28:23Z",
   "published": "2022-05-24T19:20:33Z",
   "aliases": [
     "CVE-2021-43576"
   ],
-  "details": "Jenkins pom2config Plugin 1.2 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks, allowing attackers with Overall/Read and Item/Read permissions to have Jenkins parse a crafted XML file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.",
+  "summary": "XXE vulnerability in Jenkins pom2config Plugin",
+  "details": "pom2config Plugin 1.2 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers with Overall/Read and Item/Read permissions to have Jenkins parse a crafted XML file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.\n\nAs of publication of this advisory, there is no fix.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:pom2config"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43576"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/pom2config-plugin"
     },
     {
       "type": "WEB",
@@ -35,7 +61,7 @@
     "cwe_ids": [
       "CWE-611"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-11-12/#SECURITY-2415