### PR TITLE
[GHSA-mj5v-ggjc-48p5] Jenkins OWASP Dependency-Check Plugin 5.1.1 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-mj5v-ggjc-48p5/GHSA-mj5v-ggjc-48p5.json
+++ b/advisories/unreviewed/2022/05/GHSA-mj5v-ggjc-48p5/GHSA-mj5v-ggjc-48p5.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-mj5v-ggjc-48p5",
-  "modified": "2022-05-24T19:20:32Z",
+  "modified": "2022-12-13T19:31:30Z",
   "published": "2022-05-24T19:20:32Z",
   "aliases": [
     "CVE-2021-43577"
   ],
-  "details": "Jenkins OWASP Dependency-Check Plugin 5.1.1 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability in Jenkins OWASP Dependency-Check Plugin",
+  "details": "OWASP Dependency-Check Plugin 5.1.1 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers able to control workspace contents to have Jenkins parse a crafted XML file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:dependency-check-jenkins-plugin"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.1.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 5.1.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43577"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/dependency-check-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-11-12/#SECURITY-2488

The vulnerability has been fixed in https://github.com/jenkinsci/dependency-check-plugin/commit/c10d1496f9f0301e276daecea88161a905fca6d4, which has been released in 5.1.2