### PR TITLE
[GHSA-58pr-hprx-7hg6] Jenkins Code Coverage API Plugin 1.4.0 and earlier does...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-58pr-hprx-7hg6/GHSA-58pr-hprx-7hg6.json
+++ b/advisories/unreviewed/2022/05/GHSA-58pr-hprx-7hg6/GHSA-58pr-hprx-7hg6.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-58pr-hprx-7hg6",
-  "modified": "2022-05-24T19:12:36Z",
+  "modified": "2022-12-13T19:34:34Z",
   "published": "2022-05-24T19:12:36Z",
   "aliases": [
     "CVE-2021-21677"
   ],
-  "details": "Jenkins Code Coverage API Plugin 1.4.0 and earlier does not apply Jenkins JEP-200 deserialization protection to Java objects it deserializes from disk, resulting in a remote code execution vulnerability.",
+  "summary": "RCE vulnerability in Jenkins Code Coverage API Plugin",
+  "details": "Code Coverage API Plugin 1.4.0 and earlier does not apply [JEP-200 deserialization protection](https://github.com/jenkinsci/jep/tree/master/jep/200) to Java objects it deserializes from disk.\n\nThis results in a remote code execution (RCE) vulnerability exploitable by attackers able to control agent processes.\n\nCode Coverage API Plugin 1.4.1 configures its Java object deserialization to only deserialize safe types.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.jenkins.plugins:code-coverage-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.4.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.4.0"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21677"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/code-coverage-api-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-08-31/#SECURITY-2376