### PR TITLE
[GHSA-5c2c-cvg6-ghjm] Jenkins Nomad Plugin 0.7.4 and earlier stores Docker...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5c2c-cvg6-ghjm/GHSA-5c2c-cvg6-ghjm.json
+++ b/advisories/unreviewed/2022/05/GHSA-5c2c-cvg6-ghjm/GHSA-5c2c-cvg6-ghjm.json
@@ -1,25 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-5c2c-cvg6-ghjm",
-  "modified": "2022-05-24T19:12:36Z",
+  "modified": "2022-12-13T19:39:43Z",
   "published": "2022-05-24T19:12:36Z",
   "aliases": [
     "CVE-2021-21681"
   ],
-  "details": "Jenkins Nomad Plugin 0.7.4 and earlier stores Docker passwords unencrypted in the global config.xml file on the Jenkins controller where they can be viewed by users with access to the Jenkins controller file system.",
+  "summary": "Password stored in plain text by Jenkins Nomad Plugin",
+  "details": "Nomad Plugin 0.7.4 and earlier stores the passwords to authenticate against the Docker registry unencrypted in the global `config.xml` file on the Jenkins controller as part of its worker templates configuration.\n\nThese passwords can be viewed by users with access to the Jenkins controller file system.\n\nNomad Plugin 0.7.5 stores the Docker passwords encrypted. This change is effective after Jenkins restarts.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:nomad"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.7.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.7.4"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21681"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/nomad-plugin"
     },
     {
       "type": "WEB",
@@ -32,10 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-256",
-      "CWE-522"
+      "CWE-256"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-08-31/#SECURITY-2396