### PR TITLE
[GHSA-q4wp-8c99-69pw] Jenkins 2.299 and earlier, LTS 2.289.1 and earlier allows...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-q4wp-8c99-69pw/GHSA-q4wp-8c99-69pw.json
+++ b/advisories/unreviewed/2022/05/GHSA-q4wp-8c99-69pw/GHSA-q4wp-8c99-69pw.json
@@ -1,22 +1,73 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-q4wp-8c99-69pw",
-  "modified": "2022-05-24T19:06:36Z",
+  "modified": "2022-12-13T19:49:36Z",
   "published": "2022-05-24T19:06:36Z",
   "aliases": [
     "CVE-2021-21670"
   ],
-  "details": "Jenkins 2.299 and earlier, LTS 2.289.1 and earlier allows users to cancel queue items and abort builds of jobs for which they have Item/Cancel permission even when they do not have Item/Read permission.",
+  "summary": "Improper permission checks allow canceling queue items and aborting builds in Jenkins",
+  "details": "Jenkins 2.299 and earlier, LTS 2.289.1 and earlier allows users to cancel queue items and abort builds of jobs for which they have Item/Cancel permission even when they do not have Item/Read permission.\n\nJenkins 2.300, LTS 2.289.2 requires that users have Item/Read permission for applicable types in addition to Item/Cancel permission.\n\nAs a workaround on earlier versions of Jenkins, do not grant Item/Cancel permission to users who do not have Item/Read permission.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.300"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.299"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.289.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.289.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21670"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-06-30/#SECURITY-2278

Versions 2.299 and earlier and 2.289.1 are affected. This vulnerability has been fixed in 2.300 onwards and 2.289.2 and 2.289.3