### PR TITLE
[GHSA-4wr9-2xc6-jmg5] Jenkins 2.299 and earlier, LTS 2.289.1 and earlier does...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-4wr9-2xc6-jmg5/GHSA-4wr9-2xc6-jmg5.json
+++ b/advisories/unreviewed/2022/05/GHSA-4wr9-2xc6-jmg5/GHSA-4wr9-2xc6-jmg5.json
@@ -1,22 +1,73 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4wr9-2xc6-jmg5",
-  "modified": "2022-05-24T19:06:36Z",
+  "modified": "2022-12-13T19:52:37Z",
   "published": "2022-05-24T19:06:36Z",
   "aliases": [
     "CVE-2021-21671"
   ],
-  "details": "Jenkins 2.299 and earlier, LTS 2.289.1 and earlier does not invalidate the previous session on login.",
+  "summary": "Session fixation vulnerability in Jenkins",
+  "details": "Jenkins 2.299 and earlier, LTS 2.289.1 and earlier does not invalidate the existing session on login. This allows attackers to use social engineering techniques to gain administrator access to Jenkins.\n\nThis vulnerability was introduced in Jenkins 2.266 and LTS 2.277.1.\n\nJenkins 2.300, LTS 2.289.2 invalidates the existing session on login.\n\nIn case of problems, administrators can choose a different implementation by setting the [Java system property `hudson.security.SecurityRealm.sessionFixationProtectionMode`](https://www.jenkins.io/doc/book/managing/system-properties/#hudson-security-securityrealm-sessionfixationprotectionmode) to `2`, or disable the fix entirely by setting that system property to `0`.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.300"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.299"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.289.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.289.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21671"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-06-30/#SECURITY-2371

This vulnerability affects versions 2.266 to 2.299 and LTS versions 2.277.1, 2.277.2, 2.277.3, 2.289.1 and has been fixed in 2.300 and LTS 2.289.1