### PR TITLE
[GHSA-fv42-mx39-6fpw] Jenkins Script Security Plugin vulnerable due to inadequate encryption strength

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-fv42-mx39-6fpw/GHSA-fv42-mx39-6fpw.json
+++ b/advisories/github-reviewed/2022/11/GHSA-fv42-mx39-6fpw/GHSA-fv42-mx39-6fpw.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-fv42-mx39-6fpw",
-  "modified": "2022-11-21T22:20:41Z",
+  "modified": "2022-12-14T09:06:28Z",
   "published": "2022-11-16T12:00:22Z",
   "aliases": [
     "CVE-2022-45379"
   ],
-  "summary": "Jenkins Script Security Plugin vulnerable due to inadequate encryption strength",
-  "details": "Jenkins Script Security Plugin 1189.vb_a_b_7c8fd5fde and earlier stores whole-script approvals as the SHA-1 hash of the script, making it vulnerable to collision attacks.",
+  "summary": "Whole-script approval in Jenkins Script Security Plugin vulnerable to SHA-1 collisions",
+  "details": "Script Security Plugin 1189.vb_a_b_7c8fd5fde and earlier stores whole-script approvals as the [SHA-1 hash](https://en.wikipedia.org/wiki/SHA-1) of the approved script. SHA-1 no longer meets the security standards for producing a cryptographically secure message digest.\n\nScript Security Plugin 1190.v65867a_a_47126 uses SHA-512 for new whole-script approvals. Previously approved scripts will have their SHA-1 based whole-script approval replaced with a corresponding SHA-512 whole-script approval when the script is next used.\n\nWhole-script approval only stores the SHA-1 or SHA-512 hash, so it is not possible to migrate all previously approved scripts automatically on startup.\n\nAdministrators concerned about SHA-1 collision attacks on the whole-script approval feature are able to revoke all previous (SHA-1) script approvals on the In-Process Script Approval page.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1189.vb"
+              "fixed": "1190.v65867a_a_47126"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1189.vb_a_b_7c8fd5fde"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Summary

**Comments**
Fill in versions fixed according to https://www.jenkins.io/security/advisory/2022-11-15/#SECURITY-2564