### PR TITLE
[GHSA-wcjj-qm5v-j4pc] Jenkins Reverse Proxy Auth Plugin vulnerable due to plaintext storage of passwords

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-wcjj-qm5v-j4pc/GHSA-wcjj-qm5v-j4pc.json
+++ b/advisories/github-reviewed/2022/11/GHSA-wcjj-qm5v-j4pc/GHSA-wcjj-qm5v-j4pc.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-wcjj-qm5v-j4pc",
-  "modified": "2022-11-21T22:22:01Z",
+  "modified": "2022-12-14T09:13:48Z",
   "published": "2022-11-16T12:00:23Z",
   "aliases": [
     "CVE-2022-45384"
   ],
   "summary": "Jenkins Reverse Proxy Auth Plugin vulnerable due to plaintext storage of passwords",
-  "details": "Jenkins Reverse Proxy Auth Plugin 1.7.3 and earlier stores the LDAP manager password unencrypted in the global config.xml file on the Jenkins controller where it can be viewed by attackers with access to the Jenkins controller file system.",
+  "details": "Reverse Proxy Auth Plugin 1.7.3 and earlier stores the LDAP manager password unencrypted in the global `config.xml` file on the Jenkins controller as part of its configuration.\n\nThis password can be viewed by attackers with access to the Jenkins controller file system.\n\nReverse Proxy Auth Plugin 1.7.4 stores the LDAP manager password encrypted once its configuration is saved again.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
@@ -25,14 +25,17 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.7.3"
+              "introduced": "0"
             },
             {
               "fixed": "1.7.4"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.7.3"
+      }
     }
   ],
   "references": [
@@ -54,7 +57,7 @@
       "CWE-256",
       "CWE-522"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-11-15/#SECURITY-2094

Also simplifies the version range