### PR TITLE
[GHSA-v535-pc6r-77qh] Jenkins CloudBees Docker Hub/Registry Notification Plugin is missing permission checks

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-v535-pc6r-77qh/GHSA-v535-pc6r-77qh.json
+++ b/advisories/github-reviewed/2022/11/GHSA-v535-pc6r-77qh/GHSA-v535-pc6r-77qh.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-v535-pc6r-77qh",
-  "modified": "2022-11-21T22:22:24Z",
+  "modified": "2022-12-14T09:14:56Z",
   "published": "2022-11-16T12:00:23Z",
   "aliases": [
     "CVE-2022-45385"
   ],
-  "summary": "Jenkins CloudBees Docker Hub/Registry Notification Plugin is missing permission checks",
-  "details": "A missing permission check in Jenkins CloudBees Docker Hub/Registry Notification Plugin 2.6.2 and earlier allows unauthenticated attackers to trigger builds of jobs corresponding to the attacker-specified repository.",
+  "summary": "Lack of authentication mechanism for webhook in CloudBees Docker Hub/Registry Notification Plugin",
+  "details": "CloudBees Docker Hub/Registry Notification Plugin provides several webhook endpoints that can be used to trigger builds when Docker images used by a job have been rebuilt.\n\nIn CloudBees Docker Hub/Registry Notification Plugin 2.6.2 and earlier, these endpoints can be accessed without authentication.\n\nThis allows unauthenticated attackers to trigger builds of jobs corresponding to the attacker-specified repository.\n\nCloudBees Docker Hub/Registry Notification Plugin 2.6.2.1 requires a token as a part of webhook URLs, which will act as authentication for the webhook endpoint. As a result, all webhook URLs in the plugin will be different after updating the plugin.\n\nAdministrators can set the [Java system](https://www.jenkins.io/doc/book/managing/system-properties/) property `org.jenkinsci.plugins.registry.notification.webhook.JSONWebHook.DO_NOT_REQUIRE_API_TOKEN` to `true` to disable this fix.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
     }
   ],
   "affected": [
@@ -28,17 +28,24 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.6.2"
+              "fixed": "2.6.2.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.6.2"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-45385"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/dockerhub-notification-plugin"
     },
     {
       "type": "WEB",
@@ -49,7 +56,7 @@
     "cwe_ids": [
       "CWE-862"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in versions fixed according to https://www.jenkins.io/security/advisory/2022-11-15/#SECURITY-2843