### PR TITLE
[GHSA-vj5r-mmp4-3hrx] Jenkins NS-ND Integration Performance Publisher Plugin vulnerable due to improper certificate validation

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-vj5r-mmp4-3hrx/GHSA-vj5r-mmp4-3hrx.json
+++ b/advisories/github-reviewed/2022/11/GHSA-vj5r-mmp4-3hrx/GHSA-vj5r-mmp4-3hrx.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-vj5r-mmp4-3hrx",
-  "modified": "2022-11-21T22:19:30Z",
+  "modified": "2022-12-14T09:19:36Z",
   "published": "2022-11-16T12:00:22Z",
   "aliases": [
     "CVE-2022-38666"
   ],
-  "summary": "Jenkins NS-ND Integration Performance Publisher Plugin vulnerable due to improper certificate validation",
+  "summary": "SSL/TLS certificate validation unconditionally disabled by Jenkins NS-ND Integration Performance Publisher Plugin",
   "details": "Jenkins NS-ND Integration Performance Publisher Plugin 4.8.0.146 and earlier unconditionally disables SSL/TLS certificate and hostname validation for several features. Currently, there are no known workarounds or patches.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N"
     }
   ],
   "affected": [
@@ -25,7 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.8.0.146"
+              "introduced": "0"
+            },
+            {
+              "last_affected": "4.8.0.146"
             }
           ]
         }
@@ -39,7 +42,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/jenkinsci/cavisson-ns-nd-integration-plugin/releases"
+      "url": "https://github.com/jenkinsci/cavisson-ns-nd-integration-plugin"
     },
     {
       "type": "WEB",
@@ -50,7 +53,7 @@
     "cwe_ids": [
       "CWE-295"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Source code location
- Summary

**Comments**
Correct versions affected according to https://www.jenkins.io/security/advisory/2022-11-15/#SECURITY-2910%20(2)