### PR TITLE
[GHSA-4598-wcg8-x56g] XML External Entity Reference in Jenkins Violations Plugin

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-4598-wcg8-x56g/GHSA-4598-wcg8-x56g.json
+++ b/advisories/github-reviewed/2022/11/GHSA-4598-wcg8-x56g/GHSA-4598-wcg8-x56g.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4598-wcg8-x56g",
-  "modified": "2022-11-21T22:22:34Z",
+  "modified": "2022-12-14T09:25:36Z",
   "published": "2022-11-16T12:00:23Z",
   "aliases": [
     "CVE-2022-45386"
   ],
   "summary": "XML External Entity Reference in Jenkins Violations Plugin",
-  "details": "Jenkins Violations Plugin 0.7.11 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "details": "Violations Plugin 0.7.11 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers to control XML input files for the 'Report Violations' post-build step to have agent processes parse a crafted file that uses external entities for extraction of secrets from the Jenkins agent or server-side request forgery.\n\nBecause Jenkins agent processes usually execute build tools whose input (source code, build scripts, etc.) is controlled externally, this vulnerability only has a real impact in very narrow circumstances: when attackers can control XML files, but are unable to change build steps, Jenkinsfiles, test code that gets executed on the agents, or similar.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-11-15/#SECURITY-766