### PR TITLE
[GHSA-8847-xvjw-9g43] Jenkins OSF Builder Suite XML Linter Plugin vulnerable to XML external entity (XXE) attacks

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-8847-xvjw-9g43/GHSA-8847-xvjw-9g43.json
+++ b/advisories/github-reviewed/2022/11/GHSA-8847-xvjw-9g43/GHSA-8847-xvjw-9g43.json
@@ -1,24 +1,24 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8847-xvjw-9g43",
-  "modified": "2022-11-21T22:25:46Z",
+  "modified": "2022-12-14T09:44:36Z",
   "published": "2022-11-16T12:00:23Z",
   "aliases": [
     "CVE-2022-45397"
   ],
-  "summary": "Jenkins OSF Builder Suite XML Linter Plugin vulnerable to XML external entity (XXE) attacks",
-  "details": "Jenkins OSF Builder Suite : : XML Linter Plugin 1.0.2 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability on agents in Jenkins OSF Builder Suite : : XML Linter Plugin",
+  "details": "OSF Builder Suite : : XML Linter 1.0.2 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers able to control XML files that get processed by the 'OSF Builder Suite : : XML Linter' build step to have agent processes parse a crafted file that uses external entities for extraction of secrets from the Jenkins agent or server-side request forgery.\n\nBecause Jenkins agent processes usually execute build tools whose input (source code, build scripts, etc.) is controlled externally, this vulnerability only has a real impact in very narrow circumstances: when attackers can control XML files, but are unable to change build steps, Jenkinsfiles, test code that gets executed on the agents, or similar.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.jenkins-ci:update-center2"
+        "name": "org.jenkins-ci.plugins:osf-builder-suite-xml-linter"
       },
       "ranges": [
         {
@@ -45,19 +45,19 @@
       "url": "https://github.com/jenkins-infra/update-center2/pull/658"
     },
     {
-      "type": "WEB",
-      "url": "https://www.jenkins.io/security/advisory/2022-11-15/#SECURITY-2937"
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/osf-builder-suite-xml-linter-plugin"
     },
     {
-      "type": "PACKAGE",
-      "url": " https://github.com/jenkinsci/osf-builder-suite-xml-linter-plugin"
+      "type": "WEB",
+      "url": "https://www.jenkins.io/security/advisory/2022-11-15/#SECURITY-2937"
     }
   ],
   "database_specific": {
     "cwe_ids": [
       "CWE-611"
     ],
-    "severity": "CRITICAL",
+    "severity": "MODERATE",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-11-15/#SECURITY-2937 and fix maven group and artifact name