### PR TITLE
[GHSA-fg52-xjfc-9rh8] Pterodactyl before 0.7.14 with 2FA allows credential...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-fg52-xjfc-9rh8/GHSA-fg52-xjfc-9rh8.json
+++ b/advisories/unreviewed/2022/05/GHSA-fg52-xjfc-9rh8/GHSA-fg52-xjfc-9rh8.json
@@ -1,17 +1,39 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-fg52-xjfc-9rh8",
-  "modified": "2022-05-24T16:51:37Z",
+  "modified": "2022-12-14T10:05:37Z",
   "published": "2022-05-24T16:51:37Z",
   "aliases": [
     "CVE-2019-1020002"
   ],
-  "details": "Pterodactyl before 0.7.14 with 2FA allows credential sniffing.",
+  "summary": "Pterodactyl version 0.7.13 and lower - 2FA Sniffing",
+  "details": "**Pterodactyl version 0.7.13 and lower - 2FA Sniffing**\n\nUsers who have enabled 2FA protections on their account can unintentionally have their account's existence sniffed by malicious users who enter random credentials into the login fields.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "pterodactyl/panel"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.7.14"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 0.7.13"
+      }
+    }
   ],
   "references": [
     {
@@ -21,13 +43,17 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-1020002"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/pterodactyl/panel/"
     }
   ],
   "database_specific": {
     "cwe_ids": [
 
     ],
-    "severity": null,
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Severity
- Source code location
- Summary

**Comments**
Edit description and version