### PR TITLE
[GHSA-4hjj-9gp7-4frg] Jenkins Pipeline: Groovy Libraries Plugin vulnerable to Protection Mechanism Failure

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-4hjj-9gp7-4frg/GHSA-4hjj-9gp7-4frg.json
+++ b/advisories/github-reviewed/2022/10/GHSA-4hjj-9gp7-4frg/GHSA-4hjj-9gp7-4frg.json
@@ -1,24 +1,24 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4hjj-9gp7-4frg",
-  "modified": "2022-10-25T20:38:50Z",
+  "modified": "2022-12-15T20:43:18Z",
   "published": "2022-10-19T19:00:21Z",
   "aliases": [
     "CVE-2022-43405"
   ],
-  "summary": "Jenkins Pipeline: Groovy Libraries Plugin vulnerable to Protection Mechanism Failure",
-  "details": "A sandbox bypass vulnerability in Jenkins Pipeline: Groovy Libraries Plugin 612.v84da_9c54906d and earlier allows attackers with permission to define untrusted Pipeline libraries and to define and run sandboxed scripts, including Pipelines, to bypass the sandbox protection and execute arbitrary code in the context of the Jenkins controller JVM. Pipeline: Groovy Libraries Plugin 613.v9c41a_160233f rejects improper calls to sandbox-generated synthetic constructors when using the library step.",
+  "summary": "Sandbox bypass vulnerability in Jenkins Pipeline: Groovy Libraries Plugin and Pipeline: Deprecated Groovy Libraries Plugin",
+  "details": "Pipeline: Groovy Libraries Plugin and older releases of the Pipeline: Deprecated Groovy Libraries Plugin (formerly Pipeline: Shared Groovy Libraries Plugin) define the l`ibrary` Pipeline step, which allows Pipeline authors to dynamically load Pipeline libraries. The return value of this step can be used to instantiate classes defined in the loaded library.\n\nIn Pipeline: Groovy Libraries Plugin 612.v84da_9c54906d and earlier and in Pipeline: Deprecated Groovy Libraries Plugin 583.vf3b_454e43966 and earlier, the `library` step can be used to invoke sandbox-generated synthetic constructors in crafted untrusted libraries and construct any subclassable type. This is similar to SECURITY-582 in the [2017-08-07 security advisory](https://www.jenkins.io/security/advisory/2017-08-07/#multiple-groovy-language-features-allowed-script-security-plugin-sandbox-bypass), but in a different plugin.\n\nThis vulnerability allows attackers with permission to define untrusted Pipeline libraries and to define and run sandboxed Pipelines, to bypass the sandbox protection and execute arbitrary code in the context of the Jenkins controller JVM.\n\nPipeline: Groovy Libraries Plugin 613.v9c41a_160233f rejects improper calls to sandbox-generated synthetic constructors when using the `library` step.\n\nPipeline: Deprecated Groovy Libraries Plugin 588.v576c103a_ff86 no longer contains the `library` step. It has been moved into the Pipeline: Groovy Libraries Plugin.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "o.jenkins.plugins:pipeline-groovy-lib"
+        "name": "io.jenkins.plugins:pipeline-groovy-lib"
       },
       "ranges": [
         {
@@ -35,6 +35,28 @@
       ],
       "database_specific": {
         "last_known_affected_version_range": "< 613.v9c41a"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins.workflow:workflow-cps-global-lib"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "588.v576c103a_ff86"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 583.vf3b"
       }
     }
   ],
@@ -56,7 +78,7 @@
     "cwe_ids": [
       "CWE-693"
     ],
-    "severity": "CRITICAL",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Summary

**Comments**
Updates the maven group ID and adds another software component impacted by this CVE according to https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2824%20(2)