### PR TITLE
[GHSA-g66m-fqxf-3w35] Jenkins Pipeline: Input Step Plugin vulnerable to Inappropriate Encoding for Output Context

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-g66m-fqxf-3w35/GHSA-g66m-fqxf-3w35.json
+++ b/advisories/github-reviewed/2022/10/GHSA-g66m-fqxf-3w35/GHSA-g66m-fqxf-3w35.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-g66m-fqxf-3w35",
-  "modified": "2022-10-22T01:05:28Z",
+  "modified": "2022-12-15T20:47:45Z",
   "published": "2022-10-19T19:00:22Z",
   "aliases": [
     "CVE-2022-43407"
   ],
-  "summary": "Jenkins Pipeline: Input Step Plugin vulnerable to Inappropriate Encoding for Output Context",
-  "details": "Jenkins Pipeline: Input Step Plugin 451.vf1a_a_4f405289 and earlier does not restrict or sanitize the optionally specified ID of the `input` step, which is used for the URLs that process user interactions for the given `input` step (proceed or abort) and is not correctly encoded, allowing attackers able to configure Pipelines to have Jenkins build URLs from `input` step IDs that would bypass the CSRF protection of any target URL in Jenkins when the 'input' step is interacted with. Pipeline: Input Step Plugin 456.vd8a_957db_5b_e9 limits the characters that can be used for the ID of input steps in Pipelines to alphanumeric characters and URL-safe punctuation. Pipelines with input steps having IDs with prohibited characters will fail with an error.",
+  "summary": "CSRF protection for any URL can be bypassed in Jenkins Pipeline: Input Step Plugin",
+  "details": "Pipeline: Input Step Plugin 451.vf1a_a_4f405289 and earlier does not restrict or sanitize the optionally specified ID of the `input` step. This ID is used for the URLs that process user interactions for the given `input` step (proceed or abort) and is not correctly encoded.\n\nThis allows attackers able to configure Pipelines to have Jenkins build URLs from `input` step IDs that would bypass the CSRF protection of any target URL in Jenkins when the `input` step is interacted with.\n\nPipeline: Input Step Plugin 456.vd8a_957db_5b_e9 limits the characters that can be used for the ID of `input` steps in Pipelines to alphanumeric characters and URL-safe punctuation. Pipelines with `input` steps having IDs with prohibited characters will fail with an error.\n\nThis includes Pipelines that have already been started but not finished before Jenkins is restarted to apply this update.\n\n[Pipeline: Declarative Plugin](https://plugins.jenkins.io/pipeline-model-definition/) provides an `input` directive that is internally using the `input` step, and specifies a non-default ID if not user-defined. Pipeline: Declarative Plugin 2.2114.v2654ca_721309 and earlier may specify values incompatible with this new restriction on legal values: `input` directives in a `stage` use the stage name (which may include prohibited characters) and `input` directives in a `matrix` will use a value generated from the matrix axis values (which always includes prohibited characters). Administrators are advised to update Pipeline: Input Step Plugin and Pipeline: Declarative Plugin at the same time, ideally while no Pipelines are running.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -28,17 +28,24 @@
               "introduced": "0"
             },
             {
-              "fixed": "456.vd8a"
+              "fixed": "456.vd8a_957db_5b_e9"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 456.vd8a"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43407"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/pipeline-input-step-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Correct CVSS scoring according to https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2880