### PR TITLE
[GHSA-j7pg-863g-22p6] Jenkins Mercurial Plugin provides info about jobs triggered or scheduled for polling through webhook endpoint

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-j7pg-863g-22p6/GHSA-j7pg-863g-22p6.json
+++ b/advisories/github-reviewed/2022/10/GHSA-j7pg-863g-22p6/GHSA-j7pg-863g-22p6.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-j7pg-863g-22p6",
-  "modified": "2022-11-03T19:24:46Z",
+  "modified": "2022-12-15T20:58:21Z",
   "published": "2022-10-19T19:00:18Z",
   "aliases": [
     "CVE-2022-43410"
   ],
-  "summary": "Jenkins Mercurial Plugin provides info about jobs triggered or scheduled for polling through webhook endpoint",
-  "details": "Jenkins Mercurial Plugin 1251.va_b_121f184902 and earlier provides information about which jobs were triggered or scheduled for polling through its webhook endpoint, including jobs the user has no permission to access. Mercurial Plugin 1260.vdfb_723cdcc81 does not provide the names of jobs for which polling is triggered unless the user has the appropriate Item/Read permission.",
+  "summary": "Webhook endpoint discloses job names to unauthorized users in Jenkins Mercurial Plugin",
+  "details": "Mercurial Plugin provides a webhook endpoint at `/mercurial/notifyCommit` that can be used to notify Jenkins of changes to an SCM repository. This endpoint receives a repository URL, and Jenkins will schedule polling for all jobs configured with the specified repository. It can be accessed with GET requests and without authentication.\n\nIn Mercurial Plugin 1251.va_b_121f184902 and earlier, the output of the webhook endpoint will provide information about which jobs were triggered or scheduled for polling, including jobs the user has no permission to access. This allows attackers with knowledge of Mercurial repository URLs to obtain information about the existence of jobs configured with this Mercurial repository.\n\nMercurial Plugin 1260.vdfb_723cdcc81 does not provide the names of jobs for which polling is triggered unless the user has the appropriate Item/Read permission.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43410"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/mercurial-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Description
- Source code location
- Summary

**Comments**
Provide details about the actual endpoint affected according to https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2831