### PR TITLE
[GHSA-f9f9-4r63-4qcc] Jenkins GitLab Plugin potentially allows attackers to use statistical methods to obtain valid webhook token

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-f9f9-4r63-4qcc/GHSA-f9f9-4r63-4qcc.json
+++ b/advisories/github-reviewed/2022/10/GHSA-f9f9-4r63-4qcc/GHSA-f9f9-4r63-4qcc.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-f9f9-4r63-4qcc",
-  "modified": "2022-10-20T20:11:01Z",
+  "modified": "2022-12-15T20:59:18Z",
   "published": "2022-10-19T19:00:22Z",
   "aliases": [
     "CVE-2022-43411"
   ],
-  "summary": "Jenkins GitLab Plugin potentially allows attackers to use statistical methods to obtain valid webhook token",
-  "details": "Jenkins GitLab Plugin 1.5.35 and earlier uses a non-constant time comparison function when checking whether the provided and expected webhook token are equal, potentially allowing attackers to use statistical methods to obtain a valid webhook token. GitLab Plugin 1.5.36 uses a constant-time comparison when validating the webhook token.",
+  "summary": "Non-constant time webhook token comparison in Jenkins GitLab Plugin",
+  "details": "GitLab Plugin 1.5.35 and earlier does not use a constant-time comparison when checking whether the provided and expected webhook token are equal.\n\nThis could potentially allow attackers to use statistical methods to obtain a valid webhook token.\n\nGitLab Plugin 1.5.36 uses a constant-time comparison when validating the webhook token.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
@@ -44,6 +44,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43411"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/gitlab-plugin"
+    },
+    {
       "type": "WEB",
       "url": "https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2877"
     },
@@ -57,7 +61,7 @@
       "CWE-203",
       "CWE-208"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2877