### PR TITLE
[GHSA-2w2m-ccf8-57cq] Jenkins REPO Plugin does not configure XML parser to prevent XXE attacks

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-2w2m-ccf8-57cq/GHSA-2w2m-ccf8-57cq.json
+++ b/advisories/github-reviewed/2022/10/GHSA-2w2m-ccf8-57cq/GHSA-2w2m-ccf8-57cq.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-2w2m-ccf8-57cq",
-  "modified": "2022-10-21T13:01:35Z",
+  "modified": "2022-12-15T21:01:44Z",
   "published": "2022-10-19T19:00:18Z",
   "aliases": [
     "CVE-2022-43415"
   ],
-  "summary": "Jenkins REPO Plugin does not configure XML parser to prevent XXE attacks",
-  "details": "Jenkins REPO Plugin 1.15.0 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks. REPO Plugin 1.16.0 disables external entity resolution for its XML parser.",
+  "summary": "XXE vulnerability in Jenkins REPO Plugin",
+  "details": "REPO Plugin 1.15.0 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers able to control which `repo` binary is executed on agents to have Jenkins parse a crafted XML document that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.\n\nREPO Plugin 1.16.0 disables external entity resolution for its XML parser.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
     }
   ],
   "affected": [
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43415"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/repo-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Source code location
- Summary

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2337