### PR TITLE
[GHSA-x8j7-vxh9-p67g] Jenkins Katalon Plugin vulnerable to Cross-Site Request Forgery

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-x8j7-vxh9-p67g/GHSA-x8j7-vxh9-p67g.json
+++ b/advisories/github-reviewed/2022/10/GHSA-x8j7-vxh9-p67g/GHSA-x8j7-vxh9-p67g.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-x8j7-vxh9-p67g",
-  "modified": "2022-10-21T13:02:21Z",
+  "modified": "2022-12-15T21:04:05Z",
   "published": "2022-10-19T19:00:18Z",
   "aliases": [
     "CVE-2022-43418"
   ],
-  "summary": "Jenkins Katalon Plugin vulnerable to Cross-Site Request Forgery",
-  "details": "A cross-site request forgery (CSRF) vulnerability in Jenkins Katalon Plugin 1.0.33 and earlier allows attackers to connect to an attacker-specified URL using attacker-specified credentials IDs obtained through another method, capturing credentials stored in Jenkins. Katalon Plugin 1.0.34 requires POST requests for the affected HTTP endpoints.",
+  "summary": "CSRF vulnerability in Jenkins Katalon Plugin allows capturing credentials",
+  "details": "Katalon Plugin 1.0.33 and earlier does not require POST requests for several HTTP endpoints, resulting in cross-site request forgery (CSRF) vulnerabilities.\n\nThis vulnerability allows attackers to connect to an attacker-specified URL using attacker-specified credentials IDs obtained through another method, capturing credentials stored in Jenkins.\n\nKatalon Plugin 1.0.34 requires POST requests for the affected HTTP endpoints.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43418"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/katalon-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Source code location
- Summary

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2845%20(2)