### PR TITLE
[GHSA-35rx-7pc8-6963] Jenkins Katalon Plugin stores API keys unencrypted

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-35rx-7pc8-6963/GHSA-35rx-7pc8-6963.json
+++ b/advisories/github-reviewed/2022/10/GHSA-35rx-7pc8-6963/GHSA-35rx-7pc8-6963.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-35rx-7pc8-6963",
-  "modified": "2022-10-21T13:01:10Z",
+  "modified": "2022-12-15T21:05:01Z",
   "published": "2022-10-19T19:00:18Z",
   "aliases": [
     "CVE-2022-43419"
   ],
-  "summary": "Jenkins Katalon Plugin stores API keys unencrypted",
-  "details": "Jenkins Katalon Plugin 1.0.32 and earlier stores API keys unencrypted in job config.xml files on the Jenkins controller where they can be viewed by users with Extended Read permission, or access to the Jenkins controller file system. Katalon Plugin 1.0.33 no longer stores the API keys directly, instead accessing them through its Credentials Plugin integration, once affected job configurations are saved again.",
+  "summary": "API keys stored in plain text by Jenkins Katalon Plugin",
+  "details": "Katalon Plugin 1.0.32 and earlier stores API keys unencrypted in job `config.xml` files on the Jenkins controller as part of its configuration.\n\nThese API keys can be viewed by users with Item/Extended Read permission or access to the Jenkins controller file system.\n\nKatalon Plugin 1.0.33 no longer stores the API keys directly, instead accessing them through its [Credentials Plugin](https://plugins.jenkins.io/credentials) integration, once affected job configurations are saved again.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43419"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/katalon-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Source code location
- Summary

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2846