### PR TITLE
[GHSA-vhwv-8897-jm7q] Jenkins Compuware Topaz for Total Test Plugin does not configure its XML parser to prevent XXE attacks

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-vhwv-8897-jm7q/GHSA-vhwv-8897-jm7q.json
+++ b/advisories/github-reviewed/2022/10/GHSA-vhwv-8897-jm7q/GHSA-vhwv-8897-jm7q.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-vhwv-8897-jm7q",
-  "modified": "2022-10-25T20:35:20Z",
+  "modified": "2022-12-15T21:15:36Z",
   "published": "2022-10-19T19:00:18Z",
   "aliases": [
     "CVE-2022-43430"
   ],
-  "summary": "Jenkins Compuware Topaz for Total Test Plugin does not configure its XML parser to prevent XXE attacks",
-  "details": "Jenkins Compuware Topaz for Total Test Plugin 2.4.8 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability in Jenkins Compuware Topaz for Total Test Plugin",
+  "details": "Compuware Topaz for Total Test Plugin 2.4.8 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers able to control the input files for the 'Topaz for Total Test - Execute Total Test scenarios' build step to have Jenkins parse a crafted XML document that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
     }
   ],
   "affected": [
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43430"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/compuware-topaz-for-total-test-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2625