### PR TITLE
[GHSA-px4x-hjm5-w8x3] Jenkins XFramium Builder Plugin disables Content-Security-Policy protection for user-generated content

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-px4x-hjm5-w8x3/GHSA-px4x-hjm5-w8x3.json
+++ b/advisories/github-reviewed/2022/10/GHSA-px4x-hjm5-w8x3/GHSA-px4x-hjm5-w8x3.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-px4x-hjm5-w8x3",
-  "modified": "2022-10-25T20:39:05Z",
+  "modified": "2022-12-15T21:17:20Z",
   "published": "2022-10-19T19:00:22Z",
   "aliases": [
     "CVE-2022-43432"
   ],
-  "summary": "Jenkins XFramium Builder Plugin disables Content-Security-Policy protection for user-generated content",
-  "details": "Jenkins XFramium Builder Plugin 1.0.22 and earlier programmatically disables Content-Security-Policy protection for user-generated content in workspaces, archived artifacts, etc. that Jenkins offers for download.",
+  "summary": "Content-Security-Policy protection for user content disabled by Jenkins XFramium Builder Plugin",
+  "details": "Jenkins sets the Content-Security-Policy header to static files served by Jenkins (specifically `DirectoryBrowserSupport`), such as workspaces, `/userContent`, or archived artifacts, unless a Resource Root URL is specified.\n\nXFramium Builder Plugin 1.0.22 and earlier globally disables the `Content-Security-Policy` header for static files served by Jenkins as soon as it is loaded. This allows cross-site scripting (XSS) attacks by users with the ability to control files in workspaces, archived artifacts, etc.\n\nJenkins instances with [Resource Root URL](https://www.jenkins.io/doc/book/security/user-content/#resource-root-url) configured are unaffected.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -41,6 +41,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43432"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/xframium-plugin"
+    },
+    {
       "type": "WEB",
       "url": "https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2863"
     },
@@ -53,7 +57,7 @@
     "cwe_ids": [
       "CWE-693"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2863