### PR TITLE
[GHSA-cvxj-4745-843x] Jenkins ScreenRecorder Plugin disables Content-Security-Policy protection for user-generated content

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-cvxj-4745-843x/GHSA-cvxj-4745-843x.json
+++ b/advisories/github-reviewed/2022/10/GHSA-cvxj-4745-843x/GHSA-cvxj-4745-843x.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-cvxj-4745-843x",
-  "modified": "2022-10-25T20:38:57Z",
+  "modified": "2022-12-15T21:19:16Z",
   "published": "2022-10-19T19:00:22Z",
   "aliases": [
     "CVE-2022-43433"
   ],
-  "summary": "Jenkins ScreenRecorder Plugin disables Content-Security-Policy protection for user-generated content",
-  "details": "Jenkins ScreenRecorder Plugin 0.7 and earlier programmatically disables Content-Security-Policy protection for user-generated content in workspaces, archived artifacts, etc. that Jenkins offers for download.",
+  "summary": "Content-Security-Policy protection for user content disabled by Jenkins ScreenRecorder Plugin",
+  "details": "Jenkins sets the `Content-Security-Policy` header to static files served by Jenkins (specifically `DirectoryBrowserSupport`), such as workspaces, `/userContent`, or archived artifacts, unless a Resource Root URL is specified.\n\nScreenRecorder Plugin 0.7 and earlier programmatically updates [the Java system property](https://www.jenkins.io/doc/book/managing/system-properties/#hudson-model-directorybrowsersupport-csp) allowing administrators to customize the `Content-Security-Policy` header for static files served by Jenkins to include `media-src: 'self'`. On a Jenkins instance with default configuration, this effectively disables all other directives in the default rule set, including `script-src`. This allows cross-site scripting (XSS) attacks by users with the ability to control files in workspaces, archived artifacts, etc.\n\nJenkins instances with [Resource Root URL](https://www.jenkins.io/doc/book/security/user-content/#resource-root-url) configured are unaffected.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -41,6 +41,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43433"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/screenrecorder-plugin"
+    },
+    {
       "type": "WEB",
       "url": "https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2864"
     },
@@ -53,7 +57,7 @@
     "cwe_ids": [
       "CWE-693"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2864