### PR TITLE
[GHSA-wmfh-h3vm-rcxm] Jenkins NeuVector Vulnerability Scanner Plugin disables Content-Security-Policy protection for user-generated content

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-wmfh-h3vm-rcxm/GHSA-wmfh-h3vm-rcxm.json
+++ b/advisories/github-reviewed/2022/10/GHSA-wmfh-h3vm-rcxm/GHSA-wmfh-h3vm-rcxm.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-wmfh-h3vm-rcxm",
-  "modified": "2022-10-25T20:50:05Z",
+  "modified": "2022-12-15T21:21:53Z",
   "published": "2022-10-19T19:00:18Z",
   "aliases": [
     "CVE-2022-43434"
   ],
-  "summary": "Jenkins NeuVector Vulnerability Scanner Plugin disables Content-Security-Policy protection for user-generated content",
-  "details": "Jenkins NeuVector Vulnerability Scanner Plugin 1.20 and earlier programmatically disables Content-Security-Policy protection for user-generated content in workspaces, archived artifacts, etc. that Jenkins offers for download.",
+  "summary": "Content-Security-Policy protection for user content disabled by Jenkins NeuVector Vulnerability Scanner Plugin ",
+  "details": "Jenkins sets the Content-Security-Policy header to static files served by Jenkins (specifically `DirectoryBrowserSupport`), such as workspaces, `/userContent`, or archived artifacts, unless a Resource Root URL is specified.\n\nNeuVector Vulnerability Scanner Plugin 1.20 and earlier globally disables the `Content-Security-Policy` header for static files served by Jenkins whenever the 'NeuVector Vulnerability Scanner' build step is executed. This allows cross-site scripting (XSS) attacks by users with the ability to control files in workspaces, archived artifacts, etc.\n\nJenkins instances with [Resource Root URL](https://www.jenkins.io/doc/book/security/user-content/#resource-root-url) configured are unaffected.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -28,17 +28,24 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.20"
+              "fixed": "1.22"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.20"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43434"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/neuvector-vulnerability-scanner-plugin"
     },
     {
       "type": "WEB",
@@ -53,7 +60,7 @@
     "cwe_ids": [
       "CWE-693"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2865

This has been fixed in https://github.com/jenkinsci/neuvector-vulnerability-scanner-plugin/commit/e0a72373ef1c20c41b8eb086883a7090cf04809c, which has been released in 1.22