### PR TITLE
[GHSA-7rrj-hqv6-fvpp] Jenkins 360 FireLine Plugin disables Content-Security-Policy protection for user-generated content

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-7rrj-hqv6-fvpp/GHSA-7rrj-hqv6-fvpp.json
+++ b/advisories/github-reviewed/2022/10/GHSA-7rrj-hqv6-fvpp/GHSA-7rrj-hqv6-fvpp.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-7rrj-hqv6-fvpp",
-  "modified": "2022-10-25T20:50:12Z",
+  "modified": "2022-12-15T21:23:25Z",
   "published": "2022-10-19T19:00:18Z",
   "aliases": [
     "CVE-2022-43435"
   ],
-  "summary": "Jenkins 360 FireLine Plugin disables Content-Security-Policy protection for user-generated content",
-  "details": "Jenkins 360 FireLine Plugin 1.7.2 and earlier programmatically disables Content-Security-Policy protection for user-generated content in workspaces, archived artifacts, etc. that Jenkins offers for download.",
+  "summary": "Content-Security-Policy protection for user content can be disabled in Jenkins 360 FireLine Plugin",
+  "details": "Jenkins sets the Content-Security-Policy header to static files served by Jenkins (specifically `DirectoryBrowserSupport`), such as workspaces, `/userContent`, or archived artifacts, unless a Resource Root URL is specified.\n\n360 FireLine Plugin 1.7.2 and earlier globally disables the `Content-Security-Policy` header for static files served by Jenkins whenever the 'Execute FireLine' build step is executed, if the option 'Open access to HTML with JS or CSS' is checked. This allows cross-site scripting (XSS) attacks by users with the ability to control files in workspaces, archived artifacts, etc.\n\nJenkins instances with [Resource Root URL](https://www.jenkins.io/doc/book/security/user-content/#resource-root-url) configured are unaffected.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -41,6 +41,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43435"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/fireline-plugin"
+    },
+    {
       "type": "WEB",
       "url": "https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2866"
     },
@@ -53,7 +57,7 @@
     "cwe_ids": [
       "CWE-693"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2866