### PR TITLE
[GHSA-p86x-75j8-w4xh] Jenkins Checkmarx Plugin 2022.3.3 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/12/GHSA-p86x-75j8-w4xh/GHSA-p86x-75j8-w4xh.json
+++ b/advisories/unreviewed/2022/12/GHSA-p86x-75j8-w4xh/GHSA-p86x-75j8-w4xh.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-p86x-75j8-w4xh",
-  "modified": "2022-12-12T09:30:35Z",
+  "modified": "2022-12-15T21:25:59Z",
   "published": "2022-12-12T09:30:35Z",
   "aliases": [
     "CVE-2022-46684"
   ],
-  "details": "Jenkins Checkmarx Plugin 2022.3.3 and earlier does not escape values returned from the Checkmarx service API before inserting them into HTML reports, resulting in a stored cross-site scripting (XSS) vulnerability.",
+  "summary": "Stored XSS vulnerability in Jenkins Checkmarx Plugin",
+  "details": "Checkmarx Plugin processes Checkmarx service API responses and generates HTML reports from them for rendering on the Jenkins UI.\n\nCheckmarx Plugin 2022.3.3 and earlier does not escape values returned from the Checkmarx service API before inserting them into HTML reports. This results in a stored cross-site scripting (XSS) vulnerability.\n\nWhile Jenkins users without Overall/Administer permission are not allowed to configure the URL to the Checkmarx service, this could still be exploited via man-in-the-middle attacks.\n\nCheckmarx Plugin 2022.4.3 escapes values returned from the Checkmarx service API before inserting them into HTML reports.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.checkmarx.jenkins:checkmarx"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2022.4.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2022.3.3"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-46684"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/checkmarx-plugin"
     },
     {
       "type": "WEB",
@@ -27,7 +56,7 @@
     "cwe_ids": [
 
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2022-12-07/#SECURITY-2869