### PR TITLE
[GHSA-4wx5-c723-xvwv] Jenkins Copr Plugin 0.3 and earlier stores credentials...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-4wx5-c723-xvwv/GHSA-4wx5-c723-xvwv.json
+++ b/advisories/unreviewed/2022/05/GHSA-4wx5-c723-xvwv/GHSA-4wx5-c723-xvwv.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4wx5-c723-xvwv",
-  "modified": "2022-05-24T17:15:35Z",
+  "modified": "2022-12-15T21:32:09Z",
   "published": "2022-05-24T17:15:35Z",
   "aliases": [
     "CVE-2020-2177"
   ],
-  "details": "Jenkins Copr Plugin 0.3 and earlier stores credentials unencrypted in job config.xml files on the Jenkins master where they can be viewed by users with Extended Read permission, or access to the master file system.",
+  "summary": "Credentials stored in plain text by Jenkins Copr Plugin",
+  "details": "Copr Plugin 0.3 and earlier stores credentials unencrypted in job `config.xml` files as part of its configuration. These credentials can be viewed by users with Extended Read permission or access to the Jenkins controller file system.\n\nCopr Plugin 0.6.1 stores these credentials encrypted. This change is effective once the job configuration is saved the next time.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.fedoraproject.jenkins.plugins:copr"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.6.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.3"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2177"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/copr-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-04-16/#SECURITY-1556