### PR TITLE
[GHSA-q58j-fhj7-j6fg] Jenkins Subversion Plugin 2.15.0 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-q58j-fhj7-j6fg/GHSA-q58j-fhj7-j6fg.json
+++ b/advisories/unreviewed/2022/05/GHSA-q58j-fhj7-j6fg/GHSA-q58j-fhj7-j6fg.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-q58j-fhj7-j6fg",
-  "modified": "2022-05-24T19:19:43Z",
+  "modified": "2022-12-16T11:12:44Z",
   "published": "2022-05-24T19:19:43Z",
   "aliases": [
     "CVE-2021-21698"
   ],
-  "details": "Jenkins Subversion Plugin 2.15.0 and earlier does not restrict the name of a file when looking up a subversion key file on the controller from an agent.",
+  "summary": "Path traversal vulnerability in Jenkins Subversion Plugin allows reading arbitrary files",
+  "details": "Subversion Plugin 2.15.0 and earlier does not restrict the name of a file when looking up a subversion key file on the controller from an agent.\n\nThis allows attackers able to control agent processes to read arbitrary files on the Jenkins controller file system.\n\nSubversion Plugin 2.15.1 checks for the presence of and prohibits directory separator characters as part of the file name, restricting it to the intended directory.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:subversion"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.15.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.15.0"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21698"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/subversion-plugin"
     },
     {
       "type": "WEB",
@@ -31,7 +60,7 @@
     "cwe_ids": [
       "CWE-22"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2021-11-04/#SECURITY-2506