### PR TITLE
[GHSA-g9hg-x9c9-7xgr] Jenkins CVS Plugin 2.16 and earlier does not configure...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-g9hg-x9c9-7xgr/GHSA-g9hg-x9c9-7xgr.json
+++ b/advisories/unreviewed/2022/05/GHSA-g9hg-x9c9-7xgr/GHSA-g9hg-x9c9-7xgr.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-g9hg-x9c9-7xgr",
-  "modified": "2022-05-24T17:35:09Z",
+  "modified": "2022-12-16T20:04:48Z",
   "published": "2022-05-24T17:35:09Z",
   "aliases": [
     "CVE-2020-2324"
   ],
-  "details": "Jenkins CVS Plugin 2.16 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability in Jenkins CVS Plugin",
+  "details": "CVS Plugin 2.16 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers able to control an agent process to have Jenkins parse a crafted changelog file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.\n\nCVS Plugin 2.17 disables external entity resolution for its XML parser.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:cvs"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.17"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.16"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2324"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/cvs-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-12-03/#SECURITY-2146