### PR TITLE
[GHSA-hx53-635r-vmv8] Jenkins Chaos Monkey Plugin 0.4 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-hx53-635r-vmv8/GHSA-hx53-635r-vmv8.json
+++ b/advisories/unreviewed/2022/05/GHSA-hx53-635r-vmv8/GHSA-hx53-635r-vmv8.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-hx53-635r-vmv8",
-  "modified": "2022-05-24T17:35:09Z",
+  "modified": "2022-12-16T20:09:50Z",
   "published": "2022-05-24T17:35:09Z",
   "aliases": [
     "CVE-2020-2323"
   ],
-  "details": "Jenkins Chaos Monkey Plugin 0.4 and earlier does not perform permission checks in an HTTP endpoint, allowing attackers with Overall/Read permission to access the Chaos Monkey page and to see the history of actions.",
+  "summary": "Missing permission checks in Jenkins Chaos Monkey Plugin",
+  "details": "Chaos Monkey Plugin 0.4 and earlier does not perform permission checks in an HTTP endpoint.\n\nThis allows attackers with Overall/Read permission to access the Chaos Monkey page and to see the history of actions.\n\nChaos Monkey Plugin 0.4.1 requires Overall/Administer permission to access the Chaos Monkey page and to see the history of actions.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.jenkins.plugins:chaos-monkey"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.4.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.4"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2323"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/chaos-monkey-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-12-03/#SECURITY-2109%20(2)