### PR TITLE
[GHSA-43j2-r4v3-m8jp] Insufficiently Protected Credentials in Jenkins Credentials Binding Plugin

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-43j2-r4v3-m8jp/GHSA-43j2-r4v3-m8jp.json
+++ b/advisories/github-reviewed/2022/05/GHSA-43j2-r4v3-m8jp/GHSA-43j2-r4v3-m8jp.json
@@ -1,24 +1,24 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-43j2-r4v3-m8jp",
-  "modified": "2022-06-24T00:57:14Z",
+  "modified": "2022-12-16T20:13:42Z",
   "published": "2022-05-24T17:17:14Z",
   "aliases": [
     "CVE-2020-2181"
   ],
-  "summary": "Insufficiently Protected Credentials in Jenkins Credentials Binding Plugin",
-  "details": "Jenkins Credentials Binding Plugin 1.22 and earlier does not mask (i.e., replace with asterisks) secrets in the build log when the build contains no build steps.",
+  "summary": "Secrets are not masked by Jenkins Credentials Binding Plugin in builds without build steps",
+  "details": "Credentials Binding Plugin 1.22 and earlier does not mask (i.e., replace with asterisks) secrets in the build log when the build contains no build steps.\n\nCredentials Binding Plugin 1.23 now masks secrets when the build contains no build steps. ",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
     }
   ],
   "affected": [
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.jenkins-ci.plugins:credentials"
+        "name": "org.jenkins-ci.plugins:credentials-binding"
       },
       "ranges": [
         {
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2181"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/credentials-binding-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Correct maven artifact ID according to https://www.jenkins.io/security/advisory/2020-05-06/#SECURITY-1374