### PR TITLE
[GHSA-7ff8-qfwx-8gx5] Insufficiently Protected Credentials in Jenkins Credentials Binding Plugin

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-7ff8-qfwx-8gx5/GHSA-7ff8-qfwx-8gx5.json
+++ b/advisories/github-reviewed/2022/05/GHSA-7ff8-qfwx-8gx5/GHSA-7ff8-qfwx-8gx5.json
@@ -1,24 +1,24 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-7ff8-qfwx-8gx5",
-  "modified": "2022-06-24T00:56:55Z",
+  "modified": "2022-12-16T20:15:14Z",
   "published": "2022-05-24T17:17:14Z",
   "aliases": [
     "CVE-2020-2182"
   ],
-  "summary": "Insufficiently Protected Credentials in Jenkins Credentials Binding Plugin",
-  "details": "Jenkins Credentials Binding Plugin 1.22 and earlier does not mask (i.e., replace with asterisks) secrets containing a `$` character in some circumstances.",
+  "summary": "Improper masking of some secrets in Jenkins Credentials Binding Plugin",
+  "details": "Credentials Binding Plugin allows specifying passwords and other secrets as environment variables, and will hide them from console output in builds. As a side effect of the fix for [SECURITY-698](https://www.jenkins.io/security/advisory/2018-02-05/#credentials-binding), `$` characters in secrets are escaped to `$$`. This will then be expanded to $ again once the secret is passed to (post) build steps.\n\nCredentials Binding Plugin 1.22 and earlier does not mask the escaped form of the secret (containing `$$`). This occurs for example in the \"Execute Maven top-level targets\" build step included in Jenkins.\n\nCredentials Binding Plugin 1.23 now masks secrets both in their original form and with escaped `$` characters, so they will be masked even if printed before value expansion.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.jenkins-ci.plugins:credentials"
+        "name": "org.jenkins-ci.plugins:credentials-binding"
       },
       "ranges": [
         {
@@ -44,6 +44,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2182"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/credentials-binding-plugin"
+    },
+    {
       "type": "WEB",
       "url": "https://jenkins.io/security/advisory/2020-05-06/#SECURITY-1835"
     },
@@ -56,7 +60,7 @@
     "cwe_ids": [
       "CWE-522"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fix maven artifact ID according to https://www.jenkins.io/security/advisory/2020-05-06/#SECURITY-1835