### PR TITLE
[GHSA-q8qq-2p5p-rg44] Jenkins Amazon EC2 Plugin 1.50.1 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-q8qq-2p5p-rg44/GHSA-q8qq-2p5p-rg44.json
+++ b/advisories/unreviewed/2022/05/GHSA-q8qq-2p5p-rg44/GHSA-q8qq-2p5p-rg44.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-q8qq-2p5p-rg44",
-  "modified": "2022-05-24T17:17:14Z",
+  "modified": "2022-12-16T20:19:42Z",
   "published": "2022-05-24T17:17:14Z",
   "aliases": [
     "CVE-2020-2185"
   ],
-  "details": "Jenkins Amazon EC2 Plugin 1.50.1 and earlier does not validate SSH host keys when connecting agents, enabling man-in-the-middle attacks.",
+  "summary": "Missing SSH host key validation in Amazon EC2 Plugin",
+  "details": "Amazon EC2 Plugin 1.50.1 and earlier does not use SSH host key validation when connecting to agents. This lack of validation could be abused using a man-in-the-middle attack to intercept these connections to build agents.\n\nAmazon EC2 Plugin 1.50.2 provides strategies for performing host key validation for administrators to select the one that meets their security needs. It includes assistance for administrators to migrate to a new, more secure strategy. For more information see [the plugin documentation](https://github.com/jenkinsci/ec2-plugin/#securing-the-connection-to-unix-amis).",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:ec2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.50.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.50.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2185"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/ec2-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-05-06/#SECURITY-381