### PR TITLE
[GHSA-qp4f-2w67-c8hw] Jenkins 2.213 and earlier, LTS 2.204.1 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-qp4f-2w67-c8hw/GHSA-qp4f-2w67-c8hw.json
+++ b/advisories/unreviewed/2022/05/GHSA-qp4f-2w67-c8hw/GHSA-qp4f-2w67-c8hw.json
@@ -1,17 +1,42 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-qp4f-2w67-c8hw",
-  "modified": "2022-05-24T17:07:40Z",
+  "modified": "2022-12-16T20:34:21Z",
   "published": "2022-05-24T17:07:40Z",
   "aliases": [
     "CVE-2020-2099"
   ],
-  "details": "Jenkins 2.213 and earlier, LTS 2.204.1 and earlier improperly reuses encryption key parameters in the Inbound TCP Agent Protocol/3, allowing unauthorized attackers with knowledge of agent names to obtain the connection secrets for those agents, which can be used to connect to Jenkins, impersonating those agents.",
+  "summary": "Inbound TCP Agent Protocol/3 authentication bypass in Jenkins",
+  "details": "Jenkins 2.213 and earlier, LTS 2.204.1 and earlier includes support for the Inbound TCP Agent Protocol/3 for communication between controller and agents. While [this protocol has been deprecated in 2018](https://www.jenkins.io/changelog-old/#v2.128) and was recently removed from Jenkins in 2.214, it could still easily be enabled in Jenkins LTS 2.204.1, 2.213, and older.\n\nThis protocol incorrectly reuses encryption parameters which allow an unauthenticated remote attacker to determine the connection secret. This secret can then be used to connect attacker-controlled Jenkins agents to the Jenkins controller.\n\nJenkins 2.204.2 no longer allows for the use of Inbound TCP Agent Protocol/3 by default. The system property `jenkins.slaves.JnlpSlaveAgentProtocol3.ALLOW_UNSAFE` can be set to `true` to allow enabling the Inbound TCP Agent Protocol/3 in Jenkins 2.204.2, but doing so is strongly discouraged.\n\nInbound TCP Agent Protocol/3 was removed completely from Jenkins 2.214 and will not be part of Jenkins LTS after the end of the 2.204.x line.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.214, 2.204.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.213"
+      }
+    }
   ],
   "references": [
     {
@@ -33,6 +58,10 @@
     {
       "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2020:0683"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-01-29/#SECURITY-1682

Affected versions are <= 2.213 but not 2.204.2 and 2.204.3