### PR TITLE
[GHSA-gpxv-776p-7gc7] Jenkins 2.218 and earlier, LTS 2.204.1 and earlier was...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-gpxv-776p-7gc7/GHSA-gpxv-776p-7gc7.json
+++ b/advisories/unreviewed/2022/05/GHSA-gpxv-776p-7gc7/GHSA-gpxv-776p-7gc7.json
@@ -1,17 +1,42 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-gpxv-776p-7gc7",
-  "modified": "2022-05-24T17:07:40Z",
+  "modified": "2022-12-16T20:36:44Z",
   "published": "2022-05-24T17:07:40Z",
   "aliases": [
     "CVE-2020-2100"
   ],
-  "details": "Jenkins 2.218 and earlier, LTS 2.204.1 and earlier was vulnerable to a UDP amplification reflection denial of service attack on port 33848.",
+  "summary": "Jenkins vulnerable to UDP amplification reflection attack",
+  "details": "Jenkins 2.218 and earlier, LTS 2.204.1 and earlier supports two network discovery services (UDP multicast/broadcast and DNS multicast) by default.\n\nThe UDP multicast/broadcast service can be used in an amplification reflection attack, as very few bytes sent to the respective endpoint result in much larger responses: A single byte request to this service would respond with more than 100 bytes of Jenkins metadata which could be used in a DDoS attack on a Jenkins controller. Within the same network, spoofed UDP packets could also be sent to make two Jenkins controllers go into an infinite loop of replies to one another, thus causing a denial of service.\n\nJenkins 2.219, LTS 2.204.2 now disables both UDP multicast/broadcast and DNS multicast by default.\n\nAdministrators that need these features can re-enable them again by setting the system property `hudson.DNSMultiCast.disabled` to `false` (for DNS multicast) or the system property `hudson.udp` to `33848`, or another port (for UDP broadcast/multicast). These are the same system properties that controlled whether these features were enabled in the past, so any instances explicitly enabling these features by setting these system properties will continue to have them enabled.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:L"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.219, 2.204.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.218"
+      }
+    }
   ],
   "references": [
     {
@@ -33,6 +58,10 @@
     {
       "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2020:0683"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-01-29/#SECURITY-1641

Affected versions are 2.218 and earlier, but not 2.204.2 and 2.204.3