### PR TITLE
[GHSA-w7jr-wqw6-54xc] Jenkins 2.218 and earlier, LTS 2.204.1 and earlier did...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-w7jr-wqw6-54xc/GHSA-w7jr-wqw6-54xc.json
+++ b/advisories/unreviewed/2022/05/GHSA-w7jr-wqw6-54xc/GHSA-w7jr-wqw6-54xc.json
@@ -1,17 +1,64 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-w7jr-wqw6-54xc",
-  "modified": "2022-05-24T17:07:40Z",
+  "modified": "2022-12-16T20:38:13Z",
   "published": "2022-05-24T17:07:40Z",
   "aliases": [
     "CVE-2020-2101"
   ],
-  "details": "Jenkins 2.218 and earlier, LTS 2.204.1 and earlier did not use a constant-time comparison function for validating connection secrets, which could potentially allow an attacker to use a timing attack to obtain this secret.",
+  "summary": "Non-constant time comparison of inbound TCP agent connection secret",
+  "details": "Jenkins 2.218 and earlier, LTS 2.204.1 and earlier does not use a constant-time comparison validating the connection secret when an inbound TCP agent connection is initiated. This could potentially allow attackers to use statistical methods to obtain the connection secret.\n\nJenkins 2.219, LTS 2.204.2 now uses a constant-time comparison function for verifying connection secrets.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.219"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.218"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.204.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.204.1"
+      }
+    }
   ],
   "references": [
     {
@@ -35,6 +82,10 @@
       "url": "https://access.redhat.com/errata/RHSA-2020:0683"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
+    },
+    {
       "type": "WEB",
       "url": "https://jenkins.io/security/advisory/2020-01-29/#SECURITY-1659"
     },
@@ -47,7 +98,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-01-29/#SECURITY-1659