### PR TITLE
[GHSA-fj6f-6933-839j] Jenkins 2.218 and earlier, LTS 2.204.1 and earlier used a...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-fj6f-6933-839j/GHSA-fj6f-6933-839j.json
+++ b/advisories/unreviewed/2022/05/GHSA-fj6f-6933-839j/GHSA-fj6f-6933-839j.json
@@ -1,17 +1,64 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-fj6f-6933-839j",
-  "modified": "2022-05-24T17:07:40Z",
+  "modified": "2022-12-16T20:39:25Z",
   "published": "2022-05-24T17:07:40Z",
   "aliases": [
     "CVE-2020-2102"
   ],
-  "details": "Jenkins 2.218 and earlier, LTS 2.204.1 and earlier used a non-constant time comparison function when validating an HMAC.",
+  "summary": "Non-constant time HMAC comparison",
+  "details": "Jenkins 2.218 and earlier, LTS 2.204.1 and earlier does not use a constant-time comparison when checking whether two HMACs are equal. This could potentially allow attackers to use statistical methods to obtain a valid HMAC for an attacker-controlled input value.\n\nJenkins 2.219, LTS 2.204.2 now uses a constant-time comparison when validating HMACs.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.219"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.218"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.204.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.204.1"
+      }
+    }
   ],
   "references": [
     {
@@ -35,6 +82,10 @@
       "url": "https://access.redhat.com/errata/RHSA-2020:0683"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
+    },
+    {
       "type": "WEB",
       "url": "https://jenkins.io/security/advisory/2020-01-29/#SECURITY-1660"
     },
@@ -47,7 +98,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-01-29/#SECURITY-1660

Versions 2.204.2 and 2.204.3 are not affected by this vulnerability.