### PR TITLE
[GHSA-4jjj-cm7q-v6hr] Jenkins 2.218 and earlier, LTS 2.204.1 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-4jjj-cm7q-v6hr/GHSA-4jjj-cm7q-v6hr.json
+++ b/advisories/unreviewed/2022/05/GHSA-4jjj-cm7q-v6hr/GHSA-4jjj-cm7q-v6hr.json
@@ -1,17 +1,64 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4jjj-cm7q-v6hr",
-  "modified": "2022-05-24T17:07:40Z",
+  "modified": "2022-12-16T20:41:08Z",
   "published": "2022-05-24T17:07:40Z",
   "aliases": [
     "CVE-2020-2103"
   ],
-  "details": "Jenkins 2.218 and earlier, LTS 2.204.1 and earlier exposed session identifiers on a user's detail object in the whoAmI diagnostic page.",
+  "summary": "Diagnostic page exposed session cookies",
+  "details": "Jenkins shows various technical details about the current user on the `/whoAmI` page. In [a previous fix](https://www.jenkins.io/security/advisory/2019-09-25/#SECURITY-1505), the `Cookie` header value containing the HTTP session ID was redacted. However, user metadata shown on this page could also include the HTTP session ID in Jenkins 2.218 and earlier, LTS 2.204.1 and earlier.\n\nThis allows attackers able to exploit a cross-site scripting vulnerability to obtain the HTTP session ID value from this page.\n\nJenkins 2.219, LTS 2.204.2 no longer prints out the affected user metadata that might contain the HTTP session ID.\n\nAdditionally, we also redact values of further authentication-related HTTP headers in addition to `Cookie` on this page as a hardening.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.219"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.218"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.204.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.204.1"
+      }
+    }
   ],
   "references": [
     {
@@ -33,6 +80,10 @@
     {
       "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2020:0683"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-01-29/#SECURITY-1695

Versions 2.204.2 and 2.204.3 are not affected by this vulnerability.