### PR TITLE
[GHSA-r78q-qgx6-64pp] Jenkins 2.218 and earlier, LTS 2.204.1 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-r78q-qgx6-64pp/GHSA-r78q-qgx6-64pp.json
+++ b/advisories/unreviewed/2022/05/GHSA-r78q-qgx6-64pp/GHSA-r78q-qgx6-64pp.json
@@ -1,17 +1,64 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-r78q-qgx6-64pp",
-  "modified": "2022-05-24T17:07:40Z",
+  "modified": "2022-12-16T20:42:08Z",
   "published": "2022-05-24T17:07:40Z",
   "aliases": [
     "CVE-2020-2104"
   ],
-  "details": "Jenkins 2.218 and earlier, LTS 2.204.1 and earlier allowed users with Overall/Read access to view a JVM memory usage chart.",
+  "summary": "Memory usage graphs accessible to anyone with Overall/Read",
+  "details": "Jenkins includes a feature that shows a JVM memory usage chart for the Jenkins controller.\n\nAccess to the chart in Jenkins 2.218 and earlier, LTS 2.204.1 and earlier requires no permissions beyond the general Overall/Read, allowing users who are not administrators to view JVM memory usage data.\n\nJenkins 2.219, LTS 2.204.2 now requires Overall/Administer permissions to view the JVM memory usage chart.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.219"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.218"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.204.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.204.1"
+      }
+    }
   ],
   "references": [
     {
@@ -33,6 +80,10 @@
     {
       "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2020:0683"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-01-29/#SECURITY-1650

Versions 2.204.2 and 2.204.3 are not affected