### PR TITLE
[GHSA-7xp8-7wqx-5hqx] REST API endpoints in Jenkins 2.218 and earlier, LTS 2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-7xp8-7wqx-5hqx/GHSA-7xp8-7wqx-5hqx.json
+++ b/advisories/unreviewed/2022/05/GHSA-7xp8-7wqx-5hqx/GHSA-7xp8-7wqx-5hqx.json
@@ -1,17 +1,64 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-7xp8-7wqx-5hqx",
-  "modified": "2022-05-24T17:07:41Z",
+  "modified": "2022-12-16T20:43:47Z",
   "published": "2022-05-24T17:07:41Z",
   "aliases": [
     "CVE-2020-2105"
   ],
-  "details": "REST API endpoints in Jenkins 2.218 and earlier, LTS 2.204.1 and earlier were vulnerable to clickjacking attacks.",
+  "summary": "Jenkins REST APIs vulnerable to clickjacking",
+  "details": "Jenkins 2.218 and earlier, LTS 2.204.1 and earlier does not serve the `X-Frame-Options: deny` HTTP header on REST API responses to protect against clickjacking attacks. An attacker could exploit this by routing the victim through a specially crafted web page that embeds a REST API endpoint in an iframe and tricking the user into performing an action which would allow for the attacker to learn the content of that REST API endpoint.\n\nJenkins 2.219, LTS 2.204.2 now adds the `X-Frame-Options: deny` HTTP header to REST API responses, which prevents these types of clickjacking attacks.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.219"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.218"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.204.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.204.1"
+      }
+    }
   ],
   "references": [
     {
@@ -35,6 +82,10 @@
       "url": "https://access.redhat.com/errata/RHSA-2020:0683"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
+    },
+    {
       "type": "WEB",
       "url": "https://jenkins.io/security/advisory/2020-01-29/#SECURITY-1704"
     },
@@ -47,7 +98,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-01-29/#SECURITY-1704

Versions 2.204.2 and 2.204.3 are not affected