### PR TITLE
[GHSA-xr37-pjfh-qwwc] Jenkins Fortify Plugin 19.1.29 and earlier stores proxy...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-xr37-pjfh-qwwc/GHSA-xr37-pjfh-qwwc.json
+++ b/advisories/unreviewed/2022/05/GHSA-xr37-pjfh-qwwc/GHSA-xr37-pjfh-qwwc.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-xr37-pjfh-qwwc",
-  "modified": "2022-05-24T17:07:41Z",
+  "modified": "2022-12-16T20:46:09Z",
   "published": "2022-05-24T17:07:41Z",
   "aliases": [
     "CVE-2020-2107"
   ],
-  "details": "Jenkins Fortify Plugin 19.1.29 and earlier stores proxy server passwords unencrypted in job config.xml files on the Jenkins master where they can be viewed by users with Extended Read permission, or access to the master file system.",
+  "summary": "Fortify Plugin stored credentials in plain text",
+  "details": "Fortify Plugin 19.1.29 and earlier stored its proxy server password unencrypted in job `config.xml` files. This password could be read by users with the Extended Read permission.\n\nFortify Plugin 19.2.30 now encrypts the proxy server password.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:fortify"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "19.2.30"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 19.1.29"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2107"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/fortify-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-01-29/#SECURITY-1565