### PR TITLE
[GHSA-f5wx-w2f9-82gh] Jenkins WebSphere Deployer Plugin 1.6.1 and earlier does...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-f5wx-w2f9-82gh/GHSA-f5wx-w2f9-82gh.json
+++ b/advisories/unreviewed/2022/05/GHSA-f5wx-w2f9-82gh/GHSA-f5wx-w2f9-82gh.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-f5wx-w2f9-82gh",
-  "modified": "2022-05-24T17:07:41Z",
+  "modified": "2022-12-16T20:47:33Z",
   "published": "2022-05-24T17:07:41Z",
   "aliases": [
     "CVE-2020-2108"
   ],
-  "details": "Jenkins WebSphere Deployer Plugin 1.6.1 and earlier does not configure the XML parser to prevent XXE attacks which can be exploited by a user with Job/Configure permissions.",
+  "summary": "XXE vulnerability in Jenkins WebSphere Deployer Plugin",
+  "details": "WebSphere Deployer Plugin 1.6.1 and earlier does not configure the XML parser to prevent XML external entity (XXE) attacks. This could be exploited by a user with Job/Configure permissions to upload a specially crafted war file containing a `WEB-INF/ibm-web-ext.xml` which is parsed by the plugin.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:websphere-deployer"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.6.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2108"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/websphere-deployer-plugin"
     },
     {
       "type": "WEB",
@@ -31,7 +57,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-01-29/#SECURITY-1719