### PR TITLE
[GHSA-5hw2-327v-vvr6] Jenkins Implied Labels Plugin 0.6 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5hw2-327v-vvr6/GHSA-5hw2-327v-vvr6.json
+++ b/advisories/unreviewed/2022/05/GHSA-5hw2-327v-vvr6/GHSA-5hw2-327v-vvr6.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-5hw2-327v-vvr6",
-  "modified": "2022-05-24T17:29:16Z",
+  "modified": "2022-12-16T20:53:49Z",
   "published": "2022-05-24T17:29:16Z",
   "aliases": [
     "CVE-2020-2282"
   ],
-  "details": "Jenkins Implied Labels Plugin 0.6 and earlier does not perform a permission check in an HTTP endpoint, allowing attackers with Overall/Read permission to configure the plugin.",
+  "summary": "Missing permission check in Jenkins Implied Labels Plugin allows reconfiguring the plugin",
+  "details": "Implied Labels Plugin 0.6 and earlier does not perform a permission check in an HTTP endpoint.\n\nThis allows attackers with Overall/Read permission to configure the plugin.\n\nImplied Labels Plugin 0.7 requires Overall/Administer permission to configure the plugin.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:L"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:implied-labels"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.7"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.6"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2282"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/implied-labels-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-23/#SECURITY-2004