### PR TITLE
[GHSA-xx7g-f287-f9fq] Jenkins Liquibase Runner Plugin 1.4.5 and earlier does...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-xx7g-f287-f9fq/GHSA-xx7g-f287-f9fq.json
+++ b/advisories/unreviewed/2022/05/GHSA-xx7g-f287-f9fq/GHSA-xx7g-f287-f9fq.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-xx7g-f287-f9fq",
-  "modified": "2022-05-24T17:29:16Z",
+  "modified": "2022-12-16T20:56:18Z",
   "published": "2022-05-24T17:29:16Z",
   "aliases": [
     "CVE-2020-2284"
   ],
-  "details": "Jenkins Liquibase Runner Plugin 1.4.5 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability in Jenkins Liquibase Runner Plugin",
+  "details": "Liquibase Runner Plugin 1.4.5 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers able to provide Liquibase changesets evaluated by the plugin to have Jenkins parse a crafted XML file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.\n\nLiquibase Runner Plugin 1.4.7 no longer parses Liquibase changesets.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:liquibase-runner"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.4.7"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.4.5"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2284"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/liquibase-runner-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-23/#SECURITY-1887