### PR TITLE
[GHSA-hv53-qjg6-5pm9] Jenkins Gatling Plugin 1.2.7 and earlier prevents Content...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-hv53-qjg6-5pm9/GHSA-hv53-qjg6-5pm9.json
+++ b/advisories/unreviewed/2022/05/GHSA-hv53-qjg6-5pm9/GHSA-hv53-qjg6-5pm9.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-hv53-qjg6-5pm9",
-  "modified": "2022-05-24T17:13:39Z",
+  "modified": "2022-12-17T11:15:04Z",
   "published": "2022-05-24T17:13:39Z",
   "aliases": [
     "CVE-2020-2173"
   ],
-  "details": "Jenkins Gatling Plugin 1.2.7 and earlier prevents Content-Security-Policy headers from being set for Gatling reports served by the plugin, resulting in an XSS vulnerability exploitable by users able to change report content.",
+  "summary": "XSS vulnerability in Jenkins Gatling Plugin",
+  "details": "Gatling Plugin 1.2.7 and earlier serves Gatling reports in a manner that bypasses the `Content-Security-Policy` protection introduced in Jenkins 1.641 and 1.625.3. This results in a cross-site scripting (XSS) vulnerability exploitable by users able to change report content.\n\nGatling Plugin 1.3.0 no longer allows viewing Gatling reports directly in Jenkins. Instead users need to download an archive containing the report.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:gatling"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.3.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.2.7"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2173"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/gatling-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-04-07/#SECURITY-1633