### PR TITLE
[GHSA-x9rq-9h44-f84v] Jenkins ECharts API Plugin 4.7.0-3 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-x9rq-9h44-f84v/GHSA-x9rq-9h44-f84v.json
+++ b/advisories/unreviewed/2022/05/GHSA-x9rq-9h44-f84v/GHSA-x9rq-9h44-f84v.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-x9rq-9h44-f84v",
-  "modified": "2022-05-24T17:19:04Z",
+  "modified": "2022-12-17T12:11:26Z",
   "published": "2022-05-24T17:19:04Z",
   "aliases": [
     "CVE-2020-2193"
   ],
-  "details": "Jenkins ECharts API Plugin 4.7.0-3 and earlier does not escape the parser identifier when rendering charts, resulting in a stored cross-site scripting vulnerability.",
+  "summary": "Stored XSS vulnerability in Jenkins ECharts API Plugin",
+  "details": "ECharts API Plugin 4.7.0-3 and earlier does not escape the parser identifier when rendering charts.\n\nThis results in a stored cross-site scripting (XSS) vulnerability that can be exploited by users with Job/Configure permission.\n\nECharts API Plugin 4.7.0-4 escapes the parser identifier.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.jenkins.plugins:echarts-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.7.0-4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.7.0-3"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2193"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/echarts-api-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-06-03/#SECURITY-1841