### PR TITLE
[GHSA-8696-836p-c8qp] Jenkins Gitlab Hook Plugin 1.4.2 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-8696-836p-c8qp/GHSA-8696-836p-c8qp.json
+++ b/advisories/unreviewed/2022/05/GHSA-8696-836p-c8qp/GHSA-8696-836p-c8qp.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8696-836p-c8qp",
-  "modified": "2022-05-24T17:06:23Z",
+  "modified": "2022-12-17T12:42:39Z",
   "published": "2022-05-24T17:06:23Z",
   "aliases": [
     "CVE-2020-2096"
   ],
-  "details": "Jenkins Gitlab Hook Plugin 1.4.2 and earlier does not escape project names in the build_now endpoint, resulting in a reflected XSS vulnerability.",
+  "summary": "Reflected XSS vulnerability in Jenkins gitlab-hook Plugin",
+  "details": "Jenkins Gitlab Hook Plugin 1.4.2 and earlier does not escape project names in the `build_now` endpoint, resulting in a reflected XSS vulnerability.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.ruby-plugins:gitlab-hook"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.4.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2096"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/gitlab-hook-plugin"
     },
     {
       "type": "WEB",
@@ -33,7 +59,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-01-15/#SECURITY-1683