### PR TITLE
[GHSA-h8w6-c53g-53vv] Jenkins Sounds Plugin 0.5 and earlier does not perform...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-h8w6-c53g-53vv/GHSA-h8w6-c53g-53vv.json
+++ b/advisories/unreviewed/2022/05/GHSA-h8w6-c53g-53vv/GHSA-h8w6-c53g-53vv.json
@@ -1,17 +1,42 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-h8w6-c53g-53vv",
-  "modified": "2022-05-24T17:06:23Z",
+  "modified": "2022-12-17T12:45:51Z",
   "published": "2022-05-24T17:06:23Z",
   "aliases": [
     "CVE-2020-2097"
   ],
+  "summary": "Missing permission checks in Jenkins Sounds Plugin allow OS command execution",
   "details": "Jenkins Sounds Plugin 0.5 and earlier does not perform permission checks in URLs performing form validation, allowing attackers with Overall/Read access to execute arbitrary OS commands as the OS user account running Jenkins.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:sounds"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.6"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.5"
+      }
+    }
   ],
   "references": [
     {
@@ -25,9 +50,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-285"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-01-15/#SECURITY-814

This vulnerability has been fixed in https://github.com/jenkinsci/sounds-plugin/commit/0c376d46fd91b12696e5f7389110ddece0724457 which has been released in 0.6