### PR TITLE
[GHSA-mjmj-j48q-9wg2] SnakeYaml Constructor Deserialization Remote Code Execution

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-mjmj-j48q-9wg2/GHSA-mjmj-j48q-9wg2.json
+++ b/advisories/github-reviewed/2022/12/GHSA-mjmj-j48q-9wg2/GHSA-mjmj-j48q-9wg2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-mjmj-j48q-9wg2",
-  "modified": "2022-12-12T21:19:47Z",
+  "modified": "2022-12-20T04:23:13Z",
   "published": "2022-12-12T21:19:47Z",
   "aliases": [
     "CVE-2022-1471"
@@ -20,18 +20,8 @@
         "ecosystem": "Maven",
         "name": "org.yaml:snakeyaml"
       },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "last_affected": "1.30"
-            }
-          ]
-        }
+      "versions": [
+        "1.30"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
`NVD` and `Google security-research` contain the affected version, which is only 1.30.