### PR TITLE
[GHSA-j7q2-c6r4-x2jw] Jenkins Git Parameter Plugin 0.9.12 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-j7q2-c6r4-x2jw/GHSA-j7q2-c6r4-x2jw.json
+++ b/advisories/unreviewed/2022/05/GHSA-j7q2-c6r4-x2jw/GHSA-j7q2-c6r4-x2jw.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-j7q2-c6r4-x2jw",
-  "modified": "2022-05-24T17:27:06Z",
+  "modified": "2022-12-20T09:58:17Z",
   "published": "2022-05-24T17:27:06Z",
   "aliases": [
     "CVE-2020-2238"
   ],
-  "details": "Jenkins Git Parameter Plugin 0.9.12 and earlier does not escape the repository field on the 'Build with Parameters' page, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Job/Configure permission.",
+  "summary": "Stored XSS vulnerability in Jenkins Git Parameter Plugin",
+  "details": "Jenkins Git Parameter Plugin 0.9.12 and earlier does not escape the repository field on the 'Build with Parameters' page, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Job/Configure permission.\n\nGit Parameter Plugin 0.9.13 escapes the repository field on the 'Build with Parameters' page.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.tools:git-parameter"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.9.13"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.9.12"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2238"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/git-parameter-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-01/#SECURITY-1884