### PR TITLE
[GHSA-xq2q-8hxc-7jr2] Jenkins Valgrind Plugin 0.28 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-xq2q-8hxc-7jr2/GHSA-xq2q-8hxc-7jr2.json
+++ b/advisories/unreviewed/2022/05/GHSA-xq2q-8hxc-7jr2/GHSA-xq2q-8hxc-7jr2.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-xq2q-8hxc-7jr2",
-  "modified": "2022-05-24T17:27:06Z",
+  "modified": "2022-12-20T10:09:44Z",
   "published": "2022-05-24T17:27:06Z",
   "aliases": [
     "CVE-2020-2245"
   ],
-  "details": "Jenkins Valgrind Plugin 0.28 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability in Jenkins Valgrind Plugin",
+  "details": "Valgrind Plugin 0.28 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows a user able to control the input files for the Valgrind plugin parser to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery. ",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:valgrind"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "0.28"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2245"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/valgrind-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +55,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-611"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-01/#SECURITY-1829