### PR TITLE
[GHSA-9hcr-66cj-r9hp] Jenkins Valgrind Plugin 0.28 and earlier does not escape...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-9hcr-66cj-r9hp/GHSA-9hcr-66cj-r9hp.json
+++ b/advisories/unreviewed/2022/05/GHSA-9hcr-66cj-r9hp/GHSA-9hcr-66cj-r9hp.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9hcr-66cj-r9hp",
-  "modified": "2022-05-24T17:27:06Z",
+  "modified": "2022-12-20T10:10:53Z",
   "published": "2022-05-24T17:27:06Z",
   "aliases": [
     "CVE-2020-2246"
   ],
+  "summary": "Stored XSS vulnerability in Jenkins Valgrind Plugin",
   "details": "Jenkins Valgrind Plugin 0.28 and earlier does not escape content in Valgrind XML reports, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to control Valgrind XML report contents.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:valgrind"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "0.28"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2246"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/valgrind-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +55,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-01/#SECURITY-1830