### PR TITLE
[GHSA-p6c5-737r-2r93] Jenkins Klocwork Analysis Plugin 2020.2.1 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-p6c5-737r-2r93/GHSA-p6c5-737r-2r93.json
+++ b/advisories/unreviewed/2022/05/GHSA-p6c5-737r-2r93/GHSA-p6c5-737r-2r93.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-p6c5-737r-2r93",
-  "modified": "2022-05-24T17:27:07Z",
+  "modified": "2022-12-20T10:13:04Z",
   "published": "2022-05-24T17:27:07Z",
   "aliases": [
     "CVE-2020-2247"
   ],
-  "details": "Jenkins Klocwork Analysis Plugin 2020.2.1 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability in Jenkins Klocwork Analysis Plugin",
+  "details": "Klocwork Analysis Plugin 2020.2.1 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows a user able to control the input files for the Klocwork plugin parser to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:klocwork"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2020.3.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2020.2.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2247"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/klocwork-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-611"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-01/#SECURITY-1831

This has been fixed in https://github.com/jenkinsci/klocwork-plugin/commit/44e860003a3bd4c8323f6572dc9d9ddf3d2bba8f and was released in 2020.3.1