### PR TITLE
[GHSA-54r5-wr8x-x5v3] Apiman has insufficient checks for read permissions

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-54r5-wr8x-x5v3/GHSA-54r5-wr8x-x5v3.json
+++ b/advisories/github-reviewed/2022/12/GHSA-54r5-wr8x-x5v3/GHSA-54r5-wr8x-x5v3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-54r5-wr8x-x5v3",
-  "modified": "2022-12-20T17:37:18Z",
+  "modified": "2022-12-20T22:41:08Z",
   "published": "2022-12-20T00:30:27Z",
   "aliases": [
     "CVE-2022-47551"
@@ -9,7 +9,10 @@
   "summary": "Apiman has insufficient checks for read permissions",
   "details": "Apiman 1.5.7 through 2.2.3.Final has insufficient checks for read permissions within the Apiman Manager REST API. The root cause of the issue is the Apiman project's accidental acceptance of a large contribution that was not fully compatible with the security model of Apiman versions before 3.0.0.Final. Because of this, 3.0.0.Final is not affected by the vulnerability.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
+    }
   ],
   "affected": [
     {
@@ -53,7 +56,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
**I am the Apiman project's co-founder and maintainer, Marc Savy.**

Some read permissions checks from the Apiman Manager REST API were removed in a large contribution that Apiman reviewers did not notice. After making contact with the contributor, the intent of the change was to allow APIs published in an Apiman organization (analogous to a GitHub Organization) to be discovered by an external application  but Apiman did not offer a per-API implicit permissions system to achieve this until Apiman 3.0.0.Final  so the contributor introduced this as a workaround without recognising the significant security implications.

This includes the potential for a user to guess IDs or use search and listing REST APIs to discover a variety of information they are not entitled to from organizations they are not members of:
- API Management policy configuration information.
- API names, descriptions, API versions, plans, etc.

An attacker *with* an account and with sufficient permissions in their own Apiman Organization may be able to do all the above, plus:
- Sign up to APIs they have discovered
- This could potentially allow the attacker to gain access the API Management protected resource depending on configuration, despite the attacker not being a member of the org the API belongs to, and not having appropriate permissions.

GitHub Analogy:
Think of this like someone being able to discover and clone a repo from a private GitHub organization. It's not just the fact you managed to read it that's the problem - you also got access to the contents of the repository when you shouldn't have, which may contain sensitive information.
