### PR TITLE
[GHSA-25g4-p347-x748] Jenkins Role-based Authorization Strategy Plugin 3.0 and...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-25g4-p347-x748/GHSA-25g4-p347-x748.json
+++ b/advisories/unreviewed/2022/05/GHSA-25g4-p347-x748/GHSA-25g4-p347-x748.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-25g4-p347-x748",
-  "modified": "2022-05-24T17:30:18Z",
+  "modified": "2022-12-20T22:54:13Z",
   "published": "2022-05-24T17:30:18Z",
   "aliases": [
     "CVE-2020-2286"
   ],
-  "details": "Jenkins Role-based Authorization Strategy Plugin 3.0 and earlier does not properly invalidate a permission cache when the configuration is changed, resulting in permissions being granted based on an outdated configuration.",
+  "summary": "Improper authorization due to caching in Jenkins Role-based Authorization Strategy Plugin",
+  "details": "Role-based Authorization Strategy Plugin 2.12 and newer uses a cache to speed up permission lookups.\n\nIn Role-based Authorization Strategy Plugin 3.0 and earlier this cache is not invalidated properly when an administrator changes the permission configuration. This can result in permissions being granted long after the configuration was changed to no longer grant them.\n\nRole-based Authorization Strategy Plugin 3.1 properly invalidates the cache on configuration changes.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:role-strategy"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.0"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2286"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/role-strategy-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-1767

I'm not able to fill in `<= 3.0, >= 2.12` as affected version range, but that would be the version range of this vulnerability affects, according to the advisory linked.