### PR TITLE
[GHSA-54r5-wr8x-x5v3] Apiman has insufficient checks for read permissions

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-54r5-wr8x-x5v3/GHSA-54r5-wr8x-x5v3.json
+++ b/advisories/github-reviewed/2022/12/GHSA-54r5-wr8x-x5v3/GHSA-54r5-wr8x-x5v3.json
@@ -1,21 +1,24 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-54r5-wr8x-x5v3",
-  "modified": "2022-12-20T17:37:18Z",
+  "modified": "2022-12-20T22:54:33Z",
   "published": "2022-12-20T00:30:27Z",
   "aliases": [
     "CVE-2022-47551"
   ],
   "summary": "Apiman has insufficient checks for read permissions",
-  "details": "Apiman 1.5.7 through 2.2.3.Final has insufficient checks for read permissions within the Apiman Manager REST API. The root cause of the issue is the Apiman project's accidental acceptance of a large contribution that was not fully compatible with the security model of Apiman versions before 3.0.0.Final. Because of this, 3.0.0.Final is not affected by the vulnerability.",
+  "details": "Apiman 1.5.7 through 2.2.3.Final has insufficient checks for read permissions within the Apiman Manager REST API. The root cause of the issue is the Apiman project's accidental acceptance of a large contribution that was not fully compatible with the security model of Apiman versions before 3.0.0.Final. Because of this, 3.0.0.Final is not affected by the vulnerability.\n\nA malicious user may be able to subscribe to an API they do not have permission to, thus accessing an API Management protected resource they should not be allowed to access. ",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
+    }
   ],
   "affected": [
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "io.apiman:apiman"
+        "name": "io.apiman:apiman-manager-api-rest-impl"
       },
       "ranges": [
         {
@@ -42,6 +45,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apiman/apiman/discussions/2409"
+    },
+    {
+      "type": "WEB",
       "url": "https://www.apiman.io/blog/permissions-bypass-disclosure/"
     },
     {
@@ -51,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-280"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- References
- Severity

**Comments**
**I am the Apiman project's co-founder and maintainer, Marc Savy.**

GitHub Analogy:
Think of this like someone being able to use GitHub's APIs to discover and clone a repo from someone else's private GitHub org. 

It's not just the fact you managed to read data about that private org that's the problem — you also got access to the contents of the repository when you shouldn't have, which may contain sensitive information.

I hope that makes sense.