### PR TITLE
[GHSA-9jv5-wf44-8vfm] Jenkins Active Choices Plugin 2.4 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-9jv5-wf44-8vfm/GHSA-9jv5-wf44-8vfm.json
+++ b/advisories/unreviewed/2022/05/GHSA-9jv5-wf44-8vfm/GHSA-9jv5-wf44-8vfm.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9jv5-wf44-8vfm",
-  "modified": "2022-05-24T17:30:18Z",
+  "modified": "2022-12-20T22:58:04Z",
   "published": "2022-05-24T17:30:18Z",
   "aliases": [
     "CVE-2020-2289"
   ],
-  "details": "Jenkins Active Choices Plugin 2.4 and earlier does not escape the name and description of build parameters, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Job/Configure permission.",
+  "summary": "Stored XSS vulnerability in Jenkins Active Choices Plugin",
+  "details": "Active Choices Plugin 2.4 and earlier does not escape the name and description of build parameters.\n\nThis results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Job/Configure permission.\n\nActive Choices Plugin 2.5 escapes the name of build parameters and applies the configured markup formatter to the description of build parameters.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.biouno:uno-choice"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.4"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2289"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/active-choices-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-1954