### PR TITLE
[GHSA-rjch-j5x9-fgph] Jenkins Active Choices Plugin 2.4 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-rjch-j5x9-fgph/GHSA-rjch-j5x9-fgph.json
+++ b/advisories/unreviewed/2022/05/GHSA-rjch-j5x9-fgph/GHSA-rjch-j5x9-fgph.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-rjch-j5x9-fgph",
-  "modified": "2022-05-24T17:30:18Z",
+  "modified": "2022-12-20T22:59:26Z",
   "published": "2022-05-24T17:30:18Z",
   "aliases": [
     "CVE-2020-2290"
   ],
-  "details": "Jenkins Active Choices Plugin 2.4 and earlier does not escape some return values of sandboxed scripts for Reactive Reference Parameters, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Job/Configure permission.",
+  "summary": "Stored XSS vulnerability in Jenkins Active Choices Plugin",
+  "details": "Active Choices Plugin 2.4 and earlier does not escape `List` and `Map` return values of sandboxed scripts for Reactive Reference Parameter.\n\nThis results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Job/Configure permission.\n\nThis issue is caused by an incomplete fix for [SECURITY-470](https://www.jenkins.io/security/advisory/2017-10-23/#persisted-cross-site-scripting-vulnerability-in-active-choices-plugin).\n\nActive Choices Plugin 2.5 escapes all legal return values of sandboxed scripts.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.biouno:uno-choice"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.4"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2290"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/active-choices-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-2008