### PR TITLE
[GHSA-vmg8-g8j3-m355] Jenkins Release Plugin 2.10.2 and earlier does not escape...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-vmg8-g8j3-m355/GHSA-vmg8-g8j3-m355.json
+++ b/advisories/unreviewed/2022/05/GHSA-vmg8-g8j3-m355/GHSA-vmg8-g8j3-m355.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-vmg8-g8j3-m355",
-  "modified": "2022-05-24T17:30:18Z",
+  "modified": "2022-12-20T23:02:58Z",
   "published": "2022-05-24T17:30:18Z",
   "aliases": [
     "CVE-2020-2292"
   ],
+  "summary": "Stored XSS vulnerability in Jenkins Release Plugin",
   "details": "Jenkins Release Plugin 2.10.2 and earlier does not escape the release version in badge tooltip, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Release/Release permission.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:release"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.11"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.10.2"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2292"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/release-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-1928

This has been fixed in 2.11 https://github.com/jenkinsci/release-plugin/releases/tag/release-2.11