### PR TITLE
[GHSA-5xv9-gp22-gqm5] Jenkins Maven Cascade Release Plugin 1.3.2 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5xv9-gp22-gqm5/GHSA-5xv9-gp22-gqm5.json
+++ b/advisories/unreviewed/2022/05/GHSA-5xv9-gp22-gqm5/GHSA-5xv9-gp22-gqm5.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-5xv9-gp22-gqm5",
-  "modified": "2022-05-24T17:30:19Z",
+  "modified": "2022-12-20T23:06:08Z",
   "published": "2022-05-24T17:30:19Z",
   "aliases": [
     "CVE-2020-2294"
   ],
+  "summary": "Missing permission checks in Jenkins Maven Cascade Release Plugin",
   "details": "Jenkins Maven Cascade Release Plugin 1.3.2 and earlier does not perform permission checks in several HTTP endpoints, allowing attackers with Overall/Read permission to start cascade builds and layout builds, and reconfigure the plugin.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.barchart.jenkins:maven-release-cascade"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.3.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2294"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/maven-release-cascade-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +55,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-862"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-2049