### PR TITLE
[GHSA-wcrg-92wp-4h28] Jenkins Nerrvana Plugin 1.02.06 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-wcrg-92wp-4h28/GHSA-wcrg-92wp-4h28.json
+++ b/advisories/unreviewed/2022/05/GHSA-wcrg-92wp-4h28/GHSA-wcrg-92wp-4h28.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-wcrg-92wp-4h28",
-  "modified": "2022-05-24T17:30:19Z",
+  "modified": "2022-12-20T23:11:35Z",
   "published": "2022-05-24T17:30:19Z",
   "aliases": [
     "CVE-2020-2298"
   ],
-  "details": "Jenkins Nerrvana Plugin 1.02.06 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability in Jenkins Nerrvana Plugin",
+  "details": "Nerrvana Plugin 1.02.06 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers with Overall/Read permission to have Jenkins parse a crafted HTTP request with XML data that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.\n\nAdditionally, XML parsing is exposed as a form validation endpoint that does not require POST requests, allowing exploitation by users without Overall/Read permission via CSRF.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:nerrvana-plugin"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.02.06"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2298"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/nerrvana-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +55,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-611"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-2097