### PR TITLE
[GHSA-8wcw-cw2f-h4g2] Improper Authentication (empty password) in Jenkins Active Directory Plugin

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-8wcw-cw2f-h4g2/GHSA-8wcw-cw2f-h4g2.json
+++ b/advisories/github-reviewed/2022/05/GHSA-8wcw-cw2f-h4g2/GHSA-8wcw-cw2f-h4g2.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8wcw-cw2f-h4g2",
-  "modified": "2022-09-08T00:45:01Z",
+  "modified": "2022-12-21T12:37:53Z",
   "published": "2022-05-24T17:33:07Z",
   "aliases": [
     "CVE-2020-2300"
   ],
-  "summary": "Improper Authentication (empty password) in Jenkins Active Directory Plugin",
-  "details": "Jenkins Active Directory Plugin prior to 2.20 does not prohibit the use of an empty password in Windows/ADSI mode, which allows attackers to log in to Jenkins as any user depending on the configuration of the Active Directory server.",
+  "summary": "Login allowed with empty password by Jenkins Active Directory Plugin",
+  "details": "Active Directory Plugin implements two separate modes: Integration with ADSI on Windows, and an OS agnostic LDAP-based mode.\n\nThe Windows/ADSI mode does not specifically prohibit use of empty passwords in Active Directory Plugin 2.19 and earlier. If the Active Directory server allows the unauthenticated bind operation, this allows attackers to log in to Jenkins as any user by providing an empty password.\n\nActive Directory Plugin 2.20 prohibits the use of an empty password to log in.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -57,7 +57,7 @@
     "cwe_ids": [
       "CWE-287"
     ],
-    "severity": "CRITICAL",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Severity
- Summary

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2099