### PR TITLE
[GHSA-954f-xw44-56r2] Authentication cache in Active Directory Jenkins Plugin allows logging in with any password

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-954f-xw44-56r2/GHSA-954f-xw44-56r2.json
+++ b/advisories/github-reviewed/2022/05/GHSA-954f-xw44-56r2/GHSA-954f-xw44-56r2.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-954f-xw44-56r2",
-  "modified": "2022-09-08T19:20:40Z",
+  "modified": "2022-12-21T12:38:57Z",
   "published": "2022-05-24T17:33:07Z",
   "aliases": [
     "CVE-2020-2301"
   ],
   "summary": "Authentication cache in Active Directory Jenkins Plugin allows logging in with any password",
-  "details": "Jenkins Active Directory Plugin 2.19 and earlier allows attackers to log in as any user with any password while a successful authentication of that user is still in the optional cache when using Windows/ADSI mode.",
+  "details": "Active Directory Plugin implements two separate modes: Integration with ADSI on Windows, and an OS agnostic LDAP-based mode. Optionally, to reduce lookup time, a cache can be configured to remember user lookups and user authentications.\n\nIn Active Directory Plugin 2.19 and earlier, when run in Windows/ADSI mode, the provided password was not used when looking up an applicable cache entry. This allows attackers to log in as any user using any password while a successful authentication of that user is still in the cache.\n\nAs a workaround for this issue, the cache can be disabled.\n\nActive Directory Plugin 2.20 includes the provided password in cache entry lookup.\n\nAdditionally, the Java system property `hudson.plugins.active_directory.CacheUtil.noCacheAuth` can be set to `true` to no longer cache user authentications.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -53,7 +53,7 @@
     "cwe_ids": [
       "CWE-287"
     ],
-    "severity": "CRITICAL",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Severity

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2123