### PR TITLE
[GHSA-vp5f-8jgw-j53c] Jenkins Subversion Plugin 2.13.1 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-vp5f-8jgw-j53c/GHSA-vp5f-8jgw-j53c.json
+++ b/advisories/unreviewed/2022/05/GHSA-vp5f-8jgw-j53c/GHSA-vp5f-8jgw-j53c.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-vp5f-8jgw-j53c",
-  "modified": "2022-05-24T17:33:07Z",
+  "modified": "2022-12-21T12:42:43Z",
   "published": "2022-05-24T17:33:07Z",
   "aliases": [
     "CVE-2020-2304"
   ],
-  "details": "Jenkins Subversion Plugin 2.13.1 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability in Jenkins Subversion Plugin",
+  "details": "Subversion Plugin 2.13.1 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers able to control an agent process to have Jenkins parse a crafted changelog file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.\n\nSubversion Plugin 2.13.2 disables external entity resolution for its XML parser.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:subversion"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.13.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.13.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2304"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/subversion-plugin"
     },
     {
       "type": "WEB",
@@ -31,7 +60,7 @@
     "cwe_ids": [
       "CWE-611"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2145