### PR TITLE
[GHSA-x58r-wxc3-7pqr] Improper Restriction of XML External Entity Reference in Jenkins Mercurial Plugin

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-x58r-wxc3-7pqr/GHSA-x58r-wxc3-7pqr.json
+++ b/advisories/github-reviewed/2022/05/GHSA-x58r-wxc3-7pqr/GHSA-x58r-wxc3-7pqr.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-x58r-wxc3-7pqr",
-  "modified": "2022-06-23T23:20:09Z",
+  "modified": "2022-12-21T12:44:02Z",
   "published": "2022-05-24T17:33:07Z",
   "aliases": [
     "CVE-2020-2305"
   ],
-  "summary": "Improper Restriction of XML External Entity Reference in Jenkins Mercurial Plugin",
-  "details": "Jenkins Mercurial Plugin 2.11 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability in Jenkins Mercurial Plugin",
+  "details": "Mercurial Plugin 2.11 and earlier does not configure its XML changelog parser to prevent XML external entity (XXE) attacks.\n\nThis allows attackers able to control an agent process to have Jenkins parse a crafted changelog file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.\n\nMercurial Plugin 2.12 disables external entity resolution for its XML parser.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
     }
   ],
   "affected": [
@@ -44,6 +44,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2305"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/mercurial-plugin"
+    },
+    {
       "type": "WEB",
       "url": "https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2115"
     }
@@ -52,7 +56,7 @@
     "cwe_ids": [
       "CWE-611"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Update CVSS scoring according to https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2115