### PR TITLE
[GHSA-24g8-35x9-fv8r] Jenkins FindBugs Plugin 5.0.0 and earlier does not escape...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-24g8-35x9-fv8r/GHSA-24g8-35x9-fv8r.json
+++ b/advisories/unreviewed/2022/05/GHSA-24g8-35x9-fv8r/GHSA-24g8-35x9-fv8r.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-24g8-35x9-fv8r",
-  "modified": "2022-05-24T17:33:09Z",
+  "modified": "2022-12-21T12:56:11Z",
   "published": "2022-05-24T17:33:09Z",
   "aliases": [
     "CVE-2020-2317"
   ],
+  "summary": "Stored XSS vulnerability in Jenkins FindBugs Plugin",
   "details": "Jenkins FindBugs Plugin 5.0.0 and earlier does not escape the annotation message in tooltips, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to provide report files to Jenkins FindBugs Plugin's post build step.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jvnet.hudson.plugins:findbugs"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "5.0.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2317"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/findbugs-plugin"
     },
     {
       "type": "WEB",
@@ -27,7 +53,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1918