### PR TITLE
[GHSA-xqf6-5grh-6223] Jenkins Artifactory Plugin 3.6.0 and earlier transmits...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-xqf6-5grh-6223/GHSA-xqf6-5grh-6223.json
+++ b/advisories/unreviewed/2022/05/GHSA-xqf6-5grh-6223/GHSA-xqf6-5grh-6223.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-xqf6-5grh-6223",
-  "modified": "2022-05-24T17:12:40Z",
+  "modified": "2022-12-21T14:13:49Z",
   "published": "2022-05-24T17:12:40Z",
   "aliases": [
     "CVE-2020-2165"
   ],
-  "details": "Jenkins Artifactory Plugin 3.6.0 and earlier transmits configured passwords in plain text as part of its global Jenkins configuration form, potentially resulting in their exposure.",
+  "summary": "Passwords transmitted in plain text by Jenkins Artifactory Plugin",
+  "details": "Artifactory Plugin stores Artifactory server passwords in its global configuration file `org.jfrog.hudson.ArtifactoryBuilder.xml` on the Jenkins controller as part of its configuration.\n\nWhile the password is stored encrypted on disk since Artifactory Plugin 3.6.0, it is transmitted in plain text as part of the configuration form by Artifactory Plugin 3.6.0 and earlier. This can result in exposure of the password through browser extensions, cross-site scripting vulnerabilities, and similar situations.\n\nArtifactory Plugin 3.6.1 transmits the password in its global configuration encrypted.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:artifactory"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.6.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.6.0"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2165"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/artifactory-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-319"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-03-25/#SECURITY-1542%20(2)