### PR TITLE
[GHSA-f4gq-7hvf-fjm3] Jenkins RapidDeploy Plugin 4.2 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-f4gq-7hvf-fjm3/GHSA-f4gq-7hvf-fjm3.json
+++ b/advisories/unreviewed/2022/05/GHSA-f4gq-7hvf-fjm3/GHSA-f4gq-7hvf-fjm3.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-f4gq-7hvf-fjm3",
-  "modified": "2022-05-24T17:12:40Z",
+  "modified": "2022-12-21T14:20:28Z",
   "published": "2022-05-24T17:12:40Z",
   "aliases": [
     "CVE-2020-2170"
   ],
-  "details": "Jenkins RapidDeploy Plugin 4.2 and earlier does not escape package names in the table of packages obtained from a remote server, resulting in a stored XSS vulnerability.",
+  "summary": "Stored XSS vulnerability in Jenkins RapidDeploy Plugin",
+  "details": "RapidDeploy Plugin 4.2 and earlier does not escape package names in its displayed table of packages obtained from a remote server. This results in a stored cross-site scripting (XSS) vulnerability exploitable by users able to configure jobs.\n\nRapidDeploy Plugin 4.2.1 escapes package names.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:rapiddeploy-jenkins"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.2.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.2"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2170"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/rapiddeploy-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-03-25/#SECURITY-1676