### PR TITLE
[GHSA-g7w4-r4mg-gvhx] Jenkins RapidDeploy Plugin 4.2 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-g7w4-r4mg-gvhx/GHSA-g7w4-r4mg-gvhx.json
+++ b/advisories/unreviewed/2022/05/GHSA-g7w4-r4mg-gvhx/GHSA-g7w4-r4mg-gvhx.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-g7w4-r4mg-gvhx",
-  "modified": "2022-05-24T17:12:41Z",
+  "modified": "2022-12-21T14:21:37Z",
   "published": "2022-05-24T17:12:41Z",
   "aliases": [
     "CVE-2020-2171"
   ],
-  "details": "Jenkins RapidDeploy Plugin 4.2 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability in Jenkins RapidDeploy Plugin",
+  "details": "RapidDeploy Plugin 4.2 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows a user able to control the input files for the 'RapidDeploy deployment package build' build or post-build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller, server-side request forgery, or denial-of-service attacks.\n\nRapidDeploy Plugin 4.2.1 disables external entity resolution for its XML parser.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:rapiddeploy-jenkins"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.2.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.2"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2171"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/rapiddeploy-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-611"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-03-25/#SECURITY-1677