### PR TITLE
[GHSA-27h2-hvpr-p74q] jsonwebtoken has insecure input validation in jwt.verify function

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-27h2-hvpr-p74q/GHSA-27h2-hvpr-p74q.json
+++ b/advisories/github-reviewed/2022/12/GHSA-27h2-hvpr-p74q/GHSA-27h2-hvpr-p74q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-27h2-hvpr-p74q",
-  "modified": "2022-12-22T03:31:28Z",
+  "modified": "2022-12-22T09:49:08Z",
   "published": "2022-12-22T03:31:28Z",
   "aliases": [
     "CVE-2022-23529"
@@ -57,7 +57,7 @@
     "cwe_ids": [
       "CWE-20"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Severity

**Comments**
This vulnerability is a joke. What it actually says is: "if a malicious actor has remote code execution, they can gain remote code execution".

The library has a _callback_, which is a standard Javascript programming pattern and does not result in a vulnerability all by itself. To be affected by this vulnerability, you would have to go out of your way to download untrusted code, parse it, and pass it into the callback. Or you could pass it to literally any other callback in your code base and it would do exactly the same. Even suggesting that this is an actual vulnerability is ridiculous and whoever filed the CVE was extremely incompetent.

By the way, the linked commit does nothing to change this behavior.