### PR TITLE
[GHSA-cfvw-84vq-43mx] Jenkins Deployer Framework Plugin 1.2 and earlier does...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-cfvw-84vq-43mx/GHSA-cfvw-84vq-43mx.json
+++ b/advisories/unreviewed/2022/05/GHSA-cfvw-84vq-43mx/GHSA-cfvw-84vq-43mx.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-cfvw-84vq-43mx",
-  "modified": "2022-05-24T17:23:39Z",
+  "modified": "2022-12-22T10:38:40Z",
   "published": "2022-05-24T17:23:39Z",
   "aliases": [
     "CVE-2020-2227"
   ],
-  "details": "Jenkins Deployer Framework Plugin 1.2 and earlier does not escape the URL displayed in the build home page, resulting in a stored cross-site scripting vulnerability.",
+  "summary": "Stored XSS vulnerability in Jenkins Deployer Framework Plugin",
+  "details": "Deployer Framework Plugin is a framework plugin allowing other plugins to provide a way to deploy artifacts. Deployer Framework Plugin 1.2 and earlier does not escape the URL displayed in the build home page. This results in a stored cross-site scripting (XSS) vulnerability exploitable by users able to provide the location.\n\nThe exploitability of this vulnerability depends on the specific implementation using Deployer Framework Plugin. The Jenkins security team is not aware of any exploitable implementation.\n\nDeployer Framework Plugin 1.3 escapes the URL.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:deployer-framework"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.2"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2227"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/deployer-framework-plugin"
     },
     {
       "type": "WEB",
@@ -31,7 +60,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-07-15/#SECURITY-1915