### PR TITLE
[GHSA-fq52-6cjf-jw59] Jenkins VncRecorder Plugin 1.25 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-fq52-6cjf-jw59/GHSA-fq52-6cjf-jw59.json
+++ b/advisories/unreviewed/2022/05/GHSA-fq52-6cjf-jw59/GHSA-fq52-6cjf-jw59.json
@@ -1,22 +1,45 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-fq52-6cjf-jw59",
-  "modified": "2022-05-24T17:22:19Z",
+  "modified": "2022-12-22T10:55:40Z",
   "published": "2022-05-24T17:22:19Z",
   "aliases": [
     "CVE-2020-2206"
   ],
-  "details": "Jenkins VncRecorder Plugin 1.25 and earlier does not escape a parameter value in the checkVncServ form validation endpoint, resulting in a reflected cross-site scripting (XSS) vulnerability.",
+  "summary": "Reflected XSS vulnerability in Jenkins VncRecorder Plugin",
+  "details": "VncRecorder Plugin 1.25 and earlier does not escape a parameter value in the `checkVncServ` form validation endpoint output.\n\nThis results in a reflected cross-site scripting (XSS) vulnerability.\n\nVncRecorder Plugin 1.35 escapes the parameter value in the output.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:vncrecorder"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2206"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/vncrecorder-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +52,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-07-02/#SECURITY-1728%20(2)