### PR TITLE
[GHSA-2j4h-cjgh-659v] Jenkins VncViewer Plugin 1.7 and earlier does not escape...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-2j4h-cjgh-659v/GHSA-2j4h-cjgh-659v.json
+++ b/advisories/unreviewed/2022/05/GHSA-2j4h-cjgh-659v/GHSA-2j4h-cjgh-659v.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-2j4h-cjgh-659v",
-  "modified": "2022-05-24T17:22:19Z",
+  "modified": "2022-12-22T10:58:01Z",
   "published": "2022-05-24T17:22:19Z",
   "aliases": [
     "CVE-2020-2207"
   ],
-  "details": "Jenkins VncViewer Plugin 1.7 and earlier does not escape a parameter value in the checkVncServ form validation endpoint, resulting in a reflected cross-site scripting (XSS) vulnerability.",
+  "summary": "Reflected XSS vulnerability in Jenkins VncViewer Plugin",
+  "details": "VncViewer Plugin 1.7 and earlier does not escape a parameter value in the `checkVncServ` form validation endpoint output.\n\nThis results in a reflected cross-site scripting (XSS) vulnerability.\n\nVncViewer Plugin 1.8 escapes the parameter value in the output.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:vncviewer"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.8"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.7"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2207"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/vncviewer-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +58,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-07-02/#SECURITY-1776