### PR TITLE
[GHSA-656g-hf8v-x2rw] Jenkins Slack Upload Plugin 1.7 and earlier stores a...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-656g-hf8v-x2rw/GHSA-656g-hf8v-x2rw.json
+++ b/advisories/unreviewed/2022/05/GHSA-656g-hf8v-x2rw/GHSA-656g-hf8v-x2rw.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-656g-hf8v-x2rw",
-  "modified": "2022-05-24T17:22:19Z",
+  "modified": "2022-12-22T11:26:53Z",
   "published": "2022-05-24T17:22:19Z",
   "aliases": [
     "CVE-2020-2208"
   ],
-  "details": "Jenkins Slack Upload Plugin 1.7 and earlier stores a secret unencrypted in job config.xml files on the Jenkins master where it can be viewed by users with Extended Read permission, or access to the master file system.",
+  "summary": "Secret stored in plain text by Jenkins Slack Upload Plugin",
+  "details": "Jenkins Slack Upload Plugin 1.7 and earlier stores a secret unencrypted in job `config.xml` files on the Jenkins master where it can be viewed by users with Extended Read permission, or access to the master file system.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:slack-uploader"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.7"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2208"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/slack-uploader-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +55,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-256"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-07-02/#SECURITY-1627