### PR TITLE
[GHSA-r32r-f6wr-cc3w] Jenkins TestComplete support Plugin 2.4.1 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-r32r-f6wr-cc3w/GHSA-r32r-f6wr-cc3w.json
+++ b/advisories/unreviewed/2022/05/GHSA-r32r-f6wr-cc3w/GHSA-r32r-f6wr-cc3w.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-r32r-f6wr-cc3w",
-  "modified": "2022-05-24T17:22:19Z",
+  "modified": "2022-12-22T11:29:53Z",
   "published": "2022-05-24T17:22:19Z",
   "aliases": [
     "CVE-2020-2209"
   ],
-  "details": "Jenkins TestComplete support Plugin 2.4.1 and earlier stores a password unencrypted in job config.xml files on the Jenkins master where it can be viewed by users with Extended Read permission, or access to the master file system.",
+  "summary": "Password stored in plain text by Jenkins TestComplete support Plugin",
+  "details": "Jenkins TestComplete support Plugin 2.4.1 and earlier stores a password unencrypted in job `config.xml` files on the Jenkins master where it can be viewed by users with Extended Read permission, or access to the master file system.\n\n",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:TestComplete"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.5.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.4.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2209"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/testcomplete-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +58,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-256"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-07-02/#SECURITY-1686

This has been fixed in https://github.com/jenkinsci/testcomplete-plugin/commit/00988873c6ea7e8d081380e4262538960efd6bf1, https://github.com/jenkinsci/testcomplete-plugin/commit/ca783d3b6be28b13f82865afa6a8888795d57d10 and https://github.com/jenkinsci/testcomplete-plugin/commit/91dae11421b70a334d2058286e30402cf2f86d4b; released in 2.5.2