### PR TITLE
[GHSA-5r5f-hcwf-r9jh] Jenkins GitHub Coverage Reporter Plugin 1.8 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5r5f-hcwf-r9jh/GHSA-5r5f-hcwf-r9jh.json
+++ b/advisories/unreviewed/2022/05/GHSA-5r5f-hcwf-r9jh/GHSA-5r5f-hcwf-r9jh.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-5r5f-hcwf-r9jh",
-  "modified": "2022-05-24T17:22:19Z",
+  "modified": "2022-12-22T11:35:12Z",
   "published": "2022-05-24T17:22:19Z",
   "aliases": [
     "CVE-2020-2212"
   ],
-  "details": "Jenkins GitHub Coverage Reporter Plugin 1.8 and earlier stores secrets unencrypted in its global configuration file on the Jenkins master where they can be viewed by users with access to the master file system or read permissions on the system configuration.",
+  "summary": "Secret stored in plain text by Jenkins GitHub Coverage Reporter Plugin",
+  "details": "GitHub Coverage Reporter Plugin 1.8 and earlier stores a GitHub access token in plain text in its global configuration file `io.jenkins.plugins.gcr.PluginConfiguration.xml`. This token can be viewed by users with access to the Jenkins controller file system.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.jenkins.plugins:github-coverage-reporter"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.10"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2212"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/github-coverage-reporter-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +55,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-256"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-07-02/#SECURITY-1632

Affected versions increased, because newer versions with this vulnerability exist.