### PR TITLE
[GHSA-v8v2-fhgv-3vq2] Jenkins White Source Plugin 19.1.1 and earlier stores...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-v8v2-fhgv-3vq2/GHSA-v8v2-fhgv-3vq2.json
+++ b/advisories/unreviewed/2022/05/GHSA-v8v2-fhgv-3vq2/GHSA-v8v2-fhgv-3vq2.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-v8v2-fhgv-3vq2",
-  "modified": "2022-05-24T17:22:19Z",
+  "modified": "2022-12-22T11:40:56Z",
   "published": "2022-05-24T17:22:19Z",
   "aliases": [
     "CVE-2020-2213"
   ],
-  "details": "Jenkins White Source Plugin 19.1.1 and earlier stores credentials unencrypted in its global configuration file and in job config.xml files on the Jenkins master where they can be viewed by users with Extended Read permission (config.xml), or access to the master file system.",
+  "summary": "Credentials stored in plain text by Jenkins White Source Plugin",
+  "details": "White Source Plugin 19.1.1 and earlier stores credentials in plain text as part of its global configuration file `org.whitesource.jenkins.pipeline.WhiteSourcePipelineStep.xml` and job config.xml files on the Jenkins controller. These credentials could be viewed by users with Extended Read permission (in the case of job config.xml files) or access to the Jenkins controller file system.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:whitesource"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "20.8.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 19.1.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2213"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/whitesource-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +58,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-256"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-07-02/#SECURITY-1630

This has been addressed in https://github.com/jenkinsci/whitesource-plugin/commit/4a9ee37246848c65cd41c5cf17d84992ffc6d21d, released in 20.8.1