### PR TITLE
[GHSA-2q7j-52xg-x8fm] A missing permission check in Jenkins Zephyr for JIRA...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-2q7j-52xg-x8fm/GHSA-2q7j-52xg-x8fm.json
+++ b/advisories/unreviewed/2022/05/GHSA-2q7j-52xg-x8fm/GHSA-2q7j-52xg-x8fm.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-2q7j-52xg-x8fm",
-  "modified": "2022-05-24T17:22:20Z",
+  "modified": "2022-12-22T11:49:16Z",
   "published": "2022-05-24T17:22:20Z",
   "aliases": [
     "CVE-2020-2216"
   ],
+  "summary": "Missing permission checks in Zephyr for JIRA Test Management Plugin",
   "details": "A missing permission check in Jenkins Zephyr for JIRA Test Management Plugin 1.5 and earlier allows attackers with Overall/Read permission to connect to an attacker-specified HTTP server using attacker-specified username and password.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:zephyr-for-jira-test-management"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.5"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2216"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/zephyr-for-jira-test-management-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +55,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-285"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-07-02/#SECURITY-1762