### PR TITLE
[GHSA-42hx-vrxx-5r6v] Jodit Editor vulnerable to Cross-site Scripting

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-42hx-vrxx-5r6v/GHSA-42hx-vrxx-5r6v.json
+++ b/advisories/github-reviewed/2022/09/GHSA-42hx-vrxx-5r6v/GHSA-42hx-vrxx-5r6v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-42hx-vrxx-5r6v",
-  "modified": "2022-09-27T22:48:53Z",
+  "modified": "2022-12-22T14:54:02Z",
   "published": "2022-09-25T00:00:15Z",
   "aliases": [
     "CVE-2022-23461"
@@ -26,9 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "3.19.5"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
I'm not sure if this is the proper way to mark all versions as affected, sorry if that's not the case. There is no fixed version for this issue currently.

When this advisory was created, the last released version was 3.19.5. Since then, newer versions have been released, but the issue is still not fixed (see the changelog for 3.20.1 https://github.com/xdan/jodit/blob/master/CHANGELOG.md#3201, released right after 3.19.5).