### PR TITLE
[GHSA-4qrj-99r6-jfrh] Jenkins Email Extension Plugin 2.75 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-4qrj-99r6-jfrh/GHSA-4qrj-99r6-jfrh.json
+++ b/advisories/unreviewed/2022/05/GHSA-4qrj-99r6-jfrh/GHSA-4qrj-99r6-jfrh.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4qrj-99r6-jfrh",
-  "modified": "2022-05-24T17:28:24Z",
+  "modified": "2022-12-23T10:33:21Z",
   "published": "2022-05-24T17:28:24Z",
   "aliases": [
     "CVE-2020-2253"
   ],
-  "details": "Jenkins Email Extension Plugin 2.75 and earlier does not perform hostname validation when connecting to the configured SMTP server.",
+  "summary": "Missing hostname validation in Email Extension Plugin",
+  "details": "Email Extension Plugin 2.75 and earlier does not perform hostname validation when connecting to the configured SMTP server. This lack of validation could be abused using a man-in-the-middle attack to intercept these connections.\n\nEmail Extension Plugin 2.76 validates the SMTP hostname when connecting via TLS by default. In Email Extension Plugin 2.75 and earlier, administrators can set the Java system property `mail.smtp.ssl.checkserveridentity` to `true` on startup to enable this protection. Alternatively, this protection can be enabled (or disabled in the new version) via the 'Advanced Email Properties' field in the plugin’s configuration in Configure System.\n\nIn case of problems, this protection can be disabled again by setting `mail.smtp.ssl.checkserveridentity` to `false` using either method.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:email-ext"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.76"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.75"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2253"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/email-ext-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +58,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-297"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1851