### PR TITLE
[GHSA-vc7g-4269-f7hw] A missing permission check in Jenkins Blue Ocean Plugin 1...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-vc7g-4269-f7hw/GHSA-vc7g-4269-f7hw.json
+++ b/advisories/unreviewed/2022/05/GHSA-vc7g-4269-f7hw/GHSA-vc7g-4269-f7hw.json
@@ -1,17 +1,42 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-vc7g-4269-f7hw",
-  "modified": "2022-05-24T17:28:25Z",
+  "modified": "2022-12-23T10:37:24Z",
   "published": "2022-05-24T17:28:25Z",
   "aliases": [
     "CVE-2020-2255"
   ],
-  "details": "A missing permission check in Jenkins Blue Ocean Plugin 1.23.2 and earlier allows attackers with Overall/Read permission to connect to an attacker-specified URL.",
+  "summary": "Missing permission check in Blue Ocean Plugin",
+  "details": "Updated 2020-09-16: This entry previously misidentified the problematic behavior. The HTTP request itself is legitimate, but only authorized users should be able to perform it.\n\nBlue Ocean Plugin 1.23.2 and earlier does not perform permission checks in several HTTP endpoints implementing connection tests.\n\nThis allows attackers with Overall/Read permission to connect to an attacker-specified URL.\n\nBlue Ocean Plugin 1.23.3 requires Item/Create permission to perform these connection tests.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.jenkins.blueocean:blueocean"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.23.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.23.2"
+      }
+    }
   ],
   "references": [
     {
@@ -29,7 +54,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-862"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1961