### PR TITLE
[GHSA-28x9-hc4p-9vh2] Jenkins Android Lint Plugin 2.6 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-28x9-hc4p-9vh2/GHSA-28x9-hc4p-9vh2.json
+++ b/advisories/unreviewed/2022/05/GHSA-28x9-hc4p-9vh2/GHSA-28x9-hc4p-9vh2.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-28x9-hc4p-9vh2",
-  "modified": "2022-05-24T17:28:25Z",
+  "modified": "2022-12-23T10:46:29Z",
   "published": "2022-05-24T17:28:25Z",
   "aliases": [
     "CVE-2020-2262"
   ],
+  "summary": "Stored XSS vulnerability in android-lint Plugin",
   "details": "Jenkins Android Lint Plugin 2.6 and earlier does not escape the annotation message in tooltips, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers able to provide report files to the plugin's post-build step.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jvnet.hudson.plugins:android-lint"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.6"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2262"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/android-lint-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +55,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1908