### PR TITLE
[GHSA-c26h-8h4p-4jgj] A missing permission check in Jenkins MongoDB Plugin 1.3...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-c26h-8h4p-4jgj/GHSA-c26h-8h4p-4jgj.json
+++ b/advisories/unreviewed/2022/05/GHSA-c26h-8h4p-4jgj/GHSA-c26h-8h4p-4jgj.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-c26h-8h4p-4jgj",
-  "modified": "2022-05-24T17:28:26Z",
+  "modified": "2022-12-23T10:52:28Z",
   "published": "2022-05-24T17:28:26Z",
   "aliases": [
     "CVE-2020-2267"
   ],
+  "summary": "Missing permission checks in MongoDB Plugin",
   "details": "A missing permission check in Jenkins MongoDB Plugin 1.3 and earlier allows attackers with Overall/Read permission to gain access to some metadata of any arbitrary files on the Jenkins controller.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:mongodb"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2267"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/mongodb-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +55,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-862"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1904