### PR TITLE
[GHSA-226h-qrg4-8236] Jenkins chosen-views-tabbar Plugin 1.2 and earlier does...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-226h-qrg4-8236/GHSA-226h-qrg4-8236.json
+++ b/advisories/unreviewed/2022/05/GHSA-226h-qrg4-8236/GHSA-226h-qrg4-8236.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-226h-qrg4-8236",
-  "modified": "2022-05-24T17:28:26Z",
+  "modified": "2022-12-23T10:54:38Z",
   "published": "2022-05-24T17:28:26Z",
   "aliases": [
     "CVE-2020-2269"
   ],
+  "summary": "Stored XSS vulnerability in chosen-views-tabbar Plugin",
   "details": "Jenkins chosen-views-tabbar Plugin 1.2 and earlier does not escape view names in the dropdown to select views, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with the ability to configure views.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:chosen-views-tabbar"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2269"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/chosen-views-tabbar"
     },
     {
       "type": "WEB",
@@ -29,9 +55,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1869