### PR TITLE
[GHSA-2c84-35rv-6q3f] Jenkins ClearCase Release Plugin 0.3 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-2c84-35rv-6q3f/GHSA-2c84-35rv-6q3f.json
+++ b/advisories/unreviewed/2022/05/GHSA-2c84-35rv-6q3f/GHSA-2c84-35rv-6q3f.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-2c84-35rv-6q3f",
-  "modified": "2022-05-24T17:28:26Z",
+  "modified": "2022-12-23T11:12:06Z",
   "published": "2022-05-24T17:28:26Z",
   "aliases": [
     "CVE-2020-2270"
   ],
+  "summary": "Stored XSS vulnerability in ClearCase Release Plugin",
   "details": "Jenkins ClearCase Release Plugin 0.3 and earlier does not escape the composite baseline in badge tooltip, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Job/Configure permission.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jvnet.hudson.plugins:clearcase-release"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "0.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2270"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/clearcase-release-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +55,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1911