### PR TITLE
[GHSA-9rhc-vjjp-gccw] Jenkins Locked Files Report Plugin 1.6 and earlier does...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-9rhc-vjjp-gccw/GHSA-9rhc-vjjp-gccw.json
+++ b/advisories/unreviewed/2022/05/GHSA-9rhc-vjjp-gccw/GHSA-9rhc-vjjp-gccw.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9rhc-vjjp-gccw",
-  "modified": "2022-05-24T17:28:26Z",
+  "modified": "2022-12-23T11:13:35Z",
   "published": "2022-05-24T17:28:26Z",
   "aliases": [
     "CVE-2020-2271"
   ],
+  "summary": "Stored XSS vulnerability in Locked Files Report Plugin",
   "details": "Jenkins Locked Files Report Plugin 1.6 and earlier does not escape locked files' names in tooltips, resulting in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Job/Configure permission.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jvnet.hudson.plugins:locked-files-report"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.6"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2271"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/locked-files-report-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +55,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-862"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1921