### PR TITLE
[GHSA-mr43-vf8q-q5f2] A missing permission check in Jenkins ElasTest Plugin 1.2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-mr43-vf8q-q5f2/GHSA-mr43-vf8q-q5f2.json
+++ b/advisories/unreviewed/2022/05/GHSA-mr43-vf8q-q5f2/GHSA-mr43-vf8q-q5f2.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-mr43-vf8q-q5f2",
-  "modified": "2022-05-24T17:28:27Z",
+  "modified": "2022-12-23T11:15:09Z",
   "published": "2022-05-24T17:28:27Z",
   "aliases": [
     "CVE-2020-2272"
   ],
+  "summary": "Missing permission checks in ElasTest Plugin",
   "details": "A missing permission check in Jenkins ElasTest Plugin 1.2.1 and earlier allows attackers with Overall/Read permission to connect to an attacker-specified URL using attacker-specified credentials.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:elastest"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.2.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2272"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/elastest-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +55,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-862"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1903