### PR TITLE
[GHSA-p9rc-x48f-582x] Jenkins ElasTest Plugin 1.2.1 and earlier stores its...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-p9rc-x48f-582x/GHSA-p9rc-x48f-582x.json
+++ b/advisories/unreviewed/2022/05/GHSA-p9rc-x48f-582x/GHSA-p9rc-x48f-582x.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-p9rc-x48f-582x",
-  "modified": "2022-05-24T17:28:27Z",
+  "modified": "2022-12-23T11:17:12Z",
   "published": "2022-05-24T17:28:27Z",
   "aliases": [
     "CVE-2020-2274"
   ],
+  "summary": "Passwords stored in plain text by ElasTest Plugin",
   "details": "Jenkins ElasTest Plugin 1.2.1 and earlier stores its server password unencrypted in its global configuration file on the Jenkins controller where it can be viewed by users with access to the Jenkins controller file system.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:elastest"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.2.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2274"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/elastest-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +55,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-312"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-2014