### PR TITLE
[GHSA-qv6q-4jwx-7j5c] Jenkins Storable Configs Plugin 1.0 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-qv6q-4jwx-7j5c/GHSA-qv6q-4jwx-7j5c.json
+++ b/advisories/unreviewed/2022/05/GHSA-qv6q-4jwx-7j5c/GHSA-qv6q-4jwx-7j5c.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-qv6q-4jwx-7j5c",
-  "modified": "2022-05-24T17:28:27Z",
+  "modified": "2022-12-23T11:22:21Z",
   "published": "2022-05-24T17:28:27Z",
   "aliases": [
     "CVE-2020-2278"
   ],
+  "summary": "Arbitrary file write vulnerability in Storable Configs Plugin",
   "details": "Jenkins Storable Configs Plugin 1.0 and earlier does not restrict the user-specified file name, allowing attackers with Job/Configure permission to replace any other '.xml' file on the Jenkins controller with a job config.xml file's content.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jvnet.hudson.plugins:storable-configs-plugin"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2278"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/storable-configs-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +55,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-22"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1968%20(2)