### PR TITLE
[GHSA-7fxm-c848-89q8] static-dev-server vulnerable to path traversal

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-7fxm-c848-89q8/GHSA-7fxm-c848-89q8.json
+++ b/advisories/github-reviewed/2022/11/GHSA-7fxm-c848-89q8/GHSA-7fxm-c848-89q8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-7fxm-c848-89q8",
-  "modified": "2022-12-02T22:21:45Z",
+  "modified": "2022-12-24T00:13:29Z",
   "published": "2022-11-29T18:30:18Z",
   "aliases": [
     "CVE-2022-25848"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Requesting to attribute and credit this vulnerability to GitHub user @lirantal, who discovered and reported the vulnerability to Snyk.