### PR TITLE
[GHSA-4mgv-m5cm-f9h7] Vault GitHub Action did not correctly mask multi-line secrets in output

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4mgv-m5cm-f9h7/GHSA-4mgv-m5cm-f9h7.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4mgv-m5cm-f9h7/GHSA-4mgv-m5cm-f9h7.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4mgv-m5cm-f9h7",
-  "modified": "2022-07-29T19:57:46Z",
+  "modified": "2022-12-27T11:53:41Z",
   "published": "2022-05-24T19:01:50Z",
   "aliases": [
     "CVE-2021-32074"
   ],
   "summary": "Vault GitHub Action did not correctly mask multi-line secrets in output",
-  "details": "HashiCorp vault-action (aka Vault GitHub Action) before 2.2.0 allows attackers to obtain sensitive information from log files because a multi-line secret was not correctly registered with GitHub Actions for log masking.\n\nThe vault-action implementation did not correctly handle the marking of multi-line variables. As a result, multi-line secrets were not correctly masked in vault-action output.\n\nRemediation:\nCustomers using vault-action should evaluate the risk associated with this issue, and consider upgrading to vault-action 2.2.0 or newer. Please refer to https://github.com/marketplace/actions/vault-secrets for more information.",
+  "details": "HashiCorp vault-action (aka Vault GitHub Action) before 2.2.0 allows attackers to obtain sensitive information from log files because a multi-line secret was not correctly registered with GitHub Actions for log masking.\n\nThe vault-action implementation did not correctly handle the marking of multi-line variables. As a result, multi-line secrets were not correctly masked in vault-action output.\n\n\nRemediation:\nCustomers using vault-action should evaluate the risk associated with this issue, and consider upgrading to vault-action 2.2.0 or newer. Please refer to https://github.com/marketplace/actions/vault-secrets for more information.",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Description

**Comments**
piece of the code, like "uses: hashicorp/vault-action@v2" is marked by Dependabot as one which includes vulnerability due to security issues with version < 2.2.0. in real scenario,  code "hashicorp/vault-action@v2" is equal to latest 2.4 version which includes fixes and is not vulnerable. We receive false alerts and events which is not accurate to real situation. 