### PR TITLE
[GHSA-5cqm-crxm-6qpv] Buffer overrun in CGI.escape_html

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-5cqm-crxm-6qpv/GHSA-5cqm-crxm-6qpv.json
+++ b/advisories/github-reviewed/2021/12/GHSA-5cqm-crxm-6qpv/GHSA-5cqm-crxm-6qpv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-5cqm-crxm-6qpv",
-  "modified": "2022-07-29T14:18:05Z",
+  "modified": "2022-12-28T16:08:25Z",
   "published": "2021-12-14T21:36:20Z",
   "aliases": [
     "CVE-2021-41816"
@@ -70,7 +70,32 @@
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 0.1.0"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "cgi"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.1.0.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.1.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This issue was fixed in commit https://github.com/ruby/cgi/commit/ad079c1cb5f58eba1ffac46da79995fcf94a3a6e for 0.1.0.1 version.