### PR TITLE
[GHSA-4vf4-qmvg-mh7h] Cookie prefix spoofing in CGI

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-4vf4-qmvg-mh7h/GHSA-4vf4-qmvg-mh7h.json
+++ b/advisories/github-reviewed/2022/01/GHSA-4vf4-qmvg-mh7h/GHSA-4vf4-qmvg-mh7h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4vf4-qmvg-mh7h",
-  "modified": "2022-02-14T22:21:19Z",
+  "modified": "2022-12-29T09:10:49Z",
   "published": "2022-01-21T23:22:17Z",
   "aliases": [
     "CVE-2021-41819"
@@ -25,10 +25,48 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.3.0"
             },
             {
               "fixed": "0.3.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "cgi"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.1.0.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "cgi"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.2.0"
+            },
+            {
+              "fixed": "0.2.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Sync versions with https://github.com/rubysec/ruby-advisory-db/blob/master/gems/cgi/CVE-2021-41819.yml