### PR TITLE
[GHSA-6xxf-rwv4-mrjm] Jenkins Timestamper Plugin 1.11.1 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-6xxf-rwv4-mrjm/GHSA-6xxf-rwv4-mrjm.json
+++ b/advisories/unreviewed/2022/05/GHSA-6xxf-rwv4-mrjm/GHSA-6xxf-rwv4-mrjm.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-6xxf-rwv4-mrjm",
-  "modified": "2022-05-24T17:10:27Z",
+  "modified": "2022-12-29T09:31:00Z",
   "published": "2022-05-24T17:10:27Z",
   "aliases": [
     "CVE-2020-2137"
   ],
-  "details": "Jenkins Timestamper Plugin 1.11.1 and earlier does not sanitize HTML formatting of its output, resulting in a stored XSS vulnerability exploitable by attackers with Overall/Administer permission.",
+  "summary": "Stored XSS vulnerability in Timestamper Plugin",
+  "details": "Timestamper Plugin 1.11.1 and earlier does not escape or sanitize the HTML formatting used to display the timestamps in console output for builds.\n\nThis results in a stored cross-site scripting vulnerability that can be exploited by users with Overall/Administer permission.\n\nTimestamper Plugin 1.11.2 sanitizes the HTML formatting for timestamps and only allows basic, safe HTML formatting.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:timestamper"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.11.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.11.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2137"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/timestamper-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-03-09/#SECURITY-1784