### PR TITLE
[GHSA-5pg8-f89x-wjcx] Jenkins Logstash Plugin 2.3.1 and earlier transmits...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5pg8-f89x-wjcx/GHSA-5pg8-f89x-wjcx.json
+++ b/advisories/unreviewed/2022/05/GHSA-5pg8-f89x-wjcx/GHSA-5pg8-f89x-wjcx.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-5pg8-f89x-wjcx",
-  "modified": "2022-05-24T17:10:28Z",
+  "modified": "2022-12-29T09:46:23Z",
   "published": "2022-05-24T17:10:28Z",
   "aliases": [
     "CVE-2020-2143"
   ],
-  "details": "Jenkins Logstash Plugin 2.3.1 and earlier transmits configured credentials in plain text as part of its global Jenkins configuration form, potentially resulting in their exposure.",
+  "summary": "Credentials transmitted in plain text by Jenkins Logstash Plugin",
+  "details": "Logstash Plugin stores credentials in its global configuration file `jenkins.plugins.logstash.LogstashConfiguration.xml` on the Jenkins controller as part of its configuration.\n\nWhile the credentials are stored encrypted on disk, they are transmitted in plain text as part of the configuration form by Logstash Plugin 2.3.1 and earlier. This can result in exposure of the credential through browser extensions, cross-site scripting vulnerabilities, and similar situations.\n\nLogstash Plugin 2.3.2 transmits the credentials in its global configuration encrypted.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:logstash"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.3.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.3.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2143"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/logstash-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-319"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-03-09/#SECURITY-1516