### PR TITLE
[GHSA-5xh7-6v3x-vrhj] Jenkins Rundeck Plugin 3.6.6 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5xh7-6v3x-vrhj/GHSA-5xh7-6v3x-vrhj.json
+++ b/advisories/unreviewed/2022/05/GHSA-5xh7-6v3x-vrhj/GHSA-5xh7-6v3x-vrhj.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-5xh7-6v3x-vrhj",
-  "modified": "2022-05-24T17:10:28Z",
+  "modified": "2022-12-29T09:48:14Z",
   "published": "2022-05-24T17:10:28Z",
   "aliases": [
     "CVE-2020-2144"
   ],
-  "details": "Jenkins Rundeck Plugin 3.6.6 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.",
+  "summary": "XXE vulnerability in Rundeck Plugin",
+  "details": "Rundeck Plugin 3.6.6 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.\n\nThis allows a user with Overall/Read access to have Jenkins parse a crafted HTTP request with XML data that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.\n\nRundeck Plugin 3.6.7 disables external entity resolution for its XML parser.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:rundeck"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.6.7"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.6.6"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2144"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/rundeck-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-611"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-03-09/#SECURITY-1702