### PR TITLE
[GHSA-rv9g-67f7-grq7] Jenkins Mac Plugin 1.1.0 and earlier does not validate...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-rv9g-67f7-grq7/GHSA-rv9g-67f7-grq7.json
+++ b/advisories/unreviewed/2022/05/GHSA-rv9g-67f7-grq7/GHSA-rv9g-67f7-grq7.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-rv9g-67f7-grq7",
-  "modified": "2022-05-24T17:10:29Z",
+  "modified": "2022-12-29T09:52:12Z",
   "published": "2022-05-24T17:10:29Z",
   "aliases": [
     "CVE-2020-2146"
   ],
-  "details": "Jenkins Mac Plugin 1.1.0 and earlier does not validate SSH host keys when connecting agents created by the plugin, enabling man-in-the-middle attacks.",
+  "summary": "Missing SSH host key validation in Mac Plugin",
+  "details": "Mac Plugin 1.1.0 and earlier does not use SSH host key validation when connecting to Mac Cloud host launched by the plugin. This lack of validation could be abused using a man-in-the-middle attack to intercept these connections to build agents.\n\nMac Plugin 1.2.0 validates SSH host keys when connecting to agents.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "fr.edf.jenkins.plugins:mac"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.2.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.1.0"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2146"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/mac-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +58,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-300"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-03-09/#SECURITY-1692