### PR TITLE
[GHSA-2m74-x26c-g7xc] A missing permission check in Jenkins Mac Plugin 1.1.0...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-2m74-x26c-g7xc/GHSA-2m74-x26c-g7xc.json
+++ b/advisories/unreviewed/2022/05/GHSA-2m74-x26c-g7xc/GHSA-2m74-x26c-g7xc.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-2m74-x26c-g7xc",
-  "modified": "2022-05-24T17:10:29Z",
+  "modified": "2022-12-29T09:54:34Z",
   "published": "2022-05-24T17:10:29Z",
   "aliases": [
     "CVE-2020-2148"
   ],
+  "summary": "Missing permission checks in Mac Plugin",
   "details": "A missing permission check in Jenkins Mac Plugin 1.1.0 and earlier allows attackers with Overall/Read permission to connect to an attacker-specified SSH server using attacker-specified credentials.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "fr.edf.jenkins.plugins:mac"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.2.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.1.0"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2148"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/mac-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +58,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-285"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-03-09/#SECURITY-1761