### PR TITLE
[GHSA-4fjc-fwj2-7xfg] Jenkins Repository Connector Plugin 1.2.6 and earlier...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-4fjc-fwj2-7xfg/GHSA-4fjc-fwj2-7xfg.json
+++ b/advisories/unreviewed/2022/05/GHSA-4fjc-fwj2-7xfg/GHSA-4fjc-fwj2-7xfg.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-4fjc-fwj2-7xfg",
-  "modified": "2022-05-24T17:10:28Z",
+  "modified": "2022-12-29T09:58:46Z",
   "published": "2022-05-24T17:10:28Z",
   "aliases": [
     "CVE-2020-2149"
   ],
-  "details": "Jenkins Repository Connector Plugin 1.2.6 and earlier transmits configured credentials in plain text as part of its global Jenkins configuration form, potentially resulting in their exposure.",
+  "summary": "Credentials transmitted in plain text by Repository Connector Plugin",
+  "details": "Repository Connector Plugin stores credentials in its global configuration file `org.jvnet.hudson.plugins.repositoryconnector.RepositoryConfiguration.xml` on the Jenkins controller as part of its configuration.\n\nWhile the credentials are stored encrypted on disk, they are transmitted in plain text as part of the configuration form by Repository Connector Plugin 1.2.6 and earlier. This can result in exposure of the credential through browser extensions, cross-site scripting vulnerabilities, and similar situations.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:repository-connector"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.0.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.2.6"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2149"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/repository-connector-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-319"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-03-09/#SECURITY-1520

This has been fixed in 2.0.0: https://github.com/jenkinsci/repository-connector-plugin/commit/477b878a1b8c958b81d9254687d70a8911d13981