### PR TITLE
[GHSA-p68c-xg89-2g5r] Jenkins Backlog Plugin 2.4 and earlier transmits...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-p68c-xg89-2g5r/GHSA-p68c-xg89-2g5r.json
+++ b/advisories/unreviewed/2022/05/GHSA-p68c-xg89-2g5r/GHSA-p68c-xg89-2g5r.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-p68c-xg89-2g5r",
-  "modified": "2022-05-24T17:10:29Z",
+  "modified": "2022-12-29T10:08:07Z",
   "published": "2022-05-24T17:10:29Z",
   "aliases": [
     "CVE-2020-2153"
   ],
-  "details": "Jenkins Backlog Plugin 2.4 and earlier transmits configured credentials in plain text as part of job configuration forms, potentially resulting in their exposure.",
+  "summary": "Credentials transmitted in plain text by Backlog Plugin",
+  "details": "Backlog Plugin stores credentials in job `config.xml` files as part of its configuration.\n\nWhile the credentials are stored encrypted on disk, they are transmitted in plain text as part of the configuration form by Backlog Plugin 2.4 and earlier. These credentials could be viewed by users with Extended Read permission.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:backlog"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.4"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2153"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/backlog-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-319"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-03-09/#SECURITY-1510

This has been fixed in 2.5: https://github.com/jenkinsci/backlog-plugin/blob/master/CHANGELOG.md#version-25-mar-11-2020