### PR TITLE
[GHSA-hm57-4qpx-f734] Jenkins DeployHub Plugin 8.0.14 and earlier transmits...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-hm57-4qpx-f734/GHSA-hm57-4qpx-f734.json
+++ b/advisories/unreviewed/2022/05/GHSA-hm57-4qpx-f734/GHSA-hm57-4qpx-f734.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-hm57-4qpx-f734",
-  "modified": "2022-05-24T17:10:29Z",
+  "modified": "2022-12-29T10:13:18Z",
   "published": "2022-05-24T17:10:29Z",
   "aliases": [
     "CVE-2020-2156"
   ],
-  "details": "Jenkins DeployHub Plugin 8.0.14 and earlier transmits configured credentials in plain text as part of job configuration forms, potentially resulting in their exposure.",
+  "summary": "Credentials transmitted in plain text by DeployHub Plugin",
+  "details": "DeployHub Plugin stores credentials in job `config.xml` files as part of its configuration.\n\nWhile the credentials are stored encrypted on disk, they are transmitted in plain text as part of the configuration form by DeployHub Plugin 8.0.14 and earlier. These credentials could be viewed by users with Extended Read permission.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.openmake:deployhub"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "8.0.14"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2156"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/deployhub-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +55,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-319"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-03-09/#SECURITY-1511