### PR TITLE
[GHSA-c329-r874-xc7j] Jenkins Literate Plugin 1.0 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-c329-r874-xc7j/GHSA-c329-r874-xc7j.json
+++ b/advisories/unreviewed/2022/05/GHSA-c329-r874-xc7j/GHSA-c329-r874-xc7j.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-c329-r874-xc7j",
-  "modified": "2022-05-24T17:10:30Z",
+  "modified": "2022-12-29T10:16:02Z",
   "published": "2022-05-24T17:10:30Z",
   "aliases": [
     "CVE-2020-2158"
   ],
+  "summary": "RCE vulnerability in Literate Plugin",
   "details": "Jenkins Literate Plugin 1.0 and earlier does not configure its YAML parser to prevent the instantiation of arbitrary types, resulting in a remote code execution vulnerability.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:literate"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2158"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/literate-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +55,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-502"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-03-09/#SECURITY-1750