### PR TITLE
[GHSA-p5x5-jg3j-2jcj] Jenkins CryptoMove Plugin 0.1.33 and earlier allows...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-p5x5-jg3j-2jcj/GHSA-p5x5-jg3j-2jcj.json
+++ b/advisories/unreviewed/2022/05/GHSA-p5x5-jg3j-2jcj/GHSA-p5x5-jg3j-2jcj.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-p5x5-jg3j-2jcj",
-  "modified": "2022-10-07T18:15:59Z",
+  "modified": "2022-12-29T10:17:33Z",
   "published": "2022-05-24T17:10:30Z",
   "aliases": [
     "CVE-2020-2159"
   ],
-  "details": "Jenkins CryptoMove Plugin 0.1.33 and earlier allows attackers with Job/Configure access to execute arbitrary OS commands on the Jenkins master as the OS user account running Jenkins.",
+  "summary": "OS command injection in CryptoMove Plugin",
+  "details": "CryptoMove Plugin 0.1.33 and earlier allows the configuration of an OS command to execute as part of its build step configuration.\n\nThis command will be executed on the Jenkins controller as the OS user account running Jenkins, allowing user with Job/Configure permission to execute an arbitrary OS command on the Jenkins controller.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,12 +15,34 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.jenkins.plugins:cryptomove"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "0.1.33"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2159"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/cryptomove-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-03-09/#SECURITY-1635