### PR TITLE
[GHSA-hw26-fw67-qxm9] Jenkins Git Parameter Plugin 0.9.11 and earlier does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-hw26-fw67-qxm9/GHSA-hw26-fw67-qxm9.json
+++ b/advisories/unreviewed/2022/05/GHSA-hw26-fw67-qxm9/GHSA-hw26-fw67-qxm9.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-hw26-fw67-qxm9",
-  "modified": "2022-05-24T17:08:46Z",
+  "modified": "2022-12-29T11:10:48Z",
   "published": "2022-05-24T17:08:46Z",
   "aliases": [
     "CVE-2020-2112"
   ],
+  "summary": "Stored XSS vulnerabilities in Git Parameter Plugin",
   "details": "Jenkins Git Parameter Plugin 0.9.11 and earlier does not escape the parameter name shown on the UI, resulting in a stored cross-site scripting vulnerability exploitable by users with Job/Configure permission.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.tools:git-parameter"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.9.12"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.9.11"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2112"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/git-parameter-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-02-12/#SECURITY-1709