### PR TITLE
[GHSA-7q9r-vhg2-789w] Jenkins Brakeman Plugin 0.12 and earlier did not escape...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-7q9r-vhg2-789w/GHSA-7q9r-vhg2-789w.json
+++ b/advisories/unreviewed/2022/05/GHSA-7q9r-vhg2-789w/GHSA-7q9r-vhg2-789w.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-7q9r-vhg2-789w",
-  "modified": "2022-05-24T17:08:47Z",
+  "modified": "2022-12-29T11:29:41Z",
   "published": "2022-05-24T17:08:47Z",
   "aliases": [
     "CVE-2020-2122"
   ],
-  "details": "Jenkins Brakeman Plugin 0.12 and earlier did not escape values received from parsed JSON files when rendering them, resulting in a stored cross-site scripting vulnerability exploitable by users able to control the Brakeman post-build step input data.",
+  "summary": "Stored XSS vulnerability in Jenkins brakeman Plugin",
+  "details": "brakeman Plugin 0.12 and earlier did not escape values received from parsed JSON files when rendering them, resulting in a stored cross-site scripting vulnerability.\n\nThis vulnerability can be exploited by users able to control the Brakeman post-build step input data.\n\nbrakeman Plugin 0.13 escape affected values from the parsed file as they are recorded.\n\nThis fix is only applied to newly recorded data after a fixed version of the plugin is installed; historical data may still contain unsafe values.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:brakeman"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.13"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.12"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2122"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/brakeman-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-02-12/#SECURITY-1644