### PR TITLE
[GHSA-8g6v-g8qc-5w7j] Jenkins DigitalOcean Plugin 1.1 and earlier stores a...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-8g6v-g8qc-5w7j/GHSA-8g6v-g8qc-5w7j.json
+++ b/advisories/unreviewed/2022/05/GHSA-8g6v-g8qc-5w7j/GHSA-8g6v-g8qc-5w7j.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8g6v-g8qc-5w7j",
-  "modified": "2022-05-24T17:08:47Z",
+  "modified": "2022-12-29T11:37:02Z",
   "published": "2022-05-24T17:08:47Z",
   "aliases": [
     "CVE-2020-2126"
   ],
+  "summary": "Token stored in plain text by DigitalOcean Plugin",
   "details": "Jenkins DigitalOcean Plugin 1.1 and earlier stores a token unencrypted in the global config.xml file on the Jenkins master where it can be viewed by users with access to the master file system.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.dubture.jenkins:digitalocean-plugin"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.2.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2126"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/digitalocean-plugin"
     },
     {
       "type": "WEB",
@@ -29,9 +58,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-256"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-02-12/#SECURITY-1559

This has been fixed in 1.2.0: https://github.com/jenkinsci/digitalocean-plugin/releases/tag/digitalocean-plugin-1.2.0