### PR TITLE
[GHSA-gmg2-3w6v-945p] Jenkins Parasoft Environment Manager Plugin 2.14 and...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-gmg2-3w6v-945p/GHSA-gmg2-3w6v-945p.json
+++ b/advisories/unreviewed/2022/05/GHSA-gmg2-3w6v-945p/GHSA-gmg2-3w6v-945p.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-gmg2-3w6v-945p",
-  "modified": "2022-05-24T17:08:47Z",
+  "modified": "2022-12-29T11:44:58Z",
   "published": "2022-05-24T17:08:47Z",
   "aliases": [
     "CVE-2020-2132"
   ],
+  "summary": "Password stored in plain text by Parasoft Environment Manager Plugin",
   "details": "Jenkins Parasoft Environment Manager Plugin 2.14 and earlier stores a password unencrypted in job config.xml files on the Jenkins master where it can be viewed by users with Extended Read permission, or access to the master file system.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.parasoft:environment-manager"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.18"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.14"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2132"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/environment-manager-tools-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +58,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-256"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-02-12/#SECURITY-1562

This has been fixed in 2.18: https://github.com/jenkinsci/environment-manager-tools-plugin/commit/a2511b9d3dfbd3778471c6840ae6026076f11134