### PR TITLE
[GHSA-54m9-h7qp-fwvg] Jenkins Applatix Plugin 1.1 and earlier stores a password...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-54m9-h7qp-fwvg/GHSA-54m9-h7qp-fwvg.json
+++ b/advisories/unreviewed/2022/05/GHSA-54m9-h7qp-fwvg/GHSA-54m9-h7qp-fwvg.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-54m9-h7qp-fwvg",
-  "modified": "2022-05-24T17:08:48Z",
+  "modified": "2022-12-29T11:46:10Z",
   "published": "2022-05-24T17:08:48Z",
   "aliases": [
     "CVE-2020-2133"
   ],
+  "summary": "Password stored in plain text by Applatix Plugin",
   "details": "Jenkins Applatix Plugin 1.1 and earlier stores a password unencrypted in job config.xml files on the Jenkins master where it can be viewed by users with Extended Read permission, or access to the master file system.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.applatix.jenkins:applatix"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2133"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/applatix-plugin"
     },
     {
       "type": "WEB",
@@ -29,7 +55,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-256"
     ],
     "severity": "MODERATE",
     "github_reviewed": false


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Source code location
- Summary

**Comments**
Fill in advisory details according to https://www.jenkins.io/security/advisory/2020-02-12/#SECURITY-1540