### PR TITLE
[GHSA-9c47-m6qq-7p4h] Prototype Pollution in JSON5 via Parse Method

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-9c47-m6qq-7p4h/GHSA-9c47-m6qq-7p4h.json
+++ b/advisories/github-reviewed/2022/12/GHSA-9c47-m6qq-7p4h/GHSA-9c47-m6qq-7p4h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9c47-m6qq-7p4h",
-  "modified": "2022-12-29T01:51:03Z",
+  "modified": "2022-12-30T18:09:32Z",
   "published": "2022-12-29T01:51:03Z",
   "aliases": [
     "CVE-2022-46175"
@@ -26,6 +26,22 @@
             },
             {
               "fixed": "2.2.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "json5"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
https://github.com/json5/json5/pull/298#issuecomment-1368017253

---

Ah, I think I fat-fingered this and submitted before it was finished. It seems I cannot edit this PR anymore either 😬

Anyway, what I was trying to do was report that it was also fixed in the v1 line (`json5@1.0.2`), as noted here:

- https://github.com/json5/json5/pull/298#issuecomment-1368017253

So what I would suggest is that the vulnerability have two versions entries:

| Affected versions | Patched versions |
| ---- | ---- |
| < 1.0.2 | 1.0.2 |
| >= 2.0.0, < 2.2.2 | 2.2.2 |

Similar to this `xmldom` vulnerability:

- https://github.com/advisories/GHSA-crh6-fp67-6883

<img width="816" alt="Screenshot 2022-12-30 at 19 19 20" src="https://user-images.githubusercontent.com/1935696/210100921-a722430f-29c1-4613-8409-7995ef89d160.png">
