### PR TITLE
[GHSA-9c47-m6qq-7p4h] Prototype Pollution in JSON5 via Parse Method

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-9c47-m6qq-7p4h/GHSA-9c47-m6qq-7p4h.json
+++ b/advisories/github-reviewed/2022/12/GHSA-9c47-m6qq-7p4h/GHSA-9c47-m6qq-7p4h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9c47-m6qq-7p4h",
-  "modified": "2022-12-29T01:51:03Z",
+  "modified": "2023-01-03T00:03:43Z",
   "published": "2022-12-29T01:51:03Z",
   "aliases": [
     "CVE-2022-46175"
@@ -22,10 +22,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0.0"
             },
             {
               "fixed": "2.2.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "json5"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.0.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to the 1.0.2 release notes [1] the bugfix has been backported to v1.
This has also been updated on the Security Advisory published to the json5 repo [2], but for some reason not here.

[1] https://github.com/json5/json5/releases/tag/v1.0.2
[2] https://github.com/json5/json5/security/advisories/GHSA-9c47-m6qq-7p4h