### PR TITLE
[GHSA-9c47-m6qq-7p4h] Prototype Pollution in JSON5 via Parse Method

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-9c47-m6qq-7p4h/GHSA-9c47-m6qq-7p4h.json
+++ b/advisories/github-reviewed/2022/12/GHSA-9c47-m6qq-7p4h/GHSA-9c47-m6qq-7p4h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9c47-m6qq-7p4h",
-  "modified": "2022-12-29T01:51:03Z",
+  "modified": "2023-01-03T14:43:13Z",
   "published": "2022-12-29T01:51:03Z",
   "aliases": [
     "CVE-2022-46175"
@@ -25,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.2.2"
+              "fixed": "1.0.2, 2.2.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.2.2"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
seems like patch was also backported to v1, see https://github.com/json5/json5/releases/tag/v1.0.2