### PR TITLE
[GHSA-hrm3-3xm6-x33h] golang-nanoauth authentication bypass vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-hrm3-3xm6-x33h/GHSA-hrm3-3xm6-x33h.json
+++ b/advisories/github-reviewed/2022/12/GHSA-hrm3-3xm6-x33h/GHSA-hrm3-3xm6-x33h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-hrm3-3xm6-x33h",
-  "modified": "2022-12-30T18:54:51Z",
+  "modified": "2023-01-04T01:03:10Z",
   "published": "2022-12-28T00:30:23Z",
   "aliases": [
     "CVE-2020-36569"
@@ -23,13 +23,13 @@
           "events": [
             {
               "introduced": "0.0.0-20160722212129-ac0cc4484ad4"
+            },
+            {
+              "fixed": "0.0.0-20200131131040-063a3fb69896"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 0.0.0-20200131131040-063a3fb69896"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Without this, all versions are showing as vulnerable.