### PR TITLE
[GHSA-h6xw-mghq-7523] Unsafe parsing in SWHKD

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-h6xw-mghq-7523/GHSA-h6xw-mghq-7523.json
+++ b/advisories/github-reviewed/2022/04/GHSA-h6xw-mghq-7523/GHSA-h6xw-mghq-7523.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-h6xw-mghq-7523",
-  "modified": "2022-04-15T16:14:51Z",
+  "modified": "2023-01-05T17:33:34Z",
   "published": "2022-04-08T00:00:24Z",
   "aliases": [
     "CVE-2022-27819"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.1.7"
+              "fixed": "1.2.0"
             }
           ]
         }
@@ -50,11 +50,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/waycrate/swhkd/releases"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/waycrate/swhkd/releases/tag/1.1.7"
+      "url": "https://github.com/waycrate/swhkd/releases/tag/1.2.0"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The fix is in v1.2.0.

Check this for reference : https://github.com/waycrate/swhkd/releases/tag/1.2.0