### PR TITLE
[GHSA-g56w-cwg4-hxx9] Code injection in quarkus dev ui config editor

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-g56w-cwg4-hxx9/GHSA-g56w-cwg4-hxx9.json
+++ b/advisories/github-reviewed/2022/11/GHSA-g56w-cwg4-hxx9/GHSA-g56w-cwg4-hxx9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-g56w-cwg4-hxx9",
-  "modified": "2022-11-26T20:18:38Z",
+  "modified": "2023-01-06T11:05:20Z",
   "published": "2022-11-22T21:30:17Z",
   "aliases": [
     "CVE-2022-4116"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "io.quarkus:quarkus-parent"
+        "name": "io.quarkus:quarkus-vertx-http-deployment"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "io.quarkus:quarkus-parent"
+        "name": "io.quarkus:quarkus-vertx-http-deployment"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
As indicated in https://github.com/quarkusio/quarkus/discussions/29527#discussioncomment-4387809 the affected package is:
`io.quarkus:quarkus-vertx-http-deployment` and not `io.quarkus:quarkus-parent`