### PR TITLE
[GHSA-9pgx-pf36-w46r] A vulnerability exists in CakePHP versions 4.0.x through...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-9pgx-pf36-w46r/GHSA-9pgx-pf36-w46r.json
+++ b/advisories/unreviewed/2022/05/GHSA-9pgx-pf36-w46r/GHSA-9pgx-pf36-w46r.json
@@ -1,17 +1,61 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9pgx-pf36-w46r",
-  "modified": "2022-05-24T17:40:14Z",
+  "modified": "2023-01-06T18:23:44Z",
   "published": "2022-05-24T17:40:14Z",
   "aliases": [
     "CVE-2020-35239"
   ],
+  "summary": "CsrfProtectionMiddleware component allows method override parameters to bypass CSRF checks by changing the HTTP request method to an arbitrary string",
   "details": "A vulnerability exists in CakePHP versions 4.0.x through 4.1.3. The CsrfProtectionMiddleware component allows method override parameters to bypass CSRF checks by changing the HTTP request method to an arbitrary string that is not in the list of request methods that CakePHP checks. Additionally, the route middleware does not verify that this overriden method (which can be an arbitrary string) is actually an HTTP method.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "cakephp/cakephp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.0.0"
+            },
+            {
+              "fixed": "4.0.10"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.0.9"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "cakephp/cakephp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.1.0"
+            },
+            {
+              "fixed": "4.1.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.1.3"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Added title (since mandatory).
Setup the affected product according to the available info.

Disclosure: I am a core developer of CakePHP.
