### PR TITLE
[GHSA-r7p6-fr3x-r877] CakePHP 1.3.7 allows remote attackers to obtain sensitive...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-r7p6-fr3x-r877/GHSA-r7p6-fr3x-r877.json
+++ b/advisories/unreviewed/2022/05/GHSA-r7p6-fr3x-r877/GHSA-r7p6-fr3x-r877.json
@@ -1,17 +1,39 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-r7p6-fr3x-r877",
-  "modified": "2022-05-17T05:31:33Z",
+  "modified": "2023-01-06T18:34:07Z",
   "published": "2022-05-17T05:31:33Z",
   "aliases": [
     "CVE-2011-3712"
   ],
+  "summary": "CakePHP 1.3.7 allows remote attackers to obtain sensitive information via a direct request to a .php file",
   "details": "CakePHP 1.3.7 allows remote attackers to obtain sensitive information via a direct request to a .php file, which reveals the installation path in an error message, as demonstrated by dispatcher.php and certain other files.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "cakephp/cakephp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.3.7"
+            },
+            {
+              "fixed": "1.3.8"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.3.7"
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Added title (since mandatory).
Setup the affected product according to the available info.

Disclosure: I am a core developer of CakePHP.