### PR TITLE
[GHSA-5964-pq8r-4q62] The Xml class in CakePHP 2.1.x before 2.1.5 and 2.2.x...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5964-pq8r-4q62/GHSA-5964-pq8r-4q62.json
+++ b/advisories/unreviewed/2022/05/GHSA-5964-pq8r-4q62/GHSA-5964-pq8r-4q62.json
@@ -1,17 +1,61 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-5964-pq8r-4q62",
-  "modified": "2022-05-17T05:07:14Z",
+  "modified": "2023-01-06T18:43:52Z",
   "published": "2022-05-17T05:07:14Z",
   "aliases": [
     "CVE-2012-4399"
   ],
+  "summary": "The Xml class in CakePHP 2.1.x before 2.1.5 and 2.2.x before 2.2.1 allows remote attackers to read arbitrary files via XML data containing external entity references",
   "details": "The Xml class in CakePHP 2.1.x before 2.1.5 and 2.2.x before 2.2.1 allows remote attackers to read arbitrary files via XML data containing external entity references, aka an XML external entity (XXE) injection attack.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "cakephp/cakephp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.1.0:alpha"
+            },
+            {
+              "fixed": "2.1.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.1.4"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "cakephp/cakephp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.2.0-beta"
+            },
+            {
+              "fixed": "2.2.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.2.0"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Added title (since mandatory).
Setup the affected product according to the available info.

Disclosure: I am a core developer of CakePHP.