### PR TITLE
[GHSA-556q-h4vr-pgh2] CakePHP 2.x and 3.x before 3.1.5 might allow remote...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-556q-h4vr-pgh2/GHSA-556q-h4vr-pgh2.json
+++ b/advisories/unreviewed/2022/05/GHSA-556q-h4vr-pgh2/GHSA-556q-h4vr-pgh2.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-556q-h4vr-pgh2",
-  "modified": "2022-05-14T02:47:10Z",
+  "modified": "2023-01-06T18:47:15Z",
   "published": "2022-05-14T02:47:10Z",
   "aliases": [
     "CVE-2015-8379"
   ],
+  "summary": "CakePHP 2.x and 3.x before 3.1.5 might allow remote attackers to bypass the CSRF protection mechanism via the _method parameter",
   "details": "CakePHP 2.x and 3.x before 3.1.5 might allow remote attackers to bypass the CSRF protection mechanism via the _method parameter.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "cakephp/cakephp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0:alpha"
+            },
+            {
+              "fixed": "3.1.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.1.4"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Added title (since mandatory).
Setup the affected product according to the available info.

Disclosure: I am a core developer of CakePHP.