### PR TITLE
[GHSA-8jmw-wjr8-2x66] Command injection in git-clone

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-8jmw-wjr8-2x66/GHSA-8jmw-wjr8-2x66.json
+++ b/advisories/github-reviewed/2022/07/GHSA-8jmw-wjr8-2x66/GHSA-8jmw-wjr8-2x66.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8jmw-wjr8-2x66",
-  "modified": "2022-08-22T20:36:58Z",
+  "modified": "2023-01-07T14:09:24Z",
   "published": "2022-07-02T00:00:19Z",
   "aliases": [
     "CVE-2022-25900"
@@ -55,8 +55,8 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-74",
-      "CWE-78"
+      "CWE-77",
+      "CWE-88"
     ],
     "severity": "HIGH",
     "github_reviewed": true


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs

**Comments**
To be precise, this vulnerability should actually be specified as CWE-88