### PR TITLE
[GHSA-3xq5-wjfh-ppjc] Luxon Inefficient Regular Expression Complexity vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-3xq5-wjfh-ppjc/GHSA-3xq5-wjfh-ppjc.json
+++ b/advisories/github-reviewed/2023/01/GHSA-3xq5-wjfh-ppjc/GHSA-3xq5-wjfh-ppjc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-3xq5-wjfh-ppjc",
-  "modified": "2023-01-09T14:10:49Z",
+  "modified": "2023-01-09T17:57:55Z",
   "published": "2023-01-09T14:10:49Z",
   "aliases": [
     "CVE-2023-22467"
@@ -28,7 +28,7 @@
               "introduced": "1.0.0"
             },
             {
-              "fixed": "1.38.1"
+              "fixed": "1.28.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Original maintainer advisory says 1.28.1.  Looks like conversion to general GHSA typo'd this at 1.38.1.  As such, fixing version to recent tag does not allow audits to pass as they are looking for 1.38.1.