### PR TITLE
[GHSA-9783-42pm-x5jq] Use of Uninitialized Resource in csv-sniffer.

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-9783-42pm-x5jq/GHSA-9783-42pm-x5jq.json
+++ b/advisories/github-reviewed/2022/01/GHSA-9783-42pm-x5jq/GHSA-9783-42pm-x5jq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9783-42pm-x5jq",
-  "modified": "2022-01-07T17:33:33Z",
+  "modified": "2023-01-10T07:01:35Z",
   "published": "2022-01-06T22:13:58Z",
   "aliases": [
     "CVE-2021-45686"
@@ -28,17 +28,24 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.1.1"
+              "fixed": "0.3.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.1.1"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-45686"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jblondin/csv-sniffer/pull/2"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The issue is fixed refer : https://github.com/jblondin/csv-sniffer/pull/2