### PR TITLE
[GHSA-27h2-hvpr-p74q] Request to reject CVE: jsonwebtoken has insecure input validation in jwt.verify function

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-27h2-hvpr-p74q/GHSA-27h2-hvpr-p74q.json
+++ b/advisories/github-reviewed/2022/12/GHSA-27h2-hvpr-p74q/GHSA-27h2-hvpr-p74q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-27h2-hvpr-p74q",
-  "modified": "2022-12-27T22:57:35Z",
+  "modified": "2023-01-10T15:48:56Z",
   "published": "2022-12-22T03:31:28Z",
   "aliases": [
     "CVE-2022-23529"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:H/A:L"
+      "score": "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -60,7 +60,7 @@
     "cwe_ids": [
       "CWE-20"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- Severity
- Request of withdrawal 

**Comments**
The CVE is a joke, it requires the „attacker“ to create an object in the application context, not just parsed JSON but an object with an executable function. 

This can only happen if the „attacker“ can modify the source code itself, if that is possible, he may execute the malicious code directly. 

See @n1nj4sec reply, even `btoa` contains this so-called "vulnerability" 😱 https://github.com/github/advisory-database/pull/1595#issuecomment-1377826774

Every known transport to a secret manager will serialize the data using `JSON.parse/JSON.strinigify`, this will render the `toString` property as a string. 

So even this very hypothetical case constructed in the original disclosure could only happen if the secret manager would be part of the same context (app) so the secret is not serialized and that secret manager would have to contain a vulnerability allowing users to define a function 🤯 

References:
CVE: https://www.cve.org/CVERecord?id=CVE-2022-23529
"Disclosure": `https://unit42.paloaltonetworks.com/jsonwebtoken-vulnerability-cve-2022-23529/`
