### PR TITLE
[GHSA-m7r3-6mr9-xj8f] workers/extractor.py in Pandora (aka pandora-analysis...

### DIFF
--- a/advisories/unreviewed/2023/01/GHSA-m7r3-6mr9-xj8f/GHSA-m7r3-6mr9-xj8f.json
+++ b/advisories/unreviewed/2023/01/GHSA-m7r3-6mr9-xj8f/GHSA-m7r3-6mr9-xj8f.json
@@ -1,19 +1,39 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-m7r3-6mr9-xj8f",
-  "modified": "2023-01-10T03:30:29Z",
+  "modified": "2023-01-10T17:16:46Z",
   "published": "2023-01-10T03:30:29Z",
   "aliases": [
     "CVE-2023-22898"
   ],
+  "summary": "Link this CVE to the advisory of the repo",
   "details": "workers/extractor.py in Pandora (aka pandora-analysis/pandora) 1.3.0 allows a denial of service when an attacker submits a deeply nested ZIP archive (aka ZIP bomb).",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/pandora-analysis/pandora/security/advisories/GHSA-pc3j-vcjp-8rhv"
+    },
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-22898"
@@ -21,6 +41,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/pandora-analysis/pandora/commit/1dc06327fdc07c56eae653e497dd137ec70d8265"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/pandora-analysis/pandora"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
A CVE was requested directly, and this is the advisory in Pandora: https://github.com/pandora-analysis/pandora/security/advisories/GHSA-pc3j-vcjp-8rhv