### PR TITLE
Fix GHSA-hh82-3pmq-7frp CVSS vector

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-hh82-3pmq-7frp/GHSA-hh82-3pmq-7frp.json
+++ b/advisories/github-reviewed/2022/12/GHSA-hh82-3pmq-7frp/GHSA-hh82-3pmq-7frp.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
CVSS vector is not correct, it should be:

CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N

but is:

CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:N