### PR TITLE
[GHSA-9c47-m6qq-7p4h] Prototype Pollution in JSON5 via Parse Method

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-9c47-m6qq-7p4h/GHSA-9c47-m6qq-7p4h.json
+++ b/advisories/github-reviewed/2022/12/GHSA-9c47-m6qq-7p4h/GHSA-9c47-m6qq-7p4h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9c47-m6qq-7p4h",
-  "modified": "2023-01-04T13:47:05Z",
+  "modified": "2023-01-10T21:41:28Z",
   "published": "2022-12-29T01:51:03Z",
   "aliases": [
     "CVE-2022-46175"
@@ -47,11 +47,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.0.2"
+              "fixed": ">= 1.0.2, < 2.0.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.0.2"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Mitigation details indicate that the patch was backported to v1 in versions >= 1.0.2, < 2.0.0.

Unclear how patched versions should be formatted, but patched versions should also include >= 1.0.2 but < 2.0.0.
"This vulnerability is patched in json5 v2.2.2 and later. A patch has also been backported for json5 v1 in versions v1.0.2 and later."