### PR TITLE
[GHSA-27h2-hvpr-p74q] jsonwebtoken has insecure input validation in jwt.verify function

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-27h2-hvpr-p74q/GHSA-27h2-hvpr-p74q.json
+++ b/advisories/github-reviewed/2022/12/GHSA-27h2-hvpr-p74q/GHSA-27h2-hvpr-p74q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-27h2-hvpr-p74q",
-  "modified": "2022-12-27T22:57:35Z",
+  "modified": "2023-01-11T01:15:59Z",
   "published": "2022-12-22T03:31:28Z",
   "aliases": [
     "CVE-2022-23529"
@@ -54,6 +54,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/auth0/node-jsonwebtoken"
+    },
+    {
+      "type": "WEB",
+      "url": "https://unit42.paloaltonetworks.com/jsonwebtoken-vulnerability-cve-2022-23529/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add writeup from Palo alto as reference