### PR TITLE
[GHSA-9vvw-cc9w-f27h] debug Inefficient Regular Expression Complexity vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-9vvw-cc9w-f27h/GHSA-9vvw-cc9w-f27h.json
+++ b/advisories/github-reviewed/2023/01/GHSA-9vvw-cc9w-f27h/GHSA-9vvw-cc9w-f27h.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9vvw-cc9w-f27h",
-  "modified": "2023-01-10T21:49:01Z",
+  "modified": "2023-01-11T13:31:19Z",
   "published": "2023-01-09T12:30:19Z",
   "aliases": [
     "CVE-2017-20165"
   ],
   "summary": "debug Inefficient Regular Expression Complexity vulnerability",
-  "details": "A vulnerability classified as problematic has been found in debug-js debug up to 3.0.x. This affects the function useColors of the file src/node.js. The manipulation of the argument str leads to inefficient regular expression complexity. Upgrading to version 3.1.0 is able to address this issue. The name of the patch is c38a0166c266a679c8de012d4eaccec3f944e685. It is recommended to upgrade the affected component. The identifier VDB-217665 was assigned to this vulnerability.",
+  "details": "A vulnerability classified as problematic has been found in debug-js debug up to 3.0.x. This affects the function useColors of the file src/node.js. The manipulation of the argument str leads to inefficient regular expression complexity. Upgrading to version 3.1.0, or 2.6.9 is able to address this issue. The name of the patch is c38a0166c266a679c8de012d4eaccec3f944e685. It is recommended to upgrade the affected component. The identifier VDB-217665 was assigned to this vulnerability.",
   "severity": [
 
   ],
@@ -22,10 +22,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.0.0"
             },
             {
               "fixed": "3.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "debug"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.6.9"
             }
           ]
         }
@@ -48,6 +67,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/debug-js/debug"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/debug-js/debug/releases/tag/2.6.9"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
Fix for this was backported to the 2.x version at version 2.6.9 (https://github.com/debug-js/debug/releases/tag/2.6.9)

Hopefully I have expressed the versions correctly