### PR TITLE
[GHSA-9chr-4fjh-5rgw] Cross-site Scripting in actionpack

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-9chr-4fjh-5rgw/GHSA-9chr-4fjh-5rgw.json
+++ b/advisories/github-reviewed/2022/10/GHSA-9chr-4fjh-5rgw/GHSA-9chr-4fjh-5rgw.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9chr-4fjh-5rgw",
-  "modified": "2022-10-28T19:17:53Z",
+  "modified": "2023-01-11T21:09:04Z",
   "published": "2022-10-27T12:00:27Z",
   "aliases": [
     "CVE-2022-3704"
   ],
   "summary": "Cross-site Scripting in actionpack",
-  "details": "actionpack from the Ruby on Rails project is vulnerable to Cross-site Scripting in the Route Error Page. This issue has been patched with this [commit](https://github.com/rails/rails/commit/be177e4566747b73ff63fd5f529fab564e475ed4). There are no known workarounds for this issue.",
+  "details": "This advisory is invalid. There is no issue here. Those error pages are only show in development mode, where no attacker has access to, even if a DNS rebind attack is tried since Rails protects against DNS rebind.\n\nPlease delete it, and next time. Before creating security advisories for Rails, consult with the Rails security team",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -37,28 +37,8 @@
   ],
   "references": [
     {
-      "type": "ADVISORY",
-      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-3704"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/rails/rails/issues/46244"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/rails/rails/pull/46269"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/rails/rails/commit/be177e4566747b73ff63fd5f529fab564e475ed4"
-    },
-    {
       "type": "PACKAGE",
       "url": "https://github.com/rails/rails"
-    },
-    {
-      "type": "WEB",
-      "url": "https://vuldb.com/?id.212319"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
This advisory is invalid. There is no issue here. Those error pages are only show in development mode, where no attacker has access to, even if a DNS rebind attack is tried since Rails protects against DNS rebind.

Please delete it.