### PR TITLE
[GHSA-69cg-p879-7622] In net/http in Go before 1.18.6 and 1.19.x before 1.19.1,...

### DIFF
--- a/advisories/unreviewed/2022/09/GHSA-69cg-p879-7622/GHSA-69cg-p879-7622.json
+++ b/advisories/unreviewed/2022/09/GHSA-69cg-p879-7622/GHSA-69cg-p879-7622.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-69cg-p879-7622",
-  "modified": "2022-09-10T00:00:34Z",
+  "modified": "2023-01-17T22:07:12Z",
   "published": "2022-09-07T00:01:51Z",
   "aliases": [
     "CVE-2022-27664"
   ],
+  "summary": "Denial of service in golang.org/x/net/http2",
   "details": "In net/http in Go before 1.18.6 and 1.19.x before 1.19.1, attackers can cause a denial of service because an HTTP/2 connection can hang during closing if shutdown were preempted by a fatal error.",
   "severity": [
     {
@@ -14,12 +15,34 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "golang.org/x/net/http2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.0.0-20220906165146-f3363e06e74c"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-27664"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://cs.opensource.google/go/x/net"
     },
     {
       "type": "WEB",
@@ -36,6 +59,10 @@
     {
       "type": "WEB",
       "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXS2OQ57KZC5XZKK5UW4SYKPVQAHIOJX/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://pkg.go.dev/vuln/GO-2022-0969"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
https://pkg.go.dev/vuln/GO-2022-0969