### PR TITLE
[GHSA-xrjj-mj9h-534m] An attacker can cause excessive memory growth in a Go...

### DIFF
--- a/advisories/unreviewed/2022/12/GHSA-xrjj-mj9h-534m/GHSA-xrjj-mj9h-534m.json
+++ b/advisories/unreviewed/2022/12/GHSA-xrjj-mj9h-534m/GHSA-xrjj-mj9h-534m.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-xrjj-mj9h-534m",
-  "modified": "2022-12-12T18:30:28Z",
+  "modified": "2023-01-17T22:14:54Z",
   "published": "2022-12-08T21:30:19Z",
   "aliases": [
     "CVE-2022-41717"
   ],
+  "summary": "Excessive memory growth possible in golang.org/x/net/http2",
   "details": "An attacker can cause excessive memory growth in a Go server accepting HTTP/2 requests. HTTP/2 server connections contain a cache of HTTP header keys sent by the client. While the total number of entries in this cache is capped, an attacker sending very large keys can cause the server to allocate approximately 64 MiB per open connection.",
   "severity": [
     {
@@ -14,12 +15,34 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "golang.org/x/net/http2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.4.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41717"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://cs.opensource.google/go/x/net"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
https://pkg.go.dev/vuln/GO-2022-1144