### PR TITLE
[GHSA-rc2q-x9mf-w3vf] TestNG is vulnerable to Path Traversal

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-rc2q-x9mf-w3vf/GHSA-rc2q-x9mf-w3vf.json
+++ b/advisories/github-reviewed/2022/11/GHSA-rc2q-x9mf-w3vf/GHSA-rc2q-x9mf-w3vf.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-rc2q-x9mf-w3vf",
-  "modified": "2022-12-02T22:31:06Z",
+  "modified": "2023-01-18T17:31:16Z",
   "published": "2022-11-19T21:30:25Z",
   "aliases": [
     "CVE-2022-4065"
   ],
   "summary": "TestNG is vulnerable to Path Traversal",
-  "details": "A vulnerability was found in cbeust testng. It has been declared as critical. Affected by this vulnerability is the function testngXmlExistsInJar of the file testng-core/src/main/java/org/testng/JarFileUtils.java of the component XML File Parser. The manipulation leads to path traversal. The attack can be launched remotely. A patch is available in commit 9150736cd2c123a6a3b60e6193630859f9f0422b. It is recommended to apply a patch to fix this issue. The patch was pushed into the master branch but no releases have yet been made with the patch included.",
+  "details": "A vulnerability was found in cbeust testng. It has been declared as critical. Affected by this vulnerability is the function testngXmlExistsInJar of the file testng-core/src/main/java/org/testng/JarFileUtils.java of the component XML File Parser. The manipulation leads to path traversal. The attack can be launched remotely. A patch is available in commit 9150736cd2c123a6a3b60e6193630859f9f0422b. The patch is available as of  [TestNG v7.7.0](https://github.com/cbeust/testng/releases/tag/7.7.0).",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "7.6.1"
+              "fixed": ">= 7.7.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 7.6.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Patch is available as of TestNG v7.7.0