### PR TITLE
[GHSA-hrpp-h998-j3pp] qs vulnerable to Prototype Pollution

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-hrpp-h998-j3pp/GHSA-hrpp-h998-j3pp.json
+++ b/advisories/github-reviewed/2022/11/GHSA-hrpp-h998-j3pp/GHSA-hrpp-h998-j3pp.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-hrpp-h998-j3pp",
-  "modified": "2022-12-06T14:32:46Z",
+  "modified": "2023-01-18T21:27:46Z",
   "published": "2022-11-27T00:30:50Z",
   "aliases": [
     "CVE-2022-24999"
   ],
   "summary": "qs vulnerable to Prototype Pollution",
-  "details": "qs before 6.10.3, as used in Express before 4.17.3 and other products, allows attackers to cause a Node process hang for an Express application because an __ proto__ key can be used. In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as a[__proto__]=b&a[__proto__]&a[length]=100000000. The fix was backported to qs 6.9.7, 6.8.3, 6.7.3, 6.6.1, 6.5.3, 6.4.1, 6.3.3, and 6.2.4 (and therefore Express 4.17.3, which has \"deps: qs@6.9.7\" in its release description, is not vulnerable).",
+  "details": "qs before 6.10.3, allows attackers to cause a Node process hang because an __ proto__ key can be used. In many typical web framework use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as a[__proto__]=b&a[__proto__]&a[length]=100000000. The fix was backported to qs 6.9.7, 6.8.3, 6.7.3, 6.6.1, 6.5.3, 6.4.1, 6.3.3, and 6.2.4.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -15,25 +15,6 @@
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "express"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.17.3"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "npm",
@@ -214,10 +195,6 @@
     {
       "type": "WEB",
       "url": "https://github.com/ljharb/qs/pull/428"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/expressjs/express/releases/tag/4.17.3"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
This issue is not specific to Express and affects multiple web frameworks that use `qs` for query string parsing, and having it in there incorrectly flags older Express versions with looser `qs` dependencies or yarn and other override configurations that update the `qs` version. Only `qs` module needs to be updated, no specific code change was done in the `express` module itself to mitigate the issue outlined.