### PR TITLE
[GHSA-cpx3-93w7-457x] A flaw was found in Ansible in the amazon.aws collection...

### DIFF
--- a/advisories/unreviewed/2022/10/GHSA-cpx3-93w7-457x/GHSA-cpx3-93w7-457x.json
+++ b/advisories/unreviewed/2022/10/GHSA-cpx3-93w7-457x/GHSA-cpx3-93w7-457x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-cpx3-93w7-457x",
-  "modified": "2023-01-19T09:33:27Z",
+  "modified": "2023-01-19T09:39:09Z",
   "published": "2022-10-28T19:00:38Z",
   "aliases": [
     "CVE-2022-3697"

--- a/advisories/unreviewed/2022/10/GHSA-cpx3-93w7-457x/GHSA-cpx3-93w7-457x.json
+++ b/advisories/unreviewed/2022/10/GHSA-cpx3-93w7-457x/GHSA-cpx3-93w7-457x.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-cpx3-93w7-457x",
-  "modified": "2023-01-19T09:39:09Z",
+  "modified": "2023-01-19T09:40:03Z",
   "published": "2022-10-28T19:00:38Z",
   "aliases": [
     "CVE-2022-3697"
   ],
-  "summary": "amazon.aws.ec2_instance leaks passwords into logs when is tower_callback.windows is set",
+  "summary": "amazon.aws.ec2_instance leaks passwords into logs when tower_callback.windows is set",
   "details": "A flaw was found in Ansible in the amazon.aws collection when using the tower_callback parameter from the amazon.aws.ec2_instance module. This flaw allows an attacker to take advantage of this issue as the module is handling the parameter insecurely, leading to the password leaking in the logs.",
   "severity": [
     {

--- a/advisories/unreviewed/2022/10/GHSA-cpx3-93w7-457x/GHSA-cpx3-93w7-457x.json
+++ b/advisories/unreviewed/2022/10/GHSA-cpx3-93w7-457x/GHSA-cpx3-93w7-457x.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-cpx3-93w7-457x",
-  "modified": "2022-11-01T19:00:27Z",
+  "modified": "2023-01-19T09:33:27Z",
   "published": "2022-10-28T19:00:38Z",
   "aliases": [
     "CVE-2022-3697"
   ],
+  "summary": "amazon.aws.ec2_instance leaks passwords into logs when is tower_callback.windows is set",
   "details": "A flaw was found in Ansible in the amazon.aws collection when using the tower_callback parameter from the amazon.aws.ec2_instance module. This flaw allows an attacker to take advantage of this issue as the module is handling the parameter insecurely, leading to the password leaking in the logs.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "ansible"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.0"
+            },
+            {
+              "fixed": "7.0.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
ec2_instance was introduced in https://github.com/ansible/ansible/pull/35749, and had tower_callback.windows from the initial release. The issue was fixed in 3.5.1/4.4.0/5.1.0, and according to https://github.com/ansible-community/ansible-build-data/blob/main/6/CHANGELOG-v6.rst, ansible 6 never did update the version to 3.5.1.