### PR TITLE
[GHSA-28fm-qh2h-3mch] html2xhtml v1.3 was discovered to contain an Out-Of...

### DIFF
--- a/advisories/unreviewed/2022/11/GHSA-28fm-qh2h-3mch/GHSA-28fm-qh2h-3mch.json
+++ b/advisories/unreviewed/2022/11/GHSA-28fm-qh2h-3mch/GHSA-28fm-qh2h-3mch.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-28fm-qh2h-3mch",
-  "modified": "2022-11-09T19:02:22Z",
+  "modified": "2023-01-24T13:17:46Z",
   "published": "2022-11-08T19:00:23Z",
   "aliases": [
     "CVE-2022-44311"
   ],
-  "details": "html2xhtml v1.3 was discovered to contain an Out-Of-Bounds read in the function static void elm_close(tree_node_t *nodo) at procesador.c. This vulnerability allows attackers to access sensitive files or cause a Denial of Service (DoS) via a crafted html file.",
+  "summary": "html2xhmtl v1.3 Contains Out-Of-Bounds read ",
+  "details": "html2xhmtl is a command-line tool that helps you easily convert HTML code to XHTML, by grabbing code from existing pages. It also fixes common errors in HTML files like missing tags, non-standard elements, and so on. However, html2xhmtl v1.3 contains an Out-Of-Bounds read in the function static void elm_close(tree_node_t *nodo) at procesador.c. \n\n## Impact\nThe Out-Of-Bounds read in the function static void elm_close(tree_node_t *nodo) at procesador.c of html2xhmtl v1.3 is a type of software error that occurs when reading data from memory. This often happens  if the program tries to read beyond the end or beginning of an array or intended buffer. This vulnerability typically allows the attacker to read and access sensitive information from the command line or other memory locations, prevent user access through a Denial of Service (DOS), or cause a crash through a crafted html file.\n\nFor example, an attacker may be able to craft html files that can access sensitive information from various memory locations, like the operating system, program memory, and so on.  Attackers can go further to prevent users from logging into their computer systems and cause a total crash. \n\nTherefore, a malicious attacker will be able to:\n\n- Obtain sensitive information about the user that they ordinarily don’t have.\n\n- Prevent the users’ computer access or log in.\n\n- Shut down and crash the system’s functionalities. \n## Components affected by the html2xhtml Out-of-bounds read vulnerability \nThe command line is major component that this vulnerability affects. npm has released security updates to fix all forms of vulnerabilities. Kindly visit the npm website to learn more about fixing vulnerability issues in npm.\n\nnpm-audit: https://docs.npmjs.com/cli/v9/commands/npm-audit/  \n## Workarounds\nThe cause of the Out-of-Bound read issue was that the elm_close receives a node that was supposed to be of type element, but instead it was of type comment. You can fix the issue by making these changes and your files won't cause a segmentation fault anymore. Furthermore, html2xhtml has fixed the Out-of-Bound read issue in html2xhtml v1.3. Upgrade to this version to avoid the issue. ",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "io.html2xhmtl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -24,6 +43,26 @@
     {
       "type": "WEB",
       "url": "https://github.com/jfisteus/html2xhtml/issues/19"
+    },
+    {
+      "type": "WEB",
+      "url": "https://securityboulevard.com/2022/06/what-is-an-out-of-bounds-read-and-out-of-bounds-write-error/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://stackoverflow.com/questions/2346806/what-is-a-segmentation-fault"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.nuget.org/packages/Html2Xhtml"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.softpedia.com/get/Office-tools/Other-Office-Tools/Html2Xhtml.shtml"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "jfisteus/html2xhtml"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Source code location
- Summary

**Comments**
This change was necessary to provide a more comprehensive context and explanation for the Out-of-Bound read issues with html2xhtml. The previous advisory document did not cover the severity of this security vulnerability enough. The essential resources useful for this improvement include:

https://nvd.nist.gov/vuln/detail/CVE-2022-44311
https://github.com/jfisteus/html2xhtml/issues/19
https://www.softpedia.com/get/Office-tools/Other-Office-Tools/Html2Xhtml.shtml 
https://www.nuget.org/packages/Html2Xhtml 
https://securityboulevard.com/2022/06/what-is-an-out-of-bounds-read-and-out-of-bounds-write-error/ 
https://stackoverflow.com/questions/2346806/what-is-a-segmentation-fault