### PR TITLE
[GHSA-mxhp-79qh-mcx6] taffy can allow access to any data items in the DB

### DIFF
--- a/advisories/github-reviewed/2020/02/GHSA-mxhp-79qh-mcx6/GHSA-mxhp-79qh-mcx6.json
+++ b/advisories/github-reviewed/2020/02/GHSA-mxhp-79qh-mcx6/GHSA-mxhp-79qh-mcx6.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-mxhp-79qh-mcx6",
-  "modified": "2021-07-28T18:32:27Z",
+  "modified": "2023-01-24T18:50:09Z",
   "published": "2020-02-19T16:43:42Z",
   "aliases": [
     "CVE-2019-10790"
   ],
-  "summary": "taffy can allow access to any data items in the DB",
-  "details": "taffy through 2.6.2 allows attackers to forge adding additional properties into user-input processed by taffy which can allow access to any data items in the DB. taffy sets an internal index for each data item in its DB. However, it is found that the internal index can be forged by adding additional properties into user-input. If index is found in the query, taffyDB will ignore other query conditions and directly return the indexed data item. Moreover, the internal index is in an easily-guessable format (e.g., T000002R000001). As such, attackers can use this vulnerability to access any data items in the DB.",
+  "summary": "TaffyDB can allow access to any data items in the DB",
+  "details": "TaffyDB allows attackers to forge adding additional properties into user-input processed by taffy which can allow access to any data items in the DB. Taffy sets an internal index for each data item in its DB. However, it is found that the internal index can be forged by adding additional properties into user-input. If index is found in the query, TaffyDB will ignore other query conditions and directly return the indexed data item. Moreover, the internal index is in an easily-guessable format (e.g., T000002R000001). As such, attackers can use this vulnerability to access any data items in the DB.\n\n**Note:** `taffy` and its successor package `taffydb` are not maintained.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -33,6 +33,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "taffydb"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.7.3"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
@@ -47,6 +66,10 @@
     {
       "type": "WEB",
       "url": "https://www.npmjs.com/package/taffy"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.npmjs.com/package/taffydb"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Summary

**Comments**
The original research at https://www.usenix.org/system/files/sec21-xiao.pdf indicates that taffydb version 2.7.3 is vulnerable. Version 2.7.3 is the latest version of taffydb available at https://www.npmjs.com/package/taffydb. 

Snyk published CVE-2019-10790 and omitted the issue with "taffydb" and the affected newer versions. Their own vulnerability database is accurate: https://security.snyk.io/vuln/SNYK-JS-TAFFYDB-2992450