### PR TITLE
[GHSA-cpx3-93w7-457x] A flaw was found in Ansible in the amazon.aws collection...

### DIFF
--- a/advisories/unreviewed/2022/10/GHSA-cpx3-93w7-457x/GHSA-cpx3-93w7-457x.json
+++ b/advisories/unreviewed/2022/10/GHSA-cpx3-93w7-457x/GHSA-cpx3-93w7-457x.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-cpx3-93w7-457x",
-  "modified": "2022-11-01T19:00:27Z",
+  "modified": "2023-01-24T20:48:20Z",
   "published": "2022-10-28T19:00:38Z",
   "aliases": [
     "CVE-2022-3697"
   ],
+  "summary": "amazon.aws.ec2_instance leaks passwords into logs when tower_callback.windows is set",
   "details": "A flaw was found in Ansible in the amazon.aws collection when using the tower_callback parameter from the amazon.aws.ec2_instance module. This flaw allows an attacker to take advantage of this issue as the module is handling the parameter insecurely, leading to the password leaking in the logs.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "ansible"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.0"
+            },
+            {
+              "fixed": "7.0.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Continuing from https://github.com/github/advisory-database/pull/1626.

ec2_instance was introduced in ansible/ansible#35749, and had tower_callback.windows from the initial release. The issue was fixed in 3.5.1/4.4.0/5.1.0, and according to https://github.com/ansible-community/ansible-build-data/blob/main/6/CHANGELOG-v6.rst, ansible 6 never did update the version to 3.5.1.