### PR TITLE
[GHSA-f85w-wvc7-crwc] bumpalo has use-after-free due to a lifetime error in `Vec::into_iter()`

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-f85w-wvc7-crwc/GHSA-f85w-wvc7-crwc.json
+++ b/advisories/github-reviewed/2023/01/GHSA-f85w-wvc7-crwc/GHSA-f85w-wvc7-crwc.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-f85w-wvc7-crwc",
-  "modified": "2023-01-20T21:54:22Z",
+  "modified": "2023-01-27T00:32:07Z",
   "published": "2023-01-20T21:54:22Z",
   "aliases": [
 
   ],
-  "summary": "bumpalo has use-after-free due to a lifetime error in `Vec::into_iter()`",
-  "details": "In affected versions of this crate, the lifetime of the iterator produced by `Vec::into_iter()` is not constrained to the lifetime of the `Bump` that allocated the vector's memory. Using the iterator after the `Bump` is dropped causes use-after-free accesses.\n\nThe following example demonstrates memory corruption arising from a misuse of this unsoundness.\n\n```rust\nuse bumpalo::{collections::Vec, Bump};\n\nfn main() {\n    let bump = Bump::new();\n    let mut vec = Vec::new_in(&bump);\n    vec.extend([0x01u8; 32]);\n    let into_iter = vec.into_iter();\n    drop(bump);\n\n    for _ in 0..100 {\n        let reuse_bump = Bump::new();\n        let _reuse_alloc = reuse_bump.alloc([0x41u8; 10]);\n    }\n\n    for x in into_iter {\n        print!(\"0x{:02x} \", x);\n    }\n    println!();\n}\n```\n\nThe issue was corrected in version 3.11.1 by adding a lifetime to the `IntoIter` type, and updating the signature of `Vec::into_iter()` to constrain this lifetime.\n",
+  "summary": "improve Dependabot Alerts interface for closing Alerts",
+  "details": "This Improve reply is regarding the User Interface.\n\nIn my comment to close this _Dependabot Alert_, I am only able to create a text comment with newlines removed. My closure explanation is difficult to read.\n**I would like to be able to create a normal markdown comment when closing a Dependabot Alert.**\n\nThe closed _Alert_ is here https://github.com/jtmoon79/super-speedy-syslog-searcher/security/dependabot/3\n\nScreenshot at https://imgur.com/a/2Hvitg7",
   "severity": [
 
   ],
@@ -15,17 +15,14 @@
     {
       "package": {
         "ecosystem": "crates.io",
-        "name": "bumpalo"
+        "name": ""
       },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.1.0"
-            },
-            {
-              "fixed": "3.11.1"
+              "introduced": "0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Summary

**Comments**
This is a request for change to the Dependabot Alert UI.