### PR TITLE
[GHSA-8xww-x3g3-6jcv] ReDoS based DoS vulnerability in Action Dispatch

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-8xww-x3g3-6jcv/GHSA-8xww-x3g3-6jcv.json
+++ b/advisories/github-reviewed/2023/01/GHSA-8xww-x3g3-6jcv/GHSA-8xww-x3g3-6jcv.json
@@ -1,36 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8xww-x3g3-6jcv",
-  "modified": "2023-01-23T18:46:26Z",
+  "modified": "2023-01-30T09:11:24Z",
   "published": "2023-01-18T18:20:51Z",
   "aliases": [
     "CVE-2023-22795"
   ],
   "summary": "ReDoS based DoS vulnerability in Action Dispatch",
-  "details": "There is a possible regular expression based DoS vulnerability in Action Dispatch related to the If-None-Match header. This vulnerability has been assigned the CVE identifier CVE-2023-22795.\n\nVersions Affected: All Not affected: None Fixed Versions: 5.2.8.15 (Rails LTS), 6.1.7.1, 7.0.4.1\n\nImpact\n\nA specially crafted HTTP If-None-Match header can cause the regular expression engine to enter a state of catastrophic backtracking, when on a version of Ruby below 3.2.0. This can cause the process to use large amounts of CPU and memory, leading to a possible DoS vulnerability All users running an affected release should either upgrade or use one of the workarounds immediately.\nReleases\n\nThe FIXED releases are available at the normal locations.\nWorkarounds\n\nWe recommend that all users upgrade to one of the FIXED versions. In the meantime, users can mitigate this vulnerability by using a load balancer or other device to filter out malicious If-None-Match headers before they reach the application.\n\nUsers on Ruby 3.2.0 or greater are not affected by this vulnerability.\nPatches\n\nTo aid users who aren’t able to upgrade immediately we have provided patches for the two supported release series. They are in git-am format and consist of a single changeset.\n\n    6-1-Avoid-regex-backtracking-on-If-None-Match-header.patch - Patch for 6.1 series\n    7-0-Avoid-regex-backtracking-on-If-None-Match-header.patch - Patch for 7.0 series\n\nPlease note that only the 7.0.Z and 6.1.Z series are supported at present, and 6.0.Z for severe vulnerabilities. Users of earlier unsupported releases are advised to upgrade as soon as possible as we cannot guarantee the continued availability of security fixes for unsupported releases.",
+  "details": "There is a possible regular expression based DoS vulnerability in Action Dispatch related to the If-None-Match header. This vulnerability has been assigned the CVE identifier CVE-2023-22795.\n\nVersions Affected: All Not affected: None Fixed Versions: 5.2.8.15 (Rails LTS), 6.0.6.1, 6.1.7.1, 7.0.4.1\n\nImpact\n\nA specially crafted HTTP If-None-Match header can cause the regular expression engine to enter a state of catastrophic backtracking, when on a version of Ruby below 3.2.0. This can cause the process to use large amounts of CPU and memory, leading to a possible DoS vulnerability All users running an affected release should either upgrade or use one of the workarounds immediately.\nReleases\n\nThe FIXED releases are available at the normal locations.\nWorkarounds\n\nWe recommend that all users upgrade to one of the FIXED versions. In the meantime, users can mitigate this vulnerability by using a load balancer or other device to filter out malicious If-None-Match headers before they reach the application.\n\nUsers on Ruby 3.2.0 or greater are not affected by this vulnerability.\nPatches\n\nTo aid users who aren’t able to upgrade immediately we have provided patches for the two supported release series. They are in git-am format and consist of a single changeset.\n\n    6-1-Avoid-regex-backtracking-on-If-None-Match-header.patch - Patch for 6.1 series\n    7-0-Avoid-regex-backtracking-on-If-None-Match-header.patch - Patch for 7.0 series\n\nPlease note that only the 7.0.Z and 6.1.Z series are supported at present, and 6.0.Z for severe vulnerabilities. Users of earlier unsupported releases are advised to upgrade as soon as possible as we cannot guarantee the continued availability of security fixes for unsupported releases.",
   "severity": [
 
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "actionpack"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "6.0.0"
-            },
-            {
-              "fixed": "6.1.7.1"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "RubyGems",
@@ -60,10 +41,45 @@
           "type": "ECOSYSTEM",
           "events": [
             {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.1.7.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "actionpack"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
               "introduced": "0"
             },
             {
               "fixed": "5.2.8.15"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "actionpack"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Based on this release note https://rubyonrails.org/2023/1/17/Rails-Versions-6-0-6-1-6-1-7-1-7-0-4-1-have-been-released also the version 6.0.6.1 is fixing this vulnerability