### PR TITLE
[GHSA-579w-22j4-4749] Denial of Service Vulnerability in ActiveRecord’s PostgreSQL adapter

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-579w-22j4-4749/GHSA-579w-22j4-4749.json
+++ b/advisories/github-reviewed/2023/01/GHSA-579w-22j4-4749/GHSA-579w-22j4-4749.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-579w-22j4-4749",
-  "modified": "2023-01-23T18:47:02Z",
+  "modified": "2023-01-30T09:15:45Z",
   "published": "2023-01-18T18:21:12Z",
   "aliases": [
     "CVE-2022-44566"
   ],
   "summary": "Denial of Service Vulnerability in ActiveRecord’s PostgreSQL adapter",
-  "details": "There is a potential denial of service vulnerability present in ActiveRecord’s PostgreSQL adapter.\n\nThis has been assigned the CVE identifier CVE-2022-44566.\n\nVersions Affected: All. Not affected: None. Fixed Versions: 5.2.8.15 (Rails LTS), 6.1.7.1, 7.0.4.1\n\nImpact:\nIn ActiveRecord <7.0.4.1 and <6.1.7.1, when a value outside the range for a 64bit signed integer is provided to the PostgreSQL connection adapter, it will treat the target column type as numeric. Comparing integer values against numeric values can result in a slow sequential scan resulting in potential Denial of Service.\nReleases\n\nThe fixed releases are available at the normal locations.\nWorkarounds\n\nEnsure that user supplied input which is provided to ActiveRecord clauses do not contain integers wider than a signed 64bit representation or floats.\nPatches\n\nTo aid users who aren’t able to upgrade immediately we have provided patches for the supported release series in accordance with our maintenance policy 1 regarding security issues. They are in git-am format and consist of a single changeset.\n\n    6-1-Added-integer-width-check-to-PostgreSQL-Quoting.patch - Patch for 6.1 series\n    7-0-Added-integer-width-check-to-PostgreSQL-Quoting.patch - Patch for 7.0 series\n",
+  "details": "There is a potential denial of service vulnerability present in ActiveRecord’s PostgreSQL adapter.\n\nThis has been assigned the CVE identifier CVE-2022-44566.\n\nVersions Affected: All. Not affected: None. Fixed Versions: 5.2.8.15 (Rails LTS), 6.0.6.1, 6.1.7.1, 7.0.4.1\n\nImpact:\nIn ActiveRecord <7.0.4.1 and <6.1.7.1, when a value outside the range for a 64bit signed integer is provided to the PostgreSQL connection adapter, it will treat the target column type as numeric. Comparing integer values against numeric values can result in a slow sequential scan resulting in potential Denial of Service.\nReleases\n\nThe fixed releases are available at the normal locations.\nWorkarounds\n\nEnsure that user supplied input which is provided to ActiveRecord clauses do not contain integers wider than a signed 64bit representation or floats.\nPatches\n\nTo aid users who aren’t able to upgrade immediately we have provided patches for the supported release series in accordance with our maintenance policy 1 regarding security issues. They are in git-am format and consist of a single changeset.\n\n    6-1-Added-integer-width-check-to-PostgreSQL-Quoting.patch - Patch for 6.1 series\n    7-0-Added-integer-width-check-to-PostgreSQL-Quoting.patch - Patch for 7.0 series\n",
   "severity": [
 
   ],
@@ -22,10 +22,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "6.0.0"
+              "introduced": "7.0.0"
             },
             {
-              "fixed": "6.1.7.1"
+              "fixed": "7.0.4.1"
             }
           ]
         }
@@ -41,10 +41,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "7.0.0"
+              "introduced": "6.0.0"
             },
             {
-              "fixed": "7.0.4.1"
+              "fixed": "6.1.7.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Description

**Comments**
Based on this release note https://rubyonrails.org/2023/1/17/Rails-Versions-6-0-6-1-6-1-7-1-7-0-4-1-have-been-released also the version 6.0.6.1 is fixing this vulnerability