### PR TITLE
[GHSA-j6gc-792m-qgm2] ReDoS based DoS vulnerability in Active Support’s underscore

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-j6gc-792m-qgm2/GHSA-j6gc-792m-qgm2.json
+++ b/advisories/github-reviewed/2023/01/GHSA-j6gc-792m-qgm2/GHSA-j6gc-792m-qgm2.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-j6gc-792m-qgm2",
-  "modified": "2023-01-23T18:45:39Z",
+  "modified": "2023-01-30T09:18:46Z",
   "published": "2023-01-18T18:23:20Z",
   "aliases": [
     "CVE-2023-22796"
   ],
   "summary": "ReDoS based DoS vulnerability in Active Support’s underscore",
-  "details": "There is a possible regular expression based DoS vulnerability in Active Support. This vulnerability has been assigned the CVE identifier CVE-2023-22796.\n\nVersions Affected: All Not affected: None Fixed Versions: 5.2.8.15 (Rails LTS), 6.1.7.1, 7.0.4.1\nImpact\n\nA specially crafted string passed to the underscore method can cause the regular expression engine to enter a state of catastrophic backtracking. This can cause the process to use large amounts of CPU and memory, leading to a possible DoS vulnerability.\n\nThis affects String#underscore, ActiveSupport::Inflector.underscore, String#titleize, and any other methods using these.\n\nAll users running an affected release should either upgrade or use one of the workarounds immediately.\nReleases\n\nThe FIXED releases are available at the normal locations.\nWorkarounds\n\nThere are no feasible workarounds for this issue.\n\nUsers on Ruby 3.2.0 or greater may be able to reduce the impact by configuring Regexp.timeout.\nPatches\n\nTo aid users who aren’t able to upgrade immediately we have provided patches for the two supported release series. They are in git-am format and consist of a single changeset.\n\n    6-1-Avoid-regex-backtracking-in-Inflector.underscore.patch - Patch for 6.1 series\n    7-0-Avoid-regex-backtracking-in-Inflector.underscore.patch - Patch for 7.0 series\n\nPlease note that only the 7.0.Z and 6.1.Z series are supported at present, and 6.0.Z for severe vulnerabilities. Users of earlier unsupported releases are advised to upgrade as soon as possible as we cannot guarantee the continued availability of security fixes for unsupported releases.",
+  "details": "There is a possible regular expression based DoS vulnerability in Active Support. This vulnerability has been assigned the CVE identifier CVE-2023-22796.\n\nVersions Affected: All Not affected: None Fixed Versions: 6.0.6.1, 6.1.7.1, 7.0.4.1\nImpact\n\nA specially crafted string passed to the underscore method can cause the regular expression engine to enter a state of catastrophic backtracking. This can cause the process to use large amounts of CPU and memory, leading to a possible DoS vulnerability.\n\nThis affects String#underscore, ActiveSupport::Inflector.underscore, String#titleize, and any other methods using these.\n\nAll users running an affected release should either upgrade or use one of the workarounds immediately.\nReleases\n\nThe FIXED releases are available at the normal locations.\nWorkarounds\n\nThere are no feasible workarounds for this issue.\n\nUsers on Ruby 3.2.0 or greater may be able to reduce the impact by configuring Regexp.timeout.\nPatches\n\nTo aid users who aren’t able to upgrade immediately we have provided patches for the two supported release series. They are in git-am format and consist of a single changeset.\n\n    6-1-Avoid-regex-backtracking-in-Inflector.underscore.patch - Patch for 6.1 series\n    7-0-Avoid-regex-backtracking-in-Inflector.underscore.patch - Patch for 7.0 series\n\nPlease note that only the 7.0.Z and 6.1.Z series are supported at present, and 6.0.Z for severe vulnerabilities. Users of earlier unsupported releases are advised to upgrade as soon as possible as we cannot guarantee the continued availability of security fixes for unsupported releases.",
   "severity": [
 
   ],
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "6.0.0"
+              "introduced": "0"
             },
             {
               "fixed": "6.1.7.1"
@@ -45,25 +45,6 @@
             },
             {
               "fixed": "7.0.4.1"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "activesupport"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "5.2.8.15"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Description

**Comments**
Based on this release note https://rubyonrails.org/2023/1/17/Rails-Versions-6-0-6-1-6-1-7-1-7-0-4-1-have-been-released also the version 6.0.6.1 is fixing the vulnerability