### PR TITLE
[GHSA-76p3-8jx3-jpfq] Prototype pollution in webpack loader-utils

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-76p3-8jx3-jpfq/GHSA-76p3-8jx3-jpfq.json
+++ b/advisories/github-reviewed/2022/10/GHSA-76p3-8jx3-jpfq/GHSA-76p3-8jx3-jpfq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-76p3-8jx3-jpfq",
-  "modified": "2022-11-04T20:29:12Z",
+  "modified": "2023-01-30T20:18:25Z",
   "published": "2022-10-13T12:00:28Z",
   "aliases": [
     "CVE-2022-37601"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -118,9 +118,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-1321"
+
     ],
-    "severity": "CRITICAL",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- CVSS
- CWEs
- Severity

**Comments**
Prototype pollution is only possible on a plain object if properties are set 2 or more levels deep. These are not equivalent: 

`result["__proto__.isAdmin"] = true; // doesn't change any prototype`

`result["__proto__"] = { isAdmin: true }; // changes prototype for result but not other objects`

`result["__proto__"]["isAdmin"] = true; // changes prototype for result and other objects`

[parseQuery.js](https://github.com/JSMike/loader-utils/blob/c937e8c77231b42018be616b784a6b45eac86f8a/lib/parseQuery.js#L29-L66) only sets top-level attributes on a plain object. Property accessors cannot set nested values in a single bracket pair.

The `for` loop in parseQuery.js is for adding a number of top-level properties, not setting them recursively.