### PR TITLE
[GHSA-2cxf-6567-7pp6] Local Information Disclosure Vulnerability

### DIFF
--- a/advisories/github-reviewed/2021/03/GHSA-2cxf-6567-7pp6/GHSA-2cxf-6567-7pp6.json
+++ b/advisories/github-reviewed/2021/03/GHSA-2cxf-6567-7pp6/GHSA-2cxf-6567-7pp6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-2cxf-6567-7pp6",
-  "modified": "2021-07-08T17:02:28Z",
+  "modified": "2023-01-31T05:42:55Z",
   "published": "2021-03-03T23:01:17Z",
   "aliases": [
     "CVE-2021-21331"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.0.0-beta.6"
             },
             {
               "fixed": "1.0.0-beta.9"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Please see https://github.com/google/osv.dev/issues/1002#issuecomment-1409795116 for full context.

Introduced: 0, Fixed: 1.0.0-beta.9 includes "1.0.0-beta10" and "1.0.0-beta11" according to Maven's version ordering rules. 
This does not appear to be intentional. 

Instead we set Introduced to 1.0.0-beta.6, which is the very first available version (and it doesn't include the erroneus  "1.0.0-beta10" and "1.0.0-beta11" versions.