### PR TITLE
[GHSA-mxhp-79qh-mcx6] TaffyDB can allow access to any data items in the DB

### DIFF
--- a/advisories/github-reviewed/2020/02/GHSA-mxhp-79qh-mcx6/GHSA-mxhp-79qh-mcx6.json
+++ b/advisories/github-reviewed/2020/02/GHSA-mxhp-79qh-mcx6/GHSA-mxhp-79qh-mcx6.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-mxhp-79qh-mcx6",
-  "modified": "2023-01-30T19:22:17Z",
+  "modified": "2023-01-31T06:33:09Z",
   "published": "2020-02-19T16:43:42Z",
   "aliases": [
     "CVE-2019-10790"
   ],
   "summary": "TaffyDB can allow access to any data items in the DB",
-  "details": "TaffyDB allows attackers to forge adding additional properties into user-input processed by taffy which can allow access to any data items in the DB. Taffy sets an internal index for each data item in its DB. However, it is found that the internal index can be forged by adding additional properties into user-input. If index is found in the query, TaffyDB will ignore other query conditions and directly return the indexed data item. Moreover, the internal index is in an easily-guessable format (e.g., T000002R000001). As such, attackers can use this vulnerability to access any data items in the DB. **Note:** `taffy` and its successor package `taffydb` are not maintained.",
+  "details": "Update:\n\nLowering the severity level.\n\nTLDR: The ___id value on TaffyDB records provides no privileged access to anyone who does not already have necessary access to the TaffyDB data loaded into memory or to the unprotected (or unvalidated) backend/SQL APIs for storage. Data loaded into a TaffyDB should be trusted at the same level as any other data loaded from a JSON service (or local storage API) and data stored from a TaffyDB table should be trusted at the same level as data from any other API, get, or form post.  \n\nOriginal:\nTaffyDB allows attackers to forge adding additional properties into user-input processed by taffy which can allow access to any data items in the DB. Taffy sets an internal index for each data item in its DB. However, it is found that the internal index can be forged by adding additional properties into user-input. If index is found in the query, TaffyDB will ignore other query conditions and directly return the indexed data item. Moreover, the internal index is in an easily-guessable format (e.g., T000002R000001). As such, attackers can use this vulnerability to access any data items in the DB. **Note:** `taffy` and its successor package `taffydb` are not maintained.\n\n\n\n",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -77,7 +77,7 @@
       "CWE-20",
       "CWE-668"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity

**Comments**
Summary:

TaffyDB is an in memory "database" that is really an array of objects wrapped in a set of handling functions. Any user data available in memory (within a Browser for a user, or within a running Node.JS instance on the sever to a developer with the necessary access) is available to be extracted. Some protections of data from 3rd party libraries is possible via scoping which is discussed below.

TaffyDB's purpose is as a thin data handling layer between a data store of some kind and the developers final front end or back end code. You should not place anything in TaffyDB that you don't want to make available to the rest of your application (or 3rd party libraries on your web page or even to the browser's console) and you should not trust anything from a TaffyDB without your own validation of the data before storage (same procedure as validating a web form post, etc).

Each array (or table) in TaffyDB must named and set via standard JavaScript such as:

`var people = TAFFY();`

Anyone with access to the variable name "people" can have access to the method people().get() to get all the records in that collection. You can scope the variable into a block scope or protect it with a closure to keep it from being available to the console/3rd party libraries. 

You cannot access the data within people without access to the variable. Access to the global TAFFY() method that creates a TaffyDB table is not enough. This is true even if you have access to the record's ___id from a different table that is is not secured in a closure.

The internal record id is not unique and is not secure and should not be used as if it is (nor would it typically be). It is primarily an internal handler used to make TaffyDB faster and detect TaffyDB record objects vs brand new objects.

The most likely result would be unexpected behavior where the entire record is passed back into the DB as a filter and the ___id value is used instead of a full filter.

Example:

```
// get only the the first bob, typical filter example

var bob = people({first_name:"bob"}).first()

// do stuff to bob, update last name and last update
bob.last_name="smith"
bob.last_update="01/01/2023'

// update only the same bob, this works because bob.___id points to the same bob record within people. The rest of the filters (such as bob.last_name) are ignored.
people(bob).update(bob);

//another way
people(bob.___id).update(bob)

//the preferably way would be to use a record ID supplied by your back-end database
people({sql_id:bob.sql_id}).update(bob)

// but you can screw everything up - update all the bobs instead, probably not what you wanted to do
people(first_name:"bob"})update(bob);
```

Where things could get odd is if:
1.  ___id exists in the custom Javascript object you are working with (such as it was previously stored in JSON from a TaffyDB table)
2. AND a record with the same ___id exists in the same TaffyDB table you are currently targeting
3. AND your code blindly used the record or a ___id to filter .get(), .update(), or .remove() calls

This would cause bugs - BUT for this to have any value to an attacker you'd need to already be pushing privileged information over the wire that an attacker could already observe or meddle with via other means (such as network sniffing, browser hack, or malicious JavaScript library on the page). TaffyDB provides no escalation to this security issue and the ___id issue itself would be less attractive for a privileged attacker than just using the starting TaffyDB APIs.