### PR TITLE
[GHSA-vp2x-3mc3-3cj4] ubireader_extract_files is vulnerable to path traversal...

### DIFF
--- a/advisories/unreviewed/2023/01/GHSA-vp2x-3mc3-3cj4/GHSA-vp2x-3mc3-3cj4.json
+++ b/advisories/unreviewed/2023/01/GHSA-vp2x-3mc3-3cj4/GHSA-vp2x-3mc3-3cj4.json
@@ -1,17 +1,39 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-vp2x-3mc3-3cj4",
-  "modified": "2023-01-31T12:30:24Z",
+  "modified": "2023-01-31T16:31:12Z",
   "published": "2023-01-31T12:30:24Z",
   "aliases": [
     "CVE-2023-0591"
   ],
+  "summary": "path traversal in ubi-reader",
   "details": "ubireader_extract_files is vulnerable to path traversal when run against specifically crafted UBIFS files, allowing the attacker to overwrite files outside of the extraction directory (provided the process has write access to that file or directory). This is due to the fact that a node name (dent_node.name) is considered trusted and joined to the extraction directory path during processing, then the node content is written to that joined path. By crafting a malicious UBIFS file with node names holding path traversal payloads (e.g. ../../tmp/outside.txt), it's possible to force ubi_reader to write outside of the extraction directory. This issue affects ubi-reader before 0.8.5.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "ubi-reader"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.8.5"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,15 +45,19 @@
       "url": "https://github.com/jrspruitt/ubi_reader/pull/57"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/jrspruitt/ubi_reader"
+    },
+    {
       "type": "WEB",
       "url": "https://onekey.com/blog/security-advisory-remote-command-execution-in-binwalk/"
     }
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-22"
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Source code location
- Summary

**Comments**
I'm part of the team who reported it. I provided some more information such as PyPi package affected versions, CVSS, and title.