### PR TITLE
[GHSA-p5gc-65fr-7vfc] A path traversal vulnerability affects jefferson's JFFS2...

### DIFF
--- a/advisories/unreviewed/2023/01/GHSA-p5gc-65fr-7vfc/GHSA-p5gc-65fr-7vfc.json
+++ b/advisories/unreviewed/2023/01/GHSA-p5gc-65fr-7vfc/GHSA-p5gc-65fr-7vfc.json
@@ -1,17 +1,39 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-p5gc-65fr-7vfc",
-  "modified": "2023-01-31T12:30:24Z",
+  "modified": "2023-01-31T16:32:58Z",
   "published": "2023-01-31T12:30:24Z",
   "aliases": [
     "CVE-2023-0592"
   ],
+  "summary": "Path traversal in jefferson",
   "details": "A path traversal vulnerability affects jefferson's JFFS2 filesystem extractor. By crafting malicious JFFS2 files, attackers could force jefferson to write outside of the extraction directory.This issue affects jefferson: before 0.4.1.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "jefferson"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.4.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,15 +45,19 @@
       "url": "https://github.com/sviehb/jefferson/commit/971aca1a8b3b9f4fcb4674fa9621d3349195cdc6"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/sviehb/jefferson/"
+    },
+    {
       "type": "WEB",
       "url": "https://onekey.com/blog/security-advisory-remote-command-execution-in-binwalk/"
     }
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-22"
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Source code location
- Summary

**Comments**
Part of the team who reported this. I provided some more details about the package so that dependabot can do its work.