### PR TITLE
[GHSA-3pgj-pg6c-r5p7] OAuthLib vulnerable to DoS when attacker provides malicious IPV6 URI

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-3pgj-pg6c-r5p7/GHSA-3pgj-pg6c-r5p7.json
+++ b/advisories/github-reviewed/2022/09/GHSA-3pgj-pg6c-r5p7/GHSA-3pgj-pg6c-r5p7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-3pgj-pg6c-r5p7",
-  "modified": "2022-09-16T21:02:52Z",
+  "modified": "2023-02-06T17:29:54Z",
   "published": "2022-09-16T21:02:52Z",
   "aliases": [
     "CVE-2022-36087"
@@ -28,7 +28,7 @@
               "introduced": "3.1.1"
             },
             {
-              "fixed": "3.2.1"
+              "fixed": "3.2.2"
             }
           ]
         }
@@ -62,6 +62,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/oauthlib/oauthlib/releases"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/oauthlib/oauthlib/releases/tag/v3.2.1"
     },
     {
@@ -79,6 +83,8 @@
       "CWE-601"
     ],
     "severity": "MODERATE",
-    "github_reviewed": true
+    "github_reviewed": true,
+    "github_reviewed_at": "2022-09-16T21:02:52Z",
+    "nvd_published_at": "2022-09-09T21:15:00Z"
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
CVE was not addressed until 3.2.2 - see oauthlib release notes: https://github.com/oauthlib/oauthlib/releases