### PR TITLE
[GHSA-p84v-45xj-wwqj] ReDoS based DoS vulnerability in Action Dispatch

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-p84v-45xj-wwqj/GHSA-p84v-45xj-wwqj.json
+++ b/advisories/github-reviewed/2023/01/GHSA-p84v-45xj-wwqj/GHSA-p84v-45xj-wwqj.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-p84v-45xj-wwqj",
-  "modified": "2023-01-30T22:48:17Z",
+  "modified": "2023-02-06T23:17:14Z",
   "published": "2023-01-18T18:23:34Z",
   "aliases": [
     "CVE-2023-22792"
   ],
   "summary": "ReDoS based DoS vulnerability in Action Dispatch",
-  "details": "There is a possible regular expression based DoS vulnerability in Action Dispatch. This vulnerability has been assigned the CVE identifier CVE-2023-22792.\n\nVersions Affected: >= 3.0.0 Not affected: < 3.0.0 Fixed Versions: 5.2.8.15 (Rails LTS), 6.0.6.1, 6.1.7.1, 7.0.4.1\nImpact\n\nSpecially crafted cookies, in combination with a specially crafted X_FORWARDED_HOST header can cause the regular expression engine to enter a state of catastrophic backtracking. This can cause the process to use large amounts of CPU and memory, leading to a possible DoS vulnerability All users running an affected release should either upgrade or use one of the workarounds immediately.\nReleases\n\nThe FIXED releases are available at the normal locations.\nWorkarounds\n\nWe recommend that all users upgrade to one of the FIXED versions. In the meantime, users can mitigate this vulnerability by using a load balancer or other device to filter out malicious X_FORWARDED_HOST headers before they reach the application.\nPatches\n\nTo aid users who aren’t able to upgrade immediately we have provided patches for the two supported release series. They are in git-am format and consist of a single changeset.\n\n    6-1-Use-string-split-instead-of-regex-for-domain-parts.patch - Patch for 6.1 series\n    7-0-Use-string-split-instead-of-regex-for-domain-parts.patch - Patch for 7.0 series\n\nPlease note that only the 7.0.Z and 6.1.Z series are supported at present, and 6.0.Z for severe vulnerabilities. Users of earlier unsupported releases are advised to upgrade as soon as possible as we cannot guarantee the continued availability of security fixes for unsupported releases.\n\nhttps://rubyonrails.org/2023/1/17/Rails-Versions-6-0-6-1-6-1-7-1-7-0-4-1-have-been-released\n",
+  "details": "There is a possible regular expression based DoS vulnerability in Action Dispatch. This vulnerability has been assigned the CVE identifier CVE-2023-22792.\n\nVersions Affected: >= 3.0.0 Not affected: < 3.0.0 Fixed Versions: 5.2.8.15 (Rails LTS), 6.1.7.1, 7.0.4.1\nImpact\n\nSpecially crafted cookies, in combination with a specially crafted X_FORWARDED_HOST header can cause the regular expression engine to enter a state of catastrophic backtracking. This can cause the process to use large amounts of CPU and memory, leading to a possible DoS vulnerability All users running an affected release should either upgrade or use one of the workarounds immediately.\nReleases\n\nThe FIXED releases are available at the normal locations.\nWorkarounds\n\nWe recommend that all users upgrade to one of the FIXED versions. In the meantime, users can mitigate this vulnerability by using a load balancer or other device to filter out malicious X_FORWARDED_HOST headers before they reach the application.\nPatches\n\nTo aid users who aren’t able to upgrade immediately we have provided patches for the two supported release series. They are in git-am format and consist of a single changeset.\n\n    6-1-Use-string-split-instead-of-regex-for-domain-parts.patch - Patch for 6.1 series\n    7-0-Use-string-split-instead-of-regex-for-domain-parts.patch - Patch for 7.0 series\n\nPlease note that only the 7.0.Z and 6.1.Z series are supported at present, and 6.0.Z for severe vulnerabilities. Users of earlier unsupported releases are advised to upgrade as soon as possible as we cannot guarantee the continued availability of security fixes for unsupported releases.\n\nhttps://rubyonrails.org/2023/1/17/Rails-Versions-6-0-6-1-6-1-7-1-7-0-4-1-have-been-released\n",
   "severity": [
 
   ],
@@ -26,25 +26,6 @@
             },
             {
               "fixed": "5.2.8.15"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "actionpack"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "6.1.0"
-            },
-            {
-              "fixed": "6.1.7.1"
             }
           ]
         }
@@ -79,10 +60,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "6.0.0"
+              "introduced": "6.1.0"
             },
             {
-              "fixed": "6.0.6.1"
+              "fixed": "6.1.7.1"
             }
           ]
         }
@@ -108,6 +89,8 @@
       "CWE-1333"
     ],
     "severity": "LOW",
-    "github_reviewed": true
+    "github_reviewed": true,
+    "github_reviewed_at": "2023-01-18T18:23:34Z",
+    "nvd_published_at": null
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
The original Rails advisory for [CVE-2023-22792](https://discuss.rubyonrails.org/t/cve-2023-22792-possible-redos-based-dos-vulnerability-in-action-dispatch/82115) states that there is no fixed version for actionpack 6.0.x.