### PR TITLE
[GHSA-j6gc-792m-qgm2] ReDoS based DoS vulnerability in Active Support’s underscore

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-j6gc-792m-qgm2/GHSA-j6gc-792m-qgm2.json
+++ b/advisories/github-reviewed/2023/01/GHSA-j6gc-792m-qgm2/GHSA-j6gc-792m-qgm2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-j6gc-792m-qgm2",
-  "modified": "2023-01-30T22:56:04Z",
+  "modified": "2023-02-06T23:35:26Z",
   "published": "2023-01-18T18:23:20Z",
   "aliases": [
     "CVE-2023-22796"
@@ -12,25 +12,6 @@
 
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "activesupport"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "6.1.0"
-            },
-            {
-              "fixed": "6.1.7.1"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "RubyGems",
@@ -60,10 +41,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "6.1.0"
             },
             {
-              "fixed": "5.2.8.15"
+              "fixed": "6.1.7.1"
             }
           ]
         }
@@ -79,10 +60,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "6.0.0"
+              "introduced": "0"
             },
             {
-              "fixed": "6.0.6.1"
+              "fixed": "5.2.8.15"
             }
           ]
         }
@@ -108,6 +89,8 @@
       "CWE-1333"
     ],
     "severity": "LOW",
-    "github_reviewed": true
+    "github_reviewed": true,
+    "github_reviewed_at": "2023-01-18T18:23:20Z",
+    "nvd_published_at": null
   }
 }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The [original Rails advisory announcement for CVE-2023-22796](https://discuss.rubyonrails.org/t/cve-2023-22796-possible-redos-based-dos-vulnerability-in-active-supports-underscore/82116) states that there is no fixed version for activesupport 6.0.x.