### PR TITLE
[GHSA-3p9x-xxx6-2w4p] An issue was discovered in the femanager extension before...

### DIFF
--- a/advisories/unreviewed/2023/02/GHSA-3p9x-xxx6-2w4p/GHSA-3p9x-xxx6-2w4p.json
+++ b/advisories/unreviewed/2023/02/GHSA-3p9x-xxx6-2w4p/GHSA-3p9x-xxx6-2w4p.json
@@ -1,22 +1,89 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-3p9x-xxx6-2w4p",
-  "modified": "2023-02-02T03:30:23Z",
+  "modified": "2023-02-07T19:38:52Z",
   "published": "2023-02-02T03:30:23Z",
   "aliases": [
     "CVE-2023-25014"
   ],
-  "details": "An issue was discovered in the femanager extension before 5.5.3, 6.x before 6.3.4, and 7.x before 7.1.0 for TYPO3. Missing access checks in the InvitationController allow an unauthenticated user to delete all frontend users.",
+  "summary": "Broken Access Control in 3rd party TYPO3 extension \"femanager\"",
+  "details": "A missing access check in the `InvitationController` allows an unauthenticated user to delete all frontend users.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:L"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "in2code/femanager"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.5.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "in2code/femanager"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.3.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "in2code/femanager"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "7.0.0"
+            },
+            {
+              "fixed": "7.1.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 7.0.1"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25014"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/in2code-de/femanager"
     },
     {
       "type": "WEB",
@@ -29,9 +96,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-284"
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-02-02T01:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Package context from the TYPO3 PSIRT.
https://github.com/advisories/GHSA-mm8v-wmqx-8h2j is pretty similar, MITRE issued two CVEs for those two different vulnerabilities in the same component.