### PR TITLE
[GHSA-3c7p-vv5r-cmr5] Incorrect Authorization in Apache Solr

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-3c7p-vv5r-cmr5/GHSA-3c7p-vv5r-cmr5.json
+++ b/advisories/github-reviewed/2022/02/GHSA-3c7p-vv5r-cmr5/GHSA-3c7p-vv5r-cmr5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-3c7p-vv5r-cmr5",
-  "modified": "2021-08-02T15:29:08Z",
+  "modified": "2023-02-08T00:03:38Z",
   "published": "2022-02-10T00:31:27Z",
   "aliases": [
     "CVE-2020-13957"
@@ -80,6 +80,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-13957"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/solr/commit/e001c2221812a0ba9e9378855040ce72f93eced4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/SOLR-14663"
     },
     {
       "type": "WEB",
@@ -175,6 +183,8 @@
       "CWE-863"
     ],
     "severity": "CRITICAL",
-    "github_reviewed": true
+    "github_reviewed": true,
+    "github_reviewed_at": "2021-04-14T17:55:51Z",
+    "nvd_published_at": "2020-10-13T19:15:00Z"
   }
 }


### PR DESCRIPTION
**Updates**
- References

**Comments**
The patch for SOLR-14663 (CVE-2020-13957) is in 8.6.3, *not* 8.6.2 - https://github.com/apache/solr/commit/e001c2221812a0ba9e9378855040ce72f93eced4. Furthermore, since there is no LTS patch for 7.x and the Solr project itself is only tracking fixes for 8.x/9.x (see SOLR-14925 https://issues.apache.org/jira/browse/SOLR-14925), if the 7.x version is to be the *minimum* version bump required to fix the issue it should agree with the 8.x patch which is 8.6.3.