### PR TITLE
[GHSA-8xww-x3g3-6jcv] ReDoS based DoS vulnerability in Action Dispatch

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-8xww-x3g3-6jcv/GHSA-8xww-x3g3-6jcv.json
+++ b/advisories/github-reviewed/2023/01/GHSA-8xww-x3g3-6jcv/GHSA-8xww-x3g3-6jcv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8xww-x3g3-6jcv",
-  "modified": "2023-01-30T22:55:10Z",
+  "modified": "2023-02-08T07:43:30Z",
   "published": "2023-01-18T18:20:51Z",
   "aliases": [
     "CVE-2023-22795"
@@ -12,25 +12,6 @@
 
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "actionpack"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "6.1.0"
-            },
-            {
-              "fixed": "6.1.7.1"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "RubyGems",
@@ -82,7 +63,7 @@
               "introduced": "6.0.0"
             },
             {
-              "fixed": "6.0.6.1"
+              "fixed": "6.1.7.1"
             }
           ]
         }
@@ -90,6 +71,10 @@
     }
   ],
   "references": [
+    {
+      "type": "WEB",
+      "url": "https://discuss.rubyonrails.org/t/cve-2023-22795-possible-redos-based-dos-vulnerability-in-action-dispatch/82118"
+    },
     {
       "type": "WEB",
       "url": "https://github.com/rails/rails/releases/tag/v7.0.4.1"


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Same as in https://github.com/github/advisory-database/pull/1674 , the original report issued by Rails security team it's explicit there's no fix for 6.0.x branch and should be upgrade to at least 6.1.x branch which includes the fixes: https://discuss.rubyonrails.org/t/cve-2023-22795-possible-redos-based-dos-vulnerability-in-action-dispatch/82118

actionpack 6.0.6.1 doesn't include new fixes https://my.diffend.io/gems/actionpack/6.0.6/6.0.6.1