### PR TITLE
[GHSA-6pm2-j2v8-h3cj] Fortra GoAnywhere MFT Deserialization of Untrusted Data vulnerability affects metasploit-framework

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-6pm2-j2v8-h3cj/GHSA-6pm2-j2v8-h3cj.json
+++ b/advisories/github-reviewed/2023/02/GHSA-6pm2-j2v8-h3cj/GHSA-6pm2-j2v8-h3cj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-6pm2-j2v8-h3cj",
-  "modified": "2023-02-08T22:39:43Z",
+  "modified": "2023-02-09T20:57:27Z",
   "published": "2023-02-06T21:30:29Z",
   "aliases": [
     "CVE-2023-0669"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "metasploit-framework"
+        "name": ""
       },
       "ranges": [
         {
@@ -23,9 +23,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "6.0.33"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The metasploit-framework is not affected by this vulnerability.