### PR TITLE
[GHSA-8x6c-cv3v-vp6g] cacheable-request depends on http-cache-semantics, which is vulnerable to Regular Expression Denial of Service

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-8x6c-cv3v-vp6g/GHSA-8x6c-cv3v-vp6g.json
+++ b/advisories/github-reviewed/2023/02/GHSA-8x6c-cv3v-vp6g/GHSA-8x6c-cv3v-vp6g.json
@@ -1,18 +1,15 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8x6c-cv3v-vp6g",
-  "modified": "2023-02-11T00:13:31Z",
+  "modified": "2023-02-13T10:03:34Z",
   "published": "2023-02-11T00:13:31Z",
   "aliases": [
 
   ],
-  "summary": "cacheable-request depends on http-cache-semantics, which is vulnerable to Regular Expression Denial of Service",
+  "summary": "WITHDRAW THIS AS INVALID",
   "details": "cacheable-request depends on http-cache-semanttics, which contains an Inefficient Regular Expression Complexity in versions prior to 4.1.1 of that package. cacheable-request has been updated to rely on the fixed version in 10.2.7. \n\n### Summary of http-cache-semantics vulnerability\nhttp-cache semantics contains an Inefficient Regular Expression Complexity , leading to Denial of Service. This affects versions of the package http-cache-semantics before 4.1.1. The issue can be exploited via malicious request header values sent to a server, when that server reads the cache policy from the request using this library.\n\n### Details\nhttps://github.com/advisories/GHSA-rc47-6667-2j5j\n\n",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    }
+
   ],
   "affected": [
     {
@@ -55,9 +52,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-1333"
+
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2023-02-11T00:13:31Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- CVSS
- CWEs
- Severity
- Summary

**Comments**
This advisory should be deleted because (as stated in description) it is NO vulnerability within this package but an problem with a dependency only. And all latest versions of this package "cacheable-request" use an semver range for the vulnerable "http-cache-semantics" allowing them to simply update to the secured "http-cache-semantics@4.1.1".

There is no vulnerability in this package and this package works with secured dependency without changes needed.
Therefore no security thread and no advisory needed.