### PR TITLE
[GHSA-8x6c-cv3v-vp6g] cacheable-request depends on http-cache-semantics, which is vulnerable to Regular Expression Denial of Service

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-8x6c-cv3v-vp6g/GHSA-8x6c-cv3v-vp6g.json
+++ b/advisories/github-reviewed/2023/02/GHSA-8x6c-cv3v-vp6g/GHSA-8x6c-cv3v-vp6g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8x6c-cv3v-vp6g",
-  "modified": "2023-02-11T00:13:31Z",
+  "modified": "2023-02-13T13:36:48Z",
   "published": "2023-02-11T00:13:31Z",
   "aliases": [
 
@@ -9,10 +9,7 @@
   "summary": "cacheable-request depends on http-cache-semantics, which is vulnerable to Regular Expression Denial of Service",
   "details": "cacheable-request depends on http-cache-semanttics, which contains an Inefficient Regular Expression Complexity in versions prior to 4.1.1 of that package. cacheable-request has been updated to rely on the fixed version in 10.2.7. \n\n### Summary of http-cache-semantics vulnerability\nhttp-cache semantics contains an Inefficient Regular Expression Complexity , leading to Denial of Service. This affects versions of the package http-cache-semantics before 4.1.1. The issue can be exploited via malicious request header values sent to a server, when that server reads the cache policy from the request using this library.\n\n### Details\nhttps://github.com/advisories/GHSA-rc47-6667-2j5j\n\n",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    }
+
   ],
   "affected": [
     {
@@ -57,7 +54,7 @@
     "cwe_ids": [
       "CWE-1333"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2023-02-11T00:13:31Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
This is a bad advisory and should not have been accepted, please delete.
https://github.com/jaredwray/cacheable-request/issues/225#issuecomment-1427635893