### PR TITLE
[GHSA-8x6c-cv3v-vp6g] cacheable-request depends on http-cache-semantics, which is vulnerable to Regular Expression Denial of Service

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-8x6c-cv3v-vp6g/GHSA-8x6c-cv3v-vp6g.json
+++ b/advisories/github-reviewed/2023/02/GHSA-8x6c-cv3v-vp6g/GHSA-8x6c-cv3v-vp6g.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-8x6c-cv3v-vp6g",
-  "modified": "2023-02-11T00:13:31Z",
+  "modified": "2023-02-13T18:25:32Z",
   "published": "2023-02-11T00:13:31Z",
   "aliases": [
 
   ],
   "summary": "cacheable-request depends on http-cache-semantics, which is vulnerable to Regular Expression Denial of Service",
-  "details": "cacheable-request depends on http-cache-semanttics, which contains an Inefficient Regular Expression Complexity in versions prior to 4.1.1 of that package. cacheable-request has been updated to rely on the fixed version in 10.2.7. \n\n### Summary of http-cache-semantics vulnerability\nhttp-cache semantics contains an Inefficient Regular Expression Complexity , leading to Denial of Service. This affects versions of the package http-cache-semantics before 4.1.1. The issue can be exploited via malicious request header values sent to a server, when that server reads the cache policy from the request using this library.\n\n### Details\nhttps://github.com/advisories/GHSA-rc47-6667-2j5j\n\n",
+  "details": "This is wrong and causing a lot of CI environments to break, at least those whom use `yarn audit` as part of the CI validations, quote from an issue in the project subjected to this report (https://github.com/jaredwray/cacheable-request/pull/226#issuecomment-1427838687):\n\n> I don't even understand this advisory, doesn't ^4.1.0 mean compatible with? Consumers of the package can just reinstall dependencies of the package and 4.1.1 would get installed automatically. This advisory and PR would only be needed if it was fixed versioned to 4.1.0, which it isn't.\n\nPlease **remove this advisory** !",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -37,18 +37,6 @@
   ],
   "references": [
     {
-      "type": "WEB",
-      "url": "https://github.com/jaredwray/cacheable-request/security/advisories/GHSA-8x6c-cv3v-vp6g"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/jaredwray/cacheable-request/commit/8a47777e4eb61960469873cf4b3a2823742fc15e"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://github.com/advisories/GHSA-rc47-6667-2j5j"
-    },
-    {
       "type": "PACKAGE",
       "url": "https://github.com/jaredwray/cacheable-request"
     }
@@ -57,7 +45,7 @@
     "cwe_ids": [
       "CWE-1333"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2023-02-11T00:13:31Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- CVSS
- Description
- References
- Severity

**Comments**
Again because I'm not modifying the advisory but asking to be removed. The advisory is wrong / invalid, and causing a lot of CI environments to break, quote from https://github.com/jaredwray/cacheable-request/pull/226#issuecomment-1427838687: 

> I don't even understand this advisory, doesn't ^4.1.0 mean compatible with? Consumers of the package can just reinstall dependencies of the package and 4.1.1 would get installed automatically. This advisory and PR would only be needed if it was fixed versioned to 4.1.0, which it isn't.