### PR TITLE
[GHSA-2hrw-hx67-34x6] Resource exhaustion in Django

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-2hrw-hx67-34x6/GHSA-2hrw-hx67-34x6.json
+++ b/advisories/github-reviewed/2023/02/GHSA-2hrw-hx67-34x6/GHSA-2hrw-hx67-34x6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-2hrw-hx67-34x6",
-  "modified": "2023-02-15T17:42:14Z",
+  "modified": "2023-02-19T07:35:39Z",
   "published": "2023-02-15T03:30:47Z",
   "aliases": [
     "CVE-2023-24580"
@@ -42,6 +42,25 @@
           "events": [
             {
               "introduced": "4.0.0"
+            },
+            {
+              "fixed": "4.0.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "Django"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.1.0"
             },
             {
               "fixed": "4.1.7"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Range >= 4.0.0, <= 4.1.7 was not in line with textual description of the affected versions and cause a false-positive when using 4.0.10