### PR TITLE
[GHSA-28f8-hqmc-7ph8] Malicious Package in ember-power-timepicker

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-28f8-hqmc-7ph8/GHSA-28f8-hqmc-7ph8.json
+++ b/advisories/github-reviewed/2020/09/GHSA-28f8-hqmc-7ph8/GHSA-28f8-hqmc-7ph8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-28f8-hqmc-7ph8",
-  "modified": "2020-08-31T18:40:57Z",
+  "modified": "2023-02-20T23:44:42Z",
   "published": "2020-09-11T21:19:09Z",
   "aliases": [
 
@@ -17,19 +17,6 @@
         "ecosystem": "npm",
         "name": "ember-power-timepicker"
       },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "1.0.8"
-            },
-            {
-              "fixed": "1.0.7"
-            }
-          ]
-        }
-      ],
       "versions": [
         "1.0.8"
       ]


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Having 1.0.7 as the patch version results in an invalid OSV entry:

https://github.com/google/osv.dev/issues/1055