### PR TITLE
[GHSA-x4rg-4545-4w7w] Improper Input Validation and Excessive Iteration in Go Facebook Thrift

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-x4rg-4545-4w7w/GHSA-x4rg-4545-4w7w.json
+++ b/advisories/github-reviewed/2022/02/GHSA-x4rg-4545-4w7w/GHSA-x4rg-4545-4w7w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-x4rg-4545-4w7w",
-  "modified": "2021-11-03T14:59:45Z",
+  "modified": "2023-02-21T06:14:28Z",
   "published": "2022-02-15T01:57:18Z",
   "aliases": [
     "CVE-2019-3564"
@@ -28,14 +28,11 @@
               "introduced": "0"
             },
             {
-              "fixed": "2019.03.04.00"
+              "fixed": "v0.31.1-0.20190225164308-c461c1bd1a3e"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 2019.02.25.00"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
"2019.02.25.00" is not a valid SemVer or Go module version (i.e. it's not possible to install a Go package at such a version).

This change aligns this entry with https://pkg.go.dev/vuln/GO-2021-0088