### PR TITLE
[GHSA-2w7w-2j92-44hx] HTTP Request Smuggling in akka-http-core

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-2w7w-2j92-44hx/GHSA-2w7w-2j92-44hx.json
+++ b/advisories/github-reviewed/2021/05/GHSA-2w7w-2j92-44hx/GHSA-2w7w-2j92-44hx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-2w7w-2j92-44hx",
-  "modified": "2021-03-19T22:36:01Z",
+  "modified": "2023-02-21T06:17:58Z",
   "published": "2021-05-10T15:17:09Z",
   "aliases": [
     "CVE-2021-23339"
@@ -45,13 +45,13 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "10.1.14"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 10.1.14"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The current OSV entry has this as the encoding for one of the ranges:

```
     "ranges": [
        {
          "type": "ECOSYSTEM",
          "events": [
            {
              "introduced": "0"
            }
          ]
        }
      ],
```

This incorrectly means that every version is affected according to the OSV schema's evaluation rules. Add a patch version explicitly to have the "fix" version be reflected for the "10.1.*" branch as an upper bound. 