### PR TITLE
[GHSA-3wxh-43c2-qm9r] In NatHack between 3.6.0 and 3.6.3, a buffer overflow...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-3wxh-43c2-qm9r/GHSA-3wxh-43c2-qm9r.json
+++ b/advisories/unreviewed/2022/05/GHSA-3wxh-43c2-qm9r/GHSA-3wxh-43c2-qm9r.json
@@ -1,17 +1,33 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-3wxh-43c2-qm9r",
-  "modified": "2022-05-24T17:04:51Z",
+  "modified": "2023-02-21T17:04:05Z",
   "published": "2022-05-24T17:04:51Z",
   "aliases": [
     "CVE-2019-16787"
   ],
+  "summary": "NetHack CVE duplicating CVE-2019-19905",
   "details": "In NatHack between 3.6.0 and 3.6.3, a buffer overflow issue exists when reading very long lines from a NetHack configuration file (usually named .nethackrc). This vulnerability affects systems that have NetHack installed suid/sgid and shared systems that allow users to upload their own configuration files. All users are urged to upgrade to NetHack 3.6.4 as soon as possible.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
This CVE (which has the erroneous name "NatHack" instead of "NetHack" - I have not corrected that) is not from the NetHack developers (see repo NetHack/NetHack), and is a duplicate of CVE-2019-19905, which IS from the NetHack developers.  According to https://nvd.nist.gov/vuln/detail/CVE-2019-16787 it apparently (and logically) should no longer show up in search results, but I found it by searching for nethack at https://github.com/advisories?query=nethack .  Perhaps it shouldn't show up there?  Thanks!  Ken Lorber (keni@his.com, keni@nethack.org, nhkeni on github).
PS - I had to put this CVE into ecosystem "Composer" because I don't get an "Other" option which is where it should be.