### PR TITLE
[GHSA-9qh2-6fxg-9m4g] Open Chinese Convert subject to Denial of Service via Out-of-bounds Read

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9qh2-6fxg-9m4g/GHSA-9qh2-6fxg-9m4g.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9qh2-6fxg-9m4g/GHSA-9qh2-6fxg-9m4g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-9qh2-6fxg-9m4g",
-  "modified": "2022-09-30T23:13:59Z",
+  "modified": "2023-02-22T21:04:20Z",
   "published": "2022-05-14T01:55:28Z",
   "aliases": [
     "CVE-2018-16982"
@@ -25,11 +25,36 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.0.5"
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.1.2"
             }
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "opencc"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "< 1.1.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.1.2"
+      }
     }
   ],
   "references": [
@@ -52,6 +77,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/BYVoid/OpenCC/pull/560/commits/e1b8c7949738100e4747dd4109ef1f16e1bd99c4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/BYVoid/OpenCC/commit/4a4f9e58e505fca93605f22363c133df66a91a5e"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Change 1) 
    version: The following commit which adds a length check was included in version 1.1.2  https://github.com/BYVoid/OpenCC/commit/4a4f9e58e505fca93605f22363c133df66a91a5e it was originally part of PR560 ( https://github.com/BYVoid/OpenCC/pull/560 )

Change 2)
   pip: OpenCC is also available in pip via pypi  https://pypi.org/project/OpenCC/