### PR TITLE
[GHSA-ww4x-rwq6-qpgf] Cross-site Request Forgery in OmniAuth

### DIFF
--- a/advisories/github-reviewed/2019/05/GHSA-ww4x-rwq6-qpgf/GHSA-ww4x-rwq6-qpgf.json
+++ b/advisories/github-reviewed/2019/05/GHSA-ww4x-rwq6-qpgf/GHSA-ww4x-rwq6-qpgf.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-ww4x-rwq6-qpgf",
-  "modified": "2023-01-25T22:41:50Z",
+  "modified": "2023-02-24T13:00:05Z",
   "published": "2019-05-29T19:11:31Z",
   "aliases": [
     "CVE-2015-9284"
   ],
   "summary": "Cross-site Request Forgery in OmniAuth",
-  "details": "The request phase of the OmniAuth Ruby gem (1.9.1 and earlier) is vulnerable to Cross-Site Request Forgery when used as part of the Ruby on Rails framework, allowing accounts to be connected without user intent, user interaction, or feedback to the user. This permits a secondary account to be able to sign into the web application as the primary account.\n\nAs of v2 OmniAuth no longer has the vulnerable configuration by default, but it is still possible to configure OmniAuth in such a way that the web application becomes vulnerable to Cross-Site Request Forgery. There is a recommended remediation described [here](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284).",
+  "details": "The request phase of the OmniAuth Ruby gem (1.9.2 and earlier) is vulnerable to Cross-Site Request Forgery when used as part of the Ruby on Rails framework, allowing accounts to be connected without user intent, user interaction, or feedback to the user. This permits a secondary account to be able to sign into the web application as the primary account.\n\nAs of v2 OmniAuth no longer has the vulnerable configuration by default, but it is still possible to configure OmniAuth in such a way that the web application becomes vulnerable to Cross-Site Request Forgery. There is a recommended remediation described [here](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284).",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -34,7 +34,7 @@
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 1.9.1"
+        "last_known_affected_version_range": "<= 1.9.2"
       }
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
omniauth 1.9.2 fixes an unrelated security issue, and is just as vulnerable to this problem as omniauth 1.9.1.

https://github.com/omniauth/omniauth/releases/tag/v1.9.2