### PR TITLE
[GHSA-gwc9-m7rh-j2ww] x/crypto/ssh vulnerable to panic via SSH server

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-gwc9-m7rh-j2ww/GHSA-gwc9-m7rh-j2ww.json
+++ b/advisories/github-reviewed/2022/09/GHSA-gwc9-m7rh-j2ww/GHSA-gwc9-m7rh-j2ww.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-gwc9-m7rh-j2ww",
-  "modified": "2022-09-16T17:40:34Z",
+  "modified": "2023-02-24T13:55:16Z",
   "published": "2022-09-07T00:01:52Z",
   "aliases": [
     "CVE-2021-43565"
   ],
   "summary": "x/crypto/ssh vulnerable to panic via SSH server",
-  "details": "The x/crypto/ssh package before 0.0.0-20211202192323-5770296d904e of golang.org/x/crypto allows an attacker to panic an SSH server.",
+  "details": "The x/crypto/ssh package before 0.0.0-20211202192323-5770296d904e of golang.org/x/crypto allows an unauthenticated attacker to panic an SSH server.",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Description

**Comments**
In the announcement it is mentioned that the attacker can be unauthenticated. That's an important distinction.