### PR TITLE
[GHSA-x4qr-2fvf-3mr5] Vulnerable OpenSSL included in cryptography wheels

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-x4qr-2fvf-3mr5/GHSA-x4qr-2fvf-3mr5.json
+++ b/advisories/github-reviewed/2023/02/GHSA-x4qr-2fvf-3mr5/GHSA-x4qr-2fvf-3mr5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-x4qr-2fvf-3mr5",
-  "modified": "2023-02-21T19:01:55Z",
+  "modified": "2023-02-28T00:00:47Z",
   "published": "2023-02-08T22:17:06Z",
   "aliases": [
     "CVE-2023-0286"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H"
     }
   ],
   "affected": [
@@ -111,7 +111,7 @@
     "cwe_ids": [
       "CWE-843"
     ],
-    "severity": "CRITICAL",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2023-02-08T22:17:06Z",
     "nvd_published_at": "2023-02-08T20:15:00Z"


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
The official CVE sites list CVE-2023-0286 as being a high attack complexity (see https://nvd.nist.gov/vuln/detail/CVE-2023-0286, https://access.redhat.com/security/cve/cve-2023-0286)