### PR TITLE
[GHSA-75qm-2q4j-qx6g] A cleartext transmission of sensitive information...

### DIFF
--- a/advisories/unreviewed/2023/02/GHSA-75qm-2q4j-qx6g/GHSA-75qm-2q4j-qx6g.json
+++ b/advisories/unreviewed/2023/02/GHSA-75qm-2q4j-qx6g/GHSA-75qm-2q4j-qx6g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-75qm-2q4j-qx6g",
-  "modified": "2023-03-01T17:36:59Z",
+  "modified": "2023-03-01T17:59:38Z",
   "published": "2023-02-23T21:30:16Z",
   "aliases": [
     "CVE-2023-23914"
@@ -22,13 +22,35 @@
           "type": "ECOSYSTEM",
           "events": [
             {
+              "introduced": "7.77.0"
+            },
+            {
+              "fixed": "7.88.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "curl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
               "introduced": "0"
+            },
+            {
+              "fixed": "7.88.0"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "< 7.88.0"
+        "last_known_affected_version_range": "<= 7.87.0"
       }
     }
   ],

--- a/advisories/unreviewed/2023/02/GHSA-75qm-2q4j-qx6g/GHSA-75qm-2q4j-qx6g.json
+++ b/advisories/unreviewed/2023/02/GHSA-75qm-2q4j-qx6g/GHSA-75qm-2q4j-qx6g.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-75qm-2q4j-qx6g",
-  "modified": "2023-02-28T14:22:47Z",
+  "modified": "2023-03-01T17:36:59Z",
   "published": "2023-02-23T21:30:16Z",
   "aliases": [
     "CVE-2023-23914"
   ],
-  "summary": "Cleartext Transmission of Sensitive Information",
+  "summary": "HSTS ignored on multiple requests",
   "details": "A cleartext transmission of sensitive information vulnerability exists in curl <v7.88.0 that could cause HSTS functionality fail when multiple URLs are requested serially. Using its HSTS support, curl can be instructed to use HTTPS instead of usingan insecure clear-text HTTP step even when HTTP is provided in the URL. ThisHSTS mechanism would however surprisingly be ignored by subsequent transferswhen done on the same command line because the state would not be properlycarried on.",
   "severity": [
 
@@ -40,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://hackerone.com/reports/1813864"
+    },
+    {
+      "type": "WEB",
+      "url": "https://curl.se/docs/CVE-2023-23914.html"
     }
   ],
   "database_specific": {

--- a/advisories/unreviewed/2023/02/GHSA-75qm-2q4j-qx6g/GHSA-75qm-2q4j-qx6g.json
+++ b/advisories/unreviewed/2023/02/GHSA-75qm-2q4j-qx6g/GHSA-75qm-2q4j-qx6g.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-75qm-2q4j-qx6g",
-  "modified": "2023-02-23T21:30:16Z",
+  "modified": "2023-02-28T14:22:47Z",
   "published": "2023-02-23T21:30:16Z",
   "aliases": [
     "CVE-2023-23914"
   ],
+  "summary": "Cleartext Transmission of Sensitive Information",
   "details": "A cleartext transmission of sensitive information vulnerability exists in curl <v7.88.0 that could cause HSTS functionality fail when multiple URLs are requested serially. Using its HSTS support, curl can be instructed to use HTTPS instead of usingan insecure clear-text HTTP step even when HTTP is provided in the URL. ThisHSTS mechanism would however surprisingly be ignored by subsequent transferswhen done on the same command line because the state would not be properlycarried on.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "curl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 7.88.0"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The cURL binaries are independently published to NuGet.org. There are affected cURL versions that should be marked as vulnerable based on GitHub security advisory metadata.