### PR TITLE
[GHSA-674j-7m97-j2p9] A buffer overflow exists in curl 7.12.3 to and including...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-674j-7m97-j2p9/GHSA-674j-7m97-j2p9.json
+++ b/advisories/unreviewed/2022/05/GHSA-674j-7m97-j2p9/GHSA-674j-7m97-j2p9.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-674j-7m97-j2p9",
-  "modified": "2022-05-14T00:58:02Z",
+  "modified": "2023-02-28T14:33:25Z",
   "published": "2022-05-14T00:58:02Z",
   "aliases": [
     "CVE-2018-1000120"
   ],
+  "summary": "FTP path trickery leads to NIL byte out of bounds write",
   "details": "A buffer overflow exists in curl 7.12.3 to and including curl 7.58.0 in the FTP URL handling that allows an attacker to cause a denial of service or worse.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "curl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.59.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {

--- a/advisories/unreviewed/2022/05/GHSA-674j-7m97-j2p9/GHSA-674j-7m97-j2p9.json
+++ b/advisories/unreviewed/2022/05/GHSA-674j-7m97-j2p9/GHSA-674j-7m97-j2p9.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-674j-7m97-j2p9",
-  "modified": "2023-02-28T14:33:25Z",
+  "modified": "2023-03-01T17:51:06Z",
   "published": "2022-05-14T00:58:02Z",
   "aliases": [
     "CVE-2018-1000120"
   ],
   "summary": "FTP path trickery leads to NIL byte out of bounds write",
-  "details": "A buffer overflow exists in curl 7.12.3 to and including curl 7.58.0 in the FTP URL handling that allows an attacker to cause a denial of service or worse.",
+  "details": "curl can be fooled into writing a zero byte out of bounds.\n\nThis bug can trigger when curl is told to work on an FTP URL, with the setting to only issue a single CWD command (--ftp-method singlecwd or the libcurl alternative [CURLOPT_FTP_FILEMETHOD](https://curl.se/libcurl/c/CURLOPT_FTP_FILEMETHOD.html)).\n\ncurl then URL-decodes the given path, calls strlen() on the result and deducts the length of the file name part to find the end of the directory within the buffer. It then writes a zero byte on that index, in a buffer allocated on the heap.\n\nIf the directory part of the URL contains a \"%00\" sequence, the directory length might end up shorter than the file name path, making the calculation size_t index = directory_len - filepart_len end up with a huge index variable for where the zero byte gets stored: heap_buffer[index] = 0. On several architectures that huge index will wrap and work as a negative value, thus overwriting memory before the intended heap buffer.\n\nBy using different file part lengths and putting %00 in different places in the URL, an attacker that can control what paths a curl-using application uses can write that zero byte on different indexes.\n\nWe are not aware of any exploit of this flaw.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.12.3"
             },
             {
               "fixed": "7.59.0"
@@ -33,6 +33,28 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "curl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.59.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 7.58.0"
+      }
     }
   ],
   "references": [
@@ -66,7 +88,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://curl.haxx.se/docs/adv_2018-9cd6.html"
+      "url": "https://curl.se/docs/CVE-2018-1000120.html"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The curl binaries are independently published to NuGet.org. There are affected curl versions that should be marked as vulnerable based on GitHub security advisory metadata.

Note that this suggested metadata update focuses primarily on correlating NuGet package ID and version ranges so that the (unlisted) package on NuGet.org also has proper vulnerability markings. 

Also note that there are other unreviewed curl CVEs in the GitHub Advisory queue (https://github.com/advisories?query=curl+type%3Aunreviewed) that may also impact the versions on NuGet.org. I focused on the most critical CVE that impacts the versions in question in order to have _some_ vulnerability marking flow into NuGet.org.

Please double check the correctness. I tried to be honest to the official curl CVE listing (https://curl.se/docs/CVE-2018-1000120.html). This is alluded to as the proper source by the curl author here: https://github.com/github/advisory-database/pull/1732#issuecomment-1449480728.