### PR TITLE
[GHSA-p699-3wgc-7h72] Moderate severity vulnerability that affects org.apache.tika:tika-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-p699-3wgc-7h72/GHSA-p699-3wgc-7h72.json
+++ b/advisories/github-reviewed/2018/10/GHSA-p699-3wgc-7h72/GHSA-p699-3wgc-7h72.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-p699-3wgc-7h72",
-  "modified": "2021-09-15T21:42:36Z",
+  "modified": "2023-02-28T14:34:32Z",
   "published": "2018-10-17T15:43:59Z",
   "aliases": [
     "CVE-2018-1339"
   ],
-  "summary": "Moderate severity vulnerability that affects org.apache.tika:tika-core",
-  "details": "A carefully crafted (or fuzzed) file can trigger an infinite loop in Apache Tika's ChmParser in versions of Apache Tika before 1.18.",
+  "summary": "Moderate severity vulnerability that affects org.apache.tika:tika-parsers",
+  "details": "Affected versions of this package before version 1.18 are vulnerable to Denial of Service (DoS) via a carefully crafted (or fuzzed) file that can trigger an infinite loop via the ChmParser.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tika:tika-core"
+        "name": "org.apache.tika:tika-parsers"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Summary

**Comments**
This vulnerability is related to another package org.apache.tika:tika-parsers. Please see this commit: https://github.com/apache/tika/commit/1b6ca3685c196cfd89f5f95c19cc919ce10c5aff#diff-43f8cbe58aaab159ce88bd95fafc46dd