### PR TITLE
[GHSA-wjxj-f8rg-99wx] Improper Input Validation in Apache Thrift

### DIFF
--- a/advisories/github-reviewed/2019/01/GHSA-wjxj-f8rg-99wx/GHSA-wjxj-f8rg-99wx.json
+++ b/advisories/github-reviewed/2019/01/GHSA-wjxj-f8rg-99wx/GHSA-wjxj-f8rg-99wx.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-wjxj-f8rg-99wx",
-  "modified": "2022-09-14T22:36:55Z",
+  "modified": "2023-03-01T13:12:52Z",
   "published": "2019-01-17T13:56:40Z",
   "aliases": [
     "CVE-2018-1320"
   ],
   "summary": "Improper Input Validation in Apache Thrift",
-  "details": "Apache Thrift Java client library versions 0.5.0 through 0.11.0 can bypass SASL negotiation isComplete validation in the org.apache.thrift.transport.TSaslTransport class. An assert used to determine if the SASL handshake had successfully completed could be disabled in production settings making the validation incomplete.",
+  "details": "Apache Thrift Java client library versions 0.5.0 through 0.11.0 with the exception of 0.9.3-1 can bypass SASL negotiation isComplete validation in the org.apache.thrift.transport.TSaslTransport class. An assert used to determine if the SASL handshake had successfully completed could be disabled in production settings making the validation incomplete.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -26,6 +26,25 @@
           "events": [
             {
               "introduced": "0.5.0"
+            },
+            {
+              "fixed": "0.9.3-1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.thrift:libthrift"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.10.0"
             },
             {
               "fixed": "0.12.0"


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
https://github.com/apache/thrift/releases/tag/0.9.3.1 describes that CVE-2018-1320 has been fixed there by implementing https://issues.apache.org/jira/browse/THRIFT-4506.