### PR TITLE
[GHSA-vqp6-rc3h-83cp] Tailscale Windows daemon is vulnerable to RCE via CSRF

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-vqp6-rc3h-83cp/GHSA-vqp6-rc3h-83cp.json
+++ b/advisories/github-reviewed/2022/11/GHSA-vqp6-rc3h-83cp/GHSA-vqp6-rc3h-83cp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-vqp6-rc3h-83cp",
-  "modified": "2022-11-21T22:34:00Z",
+  "modified": "2023-03-02T11:30:50Z",
   "published": "2022-11-21T22:34:00Z",
   "aliases": [
     "CVE-2022-41924"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "tailscale/tailscale.com/cmd"
+        "name": "pkg.go.dev/tailscale.com/cmd"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
package name isn't the actual package name and can't be detected by package scanners.