### PR TITLE
Improve https://github.com/advisories/GHSA-6q8m-42qq-64r7

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-6q8m-42qq-64r7/GHSA-6q8m-42qq-64r7.json
+++ b/advisories/github-reviewed/2023/03/GHSA-6q8m-42qq-64r7/GHSA-6q8m-42qq-64r7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-6q8m-42qq-64r7",
-  "modified": "2023-03-01T22:57:51Z",
+  "modified": "2023-03-02T14:53:55Z",
   "published": "2023-03-01T09:30:29Z",
   "aliases": [
     "CVE-2021-4326"
@@ -9,9 +9,34 @@
   "summary": "Imperative CLI vulnerable to Command Injection",
   "details": "A vulnerability in Imperative framework which allows already-privileged local actors to execute arbitrary shell commands via plugin install/update commands, or maliciously formed environment variables. Impacts Zowe CLI.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@zowe/imperative"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.0.0"
+            },
+            {
+              "fixed": "5.7.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 5.7.1"
+      }
+    },
     {
       "package": {
         "ecosystem": "npm",
@@ -25,11 +50,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "5.9.0"
+              "fixed": "4.18.10"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.18.10"
+      }
     }
   ],
   "references": [
@@ -39,7 +67,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/zowe/imperative/commit/1f3d99a729f1f541f002ce83d522d5b8174ba78d"
+      "url": "https://github.com/zowe/imperative/pull/900"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/zowe/imperative/pull/902"
     },
     {
       "type": "PACKAGE",
@@ -50,7 +82,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2023-03-01T22:57:51Z",
     "nvd_published_at": "2023-03-01T08:15:00Z"


### PR DESCRIPTION
Copied/following from #1744 to fix a minor mistake in 'fixed' version fields.

**Updates**
- Affected products
- CVSS
- References
- Severity

**Comments**
I am part of the team that submitted the CVE Request. Due to confusion in communicating versioning, this advisory appears to be incorrect. We marked the CVE as impacting Zowe versions < 1.28.2 or < 2.5.0 which is understood by many of our consumers, but not by automation. We'll fix this going forward. The actual Imperative versions affected are < 4.18.10 or >= 5.0.0, < 5.7.1, and the PRs which fixed the issue were added to the references section.  As for verifying my authenticity, I am a Zowe Organization Owner/Administrator and Zowe CLI Squad Member (which owns the Imperative framework). I can provide additional information if required, please let me know if that's the case.