### PR TITLE
[GHSA-rc2q-x9mf-w3vf] TestNG is vulnerable to Path Traversal

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-rc2q-x9mf-w3vf/GHSA-rc2q-x9mf-w3vf.json
+++ b/advisories/github-reviewed/2022/11/GHSA-rc2q-x9mf-w3vf/GHSA-rc2q-x9mf-w3vf.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-rc2q-x9mf-w3vf",
-  "modified": "2023-01-18T18:46:58Z",
+  "modified": "2023-03-02T19:34:20Z",
   "published": "2022-11-19T21:30:25Z",
   "aliases": [
     "CVE-2022-4065"
   ],
   "summary": "TestNG is vulnerable to Path Traversal",
-  "details": "A vulnerability was found in cbeust testng. It has been declared as critical. Affected by this vulnerability is the function `testngXmlExistsInJar` of the file `testng-core/src/main/java/org/testng/JarFileUtils.java` of the component `XML File Parser`. The manipulation leads to path traversal. The attack can be launched remotely. A patch is available in [version 7.7.0](https://github.com/cbeust/testng/releases/tag/7.7.0) at commit 9150736cd2c123a6a3b60e6193630859f9f0422b. It is recommended to apply a patch to fix this issue. The patch was pushed into the master branch but no releases have yet been made with the patch included.",
+  "details": "A vulnerability was found in cbeust testng. It has been declared as critical. Affected by this vulnerability is the function `testngXmlExistsInJar` of the file `testng-core/src/main/java/org/testng/JarFileUtils.java` of the component `XML File Parser`. The manipulation leads to path traversal. The attack can be launched remotely. A patch is available in [version 7.7.0](https://github.com/cbeust/testng/releases/tag/7.7.0) at commit 9150736cd2c123a6a3b60e6193630859f9f0422b. It is recommended to apply a patch to fix this issue. The patch was pushed into the master branch but no releases have yet been made with the patch included.  \n\nThis fix is not compatible with Java 1.8 and so far there is no solution for systems that still require Java 1.8.",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Description

**Comments**
TestNG versions > 7.5 are not compatible with Java 1.8 and so far there is no solution for systems that still require Java 1.8 even though Java 1.8 is still a Long-Term Supported version by Oracle.  