### PR TITLE
[GHSA-3mq5-fq9h-gj7j] Denial of Service due to parser crash

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-3mq5-fq9h-gj7j/GHSA-3mq5-fq9h-gj7j.json
+++ b/advisories/github-reviewed/2022/09/GHSA-3mq5-fq9h-gj7j/GHSA-3mq5-fq9h-gj7j.json
@@ -1,6 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-3mq5-fq9h-gj7j",
+  "modified": "2022-12-29T16:36:19Z",
   "published": "2022-09-17T00:00:41Z",
   "aliases": [
 

--- a/advisories/github-reviewed/2022/09/GHSA-3mq5-fq9h-gj7j/GHSA-3mq5-fq9h-gj7j.json
+++ b/advisories/github-reviewed/2022/09/GHSA-3mq5-fq9h-gj7j/GHSA-3mq5-fq9h-gj7j.json
@@ -1,7 +1,6 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-3mq5-fq9h-gj7j",
-  "modified": "2022-12-29T16:36:19Z",
   "published": "2022-09-17T00:00:41Z",
   "aliases": [
 
@@ -51,7 +50,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/FasterXML/woodstox"
+      "url": "https://github.com/x-stream/xstream"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
Source code link is wrong. Also, the canonical advisory with better info is GHSA-f8cc-g7j8-xxpm which is *technically* a duplicate but was submitted and enriched by the xstream team and should be considered ground truth over this advisory.