### PR TITLE
[GHSA-3295-h9qx-r82x] Authentication Bypass Using an Alternate Path or Channel in SpringSource Spring Security and Acegi Security

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-3295-h9qx-r82x/GHSA-3295-h9qx-r82x.json
+++ b/advisories/github-reviewed/2022/05/GHSA-3295-h9qx-r82x/GHSA-3295-h9qx-r82x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-3295-h9qx-r82x",
-  "modified": "2022-07-08T18:48:11Z",
+  "modified": "2023-01-27T05:02:25Z",
   "published": "2022-05-14T02:43:11Z",
   "aliases": [
     "CVE-2010-3700"
@@ -63,7 +63,7 @@
               "introduced": "1.0.0"
             },
             {
-              "fixed": "1.0.7"
+              "last_affected": "1.0.7"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
v1.0.7 of acegi-security appears to be listed as affected in the original announcement url (per Internet Archive) https://web.archive.org/web/20110802082343/http://www.springsource.com/security/cve-2010-3700, and there appear to be no fixed versions released