### PR TITLE
[GHSA-wrx5-rp7m-mm49] JXPath vulnerable to remote code execution when interpreting untrusted XPath expressions: Rejected

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-wrx5-rp7m-mm49/GHSA-wrx5-rp7m-mm49.json
+++ b/advisories/github-reviewed/2022/10/GHSA-wrx5-rp7m-mm49/GHSA-wrx5-rp7m-mm49.json
@@ -1,18 +1,15 @@
 {
   "schema_version": "1.3.0",
   "id": "GHSA-wrx5-rp7m-mm49",
-  "modified": "2022-10-10T16:55:26Z",
+  "modified": "2023-01-30T05:02:56Z",
   "published": "2022-10-06T18:52:05Z",
   "aliases": [
     "CVE-2022-41852"
   ],
   "summary": "JXPath vulnerable to remote code execution when interpreting untrusted XPath expressions",
-  "details": "Those using JXPath to interpret untrusted XPath expressions may be vulnerable to a remote code execution attack. All JXPathContext class functions processing a XPath string are vulnerable except `compile()` and `compilePath()` function. The XPath expression can be used by an attacker to load any Java class from the classpath resulting in code execution.",
+  "details": "Rejected. https://nvd.nist.gov/vuln/detail/CVE-2022-41852\n\nThat issue got dismissed.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-    }
+
   ],
   "affected": [
     {
@@ -61,7 +58,7 @@
     "cwe_ids": [
       "CWE-470"
     ],
-    "severity": "CRITICAL",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2022-10-06T20:35:33Z",
     "nvd_published_at": "2022-10-06T18:17:00Z"


### PR DESCRIPTION
**Updates**
- Affected products: None
- CVSS: None
- Description: Rejected
- Severity: None

**Comments**
This issue got dismissed: https://nvd.nist.gov/vuln/detail/CVE-2022-41852

We should remove it from the GitHub Advisory database.

Do we have a procedure for such cases somewhere?

Thanks!