### PR TITLE
[GHSA-75rw-34q6-72cr] Signature forgery in Biscuit

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-75rw-34q6-72cr/GHSA-75rw-34q6-72cr.json
+++ b/advisories/github-reviewed/2022/06/GHSA-75rw-34q6-72cr/GHSA-75rw-34q6-72cr.json
@@ -1,7 +1,7 @@
 {
-  "schema_version": "1.3.0",
+  "schema_version": "1.4.0",
   "id": "GHSA-75rw-34q6-72cr",
-  "modified": "2023-03-01T18:35:12Z",
+  "modified": "2023-03-01T18:35:16Z",
   "published": "2022-06-17T00:38:03Z",
   "aliases": [
     "CVE-2022-31053"
@@ -36,8 +36,8 @@
     },
     {
       "package": {
-        "ecosystem": "Go",
-        "name": "github.com/biscuit-auth/biscuit-go"
+        "ecosystem": "Maven",
+        "name": "com.clever-cloud:biscuit-java"
       },
       "ranges": [
         {
@@ -47,7 +47,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.0"
+              "fixed": "2.0.0"
             }
           ]
         }
@@ -55,8 +55,8 @@
     },
     {
       "package": {
-        "ecosystem": "Maven",
-        "name": "com.clever-cloud:biscuit-java"
+        "ecosystem": "Go",
+        "name": "github.com/biscuit-auth/biscuit-go"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The affected Go package github.com/biscuit-auth/biscuit-go was released in semantic version 2.0.0, instead of 2.0. This change also makes it compliant to the semantic versioning scheme natively used in Go.