### PR TITLE
[GHSA-mc23-976p-j42x] xterm vulnerable to remote code execution 

### DIFF
--- a/advisories/github-reviewed/2019/01/GHSA-mc23-976p-j42x/GHSA-mc23-976p-j42x.json
+++ b/advisories/github-reviewed/2019/01/GHSA-mc23-976p-j42x/GHSA-mc23-976p-j42x.json
@@ -1,7 +1,7 @@
 {
-  "schema_version": "1.3.0",
+  "schema_version": "1.4.0",
   "id": "GHSA-mc23-976p-j42x",
-  "modified": "2022-12-18T23:44:26Z",
+  "modified": "2023-02-03T05:05:12Z",
   "published": "2019-01-14T16:19:55Z",
   "aliases": [
     "CVE-2019-0542"
@@ -63,7 +63,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.10"
+              "introduced": "3.10.0"
             },
             {
               "fixed": "3.10.1"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The affected version was mistakenly listed as `>= 3.10`, whereas `>= 3.10.0` would be semantically correct. See https://github.com/xtermjs/xterm.js/releases/tag/3.10.0 for reference.