### PR TITLE
[GHSA-qpm3-vr34-h8w8] Open Redirect in Caddy

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-qpm3-vr34-h8w8/GHSA-qpm3-vr34-h8w8.json
+++ b/advisories/github-reviewed/2023/02/GHSA-qpm3-vr34-h8w8/GHSA-qpm3-vr34-h8w8.json
@@ -1,7 +1,7 @@
 {
-  "schema_version": "1.3.0",
+  "schema_version": "1.4.0",
   "id": "GHSA-qpm3-vr34-h8w8",
-  "modified": "2023-02-16T21:55:13Z",
+  "modified": "2023-02-16T21:55:15Z",
   "published": "2023-02-07T00:30:24Z",
   "aliases": [
     "CVE-2022-28923"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.5.0"
+              "fixed": "2.5.0-beta.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The fix is been made in v2.5.0-beta.1 

Refer : https://pkg.go.dev/vuln/GO-2023-1567