### PR TITLE
[GHSA-6x9x-8qw9-9pp6] Jetty vulnerable to authorization bypass due to inconsistent HTTP request handling (HTTP Request Smuggling)

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-6x9x-8qw9-9pp6/GHSA-6x9x-8qw9-9pp6.json
+++ b/advisories/github-reviewed/2018/10/GHSA-6x9x-8qw9-9pp6/GHSA-6x9x-8qw9-9pp6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6x9x-8qw9-9pp6",
-  "modified": "2022-09-14T01:09:24Z",
+  "modified": "2023-01-27T05:05:08Z",
   "published": "2018-10-19T16:16:38Z",
   "aliases": [
     "CVE-2017-7658"
@@ -25,28 +25,6 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "9.2.0"
-            },
-            {
-              "fixed": "9.2.25.v20180606"
-            }
-          ]
-        }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 9.2.24.v20180105"
-      }
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.jetty:jetty-server"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
               "introduced": "9.3.0"
             },
             {
@@ -54,10 +32,7 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 9.3.23.v20180228"
-      }
+      ]
     },
     {
       "package": {
@@ -76,10 +51,26 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 9.4.10.v20180503"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.jetty:jetty-server"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "9.2.25.v20180606"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
https://bugs.eclipse.org/bugs/show_bug.cgi?id=535669 indicates that All EOL releases - 9.2.x and older (all configurations) are affected, so adjusting the ranges to reflect that