### PR TITLE
[GHSA-cf6r-3wgc-h863] Polymorphic deserialization of malicious object in jackson-databind

### DIFF
--- a/advisories/github-reviewed/2020/05/GHSA-cf6r-3wgc-h863/GHSA-cf6r-3wgc-h863.json
+++ b/advisories/github-reviewed/2020/05/GHSA-cf6r-3wgc-h863/GHSA-cf6r-3wgc-h863.json
@@ -1,7 +1,7 @@
 {
-  "schema_version": "1.3.0",
+  "schema_version": "1.4.0",
   "id": "GHSA-cf6r-3wgc-h863",
-  "modified": "2023-02-15T22:06:38Z",
+  "modified": "2023-02-15T22:07:09Z",
   "published": "2020-05-15T18:58:58Z",
   "aliases": [
     "CVE-2019-14892"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -125,7 +125,7 @@
     "cwe_ids": [
       "CWE-502"
     ],
-    "severity": "HIGH",
+    "severity": "CRITICAL",
     "github_reviewed": true,
     "github_reviewed_at": "2020-04-23T19:29:41Z",
     "nvd_published_at": "2020-03-02T17:15:00Z"


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
Looks like this was using the CVSS:3.0 score from CNA instead of the CVSS:3.1 score from NVD. I think we'd want to use the 3.1 score over the 3.0