### PR TITLE
[GHSA-fwr7-v2mv-hh25] Prototype Pollution in async

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-fwr7-v2mv-hh25/GHSA-fwr7-v2mv-hh25.json
+++ b/advisories/github-reviewed/2022/04/GHSA-fwr7-v2mv-hh25/GHSA-fwr7-v2mv-hh25.json
@@ -1,7 +1,7 @@
 {
-  "schema_version": "1.3.0",
+  "schema_version": "1.4.0",
   "id": "GHSA-fwr7-v2mv-hh25",
-  "modified": "2023-01-23T18:54:18Z",
+  "modified": "2023-01-23T18:54:20Z",
   "published": "2022-04-07T00:00:17Z",
   "aliases": [
     "CVE-2021-43138"
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.0.0"
+              "introduced": "0"
             },
             {
               "fixed": "2.6.4"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Apologies as I couldn't find much information on this one, but the [NVD entry](https://nvd.nist.gov/vuln/detail/CVE-2021-43138) does suggest that prior to 2.x should be considered affected as well (I understand that isn't always particularly reliable though).  I did see [this comment](https://github.com/caolan/async/pull/1828#issuecomment-1098060430) which suggested perhaps the vulnerability doesn't actually apply to prior versions, but I wasn't really sure so would appreciate any help in verifying that.  Thanks for maintaining such a great dataset!