### PR TITLE
[GHSA-5hq7-j5wq-p227] feathers-sequelize vulnerable to SQL injection due to improper parameter filtering

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-5hq7-j5wq-p227/GHSA-5hq7-j5wq-p227.json
+++ b/advisories/github-reviewed/2022/10/GHSA-5hq7-j5wq-p227/GHSA-5hq7-j5wq-p227.json
@@ -1,7 +1,7 @@
 {
-  "schema_version": "1.3.0",
+  "schema_version": "1.4.0",
   "id": "GHSA-5hq7-j5wq-p227",
-  "modified": "2022-10-31T19:24:51Z",
+  "modified": "2023-02-03T05:01:28Z",
   "published": "2022-10-26T12:00:28Z",
   "aliases": [
     "CVE-2022-29822"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "6.0"
+              "introduced": "6.0.0"
             },
             {
               "fixed": "6.3.4"
@@ -43,14 +43,6 @@
     {
       "type": "WEB",
       "url": "https://github.com/feathersjs-ecosystem/feathers-sequelize/commit/0f2d85f0b2d556f2b6c70423dcebdbd29d95e3dc"
-    },
-    {
-      "type": "WEB",
-      "url": "https://csirt.divd.nl/CVE-2022-29822/"
-    },
-    {
-      "type": "WEB",
-      "url": "https://csirt.divd.nl/DIVD-2022-00020"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
* Removed two redundant references that both redirected to other, already cited csirt.divd.nl references
* The affected version was mistakenly listed as >= 6.0, whereas only >= 6.0.0 is semantically correct. See https://github.com/feathersjs-ecosystem/feathers-sequelize/releases/tag/v6.0.0 for reference.