### PR TITLE
[GHSA-w7q9-p3jq-fmhm] Uncontrolled resource consumption in jpeg-js

### DIFF
--- a/advisories/github-reviewed/2020/07/GHSA-w7q9-p3jq-fmhm/GHSA-w7q9-p3jq-fmhm.json
+++ b/advisories/github-reviewed/2020/07/GHSA-w7q9-p3jq-fmhm/GHSA-w7q9-p3jq-fmhm.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w7q9-p3jq-fmhm",
-  "modified": "2020-07-27T15:48:40Z",
+  "modified": "2023-01-09T05:03:32Z",
   "published": "2020-07-27T15:46:57Z",
   "aliases": [
     "CVE-2020-8175"
   ],
   "summary": "Uncontrolled resource consumption in jpeg-js",
-  "details": "Uncontrolled resource consumption in `jpeg-js` before 0.4.0 may allow attacker to launch denial of service attacks using specially a crafted JPEG image.",
+  "details": "Uncontrolled resource consumption in `jpeg-js` before 0.4.0 may allow attacker to launch denial of service attacks using specially a crafted JPEG image.\n\n",
   "severity": [
 
   ],


### PR DESCRIPTION
**Updates**
- Description

**Comments**
I don't use this dependeny. I am assuming it is being added transatively.

I have no idea which of my 1st level dependencies are the colupurits. The warning is useless