### PR TITLE
[GHSA-jh36-q97c-9928] Kubernetes vulnerable to validation bypass

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-jh36-q97c-9928/GHSA-jh36-q97c-9928.json
+++ b/advisories/github-reviewed/2023/03/GHSA-jh36-q97c-9928/GHSA-jh36-q97c-9928.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jh36-q97c-9928",
-  "modified": "2023-03-10T22:45:03Z",
+  "modified": "2023-03-13T13:25:39Z",
   "published": "2023-03-01T21:30:18Z",
   "aliases": [
     "CVE-2022-3294"
@@ -44,6 +44,25 @@
           "type": "ECOSYSTEM",
           "events": [
             {
+              "introduced": "1.22.0"
+            },
+            {
+              "fixed": "1.22.16"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/kubernetes/kubernetes"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
               "introduced": "1.24.0"
             },
             {
@@ -71,28 +90,6 @@
           ]
         }
       ]
-    },
-    {
-      "package": {
-        "ecosystem": "Go",
-        "name": "github.com/kubernetes/kubernetes"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "1.22.0"
-            },
-            {
-              "fixed": "1.222.16"
-            }
-          ]
-        }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 1.22.16"
-      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
fix version typo

this is the 2nd or 3rd version typo that's caused programmatic issues when reading GHSAs - recommend a static analysis check as part of acceptance to remove these errors