### PR TITLE
[GHSA-jjjh-jjxp-wpff] Uncontrolled Resource Consumption in Jackson-databind

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-jjjh-jjxp-wpff/GHSA-jjjh-jjxp-wpff.json
+++ b/advisories/github-reviewed/2022/10/GHSA-jjjh-jjxp-wpff/GHSA-jjjh-jjxp-wpff.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jjjh-jjxp-wpff",
-  "modified": "2022-11-14T21:43:05Z",
+  "modified": "2023-02-02T05:07:35Z",
   "published": "2022-10-03T00:00:31Z",
   "aliases": [
     "CVE-2022-42003"
   ],
   "summary": "Uncontrolled Resource Consumption in Jackson-databind",
-  "details": "In FasterXML jackson-databind before 2.12.7.1 and in 2.13.x before 2.13.4.1 resource exhaustion can occur because of a lack of a check in primitive value deserializers to avoid deep wrapper array nesting, when the UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled. This was patched in 2.12.7.1, 2.13.4.1, and 2.14.0.",
+  "details": "In FasterXML jackson-databind before 2.12.7.1 and in 2.13.x before 2.13.4.2 resource exhaustion can occur because of a lack of a check in primitive value deserializers to avoid deep wrapper array nesting, when the UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled. This was patched in 2.12.7.1, 2.13.4.2, and 2.14.0.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.12.7.1"
+              "fixed": "2.12.7.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.12.7.1"
+      }
     },
     {
       "package": {
@@ -47,11 +50,14 @@
               "introduced": "2.13.0"
             },
             {
-              "fixed": "2.13.4.1"
+              "fixed": "2.13.4.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.13.4.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Dear reviewer,

You will notice that the patched version is 2.13.4.2, the backport fix was applied at [cd09097](https://github.com/FasterXML/jackson-databind/commit/cd090979b7ea78c75e4de8a4aed04f7e9fa8deea) and tagged [here](https://github.com/FasterXML/jackson-databind/commit/ee316a03eb073fa7bbaf0933627fc24e05299f9e)

I hope that you consider this sufficient to update this advisory. 

Kind regards
^C