### PR TITLE
[GHSA-2wpw-75c5-m9hx] The Replyable WordPress plugin before 2.2.10 does not...

### DIFF
--- a/advisories/unreviewed/2023/03/GHSA-2wpw-75c5-m9hx/GHSA-2wpw-75c5-m9hx.json
+++ b/advisories/unreviewed/2023/03/GHSA-2wpw-75c5-m9hx/GHSA-2wpw-75c5-m9hx.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2wpw-75c5-m9hx",
-  "modified": "2023-03-11T06:30:17Z",
+  "modified": "2023-03-06T15:32:10Z",
   "published": "2023-03-06T15:30:42Z",
   "aliases": [
     "CVE-2022-4265"
   ],
-  "details": "The Replyable WordPress plugin before 2.2.10 does not validate the class name submitted by the request when instantiating an object in the prompt_dismiss_notice action and also lacks CSRF check in the related action. This could allow any authenticated users, such as subscriber to perform Object Injection attacks. The attack could also be done via a CSRF vector against any authenticated user",
+  "summary": "WordPress Postmatic Plugin < 2.2.10 is vulnerable to PHP Object Injection and CSRF",
+  "details": "The Replyable WordPress plugin before 2.2.10 does not validate the class name submitted by the request when instantiating an object in the prompt_dismiss_notice action and also lacks CSRF check in the related action. This could allow any authenticated users, such as subscriber to perform Object Injection attacks. The attack could also be done via a CSRF vector against any authenticated user.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.2.10"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,12 +42,29 @@
     },
     {
       "type": "WEB",
+      "url": "https://patchstack.com/database/vulnerability/postmatic/wordpress-replyable-plugin-2-2-10-subscriber-php-object-injection-vulnerability"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&old=2831668%40postmatic&new=2831668%40postmatic&sfp_email=&sfph_mail="
+    },
+    {
+      "type": "WEB",
+      "url": "https://replyable.com/start/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://wordpress.org/plugins/postmatic/"
+    },
+    {
+      "type": "WEB",
       "url": "https://wpscan.com/vulnerability/095cba08-7edd-41fb-9776-da151c0885dd"
     }
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-352"
+      "CWE-352",
+      "CWE-502"
     ],
     "severity": "HIGH",
     "github_reviewed": false,


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- References
- Severity
- Source code location
- Summary

**Comments**
The plugin appears to have been patched to deal with at least the deserialization issue. I've added references to the updated source and other CNAs' reports.