### PR TITLE
[GHSA-933g-v89r-x8pf] Apache Dubbo vulnerable to Deserialization of Untrusted Data

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-933g-v89r-x8pf/GHSA-933g-v89r-x8pf.json
+++ b/advisories/github-reviewed/2023/03/GHSA-933g-v89r-x8pf/GHSA-933g-v89r-x8pf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-933g-v89r-x8pf",
-  "modified": "2023-03-14T19:59:10Z",
+  "modified": "2023-03-14T19:59:11Z",
   "published": "2023-03-08T12:30:16Z",
   "aliases": [
     "CVE-2023-23638"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.7.21"
+              "fixed": "2.7.22"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.7.21"
+      }
     },
     {
       "package": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
2.7.22 contains the fix for the CVE.