### PR TITLE
[GHSA-4wrc-f8pq-fpqp] Pivotal Spring Framework contains unsafe Java deserialization methods

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4wrc-f8pq-fpqp/GHSA-4wrc-f8pq-fpqp.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4wrc-f8pq-fpqp/GHSA-4wrc-f8pq-fpqp.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4wrc-f8pq-fpqp",
-  "modified": "2022-12-09T22:02:19Z",
+  "modified": "2023-02-02T05:02:46Z",
   "published": "2022-05-24T17:05:30Z",
   "aliases": [
     "CVE-2016-1000027"
   ],
-  "summary": "Pivotal Spring Framework contains unsafe Java deserialization methods",
-  "details": "Pivotal Spring Framework before 6.0.0 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data. Depending on how the library is implemented within a product, this issue may or not occur, and authentication may be required.\n\nMaintainers recommend investigating alternative components or a potential mitigating control. Version 4.2.6 and 3.2.17 contain [enhanced documentation](https://github.com/spring-projects/spring-framework/commit/5cbe90b2cd91b866a5a9586e460f311860e11cfa) advising users to take precautions against unsafe Java deserialization, and version 6.0.0 and above [deprecate the impacted classes](https://github.com/spring-projects/spring-framework/commit/2b051b8b321768a4cfef83077db65c6328ffd60f). ",
+  "summary": "Spring Framework contains unsafe Java deserialization methods",
+  "details": "Spring Framework before 6.0.0 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data. Depending on how the library is implemented within a product, this issue may or not occur, and authentication may be required.\n\nMaintainers recommend investigating alternative components or a potential mitigating control. Version 4.2.6 and 3.2.17 contain [enhanced documentation](https://github.com/spring-projects/spring-framework/commit/5cbe90b2cd91b866a5a9586e460f311860e11cfa) advising users to take precautions against unsafe Java deserialization, version 5.3.0 [deprecate the impacted classes](https://github.com/spring-projects/spring-framework/issues/25379) and version 6.0.0 [removed it entirely](https://github.com/spring-projects/spring-framework/issues/27422). ",
   "severity": [
 
   ],


### PR DESCRIPTION
**Updates**
- Description
- Summary

**Comments**
The offending feature has been deprecated much earlier than 6.0; 6.0 actually removes the feature. Replaced commit links with actual issue links to document that.