### PR TITLE
[GHSA-8mw8-j583-vqfg] RubyGems passenger 4.0.0 betas 1 and 2 allows remote...

### DIFF
--- a/advisories/unreviewed/2022/04/GHSA-8mw8-j583-vqfg/GHSA-8mw8-j583-vqfg.json
+++ b/advisories/unreviewed/2022/04/GHSA-8mw8-j583-vqfg/GHSA-8mw8-j583-vqfg.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8mw8-j583-vqfg",
-  "modified": "2022-04-23T00:40:14Z",
+  "modified": "2023-01-27T05:01:59Z",
   "published": "2022-04-23T00:40:14Z",
   "aliases": [
     "CVE-2012-6135"
   ],
-  "details": "RubyGems passenger 4.0.0 betas 1 and 2 allows remote attackers to delete arbitrary files during the startup process.",
+  "summary": "RubyGems passenger gem allows remote attackers to delete files",
+  "details": "RubyGems passenger 4.0.0 betas 1 and 2 allows remote attackers to delete arbitrary files during the startup process.\n\nAffects both open source and Enterprise versions (4.0.0.beta1, 4.0.0.beta2).",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "passenger"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.0.0.rc4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2012-6135"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/phusion/passenger/commit/8c6693e0818772c345c979840d28312c2edd4ba4#commitcomment-2643541"
     },
     {
       "type": "WEB",
@@ -25,6 +51,10 @@
     {
       "type": "WEB",
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/82533"
+    },
+    {
+      "type": "WEB",
+      "url": "https://old.blog.phusion.nl/2013/03/05/phusion-passenger-4-0-beta-1-and-2-arbitrary-file-deletion-vulnerability"
     },
     {
       "type": "WEB",
@@ -41,9 +71,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-20"
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2019-11-19T17:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- References
- Severity
- Source code location
- Summary

**Comments**
More research - in support of ruby-advisory-db project.

NOTE: Unclear how to enter 4.0.0.beta1 and 4.0.0.beta2 for "Affected Versions" - treated as invalid.