### PR TITLE
[GHSA-49jx-9cmc-xjxm] Bundler before 1.7, when multiple top-level source lines...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-49jx-9cmc-xjxm/GHSA-49jx-9cmc-xjxm.json
+++ b/advisories/unreviewed/2022/05/GHSA-49jx-9cmc-xjxm/GHSA-49jx-9cmc-xjxm.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-49jx-9cmc-xjxm",
-  "modified": "2022-05-05T02:48:48Z",
+  "modified": "2023-02-01T05:02:02Z",
   "published": "2022-05-05T02:48:48Z",
   "aliases": [
     "CVE-2013-0334"
   ],
+  "summary": "Bundler may install gems from a different source than expected",
   "details": "Bundler before 1.7, when multiple top-level source lines are used, allows remote attackers to install arbitrary gems by creating a gem with the same name as another gem in a different source.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "bundler"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 1.7.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.7.0"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-0334"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/rubygems/bundler"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
More research 

NVD link give CVSS_V2 as 5.0.