### PR TITLE
GHSA-chw2-6c7r-37p7: add fixed version

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-chw2-6c7r-37p7/GHSA-chw2-6c7r-37p7.json
+++ b/advisories/github-reviewed/2022/08/GHSA-chw2-6c7r-37p7/GHSA-chw2-6c7r-37p7.json
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": ""
+              "fixed": "22.9.0"
             }
           ]
         }


### PR DESCRIPTION
> A fix is available on the main branch of the repository.

https://github.com/litejs/uri-template-lite/commit/cbeec2b2a275d819fb534137a155df14729706f8 > https://github.com/litejs/uri-template-lite/commits/v22.9.0