### PR TITLE
[GHSA-7rpj-hg47-cx62] Improper Restriction of XML External Entity Reference in com.h2database:h2.

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-7rpj-hg47-cx62/GHSA-7rpj-hg47-cx62.json
+++ b/advisories/github-reviewed/2021/12/GHSA-7rpj-hg47-cx62/GHSA-7rpj-hg47-cx62.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7rpj-hg47-cx62",
-  "modified": "2022-04-15T19:43:21Z",
+  "modified": "2023-02-01T05:07:03Z",
   "published": "2021-12-16T14:29:57Z",
   "aliases": [
     "CVE-2021-23463"
   ],
   "summary": "Improper Restriction of XML External Entity Reference in com.h2database:h2.",
-  "details": "H2 is an embeddable RDBMS written in Java. The package com.h2database:h2 from 0 and before 2.0.202 are vulnerable to XML External Entity (XXE) Injection via the org.h2.jdbc.JdbcSQLXML class object, when it receives parsed string data from org.h2.jdbc.JdbcResultSet.getSQLXML() method. If it executes the getSource() method when the parameter is DOMSource.class it will trigger the vulnerability.",
+  "details": "H2 is an embeddable RDBMS written in Java. The package com.h2database:h2 from 1.4.198 and before 2.0.202 are vulnerable to XML External Entity (XXE) Injection via the org.h2.jdbc.JdbcSQLXML class object, when it receives parsed string data from org.h2.jdbc.JdbcResultSet.getSQLXML() method. If it executes the getSource() method when the parameter is DOMSource.class it will trigger the vulnerability.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.4.198"
             },
             {
               "fixed": "2.0.202"
@@ -50,6 +50,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/h2database/h2database/pull/3199#issuecomment-1002830390"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/h2database/h2database/commit/d83285fd2e48fb075780ee95badee6f5a15ea7f8%23diff-008c2e4462609982199cd83e7cf6f1d6b41296b516783f6752c44b9f15dc7bc3"
     },
     {
@@ -59,10 +63,6 @@
     {
       "type": "WEB",
       "url": "https://snyk.io/vuln/SNYK-JAVA-COMH2DATABASE-1769238"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpuapr2022.html"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
the first affected version is 1.4.198 (as of 1/03/2022)
see: 
- https://nvd.nist.gov/vuln/detail/CVE-2021-23463
- https://github.com/h2database/h2database/pull/3199#issuecomment-1002830390

The removed Oracle link was designated as "not applicable" and removed on 4/28/2022