### PR TITLE
Adding sources of advisories to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ You can submit a pull request to this database (see, [`Contributions`](#contribu
 
 Pull requests will be reviewed and either merged or closed by our internal security advisory curation team. If the advisory originated from a GitHub repository, we will also @mention the original publisher for optional commentary. 
 
+## Sources 
+
+We add advisories to the GitHub Advisory Database from the following sources:
+
+- [Security advisories reported on GitHub](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/about-repository-security-advisories)
+- The [National Vulnerability Database](https://nvd.nist.gov/)
+- The [npm Security Advisories Database](https://github.com/advisories?query=type%3Areviewed+ecosystem%3Anpm)
+- The [FriendsOfPHP Database](https://github.com/FriendsOfPHP/security-advisories)
+- The [Go Vulnerability Database](https://vuln.go.dev/)
+- The [Python Packaging Advisory Database](https://github.com/pypa/advisory-database)
+- The [Ruby Advisory Database](https://rubysec.com/)
+- The [RustSec Advisory Database](https://rustsec.org/)
+- [Community contributions to this repository](https://github.com/github/advisory-database/pulls)
+
+If you know of another database we should be importing advisories from, tell us about it by [opening an issue in this repository](https://github.com/github/advisory-database/issues). 
+
 ## Contributions
 
 There are two ways to contribute to the information provided in this repository. 


### PR DESCRIPTION
Wording modeled after GitHub docs: https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/about-repository-security-advisories