### PR TITLE
[GHSA-xrqq-wqh4-5hg2] svg-sanitizer has Cross-site Scripting Bypass

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-xrqq-wqh4-5hg2/GHSA-xrqq-wqh4-5hg2.json
+++ b/advisories/github-reviewed/2023/03/GHSA-xrqq-wqh4-5hg2/GHSA-xrqq-wqh4-5hg2.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xrqq-wqh4-5hg2",
-  "modified": "2023-03-20T20:44:30Z",
+  "modified": "2023-03-20T20:44:31Z",
   "published": "2023-03-20T20:44:30Z",
   "aliases": [
     "CVE-2023-28426"
   ],
   "summary": "svg-sanitizer has Cross-site Scripting Bypass",
-  "details": "A bypass has been found that allows an attacker to upload an SVG with persistent XSS.\n\nHTML elements within CDATA needed to be sanitized correctly, as we were converting them to a textnode and therefore, the library wasn't seeing them as DOM elements.\n\nAny data within a CDATA node will now be sanitised using [HTMLPurifier](https://github.com/ezyang/htmlpurifier). We've also removed many of the HTML and MathML elements from the allowed element list, as without `ForiegnObject`, they're not legal within the SVG context. \n\nAdditional tests have been added to the test suite to account for these new bypasses.\n\n### Impact\nThis impacts all users of the `svg-sanitizer` library.\n\n### Patches\nThis issue is fixed in 0.16.0 and higher.\n\n### Workarounds\nThere is currently no workaround available without upgrading.\n\n### For more information\nIf you have any questions or comments about this advisory:\n\nOpen an issue in [Github](https://github.com/darylldoyle/svg-sanitizer/issues)\nEmail us at [daryll@enshrined.co.uk](mailto:daryll@enshrined.co.uk)",
+  "details": "## Rejected CVE (according to [cve.mitre.org](https://cve.mitre.org/cve/list_rules_and_guidance/correcting_counting_issues.html))\n\nInvestigations on the behavior of `v0.15.4` of the composer package `enshrined/svg-sanitize` revealed, that there was no cross-site scripting vulnerability. CVE-2023-28426 was a false-positive and is rejected to declare `v0.15.4` of the package as secure again.\n\n**References:**\n\n* General Discussion & Investigation: https://github.com/darylldoyle/svg-sanitizer/issues/88\n* Confirmation by both maintainer and original reporter: https://github.com/darylldoyle/svg-sanitizer/issues/88#issuecomment-1478380628 & https://github.com/darylldoyle/svg-sanitizer/issues/88#issuecomment-1478268038\n\n---\n\n## Original Advisory\n\nA bypass has been found that allows an attacker to upload an SVG with persistent XSS.\n\nHTML elements within CDATA needed to be sanitized correctly, as we were converting them to a textnode and therefore, the library wasn't seeing them as DOM elements.\n\nAny data within a CDATA node will now be sanitised using [HTMLPurifier](https://github.com/ezyang/htmlpurifier). We've also removed many of the HTML and MathML elements from the allowed element list, as without `ForiegnObject`, they're not legal within the SVG context. \n\nAdditional tests have been added to the test suite to account for these new bypasses.\n\n### Impact\nThis impacts all users of the `svg-sanitizer` library.\n\n### Patches\nThis issue is fixed in 0.16.0 and higher.\n\n### Workarounds\nThere is currently no workaround available without upgrading.\n\n### For more information\nIf you have any questions or comments about this advisory:\n\nOpen an issue in [Github](https://github.com/darylldoyle/svg-sanitizer/issues)\nEmail us at [daryll@enshrined.co.uk](mailto:daryll@enshrined.co.uk)",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.16.0"
+              "fixed": "0.0.0"
             }
           ]
         }
@@ -55,9 +55,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-79"
+
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2023-03-20T20:44:30Z",
     "nvd_published_at": "2023-03-20T14:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity

**Comments**
The assigned CVE is a false-positive, the described cross-site scripting vulnerability of `v0.15.4` of the package is invalid. Please reject the corresponding CVE in order to resolve current issues with Dependabot, packagist.org and the `roave/security-advisories` package (which all use GitHub advisories as their source of truth). Investigations are available at https://github.com/darylldoyle/svg-sanitizer/issues/88