### PR TITLE
[GHSA-jwpw-q68h-r678] Improper Neutralization of CRLF Sequences in dio

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-jwpw-q68h-r678/GHSA-jwpw-q68h-r678.json
+++ b/advisories/github-reviewed/2022/05/GHSA-jwpw-q68h-r678/GHSA-jwpw-q68h-r678.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jwpw-q68h-r678",
-  "modified": "2023-03-22T12:17:25Z",
+  "modified": "2023-03-22T12:17:26Z",
   "published": "2022-05-24T17:47:44Z",
   "aliases": [
 
   ],
   "summary": "Improper Neutralization of CRLF Sequences in dio",
-  "details": "The dio package prior to 5.0.0 for Dart allows CRLF injection if the attacker controls the HTTP method string, a different vulnerability than CVE-2020-35669.",
+  "details": "The dio package 4.0.0 for Dart allows CRLF injection if the attacker controls the HTTP method string, a different vulnerability than CVE-2020-35669.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -45,8 +45,16 @@
       "url": "https://github.com/flutterchina/dio/issues/1130"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/cfug/dio/commit/927f79e93ba39f3c3a12c190624a55653d577984"
+    },
+    {
       "type": "PACKAGE",
-      "url": "https://github.com/flutterchina/dio"
+      "url": "https://github.com/cfug/dio"
+    },
+    {
+      "type": "WEB",
+      "url": "https://osv.dev/GHSA-jwpw-q68h-r678"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
This is actually a duplicate of GHSA-9324-jv53-9cc8, can we merge these as the same one? Also can we link this to the repo if they are not available for merge?