### PR TITLE
[GHSA-x5r6-x823-9848] Arbitrary Code Execution in json-ptr

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-x5r6-x823-9848/GHSA-x5r6-x823-9848.json
+++ b/advisories/github-reviewed/2021/05/GHSA-x5r6-x823-9848/GHSA-x5r6-x823-9848.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x5r6-x823-9848",
-  "modified": "2021-05-26T19:58:35Z",
+  "modified": "2023-01-27T05:07:36Z",
   "published": "2021-05-10T19:15:43Z",
   "aliases": [
     "CVE-2020-7766"
   ],
   "summary": "Arbitrary Code Execution in json-ptr",
-  "details": "npm `json-ptr` before 2.0.0 has an arbitrary code execution vulnerability. The issue occurs in the set operation (https://flitbit.github.io/json-ptr/classes/_src_pointer_.jsonpointer.htmlset) when the force flag is set to true. The function recursively set the property in the target object, however it does not properly check the key being set, leading to a prototype pollution.",
+  "details": "npm `json-ptr` before 2.1.0 has an arbitrary code execution vulnerability. The issue occurs in the set operation (https://flitbit.github.io/json-ptr/classes/_src_pointer_.jsonpointer.htmlset) when the force flag is set to true. The function recursively set the property in the target object, however it does not properly check the key being set, leading to a prototype pollution.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.0.0"
+              "fixed": "2.1.0"
             }
           ]
         }
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/418sec/json-ptr/pull/3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/flitbit/json-ptr/commit/2539e3494c80af1eef24f0f433654a61f255f011"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
The affected version is incorrect. It should be <2.1.0

When reviewing the pull (https://github.com/418sec/json-ptr/pull/3), the comment "Fixed in v2.1.0 and above." denotes when the fix occurred. 

Additionally, the apply for the fix: "I went ahead applied the fix for flitbit#30 (Eli's alternative), which also fixes flitbit#28, supplied the missing tests, and I put it in a branch in the underlying repo, which was slightly ahead of your fork (I had already updated dependencies to address other security warnings)." 

This confirms the following patch link: https://github.com/flitbit/json-ptr/commit/2539e3494c80af1eef24f0f433654a61f255f011, which is present here: https://github.com/flitbit/json-ptr/compare/v2.0.0...v2.1.0 between v2.0.0 and v2.1.0.