### PR TITLE
[GHSA-xmr7-v725-2jjr] XSS in comrak

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-xmr7-v725-2jjr/GHSA-xmr7-v725-2jjr.json
+++ b/advisories/github-reviewed/2021/08/GHSA-xmr7-v725-2jjr/GHSA-xmr7-v725-2jjr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xmr7-v725-2jjr",
-  "modified": "2021-08-19T17:34:25Z",
+  "modified": "2023-01-11T05:05:38Z",
   "published": "2021-08-25T20:52:12Z",
   "aliases": [
     "CVE-2021-27671"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-27671"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/kivikakk/comrak/commit/b3efbb6e427bcd33bb14db45753ad4fd98e0f5bf"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for the advisory (https://github.com/kivikakk/comrak/commit/b3efbb6e427bcd33bb14db45753ad4fd98e0f5bf).

As mentioned in the changelog (https://github.com/kivikakk/comrak/releases/tag/0.9.1): "SECURITY: we were matching unsafe URL prefixes, such as data: or javascript:, in a case-sensitive manner. This meant prefixes like Data: were untouched. Please upgrade as soon as possible. (Kouhei Morita)"