### PR TITLE
[GHSA-cqqj-4p63-rrmm] HTTP Request Smuggling in Netty

### DIFF
--- a/advisories/github-reviewed/2020/02/GHSA-cqqj-4p63-rrmm/GHSA-cqqj-4p63-rrmm.json
+++ b/advisories/github-reviewed/2020/02/GHSA-cqqj-4p63-rrmm/GHSA-cqqj-4p63-rrmm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cqqj-4p63-rrmm",
-  "modified": "2021-08-25T17:26:45Z",
+  "modified": "2023-02-01T05:02:46Z",
   "published": "2020-02-21T18:55:24Z",
   "aliases": [
     "CVE-2019-20444"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "io.netty:netty-handler"
+        "name": "io.netty:netty-codec-http"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
User submitted issue here: https://github.com/github/advisory-database/issues/1809#issue-1635568293

"the affected package is incorrect. the file that's edited in the patch commit (https://github.com/netty/netty/pull/9871/files#diff-e26989b9171ef22c27c9f7d80689cfb059d568c9bd10e75970d96c02d0654878) is of the package io.netty:netty-codec-http and not io.netty:netty-handler as currently mapped."