### PR TITLE
[GHSA-2q4h-h5jp-942w] Firejail before 0.9.64.4 allows attackers to bypass...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-2q4h-h5jp-942w/GHSA-2q4h-h5jp-942w.json
+++ b/advisories/unreviewed/2022/05/GHSA-2q4h-h5jp-942w/GHSA-2q4h-h5jp-942w.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2q4h-h5jp-942w",
-  "modified": "2022-05-24T17:41:21Z",
+  "modified": "2023-01-29T05:05:37Z",
   "published": "2022-05-24T17:41:21Z",
   "aliases": [
     "CVE-2021-26910"
   ],
-  "details": "Firejail before 0.9.64.4 allows attackers to bypass intended access restrictions because there is a TOCTOU race condition between a stat operation and an OverlayFS mount operation.",
+  "summary": "Firejail Privilege Escalation from outside of the sandbox (OverlayFS)",
+  "details": "Firejail before 0.9.64.4 allows attackers to bypass intended access restrictions because there is a TOCTOU race condition between a stat operation and an OverlayFS mount operation.\n\nAffected versions:\n\n* 0.9.64.2 and lower\n\nPatched versions:\n\n* 0.9.64.4\n* 0.9.66 and higher\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,7 +15,22 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -27,7 +43,23 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/netblue30/firejail/commit/fb9f2a5fb3ac1ebbb14302ecdf3c840b70b090da"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/netblue30/firejail"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/netblue30/firejail/discussions/4178"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/netblue30/firejail/releases/tag/0.9.64.4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/netblue30/firejail/releases/tag/0.9.66"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Source code location
- Summary

**Comments**
Add a few more relevant links and extend the description