### PR TITLE
[GHSA-wg72-3rf2-wvp5] api/views/user.py in LibrePhotos before e19e539 has...

### DIFF
--- a/advisories/unreviewed/2023/01/GHSA-wg72-3rf2-wvp5/GHSA-wg72-3rf2-wvp5.json
+++ b/advisories/unreviewed/2023/01/GHSA-wg72-3rf2-wvp5/GHSA-wg72-3rf2-wvp5.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wg72-3rf2-wvp5",
-  "modified": "2023-01-13T18:30:19Z",
+  "modified": "2023-01-29T05:03:27Z",
   "published": "2023-01-10T06:30:25Z",
   "aliases": [
     "CVE-2023-22903"
   ],
-  "details": "api/views/user.py in LibrePhotos before e19e539 has incorrect access control.",
+  "summary": "LibrePhotos Information Discolsure Vulnerbility",
+  "details": "api/views/user.py in LibrePhotos before e19e539 has incorrect access control.\n\nIn 2022-Q2, Librephotos, an open-source self-hosted photo cloud solution, introduced a Remote Information Disclosure Vulnerability. This allowed an attacker to obtain a list of users’: Full name, Email address, Photo count, Nextcloud Configuration and various other data points. Software versions between 2022w19 to 2022w50, released in December 2022, are vulnerable to this attack.\n\nPatched in: 2023w08",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,7 +15,22 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -24,11 +40,19 @@
     {
       "type": "WEB",
       "url": "https://github.com/LibrePhotos/librephotos/commit/e19e539356df77f6f59e7d1eea22d452b268e120"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/LibrePhotos/librephotos"
+    },
+    {
+      "type": "WEB",
+      "url": "https://raw.githubusercontent.com/go-compile/security-advisories/master/CVE-2023-22903.pdf"
     }
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-284"
     ],
     "severity": "CRITICAL",
     "github_reviewed": false,


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- Description
- References
- Source code location
- Summary

**Comments**
Linking to public advisory: https://raw.githubusercontent.com/go-compile/security-advisories/master/CVE-2023-22903.pdf