### PR TITLE
[GHSA-5mgj-mvv8-46mw] RubyGems before 1.8.23 does not verify an SSL certificate...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5mgj-mvv8-46mw/GHSA-5mgj-mvv8-46mw.json
+++ b/advisories/unreviewed/2022/05/GHSA-5mgj-mvv8-46mw/GHSA-5mgj-mvv8-46mw.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5mgj-mvv8-46mw",
-  "modified": "2022-05-17T04:54:47Z",
+  "modified": "2023-01-28T05:02:47Z",
   "published": "2022-05-17T04:54:47Z",
   "aliases": [
     "CVE-2012-2126"
   ],
+  "summary": "'CVE-2012-2125 CVE-2012-2126 rubygems: Two security fixes in v1.8.23'",
   "details": "RubyGems before 1.8.23 does not verify an SSL certificate, which allows remote attackers to modify a gem during installation via a man-in-the-middle attack.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "rubygems"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 1.8.23"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -21,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=814718"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/rubygems/rubygems"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
More research - contacting the dots in the URLs above plus ruby-advisory-db project.