### PR TITLE
[GHSA-jmhh-w7xp-wg39] Nokogiri gem 1.5.x and 1.6.x has DoS while parsing XML...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-jmhh-w7xp-wg39/GHSA-jmhh-w7xp-wg39.json
+++ b/advisories/unreviewed/2022/05/GHSA-jmhh-w7xp-wg39/GHSA-jmhh-w7xp-wg39.json
@@ -1,17 +1,58 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jmhh-w7xp-wg39",
-  "modified": "2022-05-05T00:29:01Z",
+  "modified": "2023-02-01T05:01:48Z",
   "published": "2022-05-05T00:29:01Z",
   "aliases": [
     "CVE-2013-6461"
   ],
+  "summary": "CVE-2013-6461 rubygem-nokogiri: DoS while parsing XML entities",
   "details": "Nokogiri gem 1.5.x and 1.6.x has DoS while parsing XML entities by failing to apply limits",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "nokogiri"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "~> 1.5.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "nokogiri"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 1.6.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -31,6 +72,10 @@
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/90059"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/sparklemotion/nokogiri"
+    },
+    {
       "type": "WEB",
       "url": "https://security-tracker.debian.org/tracker/CVE-2013-6461"
     },
@@ -47,7 +92,7 @@
     "cwe_ids": [
       "CWE-776"
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2019-11-05T15:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Source code location
- Summary

**Comments**
More research - contacting the dots in the URLs above plus ruby-advisory-db project.
