### PR TITLE
[GHSA-95xq-v4m2-fq3r] The Grit gem for Ruby, as used in GitLab 5.2 before 5.4.1...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-95xq-v4m2-fq3r/GHSA-95xq-v4m2-fq3r.json
+++ b/advisories/unreviewed/2022/05/GHSA-95xq-v4m2-fq3r/GHSA-95xq-v4m2-fq3r.json
@@ -1,22 +1,45 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-95xq-v4m2-fq3r",
-  "modified": "2022-05-17T04:43:33Z",
+  "modified": "2023-01-28T05:02:21Z",
   "published": "2022-05-17T04:43:33Z",
   "aliases": [
     "CVE-2013-4489"
   ],
-  "details": "The Grit gem for Ruby, as used in GitLab 5.2 before 5.4.1 and 6.x before 6.2.3, allows remote authenticated users to execute arbitrary commands, as demonstrated by the search box for the GitLab code search feature.",
+  "summary": "GitLab Grit Gem for Ruby contains a flaw allowing arbitrary commands to be executed",
+  "details": "The Grit gem for Ruby, as used in GitLab 5.2 before 5.4.1 and 6.x before 6.2.3, allows remote authenticated users to execute arbitrary commands, as demonstrated by the search box for the GitLab code search feature.\n\nGitLab Grit Gem for Ruby contains a flaw in the app/contexts/search_context.rb\nscript. The issue is triggered when input passed via the code search box is not\nproperly sanitized, which allows strings to be evaluated by the Bourne shell. This\nmay allow a remote attacker to execute arbitrary commands.\n\nFound this on GitHub's repo: \"**Grit is no longer maintained. Check out libgit2/rugged.**\"\n\n",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "grit"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 2.6.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-4489"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/mojombo/grit"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location
- Summary

**Comments**
More research - contacting the dots in the URLs above plus ruby-advisory-db project.
