### PR TITLE
[GHSA-qfwq-chf4-jvwg] The karo gem 2.3.8 for Ruby allows Remote command...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-qfwq-chf4-jvwg/GHSA-qfwq-chf4-jvwg.json
+++ b/advisories/unreviewed/2022/05/GHSA-qfwq-chf4-jvwg/GHSA-qfwq-chf4-jvwg.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qfwq-chf4-jvwg",
-  "modified": "2022-05-14T01:49:44Z",
+  "modified": "2023-02-02T05:04:23Z",
   "published": "2022-05-14T01:49:44Z",
   "aliases": [
     "CVE-2014-10075"
   ],
-  "details": "The karo gem 2.3.8 for Ruby allows Remote command injection via the host field.",
+  "summary": "karo Gem for Ruby db.rb Metacharacter Handling Remote Command Execution",
+  "details": "The karo gem 2.3.8 for Ruby allows Remote command injection via the host field.\n\nkaro Gem for Ruby contains a flaw in db.rb that is triggered when handling\nmetacharacters. This may allow a remote attacker to execute arbitrary\ncommands.\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,12 +15,38 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "karo"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 2.3.9"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-10075"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/rahult/karo"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rahult/karo/blob/master/CHANGELOG.md"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Source code location
- Summary

**Comments**
More research - contacting the dots in the URLs above plus ruby-advisory-db project.
Unclear exactly what release fixed this vulnerability.