### PR TITLE
[GHSA-m7w4-q5vg-5xfp] Mattermost subject to Denial of Service via upload of special GIF

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-m7w4-q5vg-5xfp/GHSA-m7w4-q5vg-5xfp.json
+++ b/advisories/github-reviewed/2022/09/GHSA-m7w4-q5vg-5xfp/GHSA-m7w4-q5vg-5xfp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m7w4-q5vg-5xfp",
-  "modified": "2022-09-28T14:14:03Z",
+  "modified": "2023-01-27T05:07:16Z",
   "published": "2022-09-25T00:00:21Z",
   "aliases": [
     "CVE-2022-3257"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "https://pkg.go.dev/github.com/mattermost/mattermost-server/v6"
+        "name": "github.com/mattermost/mattermost-server/v6"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Using the actual package import path so that scanners can find this package.

the actual import path is `github.com/mattermost/mattermost-server/v6` as shown [here](https://github.com/mattermost/mattermost-server/blob/master/go.mod)