### PR TITLE
[GHSA-34fr-fhqr-7235] Information Disclosure in User Authentication

### DIFF
--- a/advisories/github-reviewed/2021/07/GHSA-34fr-fhqr-7235/GHSA-34fr-fhqr-7235.json
+++ b/advisories/github-reviewed/2021/07/GHSA-34fr-fhqr-7235/GHSA-34fr-fhqr-7235.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-34fr-fhqr-7235",
-  "modified": "2021-08-31T21:23:03Z",
+  "modified": "2023-02-01T05:05:50Z",
   "published": "2021-07-26T21:16:28Z",
   "aliases": [
     "CVE-2021-32767"
@@ -123,6 +123,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-32767"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/TYPO3/typo3/commit/0b4950163b8919451964133febc65bcdfcec721c"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link (https://github.com/TYPO3/typo3/commit/0b4950163b8919451964133febc65bcdfcec721c) for the advisory. 

The CVE is in the commit message: 
Resolves: #93925
Releases: master, 11.3, 10.4, 9.5
Change-Id: I8c610a72014de571ef52b4430c43f8d149b273d9
Security-Bulletin: CORE-SA-2021-012
Security-References: CVE-2021-32767
