### PR TITLE
[GHSA-458f-26r3-x2c3] Cross-site Scripting in github.com/schollz/rwtxt

### DIFF
--- a/advisories/github-reviewed/2021/11/GHSA-458f-26r3-x2c3/GHSA-458f-26r3-x2c3.json
+++ b/advisories/github-reviewed/2021/11/GHSA-458f-26r3-x2c3/GHSA-458f-26r3-x2c3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-458f-26r3-x2c3",
-  "modified": "2021-11-25T00:24:32Z",
+  "modified": "2023-02-01T05:06:42Z",
   "published": "2021-11-29T18:00:21Z",
   "aliases": [
     "CVE-2021-20848"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-20848"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/schollz/rwtxt/commit/c09fb17375c4c47b49524c688288af1fe20e730a"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link (https://github.com/schollz/rwtxt/commit/c09fb17375c4c47b49524c688288af1fe20e730a)

In the commit, the developer started to introduce bluemonday.UGCPolicy().Sanitize, which is specifically designed to scrub user-generated content of XSS. More info here on the sanitization function: https://github.com/microcosm-cc/bluemonday.

Additionally, this was the only commit within the history related to XSS.