### PR TITLE
[GHSA-45xm-v8gq-7jqx] Excessive memory allocation

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-45xm-v8gq-7jqx/GHSA-45xm-v8gq-7jqx.json
+++ b/advisories/github-reviewed/2018/10/GHSA-45xm-v8gq-7jqx/GHSA-45xm-v8gq-7jqx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-45xm-v8gq-7jqx",
-  "modified": "2022-04-25T20:23:45Z",
+  "modified": "2023-02-01T05:03:20Z",
   "published": "2018-10-17T16:19:59Z",
   "aliases": [
     "CVE-2018-12541"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/eclipse-vertx/vert.x/issues/2648"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/eclipse-vertx/vert.x/commit/269a583330695d1418a4f5578f7169350b2e1332"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link (https://github.com/eclipse-vertx/vert.x/commit/269a583330695d1418a4f5578f7169350b2e1332)

The CVE is in the commit message and references the same issue link (2648): "CVE-2018-12541: When a WebSocket upgrade has a body > 8192 send an appropriate response immediately and close the connection afterward. - fixes #2648"