### PR TITLE
[GHSA-46m8-42hm-wvvw] Cross-Site Scripting in emojione

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-46m8-42hm-wvvw/GHSA-46m8-42hm-wvvw.json
+++ b/advisories/github-reviewed/2020/09/GHSA-46m8-42hm-wvvw/GHSA-46m8-42hm-wvvw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-46m8-42hm-wvvw",
-  "modified": "2021-09-23T21:33:00Z",
+  "modified": "2023-01-09T05:03:33Z",
   "published": "2020-09-01T15:34:16Z",
   "aliases": [
     "CVE-2016-1000231"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/Ranks/emojione/issues/61"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/joypixels/emojione/commit/613079b16c00e47fb3c44744a67ed88a9295afb1"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link (https://github.com/joypixels/emojione/commit/613079b16c00e47fb3c44744a67ed88a9295afb1)

Issue 61 (https://github.com/joypixels/emojione/issues/61) recommends how to update the escaping function. In the commit (https://github.com/joypixels/emojione/commit/613079b16c00e47fb3c44744a67ed88a9295afb1), it's a replication of the advice in the issue to resolve the XSS vulnerability. 