### PR TITLE
[GHSA-558x-2xjg-6232] Allocation of Resources Without Limits or Throttling in Spring Framework

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-558x-2xjg-6232/GHSA-558x-2xjg-6232.json
+++ b/advisories/github-reviewed/2022/04/GHSA-558x-2xjg-6232/GHSA-558x-2xjg-6232.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-558x-2xjg-6232",
-  "modified": "2022-04-12T15:23:52Z",
+  "modified": "2023-01-27T05:01:31Z",
   "published": "2022-04-03T00:01:00Z",
   "aliases": [
     "CVE-2022-22950"
@@ -47,7 +47,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "5.2.20"
+              "fixed": "5.2.20.RELEASE"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Spring only started stripping .RELEASE from their version strings with 5.3.0.

https://repo1.maven.org/maven2/org/springframework/spring-expression/