### PR TITLE
[GHSA-4p38-rc98-cr39] Zenario CMS is vulnerable to Remote Code Execution (RCE).

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-4p38-rc98-cr39/GHSA-4p38-rc98-cr39.json
+++ b/advisories/github-reviewed/2022/11/GHSA-4p38-rc98-cr39/GHSA-4p38-rc98-cr39.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4p38-rc98-cr39",
-  "modified": "2022-12-02T22:20:32Z",
+  "modified": "2023-01-28T05:02:19Z",
   "published": "2022-11-30T15:30:27Z",
   "aliases": [
     "CVE-2022-44136"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-44136"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/TribalSystems/Zenario/commit/4f95a557af3c0b82e448a6ff8f4c167525972e4a"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link (https://github.com/TribalSystems/Zenario/commit/4f95a557af3c0b82e448a6ff8f4c167525972e4a)

The commit comment (https://github.com/TribalSystems/Zenario/commit/4f95a557af3c0b82e448a6ff8f4c167525972e4a) matches the release log (https://github.com/TribalSystems/Zenario/releases/tag/9.0.57473) for the version from the advisory. Additionally, only two commits existed between the prior version and the patched version (https://github.com/TribalSystems/Zenario/compare/9.0.55141...9.0.57473) and https://github.com/TribalSystems/Zenario/commit/4f95a557af3c0b82e448a6ff8f4c167525972e4acommit 4f95a557 is related to the vulnerability. 