### PR TITLE
[GHSA-4pcg-wr6c-h9cq] fastify/websocket vulnerable to uncaught exception via crash on malformed packet

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-4pcg-wr6c-h9cq/GHSA-4pcg-wr6c-h9cq.json
+++ b/advisories/github-reviewed/2022/11/GHSA-4pcg-wr6c-h9cq/GHSA-4pcg-wr6c-h9cq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4pcg-wr6c-h9cq",
-  "modified": "2022-11-07T21:13:57Z",
+  "modified": "2023-01-30T05:07:49Z",
   "published": "2022-11-07T21:13:57Z",
   "aliases": [
     "CVE-2022-39386"
@@ -15,25 +15,6 @@
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "@fastify/websocket"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "5.0.0"
-            },
-            {
-              "fixed": "5.0.1"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "npm",
@@ -71,6 +52,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@fastify/websocket"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.0.0"
+            },
+            {
+              "fixed": "5.0.1"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
@@ -81,6 +81,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-39386"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/fastify/fastify-websocket/pull/228"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/fastify/fastify-websocket/commit/7e8c41a51c101c3d5ce88caee4f71d9c29eb2863"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/fastify/fastify-websocket/commit/c24adeb3efd57a18b2f287c35d029e88b5a47194"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding the PR: https://github.com/fastify/fastify-websocket/pull/228

Adding patch link for v5.0.1: https://github.com/fastify/fastify-websocket/commit/7e8c41a51c101c3d5ce88caee4f71d9c29eb2863

Adding patch link for v7.1.1: https://github.com/fastify/fastify-websocket/commit/c24adeb3efd57a18b2f287c35d029e88b5a47194

These were mentioned in the release of v5.0.1 (https://github.com/fastify/fastify-websocket/releases/tag/v5.0.1) and v7.1.1 (https://github.com/fastify/fastify-websocket/releases/tag/v7.1.1)