### PR TITLE
[GHSA-5229-94p3-7wwq] LibreNMS vulnerable to Cross-Site Scripting (XSS)

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-5229-94p3-7wwq/GHSA-5229-94p3-7wwq.json
+++ b/advisories/github-reviewed/2022/08/GHSA-5229-94p3-7wwq/GHSA-5229-94p3-7wwq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5229-94p3-7wwq",
-  "modified": "2022-09-16T20:26:47Z",
+  "modified": "2023-03-08T21:31:20Z",
   "published": "2022-08-31T00:00:19Z",
   "aliases": [
     "CVE-2022-36745"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/librenms/librenms/pull/14126"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/librenms/librenms/commit/e5c91a0f835d59e058d9d3e4956e079476d59ee6"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for 22.7.0: https://github.com/librenms/librenms/commit/e5c91a0f835d59e058d9d3e4956e079476d59ee6

The patch link is linked through the PR (https://github.com/librenms/librenms/pull/14126)
