### PR TITLE
[GHSA-528j-9r78-wffx] etcd user credentials are stored in WAL logs in plaintext

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-528j-9r78-wffx/GHSA-528j-9r78-wffx.json
+++ b/advisories/github-reviewed/2022/10/GHSA-528j-9r78-wffx/GHSA-528j-9r78-wffx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-528j-9r78-wffx",
-  "modified": "2022-10-06T23:17:24Z",
+  "modified": "2023-01-12T05:06:00Z",
   "published": "2022-10-06T23:17:24Z",
   "aliases": [
 
@@ -55,6 +55,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/etcd-io/etcd/security/advisories/GHSA-528j-9r78-wffx"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/etcd-io/etcd/issues/10132"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/etcd-io/etcd/pull/11818"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/etcd-io/etcd/commit/585814082b8c8b7db272b30b365b81d27df4a4cb"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/etcd-io/etcd/commit/585814082b8c8b7db272b30b365b81d27df4a4cb

Adding original issue: https://github.com/etcd-io/etcd/issues/10132

Adding PR: https://github.com/etcd-io/etcd/pull/11818

A comment on May 24, 2020, in the issue (https://github.com/etcd-io/etcd/issues/10132) regarding the plaintext password stored in WAL log entries: "I confirmed that 11818 removes the plaintext password of a WAL log entry of authenticate RPC (11818 (comment))."