### PR TITLE
[GHSA-566x-hhrf-qf8m] ordered_float:NotNan may contain NaN after panic in assignment operators

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-566x-hhrf-qf8m/GHSA-566x-hhrf-qf8m.json
+++ b/advisories/github-reviewed/2021/08/GHSA-566x-hhrf-qf8m/GHSA-566x-hhrf-qf8m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-566x-hhrf-qf8m",
-  "modified": "2022-06-08T22:33:04Z",
+  "modified": "2023-01-11T05:05:17Z",
   "published": "2021-08-25T20:50:30Z",
   "aliases": [
     "CVE-2020-35923"
@@ -65,6 +65,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/reem/rust-ordered-float/pull/71"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/reem/rust-ordered-float/commit/c55cda301c943270b7eb2b4765bedbcce56edb90"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/reem/rust-ordered-float/commit/da4a8dd49300740a434c095a9c4b408d2415cc08"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v1.1.1: https://github.com/reem/rust-ordered-float/commit/da4a8dd49300740a434c095a9c4b408d2415cc08

Adding patch link for 2.0.1: https://github.com/reem/rust-ordered-float/commit/c55cda301c943270b7eb2b4765bedbcce56edb90

The commits are the same as linked in the original PR (https://github.com/reem/rust-ordered-float/pull/71)