### PR TITLE
[GHSA-58c7-px5v-82hh] Potential sensitive information disclosed in error reports

### DIFF
--- a/advisories/github-reviewed/2021/04/GHSA-58c7-px5v-82hh/GHSA-58c7-px5v-82hh.json
+++ b/advisories/github-reviewed/2021/04/GHSA-58c7-px5v-82hh/GHSA-58c7-px5v-82hh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-58c7-px5v-82hh",
-  "modified": "2021-04-01T21:03:08Z",
+  "modified": "2023-02-01T05:05:15Z",
   "published": "2021-04-06T17:28:59Z",
   "aliases": [
     "CVE-2021-21416"
@@ -43,6 +43,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21416"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ubernostrum/django-registration/commit/2db0bb7ec35636ea46b07b146328b87b2cb13ca5"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/ubernostrum/django-registration/commit/2db0bb7ec35636ea46b07b146328b87b2cb13ca5

The GHSA-ID and CVE are in the commit message: "Merge pull request from GHSA-58c7-px5v-82hh Security: fix CVE-2021-21416."