### PR TITLE
[GHSA-5946-mpw5-pqxx] Incorrect Default Permissions in Cobbler

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-5946-mpw5-pqxx/GHSA-5946-mpw5-pqxx.json
+++ b/advisories/github-reviewed/2022/02/GHSA-5946-mpw5-pqxx/GHSA-5946-mpw5-pqxx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5946-mpw5-pqxx",
-  "modified": "2022-03-08T18:49:35Z",
+  "modified": "2023-02-03T05:06:24Z",
   "published": "2022-02-21T00:00:20Z",
   "aliases": [
     "CVE-2021-45083"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/cobbler/cobbler/pull/2945"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cobbler/cobbler/commit/10b2112db83fedfc391e900edfedc2b4e507d3f7"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/cobbler/cobbler/commit/10b2112db83fedfc391e900edfedc2b4e507d3f7

The CVE is in the commit message: "Fix CVE-2021-45082 and CVE-2021-45083"

It's also the primary merge from the original PR (https://github.com/cobbler/cobbler/pull/2945)