### PR TITLE
[GHSA-5j5w-g665-5m35] Ambiguous OCI manifest parsing

### DIFF
--- a/advisories/github-reviewed/2021/11/GHSA-5j5w-g665-5m35/GHSA-5j5w-g665-5m35.json
+++ b/advisories/github-reviewed/2021/11/GHSA-5j5w-g665-5m35/GHSA-5j5w-g665-5m35.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5j5w-g665-5m35",
-  "modified": "2021-11-18T14:43:45Z",
+  "modified": "2023-01-09T05:05:55Z",
   "published": "2021-11-18T16:08:58Z",
   "aliases": [
 
@@ -66,6 +66,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/opencontainers/image-spec/security/advisories/GHSA-77vh-xpmg-72qh"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/containerd/containerd/commit/26c76a3014e71af5ad2f396ec76e0e0ecc8e25a3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/containerd/containerd/commit/db00065a969a983ceb0a409833f93f705f284ea4"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v1.4.12: https://github.com/containerd/containerd/commit/db00065a969a983ceb0a409833f93f705f284ea4

Adding patch link for v1.5.8: https://github.com/containerd/containerd/commit/26c76a3014e71af5ad2f396ec76e0e0ecc8e25a3

The GHSA-ID is in the message: "Merge pull request from GHSA-5j5w-g665-5m35"