### PR TITLE
[GHSA-5pxj-mhwj-x5gv] Prototype Pollution in asciitable.js

### DIFF
--- a/advisories/github-reviewed/2021/04/GHSA-5pxj-mhwj-x5gv/GHSA-5pxj-mhwj-x5gv.json
+++ b/advisories/github-reviewed/2021/04/GHSA-5pxj-mhwj-x5gv/GHSA-5pxj-mhwj-x5gv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5pxj-mhwj-x5gv",
-  "modified": "2021-04-06T23:32:45Z",
+  "modified": "2023-02-01T05:05:14Z",
   "published": "2021-04-13T15:24:59Z",
   "aliases": [
     "CVE-2020-7771"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/victornpb/asciitable.js/pull/1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/victornpb/asciitable.js/commit/8db8fc5ffa7a2a6e8596709d99b200afb53f40ab"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/victornpb/asciitable.js/commit/8db8fc5ffa7a2a6e8596709d99b200afb53f40ab

This is the primary merge for v1.0.3 from the original PR (https://github.com/victornpb/asciitable.js/pull/1/commits)