### PR TITLE
[GHSA-jv3g-j58f-9mq9] JOSE vulnerable to resource exhaustion via specifically crafted JWE

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-jv3g-j58f-9mq9/GHSA-jv3g-j58f-9mq9.json
+++ b/advisories/github-reviewed/2022/09/GHSA-jv3g-j58f-9mq9/GHSA-jv3g-j58f-9mq9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jv3g-j58f-9mq9",
-  "modified": "2022-09-16T17:44:42Z",
+  "modified": "2023-01-27T05:03:06Z",
   "published": "2022-09-16T17:44:42Z",
   "aliases": [
     "CVE-2022-36083"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.0"
+              "introduced": "1.0.0"
             },
             {
               "fixed": "1.28.2"
@@ -47,7 +47,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.0"
+              "introduced": "3.0.0"
             },
             {
               "fixed": "3.20.4"
@@ -69,7 +69,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.0"
+              "introduced": "3.0.0"
             },
             {
               "fixed": "3.20.4"
@@ -91,7 +91,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.0"
+              "introduced": "3.0.0"
             },
             {
               "fixed": "3.20.4"
@@ -113,7 +113,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.0"
+              "introduced": "2.0.0"
             },
             {
               "fixed": "2.0.6"
@@ -135,7 +135,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.0"
+              "introduced": "3.0.0"
             },
             {
               "fixed": "3.20.4"
@@ -157,7 +157,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.0"
+              "introduced": "4.0.0"
             },
             {
               "fixed": "4.9.2"
@@ -179,7 +179,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.0"
+              "introduced": "4.0.0"
             },
             {
               "fixed": "4.9.2"
@@ -201,7 +201,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.0"
+              "introduced": "4.0.0"
             },
             {
               "fixed": "4.9.2"
@@ -223,7 +223,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.0"
+              "introduced": "4.0.0"
             },
             {
               "fixed": "4.9.2"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The jose library affected by this vulnerability has been released in semantic versions 1.0.0, 2.0.0, 3.0.0, and 4.0.0, instead of 1.0, 2.0, 3.0 and 4.0 (see https://github.com/panva/jose/releases). This change makes the advisory compliant to the semantic versioning scheme natively used in npm.