### PR TITLE
Removing versions 6.0.x from vulnerable versions

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-579w-22j4-4749/GHSA-579w-22j4-4749.json
+++ b/advisories/github-reviewed/2023/01/GHSA-579w-22j4-4749/GHSA-579w-22j4-4749.json
@@ -71,25 +71,6 @@
           ]
         }
       ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "activerecord"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "6.0.0"
-            },
-            {
-              "fixed": "6.0.6.1"
-            }
-          ]
-        }
-      ]
     }
   ],
   "references": [


### PR DESCRIPTION
Hello,
I see that you've reported that versions `>=6.0.0, < 6.0.6.1` are vulnerable to CVE-2022-44566. From looing in all the references that you've attached I see that none of them references to those vulnerable versions, even I can see that [Ruby On Rails official announce ](https://rubyonrails.org/2023/1/17/Rails-Versions-6-0-6-1-6-1-7-1-7-0-4-1-have-been-released) also don't reference to a fix in that version.

Can you please explain why you chose to classify those versions as vulnerable too?

Thank You