### PR TITLE
[GHSA-77qv-gh6f-pgh4] Command Injection in Limdu

### DIFF
--- a/advisories/github-reviewed/2020/06/GHSA-77qv-gh6f-pgh4/GHSA-77qv-gh6f-pgh4.json
+++ b/advisories/github-reviewed/2020/06/GHSA-77qv-gh6f-pgh4/GHSA-77qv-gh6f-pgh4.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-77qv-gh6f-pgh4",
-  "modified": "2021-01-07T23:50:29Z",
+  "modified": "2023-01-09T05:03:26Z",
   "published": "2020-06-22T15:24:06Z",
   "aliases": [
     "CVE-2020-4066"
   ],
   "summary": "Command Injection in Limdu",
-  "details": "### Impact\nThe `trainBatch` function has a command injection vulnerability. Clients of the Limdu library are unlikely to be aware of this, so they might unwittingly write code that contains a vulnerability.\n\n### Patches\nPatched in version 0.95.\n\n### Workarounds\nDo not use trainBatch with classifiers that rely on shell execution, such as SVM Perf, SVM Linear or Adaboost\n\n### References\nNo",
+  "details": "### Impact\nThe `trainBatch` function has a command injection vulnerability. Clients of the Limdu library are unlikely to be aware of this, so they might unwittingly write code that contains a vulnerability.\n\n### Patches\nPatched in version 0.9.5.\n\n### Workarounds\nDo not use trainBatch with classifiers that rely on shell execution, such as SVM Perf, SVM Linear or Adaboost\n\n### References\nNo",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.95"
+              "fixed": "0.9.5"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
The affected version was mistakenly listed as 0.95 but only 0.9.5 is correct. 0.95 has never been released. See https://github.com/erelsgl/limdu/commit/b624c7e018d977b6c6a0c8449206cd1f364d8d98 for reference. This change also ensures compliance with the semantic versioning scheme.