### PR TITLE
[GHSA-8xwg-wv7v-4vqp] Electron Vulnerable to Code Execution by Re-Enabling Node.js Integration

### DIFF
--- a/advisories/github-reviewed/2018/03/GHSA-8xwg-wv7v-4vqp/GHSA-8xwg-wv7v-4vqp.json
+++ b/advisories/github-reviewed/2018/03/GHSA-8xwg-wv7v-4vqp/GHSA-8xwg-wv7v-4vqp.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8xwg-wv7v-4vqp",
-  "modified": "2022-08-02T18:08:25Z",
+  "modified": "2023-01-11T05:08:04Z",
   "published": "2018-03-26T16:41:17Z",
   "aliases": [
     "CVE-2018-1000136"
   ],
   "summary": "Electron Vulnerable to Code Execution by Re-Enabling Node.js Integration",
-  "details": "Versions of electron \nA vulnerability has been discovered which allows Node.js integration to be re-enabled in some Electron applications that disable it.\n\nFor the application to be impacted by this vulnerability it must meet all of these conditions\n\n- Runs on Electron 1.7, 1.8, or a 2.0.0-beta\n- Allows execution of arbitrary remote code\n- Disables Node.js integration\n- Does not explicitly declare webviewTag: false in its webPreferences\n- Does not enable the nativeWindowOption option\n- Does not intercept new-window events and manually override event.newGuest without using the supplied options tag\n\n\n## Recommendation\n\nUpdate to `electron` version 1.7.13, 1.8.4, or 2.0.0.beta.5 or later\n\nIf you are unable to update your Electron version can mitigate the vulnerability with the following code.\n\n```\napp.on('web-contents-created', (event, win) => {\n  win.on('new-window', (event, newURL, frameName, disposition,\n                        options, additionalFeatures) => {\n    if (!options.webPreferences) options.webPreferences = {};\n    options.webPreferences.nodeIntegration = false;\n    options.webPreferences.nodeIntegrationInWorker = false;\n    options.webPreferences.webviewTag = false;\n    delete options.webPreferences.preload;\n  })\n})\n\n// and *IF* you don't use WebViews at all,\n// you might also want\napp.on('web-contents-created', (event, win) => {\n  win.on('will-attach-webview', (event, webPreferences, params) => {\n    event.preventDefault();\n  })\n})\n```",
+  "details": "Versions of electron \nA vulnerability has been discovered which allows Node.js integration to be re-enabled in some Electron applications that disable it.\n\nFor the application to be impacted by this vulnerability it must meet all of these conditions\n\n- Runs on Electron 1.7, 1.8, or a 2.0.0-beta\n- Allows execution of arbitrary remote code\n- Disables Node.js integration\n- Does not explicitly declare webviewTag: false in its webPreferences\n- Does not enable the nativeWindowOption option\n- Does not intercept new-window events and manually override event.newGuest without using the supplied options tag\n\n\n## Recommendation\n\nUpdate to `electron` version 1.7.13, 1.8.4, or 2.0.0-beta.5 or later\n\nIf you are unable to update your Electron version can mitigate the vulnerability with the following code.\n\n```\napp.on('web-contents-created', (event, win) => {\n  win.on('new-window', (event, newURL, frameName, disposition,\n                        options, additionalFeatures) => {\n    if (!options.webPreferences) options.webPreferences = {};\n    options.webPreferences.nodeIntegration = false;\n    options.webPreferences.nodeIntegrationInWorker = false;\n    options.webPreferences.webviewTag = false;\n    delete options.webPreferences.preload;\n  })\n})\n\n// and *IF* you don't use WebViews at all,\n// you might also want\napp.on('web-contents-created', (event, win) => {\n  win.on('will-attach-webview', (event, webPreferences, params) => {\n    event.preventDefault();\n  })\n})\n```",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.7"
+              "introduced": "1.7.0"
             },
             {
               "fixed": "1.7.13"
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.8"
+              "introduced": "1.8.0"
             },
             {
               "fixed": "1.8.4"


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Lower bounds of affected versions were mistakenly reported in a non-semver compliant format. This change adapts 1.7 to 1.7.0 and 1.8 to 1.8.0 in order to make versioning semver-compliant.