### PR TITLE
[GHSA-gxr4-xjj5-5px2] Potential XSS vulnerability in jQuery

### DIFF
--- a/advisories/github-reviewed/2020/04/GHSA-gxr4-xjj5-5px2/GHSA-gxr4-xjj5-5px2.json
+++ b/advisories/github-reviewed/2020/04/GHSA-gxr4-xjj5-5px2/GHSA-gxr4-xjj5-5px2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gxr4-xjj5-5px2",
-  "modified": "2022-02-08T22:06:37Z",
+  "modified": "2023-01-27T05:02:42Z",
   "published": "2020-04-29T22:18:55Z",
   "aliases": [
     "CVE-2020-11022"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.2"
+              "introduced": "1.2.0"
             },
             {
               "fixed": "3.5.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The lower bound of affected versions was mistakenly listed as `>= 1.2` but only `>= 1.2.0` complies with the semantic versioning scheme used with npm.