### PR TITLE
[GHSA-qpv8-4pjq-qqh7] feathers-sequelize contains improper input validation leading to SQL injection

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-qpv8-4pjq-qqh7/GHSA-qpv8-4pjq-qqh7.json
+++ b/advisories/github-reviewed/2022/10/GHSA-qpv8-4pjq-qqh7/GHSA-qpv8-4pjq-qqh7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qpv8-4pjq-qqh7",
-  "modified": "2023-01-10T16:00:54Z",
+  "modified": "2023-02-03T05:01:31Z",
   "published": "2022-10-26T12:00:28Z",
   "aliases": [
     "CVE-2022-2422"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "6.0"
+              "introduced": "6.0.0"
             },
             {
               "fixed": "6.3.4"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Lower bounds of affected versions were mistakenly reported as `6.0` but only `6.0.0` complies with the semantic versioning scheme used by npm.