### PR TITLE
[GHSA-p5m3-27vh-52j4] Feather-Sequelize cleanQuery method vulnerable to Prototype Pollution

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-p5m3-27vh-52j4/GHSA-p5m3-27vh-52j4.json
+++ b/advisories/github-reviewed/2022/10/GHSA-p5m3-27vh-52j4/GHSA-p5m3-27vh-52j4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p5m3-27vh-52j4",
-  "modified": "2022-10-31T19:25:00Z",
+  "modified": "2023-02-03T05:01:31Z",
   "published": "2022-10-26T12:00:28Z",
   "aliases": [
     "CVE-2022-29823"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "6.0"
+              "introduced": "6.0.0"
             },
             {
               "fixed": "6.3.3"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Lower bounds of affected versions were mistakenly reported as `6.0` but only `6.0.0` complies with the semantic versioning scheme used by npm.