### PR TITLE
[GHSA-vcjf-mgcg-jxjq] CKEditor 4.0 vulnerability in the HTML Data Processor

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-vcjf-mgcg-jxjq/GHSA-vcjf-mgcg-jxjq.json
+++ b/advisories/github-reviewed/2021/05/GHSA-vcjf-mgcg-jxjq/GHSA-vcjf-mgcg-jxjq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vcjf-mgcg-jxjq",
-  "modified": "2022-09-14T19:43:09Z",
+  "modified": "2023-02-01T05:05:32Z",
   "published": "2021-05-07T16:32:17Z",
   "aliases": [
     "CVE-2020-9281"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.14"
+              "fixed": "4.14.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Affected and patched version were mistakenly listed as `4.14` but only `4.14.0` is correct, see https://github.com/ckeditor/ckeditor4/releases/tag/4.14.0