### PR TITLE
[GHSA-8wg7-88cg-7p9j] Pimcore vulnerable to Cross-site Scripting

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-8wg7-88cg-7p9j/GHSA-8wg7-88cg-7p9j.json
+++ b/advisories/github-reviewed/2023/03/GHSA-8wg7-88cg-7p9j/GHSA-8wg7-88cg-7p9j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8wg7-88cg-7p9j",
-  "modified": "2023-03-13T19:17:35Z",
+  "modified": "2023-03-13T19:17:36Z",
   "published": "2023-03-07T12:30:17Z",
   "aliases": [
     "CVE-2023-1247"
@@ -11,14 +11,14 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:N/I:N/A:N"
     }
   ],
   "affected": [
     {
       "package": {
         "ecosystem": "Packagist",
-        "name": "pimcore/pimcore"
+        "name": ""
       },
       "ranges": [
         {
@@ -26,9 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "11.0.0"
             }
           ]
         }
@@ -57,7 +54,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2023-03-08T17:17:54Z",
     "nvd_published_at": "2023-03-07T10:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
This CVE has been rejected. Please remove it from advisories.