### PR TITLE
[GHSA-p9gf-gmfv-398m] Double free in slice_deque

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-p9gf-gmfv-398m/GHSA-p9gf-gmfv-398m.json
+++ b/advisories/github-reviewed/2021/08/GHSA-p9gf-gmfv-398m/GHSA-p9gf-gmfv-398m.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p9gf-gmfv-398m",
-  "modified": "2021-08-19T17:14:58Z",
+  "modified": "2023-01-09T05:05:06Z",
   "published": "2021-08-25T20:54:16Z",
   "aliases": [
     "CVE-2021-29938"
   ],
-  "summary": "Double free in slice_deque",
+  "summary": "Double free in slice-deque",
   "details": "An issue was discovered in the slice-deque crate through 2021-02-19 for Rust. A double drop can occur in SliceDeque::drain_filter upon a panic in a predicate function.",
   "severity": [
     {
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "crates.io",
-        "name": "slice_deque"
+        "name": "slice-deque"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
pkg name is dash, “-“, instead of underscore,”_”