### PR TITLE
[GHSA-7322-9mx6-5j2m] redcarpet Buffer Overflow vulnerability

### DIFF
--- a/advisories/github-reviewed/2018/08/GHSA-7322-9mx6-5j2m/GHSA-7322-9mx6-5j2m.json
+++ b/advisories/github-reviewed/2018/08/GHSA-7322-9mx6-5j2m/GHSA-7322-9mx6-5j2m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7322-9mx6-5j2m",
-  "modified": "2023-01-23T20:45:35Z",
+  "modified": "2023-01-23T20:45:37Z",
   "published": "2018-08-15T20:04:30Z",
   "aliases": [
     "CVE-2015-5147"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5147"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vmg/redcarpet/commit/2cee777c1e5babe8a1e2683d31ea75cc4afe55fb"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/vmg/redcarpet/commit/2cee777c1e5babe8a1e2683d31ea75cc4afe55fb

The fix was mentioned in the reference link from Openwall: https://www.openwall.com/lists/oss-security/2015/06/29/3