### PR TITLE
[GHSA-73rx-3f9r-x949] Insufficient Verification of Data Authenticity in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-73rx-3f9r-x949/GHSA-73rx-3f9r-x949.json
+++ b/advisories/github-reviewed/2022/05/GHSA-73rx-3f9r-x949/GHSA-73rx-3f9r-x949.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-73rx-3f9r-x949",
-  "modified": "2022-06-30T21:22:02Z",
+  "modified": "2023-01-27T05:02:23Z",
   "published": "2022-05-14T01:10:15Z",
   "aliases": [
     "CVE-2017-7674"
@@ -108,6 +108,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-7674"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/52382ebfbce20a98b01cd9d37184a12703987a5a"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding a patch link: https://github.com/apache/tomcat/commit/52382ebfbce20a98b01cd9d37184a12703987a5a

Validation comes from a previous reference link (https://lists.apache.org/thread/bol4f8wyjfsbo135tw9gy49o5nf8qpth):

- CVE-2017-7674 
- The CORS Filter did not add an HTTP Vary header indicating that the response varies depending on Origin. This permitted client and server side cache poisoning in some circumstances.
- This was fixed in revision 1795816

The revision git-svn-id matches the one in the commit message, and the message is very similar: "CORS filter should set Vary header in response. git-svn-id: https://svn.apache.org/repos/asf/tomcat/tc7.0.x/trunk@1795816"
