### PR TITLE
[GHSA-7627-mp87-jf6q] Command injection in cocoapods-downloader

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-7627-mp87-jf6q/GHSA-7627-mp87-jf6q.json
+++ b/advisories/github-reviewed/2022/04/GHSA-7627-mp87-jf6q/GHSA-7627-mp87-jf6q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7627-mp87-jf6q",
-  "modified": "2022-04-04T21:58:52Z",
+  "modified": "2023-01-27T05:01:18Z",
   "published": "2022-04-02T00:00:13Z",
   "aliases": [
     "CVE-2022-24440"
@@ -66,6 +66,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/CocoaPods/cocoapods-downloader/pull/128"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/CocoaPods/cocoapods-downloader/commit/52a0d54464932a90ded5a59c71a016e8dec0ca84"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/CocoaPods/cocoapods-downloader/commit/b70bc39c75645aa6d4a01a3ca6de40477c84f4b5"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding a patch link for v1.6.0: https://github.com/CocoaPods/cocoapods-downloader/commit/b70bc39c75645aa6d4a01a3ca6de40477c84f4b5

Adding a patch link for v1.6.3: https://github.com/CocoaPods/cocoapods-downloader/commit/52a0d54464932a90ded5a59c71a016e8dec0ca84

These are linked in PRs, in which 124 (https://github.com/CocoaPods/cocoapods-downloader/pull/124) was for v1.6.0, and 128 (https://github.com/CocoaPods/cocoapods-downloader/pull/128) was for v1.6.3.
