### PR TITLE
[GHSA-7j44-fv4x-79g9] Improper Input Validation in once_cell

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-7j44-fv4x-79g9/GHSA-7j44-fv4x-79g9.json
+++ b/advisories/github-reviewed/2021/08/GHSA-7j44-fv4x-79g9/GHSA-7j44-fv4x-79g9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7j44-fv4x-79g9",
-  "modified": "2022-06-14T21:11:20Z",
+  "modified": "2023-01-11T05:06:01Z",
   "published": "2021-08-25T20:44:18Z",
   "aliases": [
     "CVE-2019-16141"
@@ -43,6 +43,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/matklad/once_cell/issues/46"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/matklad/once_cell/pull/47"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/matklad/once_cell/commit/afcca95a05240ebd931ab20998c946f77ef1e284"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/matklad/once_cell/commit/afcca95a05240ebd931ab20998c946f77ef1e284

PR to close the original issue (https://github.com/matklad/once_cell/issues/46): https://github.com/matklad/once_cell/pull/47

The patch link is the merge of 47, which was used to close issue 46.