### PR TITLE
[GHSA-7jf5-fvgf-48c6] Velociraptor subject to Path Traversal

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-7jf5-fvgf-48c6/GHSA-7jf5-fvgf-48c6.json
+++ b/advisories/github-reviewed/2023/01/GHSA-7jf5-fvgf-48c6/GHSA-7jf5-fvgf-48c6.json
@@ -41,6 +41,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0290"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/Velocidex/velociraptor/commit/4718bb0cb426564568abc77910e90a2c211a32e6"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/Velocidex/velociraptor"
     }


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/Velocidex/velociraptor/commit/4718bb0cb426564568abc77910e90a2c211a32e6

This is the only commit between https://github.com/Velocidex/velociraptor/compare/v0.6.7-4...v0.6.7-5. The commit makes changes to the client ID to validate. They also validate user access before they write to the filesystem, which is suspect for the original path traversal. 