### PR TITLE
[GHSA-7p7c-pvvx-2vx3] hyper-staticfile's improper validation of Windows paths could lead to directory traversal attack

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-7p7c-pvvx-2vx3/GHSA-7p7c-pvvx-2vx3.json
+++ b/advisories/github-reviewed/2022/12/GHSA-7p7c-pvvx-2vx3/GHSA-7p7c-pvvx-2vx3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7p7c-pvvx-2vx3",
-  "modified": "2022-12-05T22:03:46Z",
+  "modified": "2023-01-08T05:01:31Z",
   "published": "2022-12-05T22:03:46Z",
   "aliases": [
 
@@ -58,6 +58,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/stephank/hyper-staticfile/issues/35"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/stephank/hyper-staticfile/pull/36"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/stephank/hyper-staticfile/commit/1e40e31d64bc6b32e595d24074092dcf84410b2b"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/stephank/hyper-staticfile/commit/1e40e31d64bc6b32e595d24074092dcf84410b2b

Adding PR that closes the original issue (https://github.com/stephank/hyper-staticfile/issues/35): https://github.com/stephank/hyper-staticfile/pull/36

This is the commit used to close issue 35. 