### PR TITLE
[GHSA-7rjp-fgwj-47rw] Missing authentication in ShenYu

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-7rjp-fgwj-47rw/GHSA-7rjp-fgwj-47rw.json
+++ b/advisories/github-reviewed/2022/01/GHSA-7rjp-fgwj-47rw/GHSA-7rjp-fgwj-47rw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7rjp-fgwj-47rw",
-  "modified": "2022-02-02T16:17:08Z",
+  "modified": "2023-02-03T05:05:10Z",
   "published": "2022-01-28T22:14:11Z",
   "aliases": [
     "CVE-2022-23945"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23945"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/incubator-shenyu/pull/2723"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/shenyu/commit/9a02215013037e1cc8cd41f216164628a9e9e28f"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/apache/shenyu/commit/9a02215013037e1cc8cd41f216164628a9e9e28f

Adding PR: https://github.com/apache/incubator-shenyu/pull/2723

The PR was referenced in an original reference (https://www.openwall.com/lists/oss-security/2022/01/26/3)

"Upgrade to Apache ShenYu (incubating) 2.4.2 or apply patch
https://github.com/apache/incubator-shenyu/pull/2723."