### PR TITLE
[GHSA-838h-jqp6-cf2f] Sandbox bypass leading to arbitrary code execution in Deno

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-838h-jqp6-cf2f/GHSA-838h-jqp6-cf2f.json
+++ b/advisories/github-reviewed/2022/03/GHSA-838h-jqp6-cf2f/GHSA-838h-jqp6-cf2f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-838h-jqp6-cf2f",
-  "modified": "2022-05-02T19:39:05Z",
+  "modified": "2023-01-27T05:01:04Z",
   "published": "2022-03-29T22:10:10Z",
   "aliases": [
     "CVE-2022-24783"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/denoland/deno/pull/14115"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/denoland/deno/commit/fcfce1bb869fddc629e6d889d6ba1328b80b0dcf"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v1.20.3: https://github.com/denoland/deno/commit/fcfce1bb869fddc629e6d889d6ba1328b80b0dcf

This is the commit from the PR (https://github.com/denoland/deno/pull/14115/commits) that appeared between https://github.com/denoland/deno/compare/v1.20.2...v1.20.3