### PR TITLE
[GHSA-86pv-95mj-7w5f] Stored XSS vulnerability on Bounce Management Callback

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-86pv-95mj-7w5f/GHSA-86pv-95mj-7w5f.json
+++ b/advisories/github-reviewed/2021/09/GHSA-86pv-95mj-7w5f/GHSA-86pv-95mj-7w5f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-86pv-95mj-7w5f",
-  "modified": "2021-08-30T18:05:04Z",
+  "modified": "2023-02-01T05:06:04Z",
   "published": "2021-09-01T18:40:48Z",
   "aliases": [
     "CVE-2021-27910"
@@ -43,6 +43,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-27910"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mautic/mautic/commit/e6a405975342f3cf86aa71927618d31d25135fa3"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/mautic/mautic/commit/e6a405975342f3cf86aa71927618d31d25135fa3

The GHSA-ID is in the commit message: "Merge pull request from GHSA-86pv-95mj-7w5f"