### PR TITLE
[GHSA-8864-rhmw-5m6f] Status Board vulnerable to Cross-Site Scripting before v1.1.82

### DIFF
--- a/advisories/github-reviewed/2019/09/GHSA-8864-rhmw-5m6f/GHSA-8864-rhmw-5m6f.json
+++ b/advisories/github-reviewed/2019/09/GHSA-8864-rhmw-5m6f/GHSA-8864-rhmw-5m6f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8864-rhmw-5m6f",
-  "modified": "2022-08-03T15:33:55Z",
+  "modified": "2023-01-11T05:07:51Z",
   "published": "2019-09-23T18:32:42Z",
   "aliases": [
     "CVE-2019-15479"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/jameswlane/status-board/pull/948"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/status-board/status-board/commit/19106617865406aa6f8edec036dcb1db427d5f71"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/status-board/status-board/commit/19106617865406aa6f8edec036dcb1db427d5f71

This is linked in the PR (https://github.com/status-board/status-board/pull/948), but it's the primary commit that removes the ${safeDashboardName} from the error message as described in the advisory. 