### PR TITLE
[GHSA-8c2c-jxwj-jqgf] Browsershot does not validate URL protocols passed to Browsershot URL method

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-8c2c-jxwj-jqgf/GHSA-8c2c-jxwj-jqgf.json
+++ b/advisories/github-reviewed/2022/11/GHSA-8c2c-jxwj-jqgf/GHSA-8c2c-jxwj-jqgf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8c2c-jxwj-jqgf",
-  "modified": "2022-12-02T22:18:57Z",
+  "modified": "2023-01-28T05:02:18Z",
   "published": "2022-11-25T18:30:25Z",
   "aliases": [
     "CVE-2022-41706"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41706"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spatie/browsershot/commit/92cf16fc098211731f80d21687abeafbe2c457ad"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/spatie/browsershot/commit/92cf16fc098211731f80d21687abeafbe2c457ad

The developer no longer allows URLs to direct to a file location. Additionally, the unit test is pointed at the Browsershot:url method. 