### PR TITLE
[GHSA-8c5j-9r9f-c6w8] Information disclosure in Django

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-8c5j-9r9f-c6w8/GHSA-8c5j-9r9f-c6w8.json
+++ b/advisories/github-reviewed/2022/01/GHSA-8c5j-9r9f-c6w8/GHSA-8c5j-9r9f-c6w8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8c5j-9r9f-c6w8",
-  "modified": "2022-02-14T22:16:33Z",
+  "modified": "2023-02-03T05:04:12Z",
   "published": "2022-01-12T19:21:10Z",
   "aliases": [
     "CVE-2021-45116"
@@ -77,6 +77,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-45116"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/2a8ec7f546d6d5806e221ec948c5146b55bd7489"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/c7fe895bca06daf12cc1670b56eaf72a1ef27a16"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/c9f648ccfac5ab90fb2829a66da4f77e68c7f93a"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v2.2.26: https://github.com/django/django/commit/c9f648ccfac5ab90fb2829a66da4f77e68c7f93a

Adding patch link for v3.2.11: https://github.com/django/django/commit/c7fe895bca06daf12cc1670b56eaf72a1ef27a16

Adding patch link for v4.0.1: https://github.com/django/django/commit/2a8ec7f546d6d5806e221ec948c5146b55bd7489

The CVE is in the commit message: "Fixed CVE-2021-45116 -- Fixed potential information disclosure in dictsort template filter."