### PR TITLE
[GHSA-8fgg-5v78-6g76] Deserializing an array can free uninitialized memory in byte_struct

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-8fgg-5v78-6g76/GHSA-8fgg-5v78-6g76.json
+++ b/advisories/github-reviewed/2021/08/GHSA-8fgg-5v78-6g76/GHSA-8fgg-5v78-6g76.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8fgg-5v78-6g76",
-  "modified": "2022-05-04T03:04:59Z",
+  "modified": "2023-02-03T05:06:16Z",
   "published": "2021-08-25T20:52:03Z",
   "aliases": [
     "CVE-2021-28033"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/wwylele/byte-struct-rs/issues/1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/wwylele/byte-struct-rs/commit/a535678377de12bc6bc22620c5f59bcc1369f76f"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/wwylele/byte-struct-rs/commit/a535678377de12bc6bc22620c5f59bcc1369f76f

Within the comments of the issue (https://github.com/wwylele/byte-struct-rs/issues/1), the developer references the commit: "I decided to think less and just replace it with safe code that is possible today in a535678"