### PR TITLE
[GHSA-8v4j-7jgf-5rg9] Warp vulnerable to Path Traversal via Improper validation of Windows paths

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-8v4j-7jgf-5rg9/GHSA-8v4j-7jgf-5rg9.json
+++ b/advisories/github-reviewed/2023/01/GHSA-8v4j-7jgf-5rg9/GHSA-8v4j-7jgf-5rg9.json
@@ -38,6 +38,10 @@
       "url": "https://github.com/seanmonstar/warp/issues/937"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/seanmonstar/warp/commit/0074a0a3e98786509259bfe3821d3b3f094257aa"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/seanmonstar/warp"
     },


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/seanmonstar/warp/commit/0074a0a3e98786509259bfe3821d3b3f094257aa

This PR (https://github.com/seanmonstar/warp/pull/997) closes the original issue (https://github.com/seanmonstar/warp/issues/937).