### PR TITLE
[GHSA-8vwm-8vj8-rqjf] User login denial of service in github.com/google/fscrypt

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-8vwm-8vj8-rqjf/GHSA-8vwm-8vj8-rqjf.json
+++ b/advisories/github-reviewed/2022/02/GHSA-8vwm-8vj8-rqjf/GHSA-8vwm-8vj8-rqjf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8vwm-8vj8-rqjf",
-  "modified": "2022-03-01T19:27:43Z",
+  "modified": "2023-02-03T05:06:25Z",
   "published": "2022-02-26T00:00:44Z",
   "aliases": [
     "CVE-2022-25327"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/google/fscrypt/pull/346"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/google/fscrypt/commit/91aa3ebf42032ca783c41f9ec25d885875f66ddb"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link: https://github.com/google/fscrypt/commit/91aa3ebf42032ca783c41f9ec25d885875f66ddb

This is the complete merge of the PR (https://github.com/google/fscrypt/pull/346) to validate the patch for v0.3.3