### PR TITLE
[GHSA-8fww-64cx-x8p5] redis-py Race Condition due to incomplete fix

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-8fww-64cx-x8p5/GHSA-8fww-64cx-x8p5.json
+++ b/advisories/github-reviewed/2023/03/GHSA-8fww-64cx-x8p5/GHSA-8fww-64cx-x8p5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8fww-64cx-x8p5",
-  "modified": "2023-03-27T21:31:52Z",
+  "modified": "2023-03-27T21:31:53Z",
   "published": "2023-03-26T21:30:23Z",
   "aliases": [
     "CVE-2023-28859"
@@ -22,14 +22,52 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.5.0"
             },
             {
-              "last_affected": "4.5.3"
+              "fixed": "4.5.4"
             }
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "redis"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.4.0"
+            },
+            {
+              "fixed": "4.4.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "redis"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.3.6"
+      }
     }
   ],
   "references": [
@@ -48,6 +86,14 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/redis/redis-py"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/redis/redis-py/releases/tag/v4.4.4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/redis/redis-py/releases/tag/v4.5.4"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Affected versions should match more the previous security report: https://github.com/advisories/GHSA-8fww-64cx-x8p5

Fix for 4.3.x does not seem to be out yet: https://github.com/redis/redis-py/pull/2672