### PR TITLE
[GHSA-6wxg-wh7f-rqpr] XML External Entity (XXE) vulnerability in apoc.import.graphml

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-6wxg-wh7f-rqpr/GHSA-6wxg-wh7f-rqpr.json
+++ b/advisories/github-reviewed/2023/02/GHSA-6wxg-wh7f-rqpr/GHSA-6wxg-wh7f-rqpr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6wxg-wh7f-rqpr",
-  "modified": "2023-02-24T19:03:07Z",
+  "modified": "2023-02-16T20:46:56Z",
   "published": "2023-02-16T20:46:49Z",
   "aliases": [
     "CVE-2023-23926"
@@ -29,6 +29,25 @@
             },
             {
               "fixed": "5.5.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.neo4j.procedure:apoc"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.4.0.14"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
As the different major versions of this product lives in different repos, we have done 2 separate security advisories, one in each repo. But for security tools to correctly  report if a version is vulnerable or not, both advisories need to mention both versions 4.x and 5.x.