### PR TITLE
[GHSA-8vxv-2g8p-2249] Observable Timing Discrepancy in totp-rs

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-8vxv-2g8p-2249/GHSA-8vxv-2g8p-2249.json
+++ b/advisories/github-reviewed/2022/05/GHSA-8vxv-2g8p-2249/GHSA-8vxv-2g8p-2249.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8vxv-2g8p-2249",
-  "modified": "2022-05-24T21:33:15Z",
+  "modified": "2023-01-27T05:02:52Z",
   "published": "2022-05-24T21:33:15Z",
   "aliases": [
     "CVE-2022-29185"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/constantoine/totp-rs/issues/13"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/constantoine/totp-rs/commit/1f1e1a6fe722deb1656f483b1367ea4be978db5b"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link: https://github.com/constantoine/totp-rs/commit/1f1e1a6fe722deb1656f483b1367ea4be978db5b

The developer introduced a time comparison as requested in issue 13 (https://github.com/constantoine/totp-rs/issues/13). Additionally, only two commits existed between releases https://github.com/constantoine/totp-rs/compare/v1.0...v1.1.0, with one being the commit merge. 