### PR TITLE
[GHSA-924m-4pmx-c67h] High severity vulnerability that affects pysaml2

### DIFF
--- a/advisories/github-reviewed/2018/07/GHSA-924m-4pmx-c67h/GHSA-924m-4pmx-c67h.json
+++ b/advisories/github-reviewed/2018/07/GHSA-924m-4pmx-c67h/GHSA-924m-4pmx-c67h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-924m-4pmx-c67h",
-  "modified": "2021-09-07T20:34:38Z",
+  "modified": "2023-02-01T05:03:28Z",
   "published": "2018-07-13T16:01:17Z",
   "aliases": [
     "CVE-2017-1000433"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/rohe/pysaml2/issues/451"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/IdentityPython/pysaml2/commit/6312a41e037954850867f29d329e5007df1424a5"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link: https://github.com/IdentityPython/pysaml2/commit/6312a41e037954850867f29d329e5007df1424a5

The PR (https://github.com/IdentityPython/pysaml2/pull/454) with the patch was referenced in the original issue (https://github.com/IdentityPython/pysaml2/issues/451).

It also appears that the repo owner changed from 'rohe' to 'IdentityPython,' but it redirects appropriately. 