### PR TITLE
[GHSA-92cx-4xm7-jr9m] Use After Free in rusqlite

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-92cx-4xm7-jr9m/GHSA-92cx-4xm7-jr9m.json
+++ b/advisories/github-reviewed/2022/01/GHSA-92cx-4xm7-jr9m/GHSA-92cx-4xm7-jr9m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-92cx-4xm7-jr9m",
-  "modified": "2022-01-07T16:09:58Z",
+  "modified": "2023-02-03T05:03:32Z",
   "published": "2022-01-06T22:02:56Z",
   "aliases": [
     "CVE-2021-45713"
@@ -58,6 +58,30 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-45713"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rusqlite/rusqlite/issues/1048"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rusqlite/rusqlite/pull/1049"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rusqlite/rusqlite/commit/30f8c8c502675011603c4d066396bf317fd49e71"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rusqlite/rusqlite/commit/612158507e90f41d409cd0fa80eb21c992b1bc08"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rusqlite/rusqlite/commit/934e0c709e156753881da98b32e9853f9ffe4a1b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rusqlite/rusqlite/commit/f4f95f8caf9fd53bffd0c19530be2484c644cc16"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.25.4: https://github.com/rusqlite/rusqlite/commit/f4f95f8caf9fd53bffd0c19530be2484c644cc16

Adding three patch links for v0.26.2: 
https://github.com/rusqlite/rusqlite/commit/30f8c8c502675011603c4d066396bf317fd49e71
https://github.com/rusqlite/rusqlite/commit/612158507e90f41d409cd0fa80eb21c992b1bc08
https://github.com/rusqlite/rusqlite/commit/934e0c709e156753881da98b32e9853f9ffe4a1b

Adding the issue: https://github.com/rusqlite/rusqlite/issues/1048

Adding the pull: https://github.com/rusqlite/rusqlite/pull/1049

The issue was originally linked in a reference (https://raw.githubusercontent.com/rustsec/advisory-db/main/crates/rusqlite/RUSTSEC-2021-0128.md), which has the above commits. For v0.26.2 it was a mixture of three commits for the patch. The pull can be seen here: https://github.com/rusqlite/rusqlite/pull/1049
