### PR TITLE
[GHSA-96jv-r488-c2rj] bzip2 allows attackers to cause a denial of service via a large file that triggers an integer overflow

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-96jv-r488-c2rj/GHSA-96jv-r488-c2rj.json
+++ b/advisories/github-reviewed/2023/01/GHSA-96jv-r488-c2rj/GHSA-96jv-r488-c2rj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-96jv-r488-c2rj",
-  "modified": "2023-01-13T17:18:40Z",
+  "modified": "2023-03-13T15:25:45Z",
   "published": "2023-01-10T03:30:29Z",
   "aliases": [
     "CVE-2023-22895"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/alexcrichton/bzip2-rs/pull/86"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/alexcrichton/bzip2-rs/commit/90c9c182cd5a5ebc75810aebd89b347a7bdf590b"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.4.4: https://github.com/alexcrichton/bzip2-rs/commit/90c9c182cd5a5ebc75810aebd89b347a7bdf590b

The patch is the complete merge of the original pull (https://github.com/alexcrichton/bzip2-rs/pull/86)