### PR TITLE
[GHSA-977c-63xq-cgw3] opensearch-ruby 2.x before 2.0.2 vulnerable to unsafe YAML deserialization

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-977c-63xq-cgw3/GHSA-977c-63xq-cgw3.json
+++ b/advisories/github-reviewed/2022/07/GHSA-977c-63xq-cgw3/GHSA-977c-63xq-cgw3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-977c-63xq-cgw3",
-  "modified": "2022-07-21T14:55:44Z",
+  "modified": "2023-01-27T05:05:12Z",
   "published": "2022-07-05T20:41:26Z",
   "aliases": [
     "CVE-2022-31115"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/opensearch-project/opensearch-ruby/pull/77"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/opensearch-project/opensearch-ruby/commit/d74a98b45c037671e8819fa87f6a6423458ab08a"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.0.2: https://github.com/opensearch-project/opensearch-ruby/commit/d74a98b45c037671e8819fa87f6a6423458ab08a

This is the backport patch for v2.0.2, referenced in the original pull (https://github.com/opensearch-project/opensearch-ruby/pull/77). History can be seen here: https://github.com/opensearch-project/opensearch-ruby/compare/v2.0.1...v2.0.2