### PR TITLE
[GHSA-9c2p-jw8p-f84v] SQL Injection in sequelize

### DIFF
--- a/advisories/github-reviewed/2019/02/GHSA-9c2p-jw8p-f84v/GHSA-9c2p-jw8p-f84v.json
+++ b/advisories/github-reviewed/2019/02/GHSA-9c2p-jw8p-f84v/GHSA-9c2p-jw8p-f84v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9c2p-jw8p-f84v",
-  "modified": "2020-08-31T18:10:56Z",
+  "modified": "2023-01-09T05:03:03Z",
   "published": "2019-02-18T23:54:24Z",
   "aliases": [
     "CVE-2016-10556"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/sequelize/sequelize/issues/5671"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/sequelize/sequelize/commit/23952a2b020cc3571f090e67dae7feb084e1be71"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.20.0: https://github.com/sequelize/sequelize/commit/23952a2b020cc3571f090e67dae7feb084e1be71

The patch was mentioned in the original issue (https://github.com/sequelize/sequelize/issues/5671): "somebody already fixed this one in 23952a2."