### PR TITLE
[GHSA-9cp3-fh5x-xfcj] Regular Expression Denial of Service in charset

### DIFF
--- a/advisories/github-reviewed/2018/08/GHSA-9cp3-fh5x-xfcj/GHSA-9cp3-fh5x-xfcj.json
+++ b/advisories/github-reviewed/2018/08/GHSA-9cp3-fh5x-xfcj/GHSA-9cp3-fh5x-xfcj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9cp3-fh5x-xfcj",
-  "modified": "2020-08-31T18:26:23Z",
+  "modified": "2023-01-09T05:03:03Z",
   "published": "2018-08-09T20:55:46Z",
   "aliases": [
     "CVE-2017-16098"
@@ -40,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/node-modules/charset/issues/10"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/node-modules/charset/commit/effda0c48c51b47a47f4cad7db0c51ee7407cc1b"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.0.1: https://github.com/node-modules/charset/commit/effda0c48c51b47a47f4cad7db0c51ee7407cc1b

This is the complete merge for pull (https://github.com/node-modules/charset/pull/11), which closes the original issue (https://github.com/node-modules/charset/issues/10)