### PR TITLE
[GHSA-9fgx-q25h-jxrg] DOM XSS in Theme Preview

### DIFF
--- a/advisories/github-reviewed/2021/04/GHSA-9fgx-q25h-jxrg/GHSA-9fgx-q25h-jxrg.json
+++ b/advisories/github-reviewed/2021/04/GHSA-9fgx-q25h-jxrg/GHSA-9fgx-q25h-jxrg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9fgx-q25h-jxrg",
-  "modified": "2022-11-21T19:46:10Z",
+  "modified": "2023-02-01T05:01:58Z",
   "published": "2021-04-29T21:53:18Z",
   "aliases": [
     "CVE-2021-29484"
@@ -43,6 +43,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-29484"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/TryGhost/Ghost/commit/14b3431de12e674a0bd562e9230e2891b6903ae2"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v4.3.3: https://github.com/TryGhost/Ghost/commit/14b3431de12e674a0bd562e9230e2891b6903ae2

The GHSA-ID is in the message: "Removed unused and insecure preview endpoint refs: GHSA-9fgx-q25h-jxrg"