### PR TITLE
[GHSA-9fmc-5fq4-5jwh] HashiCorp Nomad vulnerable to Insufficient Session Expiration

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-9fmc-5fq4-5jwh/GHSA-9fmc-5fq4-5jwh.json
+++ b/advisories/github-reviewed/2022/11/GHSA-9fmc-5fq4-5jwh/GHSA-9fmc-5fq4-5jwh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9fmc-5fq4-5jwh",
-  "modified": "2022-11-10T23:51:03Z",
+  "modified": "2023-01-30T05:07:28Z",
   "published": "2022-11-10T12:01:03Z",
   "aliases": [
     "CVE-2022-3867"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-3867"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hashicorp/nomad/commit/dd6a4634a9652197fe4182e830f9a737d0ae1216"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.4.2: https://github.com/hashicorp/nomad/commit/dd6a4634a9652197fe4182e830f9a737d0ae1216

In this patch, the developer is now checking if tokens expire before triggering events, which would only end once the token was garbage collected—a very similar description to the original advisory. 