### PR TITLE
[GHSA-9h6h-9g78-86f7] Yapscan's report receiver server vulnerable to path traversal and log injection

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-9h6h-9g78-86f7/GHSA-9h6h-9g78-86f7.json
+++ b/advisories/github-reviewed/2022/12/GHSA-9h6h-9g78-86f7/GHSA-9h6h-9g78-86f7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9h6h-9g78-86f7",
-  "modified": "2022-12-29T01:50:20Z",
+  "modified": "2023-01-13T05:03:13Z",
   "published": "2022-12-29T01:50:20Z",
   "aliases": [
 
@@ -43,6 +43,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/fkie-cad/yapscan/issues/35"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/fkie-cad/yapscan/commit/a75a20b50be673b96b1d42187b97f8cfe60728df"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/fkie-cad/yapscan/commit/fef9a33ceb66f6b929839f7eaf393b629681bc5d"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding two patch links for v0.19.1: 
https://github.com/fkie-cad/yapscan/commit/a75a20b50be673b96b1d42187b97f8cfe60728df
https://github.com/fkie-cad/yapscan/commit/fef9a33ceb66f6b929839f7eaf393b629681bc5d

These two patches were referenced in the original issue (https://github.com/fkie-cad/yapscan/issues/35)