### PR TITLE
[GHSA-9jc5-9wh5-mc36] Concrete CMS vulnerable to Cross-site Scripting

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-9jc5-9wh5-mc36/GHSA-9jc5-9wh5-mc36.json
+++ b/advisories/github-reviewed/2022/11/GHSA-9jc5-9wh5-mc36/GHSA-9jc5-9wh5-mc36.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9jc5-9wh5-mc36",
-  "modified": "2022-11-22T00:12:33Z",
+  "modified": "2023-02-01T05:04:03Z",
   "published": "2022-11-15T12:00:17Z",
   "aliases": [
     "CVE-2022-43688"
@@ -58,6 +58,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43688"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/pull/10999"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/commit/51f19b377a19c97a8b8f1d4d0f13724ed1c7c7a7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/commit/6d46ca042fcfeda0f7881d8744f5216ef1abce0e"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch links for v8.5.10: https://github.com/concretecms/concretecms/commit/6d46ca042fcfeda0f7881d8744f5216ef1abce0e

Adding the patch links for v9.1.3: https://github.com/concretecms/concretecms/commit/51f19b377a19c97a8b8f1d4d0f13724ed1c7c7a7

Adding the pull: https://github.com/concretecms/concretecms/pull/10999

The patches are related to the original advisory: "This PR prevents XSS in the microsoft application tile color."