### PR TITLE
[GHSA-9p29-94hp-8rvc] qiita-markdown Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-9p29-94hp-8rvc/GHSA-9p29-94hp-8rvc.json
+++ b/advisories/github-reviewed/2021/08/GHSA-9p29-94hp-8rvc/GHSA-9p29-94hp-8rvc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9p29-94hp-8rvc",
-  "modified": "2023-01-24T15:08:52Z",
+  "modified": "2023-01-24T15:08:54Z",
   "published": "2021-08-02T17:22:07Z",
   "aliases": [
     "CVE-2021-28833"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-28833"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/increments/qiita-markdown/commit/b5d4e60bf537ceb177e70bf91653d29575e1aa21"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch links for v0.34.0: https://github.com/increments/qiita-markdown/commit/b5d4e60bf537ceb177e70bf91653d29575e1aa21

Only a few commits for v0.34.0: https://github.com/increments/qiita-markdown/compare/v0.33.0...v0.34.0. The patch added is the only one related to the original XSS issue. 