### PR TITLE
[GHSA-9pp4-8p8v-g78w] Data races in lever

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-9pp4-8p8v-g78w/GHSA-9pp4-8p8v-g78w.json
+++ b/advisories/github-reviewed/2021/08/GHSA-9pp4-8p8v-g78w/GHSA-9pp4-8p8v-g78w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9pp4-8p8v-g78w",
-  "modified": "2021-08-18T20:22:32Z",
+  "modified": "2023-02-01T05:06:03Z",
   "published": "2021-08-25T20:57:26Z",
   "aliases": [
     "CVE-2020-36457"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/vertexclique/lever/issues/15"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vertexclique/lever/commit/4a4cca61cdb25061967d58522229e147483007b1"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.1.1: https://github.com/vertexclique/lever/commit/4a4cca61cdb25061967d58522229e147483007b1

The patch is the complete merge of pull (https://github.com/vertexclique/lever/pull/17), which was referenced in the original issue (https://github.com/vertexclique/lever/issues/15)