### PR TITLE
[GHSA-9wgh-vjj7-7433] Mutable reference with immutable provenance in image

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-9wgh-vjj7-7433/GHSA-9wgh-vjj7-7433.json
+++ b/advisories/github-reviewed/2021/08/GHSA-9wgh-vjj7-7433/GHSA-9wgh-vjj7-7433.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9wgh-vjj7-7433",
-  "modified": "2021-08-19T20:49:50Z",
+  "modified": "2023-01-11T05:05:39Z",
   "published": "2021-08-25T20:49:54Z",
   "aliases": [
     "CVE-2020-35916"
@@ -19,16 +19,6 @@
       "package": {
         "ecosystem": "crates.io",
         "name": "image"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "image::Bgr::from_slice_mut",
-          "image::Bgra::from_slice_mut",
-          "image::Luma::from_slice_mut",
-          "image::LumaA::from_slice_mut",
-          "image::Rgb::from_slice_mut",
-          "image::Rgba::from_slice_mut"
-        ]
       },
       "ranges": [
         {
@@ -53,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/image-rs/image/issues/1357"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/image-rs/image/commit/5cbe1e6767d11aff3f14c7ad69a06b04e8d583c7"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding the patch link for v0.23.12: https://github.com/image-rs/image/commit/5cbe1e6767d11aff3f14c7ad69a06b04e8d583c7

The patch is the complete merge of pull (https://github.com/image-rs/image/pull/1358), which was referenced in the original issue (https://github.com/image-rs/image/issues/1357) as the fix.