### PR TITLE
[GHSA-9wx7-jrvc-28mm] Signature verification vulnerability in Stark Bank ecdsa libraries

### DIFF
--- a/advisories/github-reviewed/2021/11/GHSA-9wx7-jrvc-28mm/GHSA-9wx7-jrvc-28mm.json
+++ b/advisories/github-reviewed/2021/11/GHSA-9wx7-jrvc-28mm/GHSA-9wx7-jrvc-28mm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9wx7-jrvc-28mm",
-  "modified": "2021-11-08T21:34:42Z",
+  "modified": "2023-01-09T05:05:53Z",
   "published": "2021-11-08T21:51:18Z",
   "aliases": [
 
@@ -99,6 +99,10 @@
     }
   ],
   "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/starkbank/ecdsa-python/commit/d136170666e9510eb63c2572551805807bd4c17f"
+    },
     {
       "type": "WEB",
       "url": "https://github.com/starkbank/ecdsa-dotnet"


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.0.1 of the Python instance: https://github.com/starkbank/ecdsa-python/commit/d136170666e9510eb63c2572551805807bd4c17f

Only a few commits for v2.0.1 (https://github.com/starkbank/ecdsa-python/compare/v2.0.0...v2.0.1) and the changelog also reference the same commit message: "Signature r and s range check," related to the original vulnerability. 