### PR TITLE
[GHSA-9xjr-m6f3-v5wm] HTTPS MitM vulnerability due to lack of hostname verification

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-9xjr-m6f3-v5wm/GHSA-9xjr-m6f3-v5wm.json
+++ b/advisories/github-reviewed/2021/08/GHSA-9xjr-m6f3-v5wm/GHSA-9xjr-m6f3-v5wm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9xjr-m6f3-v5wm",
-  "modified": "2021-08-19T21:25:12Z",
+  "modified": "2023-01-11T05:06:02Z",
   "published": "2021-08-25T20:43:06Z",
   "aliases": [
     "CVE-2016-10932"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-10932"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hyperium/hyper/commit/01160abd92956e5f995cc45790df7a2b86c8989f"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.9.4: https://github.com/hyperium/hyper/commit/01160abd92956e5f995cc45790df7a2b86c8989f

Referenced in changelog (https://github.com/hyperium/hyper/blob/master/CHANGELOG.md#v094-2016-05-09):  "enable hostname verification by default for OpenSSL (01160abd, closes 472)"