### PR TITLE
[GHSA-c3gv-9cxf-6f57] Cross-site Scripting in Loofah

### DIFF
--- a/advisories/github-reviewed/2019/11/GHSA-c3gv-9cxf-6f57/GHSA-c3gv-9cxf-6f57.json
+++ b/advisories/github-reviewed/2019/11/GHSA-c3gv-9cxf-6f57/GHSA-c3gv-9cxf-6f57.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c3gv-9cxf-6f57",
-  "modified": "2023-01-20T22:01:21Z",
+  "modified": "2023-01-20T22:01:23Z",
   "published": "2019-11-05T23:58:25Z",
   "aliases": [
     "CVE-2019-15587"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/flavorjones/loofah/issues/171"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/flavorjones/loofah/commit/0c6617af440879ce97440f6eb6c58636456dc8ec"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.3.1: https://github.com/flavorjones/loofah/commit/0c6617af440879ce97440f6eb6c58636456dc8ec

The CVE and original issue (171) are mentioned in the commit message: "mitigate XSS vulnerability in SVG animate attributes this addresses CVE-2019-15587 see #171 for more information"