### PR TITLE
[GHSA-7rqg-hjwc-6mjf] Grafana vulnerable to Stored Cross-site Scripting in Text plugin

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-7rqg-hjwc-6mjf/GHSA-7rqg-hjwc-6mjf.json
+++ b/advisories/github-reviewed/2023/03/GHSA-7rqg-hjwc-6mjf/GHSA-7rqg-hjwc-6mjf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7rqg-hjwc-6mjf",
-  "modified": "2023-03-02T20:41:57Z",
+  "modified": "2023-03-15T19:18:03Z",
   "published": "2023-03-01T20:56:49Z",
   "aliases": [
     "CVE-2023-22462"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "9.2"
+              "introduced": "9.2.0"
             },
             {
               "fixed": "9.2.10"
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "9.3"
+              "introduced": "9.3.0"
             },
             {
               "fixed": "9.3.4"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Lower bounds of affected versions were mistakenly reported in a non-semver compliant format. This change adapts `9.2` to `9.2.0` and `9.3` to `9.3.0`. These versions also match with the vendor-issued security advisory available at https://github.com/grafana/grafana/security/advisories/GHSA-7rqg-hjwc-6mjf