### PR TITLE
[GHSA-g6w6-r76c-28j7] Incorrect Authorization in NATS nats-server

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-g6w6-r76c-28j7/GHSA-g6w6-r76c-28j7.json
+++ b/advisories/github-reviewed/2022/02/GHSA-g6w6-r76c-28j7/GHSA-g6w6-r76c-28j7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g6w6-r76c-28j7",
-  "modified": "2022-02-08T17:23:16Z",
+  "modified": "2023-02-03T05:05:35Z",
   "published": "2022-02-08T17:23:16Z",
   "aliases": [
     "CVE-2022-24450"
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.0"
+              "introduced": "2.0.0"
             },
             {
               "fixed": "2.7.2"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The affected version was mistakenly listed as >= 2.0, whereas only >= 2.0.0 is semantically correct. See https://github.com/nats-io/nats-server/releases/tag/v2.0.0 for reference.