### PR TITLE
[GHSA-qv98-3369-g364] KubeVirt vulnerable to arbitrary file read on host

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-qv98-3369-g364/GHSA-qv98-3369-g364.json
+++ b/advisories/github-reviewed/2022/09/GHSA-qv98-3369-g364/GHSA-qv98-3369-g364.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qv98-3369-g364",
-  "modified": "2022-09-15T03:20:35Z",
+  "modified": "2023-01-10T05:07:29Z",
   "published": "2022-09-15T03:20:35Z",
   "aliases": [
 
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0.20"
+              "introduced": "0.20.0"
             },
             {
               "fixed": "0.55.1"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
 The affected version was mistakenly listed as >= 0.20, whereas only >= 0.20.0 is semantically correct. See https://github.com/kubevirt/kubevirt/releases/tag/v0.20.0 for reference.