### PR TITLE
[GHSA-c6jq-h4jp-72pr] NULL Pointer Dereference in aubio

### DIFF
--- a/advisories/github-reviewed/2019/07/GHSA-c6jq-h4jp-72pr/GHSA-c6jq-h4jp-72pr.json
+++ b/advisories/github-reviewed/2019/07/GHSA-c6jq-h4jp-72pr/GHSA-c6jq-h4jp-72pr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c6jq-h4jp-72pr",
-  "modified": "2021-08-17T19:08:15Z",
+  "modified": "2023-02-01T05:02:22Z",
   "published": "2019-07-26T16:10:25Z",
   "aliases": [
     "CVE-2018-19802"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-19802"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/aubio/aubio/commit/c5ee1307bdc004e43302abeca1802c2692b33a8e"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.4.9: https://github.com/aubio/aubio/commit/c5ee1307bdc004e43302abeca1802c2692b33a8e

In the code o->onset = new_aubio_onset(...) contains the NULL pointer dereference. Later in the commit, the developer adds checks to prevent the dereference. 