### PR TITLE
[GHSA-c6rq-rjc2-86v2] Time-of-check Time-of-use (TOCTOU) Race Condition in chownr

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-c6rq-rjc2-86v2/GHSA-c6rq-rjc2-86v2.json
+++ b/advisories/github-reviewed/2022/02/GHSA-c6rq-rjc2-86v2/GHSA-c6rq-rjc2-86v2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c6rq-rjc2-86v2",
-  "modified": "2021-05-12T20:23:29Z",
+  "modified": "2023-02-01T05:05:32Z",
   "published": "2022-02-10T23:33:39Z",
   "aliases": [
     "CVE-2017-18869"
@@ -43,6 +43,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/isaacs/chownr/issues/14"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/isaacs/chownr/commit/36a93e3f0a220062c47b237cf6ab6d5f55cd79c9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/isaacs/chownr/commit/a631d841022880e5c8d694408a7e96d6d576d0ce"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding two patch links for v1.1.0: 
https://github.com/isaacs/chownr/commit/a631d841022880e5c8d694408a7e96d6d576d0ce
https://github.com/isaacs/chownr/commit/36a93e3f0a220062c47b237cf6ab6d5f55cd79c9

Many discussions in the original issue (https://github.com/isaacs/chownr/issues/14) to use fs.lchown instead of fs.chown to address the vulnerability. The project owner eventually added patches to do so. These are the only two commits related to the patch v1.1.0: https://github.com/isaacs/chownr/compare/v1.0.1...v1.1.0. Additionally, one of the commit patch messages addresses the TOCTOU issue: "use lchown to address part 1 of TOCTOU issue"