### PR TITLE
[GHSA-c72p-9xmj-rx3w] Archive package allows chmod of file outside of unpack target directory

### DIFF
--- a/advisories/github-reviewed/2021/07/GHSA-c72p-9xmj-rx3w/GHSA-c72p-9xmj-rx3w.json
+++ b/advisories/github-reviewed/2021/07/GHSA-c72p-9xmj-rx3w/GHSA-c72p-9xmj-rx3w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c72p-9xmj-rx3w",
-  "modified": "2022-10-25T20:25:56Z",
+  "modified": "2023-01-29T05:06:51Z",
   "published": "2021-07-26T21:17:45Z",
   "aliases": [
     "CVE-2021-32760"
@@ -62,6 +62,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-32760"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/containerd/containerd/commit/22e9a70c71eff6507be71955947a611f2ed91e6c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/containerd/containerd/commit/7ad08c69e09ee4930a48dbf2aab3cd612458617f"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v1.4.8: https://github.com/containerd/containerd/commit/22e9a70c71eff6507be71955947a611f2ed91e6c

Adding patch link for v1.5.4: https://github.com/containerd/containerd/commit/7ad08c69e09ee4930a48dbf2aab3cd612458617f

The GHSA-ID is in the commit message: "Merge pull request from GHSA-c72p-9xmj-rx3w Use chmod path for checking symlink"