### PR TITLE
[GHSA-c9rv-3jmq-527w] Unexpected panic when decoding tokens in branca

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-c9rv-3jmq-527w/GHSA-c9rv-3jmq-527w.json
+++ b/advisories/github-reviewed/2021/08/GHSA-c9rv-3jmq-527w/GHSA-c9rv-3jmq-527w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c9rv-3jmq-527w",
-  "modified": "2021-08-19T20:50:27Z",
+  "modified": "2023-01-27T05:00:32Z",
   "published": "2021-08-25T20:49:50Z",
   "aliases": [
     "CVE-2020-35918"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/tuupola/branca-spec/issues/22"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/return/branca/commit/7da3274bd99b05dce9c3f9b4b129d0145c71820b"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v0.10.0: https://github.com/return/branca/commit/7da3274bd99b05dce9c3f9b4b129d0145c71820b

The patch was mentioned in the original issue (https://github.com/return/branca/issues/24): "This behavior was corrected in 7da3274:"