### PR TITLE
[GHSA-ccw8-7688-vqx4] HashiCorp Consul Privilege Escalation Vulnerability

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-ccw8-7688-vqx4/GHSA-ccw8-7688-vqx4.json
+++ b/advisories/github-reviewed/2021/09/GHSA-ccw8-7688-vqx4/GHSA-ccw8-7688-vqx4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ccw8-7688-vqx4",
-  "modified": "2022-08-10T23:49:51Z",
+  "modified": "2023-01-29T05:02:40Z",
   "published": "2021-09-08T20:14:48Z",
   "aliases": [
     "CVE-2021-37219"
@@ -80,6 +80,22 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-37219"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hashicorp/consul/pull/10925"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hashicorp/consul/commit/3357e57dac9aadabd476f7a14973e47f003c4cf0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hashicorp/consul/commit/473edd1764b6739e2e4610ea5dede4c2bc6009d1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hashicorp/consul/commit/ccf8eb1947357434eb6e66303ddab79f4c9d4103"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v1.8.15: https://github.com/hashicorp/consul/commit/ccf8eb1947357434eb6e66303ddab79f4c9d4103

Adding patch link for v1.9.9: https://github.com/hashicorp/consul/commit/473edd1764b6739e2e4610ea5dede4c2bc6009d1

Adding patch link for v1.10.2: https://github.com/hashicorp/consul/commit/3357e57dac9aadabd476f7a14973e47f003c4cf0

Adding original pull: https://github.com/hashicorp/consul/pull/10925

The CVE is mentioned in the pull and associated changelogs added on each patch: "rpc: authorize raft requests CVE-2021-37219"