### PR TITLE
[GHSA-cff4-rrq6-h78w] Command Injection in command-exists

### DIFF
--- a/advisories/github-reviewed/2019/06/GHSA-cff4-rrq6-h78w/GHSA-cff4-rrq6-h78w.json
+++ b/advisories/github-reviewed/2019/06/GHSA-cff4-rrq6-h78w/GHSA-cff4-rrq6-h78w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cff4-rrq6-h78w",
-  "modified": "2020-08-31T18:31:41Z",
+  "modified": "2023-01-09T05:01:41Z",
   "published": "2019-06-03T17:31:26Z",
   "aliases": [
 
@@ -33,6 +33,10 @@
     }
   ],
   "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/mathisonian/command-exists/commit/7ca91ba71604df6817a28c93d7776af9c49c431a"
+    },
     {
       "type": "WEB",
       "url": "https://hackerone.com/reports/324453"


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v1.2.4: https://github.com/mathisonian/command-exists/commit/7ca91ba71604df6817a28c93d7776af9c49c431a

The developer started to sanitize commands which prevented the original command injection vulnerability. Only two commits existed for v1.2.4, and the other was a release bump: https://github.com/mathisonian/command-exists/compare/v1.2.3...v1.2.4