### PR TITLE
[GHSA-cgjx-mwpx-47jv] Private Data Disclosure in express-restify-mongoose

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-cgjx-mwpx-47jv/GHSA-cgjx-mwpx-47jv.json
+++ b/advisories/github-reviewed/2018/10/GHSA-cgjx-mwpx-47jv/GHSA-cgjx-mwpx-47jv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cgjx-mwpx-47jv",
-  "modified": "2020-08-31T18:10:32Z",
+  "modified": "2023-01-09T05:02:51Z",
   "published": "2018-10-23T17:14:57Z",
   "aliases": [
     "CVE-2016-10533"
@@ -12,28 +12,6 @@
 
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "express-restify-mongoose"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.0.0"
-            },
-            {
-              "fixed": "3.1.0"
-            }
-          ]
-        }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 3.0.1"
-      }
-    },
     {
       "package": {
         "ecosystem": "npm",
@@ -55,6 +33,28 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 2.4.2"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "express-restify-mongoose"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.0.0"
+            },
+            {
+              "fixed": "3.1.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.0.1"
+      }
     }
   ],
   "references": [
@@ -65,6 +65,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/florianholzapfel/express-restify-mongoose/issues/252"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/florianholzapfel/express-restify-mongoose/commit/23ccb247d0074bfaca6737cdff52d89c6d6e4a7c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/florianholzapfel/express-restify-mongoose/commit/746defcd808e2ed1e8931dc36702b25b7db0e94b"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v2.5.0: https://github.com/florianholzapfel/express-restify-mongoose/commit/746defcd808e2ed1e8931dc36702b25b7db0e94b

Adding patch link for v3.1.0: https://github.com/florianholzapfel/express-restify-mongoose/commit/23ccb247d0074bfaca6737cdff52d89c6d6e4a7c

The pull (https://github.com/florianholzapfel/express-restify-mongoose/pull/253) was referenced as closing the original issue (https://github.com/florianholzapfel/express-restify-mongoose/issues/252)