### PR TITLE
[GHSA-cr5j-953j-xw5p] Arbitrary execution of code in Nokogiri

### DIFF
--- a/advisories/github-reviewed/2019/08/GHSA-cr5j-953j-xw5p/GHSA-cr5j-953j-xw5p.json
+++ b/advisories/github-reviewed/2019/08/GHSA-cr5j-953j-xw5p/GHSA-cr5j-953j-xw5p.json
@@ -65,6 +65,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/sparklemotion/nokogiri/commit/5d30128343573a9428c86efc758ba2c66e9f12dc"
+    },
+    {
+      "type": "WEB",
       "url": "https://hackerone.com/reports/650835"
     },
     {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for nokogirl v1.10.4: https://github.com/sparklemotion/nokogiri/commit/5d30128343573a9428c86efc758ba2c66e9f12dc

This is the complete merge related to the original issue (https://github.com/sparklemotion/nokogiri/issues/1915). The changelog was additionally updated during the merge: "Address CVE-2019-5477."