### PR TITLE
[GHSA-cvj4-g3gx-8vqq] Restlet Framework allows remote attackers to access arbitrary files via a crafted REST API HTTP request

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-cvj4-g3gx-8vqq/GHSA-cvj4-g3gx-8vqq.json
+++ b/advisories/github-reviewed/2018/10/GHSA-cvj4-g3gx-8vqq/GHSA-cvj4-g3gx-8vqq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cvj4-g3gx-8vqq",
-  "modified": "2022-04-26T21:37:05Z",
+  "modified": "2023-01-09T05:03:01Z",
   "published": "2018-10-17T00:04:18Z",
   "aliases": [
     "CVE-2017-14949"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-14949"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/restlet/restlet-framework-java/commit/fe75aff3af23b879b984db7a2b6824cee0ef0fc5"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v2.3.12: https://github.com/restlet/restlet-framework-java/commit/fe75aff3af23b879b984db7a2b6824cee0ef0fc5

The patch fixed the XEE injection security in an XML extension. Additionally, this was the only security-related commit for v2.3.12: https://github.com/restlet/restlet-framework-java/compare/2.3.11...2.3.12