### PR TITLE
[GHSA-cxw7-85xm-3xrc] Plone Code Injection vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-cxw7-85xm-3xrc/GHSA-cxw7-85xm-3xrc.json
+++ b/advisories/github-reviewed/2022/05/GHSA-cxw7-85xm-3xrc/GHSA-cxw7-85xm-3xrc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cxw7-85xm-3xrc",
-  "modified": "2023-02-08T17:56:42Z",
+  "modified": "2023-02-08T17:56:43Z",
   "published": "2022-05-17T04:31:32Z",
   "aliases": [
     "CVE-2012-5488"
@@ -55,6 +55,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2012-5488"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/plone/Products.CMFPlone/commit/a9479a5b38646fe0b0a9066ee46de9c18de32bfa"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/plone/Products.CMFPlone/commit/c3a98f4e6cf26501485de9c8354c49afdea21df8"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v4.2.3: https://github.com/plone/Products.CMFPlone/commit/c3a98f4e6cf26501485de9c8354c49afdea21df8

Adding patch link for v4.3b1: https://github.com/plone/Products.CMFPlone/commit/a9479a5b38646fe0b0a9066ee46de9c18de32bfa

The commit patch message reads: "various security fixes based on PloneHotfix20121106," which is similar to the original link provided: https://plone.org/products/plone-hotfix/releases/20121106 (even though the original link doesn't work anymore, we can note the name of plone-hotfix 20121106)