### PR TITLE
[GHSA-f2rj-m42r-6jm2] Skipper vulnerable to SSRF via X-Skipper-Proxy

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-f2rj-m42r-6jm2/GHSA-f2rj-m42r-6jm2.json
+++ b/advisories/github-reviewed/2022/10/GHSA-f2rj-m42r-6jm2/GHSA-f2rj-m42r-6jm2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f2rj-m42r-6jm2",
-  "modified": "2022-10-25T20:22:29Z",
+  "modified": "2023-02-17T22:58:57Z",
   "published": "2022-10-25T20:22:29Z",
   "aliases": [
     "CVE-2022-38580"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/zalando/skipper/pull/2058"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/zalando/skipper/commit/842634347da8fe77e396f66edea79d329fd72130"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.13.237: https://github.com/zalando/skipper/commit/842634347da8fe77e396f66edea79d329fd72130

This is the merged commit for the patch of the original pull (https://github.com/zalando/skipper/pull/2058)