### PR TITLE
[GHSA-f3pg-qwvg-p99c] Lenient Parsing of Content-Length Header When Prefixed with Plus Sign

### DIFF
--- a/advisories/github-reviewed/2021/07/GHSA-f3pg-qwvg-p99c/GHSA-f3pg-qwvg-p99c.json
+++ b/advisories/github-reviewed/2021/07/GHSA-f3pg-qwvg-p99c/GHSA-f3pg-qwvg-p99c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f3pg-qwvg-p99c",
-  "modified": "2021-09-07T21:49:21Z",
+  "modified": "2023-02-03T05:06:14Z",
   "published": "2021-07-12T16:54:20Z",
   "aliases": [
     "CVE-2021-32715"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/rust-lang/rust/pull/28826/commits/123a83326fb95366e94a3be1a74775df4db97739"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hyperium/hyper/commit/1fb719e0b61a4f3d911562a436a2ff05fd7cb759"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.14.10: https://github.com/hyperium/hyper/commit/1fb719e0b61a4f3d911562a436a2ff05fd7cb759

The GHSA-ID is in the commit message of the patch: "fix(http1): reject content-lengths that have a plus sign prefix.....See GHSA-f3pg-qwvg-p99c"