### PR TITLE
[GHSA-f8p3-q834-q9cj] php-mod/curl allows Cross-site Scripting

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-f8p3-q834-q9cj/GHSA-f8p3-q834-q9cj.json
+++ b/advisories/github-reviewed/2022/12/GHSA-f8p3-q834-q9cj/GHSA-f8p3-q834-q9cj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f8p3-q834-q9cj",
-  "modified": "2023-01-09T19:52:37Z",
+  "modified": "2023-02-02T05:01:17Z",
   "published": "2022-12-26T09:30:26Z",
   "aliases": [
     "CVE-2021-30134"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-30134"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/php-mod/curl/commit/0bddefe8bbd292065f23dd6e24d2c745c4865cf7"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.3.2: https://github.com/php-mod/curl/commit/0bddefe8bbd292065f23dd6e24d2c745c4865cf7

From an original reference link (https://wpscan.com/vulnerability/0b547728-27d2-402e-ae17-90d539344ec7), they found the underlying issue of the XSS to be the following: "the cause was found to be test files from the php-mod/curl library, which was missing appropriate response headers before outputting user input." The patch adds the missing response headers for the same post_file_path_upload.php and post_multidimensional.php files. 