### PR TITLE
[GHSA-f9vc-q3hh-qhfv] Content Injection in remarkable

### DIFF
--- a/advisories/github-reviewed/2020/08/GHSA-f9vc-q3hh-qhfv/GHSA-f9vc-q3hh-qhfv.json
+++ b/advisories/github-reviewed/2020/08/GHSA-f9vc-q3hh-qhfv/GHSA-f9vc-q3hh-qhfv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f9vc-q3hh-qhfv",
-  "modified": "2020-08-31T18:08:29Z",
+  "modified": "2023-01-09T05:03:48Z",
   "published": "2020-08-31T22:56:00Z",
   "aliases": [
     "CVE-2014-10065"
@@ -40,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/jonschlinkert/remarkable/issues/97"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jonschlinkert/remarkable/commit/d54ed887f4997221cd7cb9790e953a83c504de36"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.4.1: https://github.com/jonschlinkert/remarkable/commit/d54ed887f4997221cd7cb9790e953a83c504de36

The original issue (https://github.com/jonschlinkert/remarkable/issues/97) mentions, "Doing it in renderer is not correct. There should be url encoding only." The commit patch message is very similar: "Normalize links before they hit renderer"