### PR TITLE
[GHSA-fff8-4w9p-7v76] Command Injection in Pygments

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-fff8-4w9p-7v76/GHSA-fff8-4w9p-7v76.json
+++ b/advisories/github-reviewed/2022/05/GHSA-fff8-4w9p-7v76/GHSA-fff8-4w9p-7v76.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fff8-4w9p-7v76",
-  "modified": "2022-06-03T15:40:31Z",
+  "modified": "2023-01-29T05:01:53Z",
   "published": "2022-05-17T02:37:56Z",
   "aliases": [
     "CVE-2015-8557"
@@ -33,31 +33,16 @@
           ]
         }
       ]
-    },
-    {
-      "package": {
-        "ecosystem": "PyPI",
-        "name": "pygments"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "1.2.2"
-            },
-            {
-              "fixed": "2.1"
-            }
-          ]
-        }
-      ]
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-8557"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pygments/pygments/commit/db6dd826f8624179e563aaded391efe824462f51"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.1: https://github.com/pygments/pygments/commit/db6dd826f8624179e563aaded391efe824462f51

The patch message is very similar to the original advisory: "Fix Shell Injection in FontManager._get_nix_font_path" 