### PR TITLE
[GHSA-frxx-2m33-6wcr] Improper Restriction of Operations within the Bounds of a Memory Buffer in Google TensorFlow

### DIFF
--- a/advisories/github-reviewed/2019/04/GHSA-frxx-2m33-6wcr/GHSA-frxx-2m33-6wcr.json
+++ b/advisories/github-reviewed/2019/04/GHSA-frxx-2m33-6wcr/GHSA-frxx-2m33-6wcr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-frxx-2m33-6wcr",
-  "modified": "2021-08-03T20:54:53Z",
+  "modified": "2023-02-01T05:01:42Z",
   "published": "2019-04-24T16:11:30Z",
   "aliases": [
     "CVE-2018-8825"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-8825"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/tensorflow/tensorflow/commit/41335abb46f80ca644b5738550daef6136ba5476"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/tensorflow/tensorflow/commit/8badd11d875a826bd318ed439909d5c47a7fb811"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patches for v1.7.1: 
https://github.com/tensorflow/tensorflow/commit/41335abb46f80ca644b5738550daef6136ba5476
https://github.com/tensorflow/tensorflow/commit/8badd11d875a826bd318ed439909d5c47a7fb811

The patches are mentioned in an original reference link (https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2018-003.md): "We have patched the vulnerability in GitHub commits 41335abb and 8badd11d."