### PR TITLE
[GHSA-fxpg-gg9g-76gj] Moderate severity vulnerability that affects django

### DIFF
--- a/advisories/github-reviewed/2018/07/GHSA-fxpg-gg9g-76gj/GHSA-fxpg-gg9g-76gj.json
+++ b/advisories/github-reviewed/2018/07/GHSA-fxpg-gg9g-76gj/GHSA-fxpg-gg9g-76gj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fxpg-gg9g-76gj",
-  "modified": "2021-09-10T20:17:17Z",
+  "modified": "2023-01-09T05:02:53Z",
   "published": "2018-07-23T19:52:42Z",
   "aliases": [
     "CVE-2010-3082"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2010-3082"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/7f84657b6b2243cc787bdb9f296710c8d13ad0bd"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patches for v1.2.2: 
https://github.com/django/django/commit/7f84657b6b2243cc787bdb9f296710c8d13ad0bd

The patches are mentioned in an original reference link (https://www.djangoproject.com/weblog/2010/sep/08/security-release/): "Patches may be obtained directly from the appropriate changesets:
Django trunk: https://github.com/django/django/commit/9e3b327aca
Django 1.2: https://github.com/django/django/commit/7f84657b6b"