### PR TITLE
[GHSA-v5w6-wcm8-jm4q] openssl-src contains Double free after calling `PEM_read_bio_ex`

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-v5w6-wcm8-jm4q/GHSA-v5w6-wcm8-jm4q.json
+++ b/advisories/github-reviewed/2023/02/GHSA-v5w6-wcm8-jm4q/GHSA-v5w6-wcm8-jm4q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v5w6-wcm8-jm4q",
-  "modified": "2023-02-21T19:59:57Z",
+  "modified": "2023-02-24T16:06:21Z",
   "published": "2023-02-08T22:22:58Z",
   "aliases": [
     "CVE-2022-4450"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "111.25"
+              "fixed": "111.25.0"
             }
           ]
         }
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "300.0"
+              "introduced": "300.0.0"
             },
             {
               "fixed": "300.0.12"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Make 'affected products' versions SemVer compliant.