### PR TITLE
[GHSA-3wx7-46ch-7rq2] AES OCB fails to encrypt some bytes

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-3wx7-46ch-7rq2/GHSA-3wx7-46ch-7rq2.json
+++ b/advisories/github-reviewed/2022/07/GHSA-3wx7-46ch-7rq2/GHSA-3wx7-46ch-7rq2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3wx7-46ch-7rq2",
-  "modified": "2022-09-08T14:25:14Z",
+  "modified": "2023-02-21T20:03:14Z",
   "published": "2022-07-06T19:57:19Z",
   "aliases": [
     "CVE-2022-2097"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "111.22"
+              "fixed": "111.22.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Make the affected product versions SemVer compliant and match the actual package version: https://crates.io/crates/openssl-src/111.22.0+1.1.1q)