### PR TITLE
[GHSA-5ww6-px42-wc85] SM2 Decryption Buffer Overflow

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-5ww6-px42-wc85/GHSA-5ww6-px42-wc85.json
+++ b/advisories/github-reviewed/2022/05/GHSA-5ww6-px42-wc85/GHSA-5ww6-px42-wc85.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5ww6-px42-wc85",
-  "modified": "2022-06-17T00:06:51Z",
+  "modified": "2023-01-30T05:06:43Z",
   "published": "2022-05-24T19:12:03Z",
   "aliases": [
     "CVE-2021-3711"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "111.16"
+              "fixed": "111.16.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Make the affected product versions SemVer compliant and match the actual package version: https://crates.io/crates/openssl-src/111.16.0+1.1.1l