### PR TITLE
[GHSA-83mx-573x-5rw9] Null pointer deference in openssl-src

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-83mx-573x-5rw9/GHSA-83mx-573x-5rw9.json
+++ b/advisories/github-reviewed/2021/08/GHSA-83mx-573x-5rw9/GHSA-83mx-573x-5rw9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-83mx-573x-5rw9",
-  "modified": "2021-08-19T17:21:40Z",
+  "modified": "2023-01-27T05:02:19Z",
   "published": "2021-08-25T20:54:02Z",
   "aliases": [
     "CVE-2021-3449"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "111.15"
+              "fixed": "111.15.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Make the affected product versions SemVer compliant and match the actual package version: https://crates.io/crates/openssl-src/111.15.0+1.1.1k