### PR TITLE
[GHSA-84rm-qf37-fgc2] Integer Overflow in openssl-src

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-84rm-qf37-fgc2/GHSA-84rm-qf37-fgc2.json
+++ b/advisories/github-reviewed/2021/08/GHSA-84rm-qf37-fgc2/GHSA-84rm-qf37-fgc2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-84rm-qf37-fgc2",
-  "modified": "2021-08-19T17:35:19Z",
+  "modified": "2023-02-03T05:00:49Z",
   "published": "2021-08-25T20:52:21Z",
   "aliases": [
     "CVE-2021-23841"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "111.14"
+              "fixed": "111.14.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Make the affected product versions SemVer compliant and match the actual package version: https://crates.io/crates/openssl-src/111.14.0+1.1.1j