### PR TITLE
[GHSA-8hfj-xrj2-pm22] Certificate check bypass in openssl-src

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-8hfj-xrj2-pm22/GHSA-8hfj-xrj2-pm22.json
+++ b/advisories/github-reviewed/2021/08/GHSA-8hfj-xrj2-pm22/GHSA-8hfj-xrj2-pm22.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8hfj-xrj2-pm22",
-  "modified": "2021-08-19T17:22:00Z",
+  "modified": "2023-01-27T05:02:45Z",
   "published": "2021-08-25T20:54:00Z",
   "aliases": [
     "CVE-2021-3450"
@@ -25,10 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "111.11"
+              "introduced": "111.11.0"
             },
             {
-              "fixed": "111.15"
+              "fixed": "111.15.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Make the affected product versions SemVer compliant and match the actual package version:

https://crates.io/crates/openssl-src/111.11.0+1.1.1h   
https://crates.io/crates/openssl-src/111.15.0+1.1.1k