### PR TITLE
[GHSA-jq65-29v4-4x35] Null pointer deference in openssl-src 

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-jq65-29v4-4x35/GHSA-jq65-29v4-4x35.json
+++ b/advisories/github-reviewed/2021/08/GHSA-jq65-29v4-4x35/GHSA-jq65-29v4-4x35.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jq65-29v4-4x35",
-  "modified": "2021-08-19T21:21:21Z",
+  "modified": "2023-01-27T05:00:33Z",
   "published": "2021-08-25T20:45:15Z",
   "aliases": [
     "CVE-2020-1967"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "111.9"
+              "fixed": "111.9.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Make the affected product versions SemVer compliant and match the actual package version: https://crates.io/crates/openssl-src/111.9.0+1.1.1g