### PR TITLE
[GHSA-mc52-jpm2-cqh6] Deno is vulnerable to race condition via interactive permission prompt spoofing

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-mc52-jpm2-cqh6/GHSA-mc52-jpm2-cqh6.json
+++ b/advisories/github-reviewed/2023/01/GHSA-mc52-jpm2-cqh6/GHSA-mc52-jpm2-cqh6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mc52-jpm2-cqh6",
-  "modified": "2023-01-25T18:41:53Z",
+  "modified": "2023-01-25T18:41:54Z",
   "published": "2023-01-20T16:56:40Z",
   "aliases": [
     "CVE-2023-22499"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.9"
+              "introduced": "1.9.0"
             },
             {
               "fixed": "1.29.3"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Make the affected product versions SemVer compliant and match the actual package version: https://crates.io/crates/deno/1.9.0