### PR TITLE
[GHSA-p52g-cm5j-mjv4] openssl-src subject to Timing Oracle in RSA Decryption

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-p52g-cm5j-mjv4/GHSA-p52g-cm5j-mjv4.json
+++ b/advisories/github-reviewed/2023/02/GHSA-p52g-cm5j-mjv4/GHSA-p52g-cm5j-mjv4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p52g-cm5j-mjv4",
-  "modified": "2023-02-24T19:03:43Z",
+  "modified": "2023-02-24T19:03:44Z",
   "published": "2023-02-08T22:31:42Z",
   "aliases": [
     "CVE-2022-4304"
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "300.0"
+              "introduced": "300.0.0"
             },
             {
               "fixed": "300.0.12"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Make the affected product versions SemVer compliant and match the actual package version: https://crates.io/crates/openssl-src/300.0.0+3.0.0