### PR TITLE
[GHSA-q9wj-f4qw-6vfj] Read buffer overruns processing ASN.1 strings

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-q9wj-f4qw-6vfj/GHSA-q9wj-f4qw-6vfj.json
+++ b/advisories/github-reviewed/2022/05/GHSA-q9wj-f4qw-6vfj/GHSA-q9wj-f4qw-6vfj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q9wj-f4qw-6vfj",
-  "modified": "2022-06-17T00:09:35Z",
+  "modified": "2023-01-30T05:06:31Z",
   "published": "2022-05-24T19:12:03Z",
   "aliases": [
     "CVE-2021-3712"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "111.16"
+              "fixed": "111.16.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Make the affected product versions SemVer compliant and match the actual package version: https://crates.io/crates/openssl-src/111.16.0+1.1.1l