### PR TITLE
[GHSA-3637-v6vq-xqqw] Harbor fails to validate the user permissions when updating tag retention policies

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-3637-v6vq-xqqw/GHSA-3637-v6vq-xqqw.json
+++ b/advisories/github-reviewed/2022/09/GHSA-3637-v6vq-xqqw/GHSA-3637-v6vq-xqqw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3637-v6vq-xqqw",
-  "modified": "2022-09-16T19:29:31Z",
+  "modified": "2023-01-11T05:08:03Z",
   "published": "2022-09-16T19:29:31Z",
   "aliases": [
     "CVE-2022-31670"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.0"
+              "introduced": "1.0.0"
             },
             {
               "fixed": "1.10.13"
@@ -47,7 +47,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.0"
+              "introduced": "2.0.0"
             },
             {
               "fixed": "2.4.3"
@@ -69,7 +69,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.5"
+              "introduced": "2.5.0"
             },
             {
               "fixed": "2.5.2"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Make 'affected products' versions SemVer compliant.