### PR TITLE
[GHSA-r7jw-wp68-3xch] openssl-src vulnerable to Use-after-free following `BIO_new_NDEF`

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-r7jw-wp68-3xch/GHSA-r7jw-wp68-3xch.json
+++ b/advisories/github-reviewed/2023/02/GHSA-r7jw-wp68-3xch/GHSA-r7jw-wp68-3xch.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r7jw-wp68-3xch",
-  "modified": "2023-02-21T20:00:42Z",
+  "modified": "2023-02-24T16:07:37Z",
   "published": "2023-02-08T22:28:34Z",
   "aliases": [
     "CVE-2023-0215"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "111.25"
+              "fixed": "111.25.0"
             }
           ]
         }
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "300.0"
+              "introduced": "300.0.0"
             },
             {
               "fixed": "300.0.12"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Make the affected product versions SemVer compliant and match the actual package version: 
https://crates.io/crates/openssl-src/111.25.0+1.1.1t