### PR TITLE
[GHSA-gw62-c7w4-x449] studygolang vulnerable to cross-site scripting

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-gw62-c7w4-x449/GHSA-gw62-c7w4-x449.json
+++ b/advisories/github-reviewed/2022/12/GHSA-gw62-c7w4-x449/GHSA-gw62-c7w4-x449.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gw62-c7w4-x449",
-  "modified": "2022-12-30T00:58:42Z",
+  "modified": "2023-01-29T05:05:46Z",
   "published": "2022-12-21T21:30:15Z",
   "aliases": [
     "CVE-2021-4272"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.1"
+              "last_affected": "0.1.0-20210311151546-0fb30f9"
             }
           ]
         }

--- a/advisories/github-reviewed/2022/12/GHSA-gw62-c7w4-x449/GHSA-gw62-c7w4-x449.json
+++ b/advisories/github-reviewed/2022/12/GHSA-gw62-c7w4-x449/GHSA-gw62-c7w4-x449.json
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.1.0-20210311151546-0fb30f9"
+              "last_affected": "0.1.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Convert affected version to a pseudoversion based off the fixed commit to make it SEMVER compliant