### PR TITLE
[GHSA-g5mm-vmx4-3rg7] Improper handling of case sensitivity in Spring Framework

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-g5mm-vmx4-3rg7/GHSA-g5mm-vmx4-3rg7.json
+++ b/advisories/github-reviewed/2022/04/GHSA-g5mm-vmx4-3rg7/GHSA-g5mm-vmx4-3rg7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g5mm-vmx4-3rg7",
-  "modified": "2022-04-25T23:18:51Z",
+  "modified": "2023-01-27T05:02:47Z",
   "published": "2022-04-15T00:00:32Z",
   "aliases": [
     "CVE-2022-22968"
@@ -58,6 +58,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-22968"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/833e750175349ab4fd502109a8b41af77e25cdea"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/a7cf19cec5ebd270f97a194d749e2d5701ad2ab7"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v5.2.21: https://github.com/spring-projects/spring-framework/commit/833e750175349ab4fd502109a8b41af77e25cdea

Adding the patch link for v5.3.19: 
https://github.com/spring-projects/spring-framework/commit/a7cf19cec5ebd270f97a194d749e2d5701ad2ab7

In this patch, the developer starts lower casing to prevent the case sensitivity in the disallowedField on a DataBinder: PropertyAccessorUtils.canonicalPropertyName(disallowedFields[i]).toLowerCase(); Surrounding text also helps validate this is the patch link: "support case-insensitive pattern matching in {@link #isAllowed}. Subclasses"