### PR TITLE
[GHSA-g7q5-pjjr-gqvp] Regular Expression Denial of Service in tough-cookie

### DIFF
--- a/advisories/github-reviewed/2018/07/GHSA-g7q5-pjjr-gqvp/GHSA-g7q5-pjjr-gqvp.json
+++ b/advisories/github-reviewed/2018/07/GHSA-g7q5-pjjr-gqvp/GHSA-g7q5-pjjr-gqvp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g7q5-pjjr-gqvp",
-  "modified": "2021-09-10T20:28:19Z",
+  "modified": "2023-01-09T05:02:53Z",
   "published": "2018-07-24T20:14:39Z",
   "aliases": [
     "CVE-2017-15010"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/salesforce/tough-cookie/issues/92"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/salesforce/tough-cookie/commit/f1ed420a6a92ea7a5418df6e39e676556bc0c71d"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.3.3: https://github.com/salesforce/tough-cookie/commit/f1ed420a6a92ea7a5418df6e39e676556bc0c71d

The commit patch message references the original issue: "Constrain spaces before = to 256 Side-steps ReDoS in Issue 92."