### PR TITLE
[GHSA-gcqq-w6gr-h9j9] Directory traversal vulnerability in RubyZip

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-gcqq-w6gr-h9j9/GHSA-gcqq-w6gr-h9j9.json
+++ b/advisories/github-reviewed/2017/10/GHSA-gcqq-w6gr-h9j9/GHSA-gcqq-w6gr-h9j9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gcqq-w6gr-h9j9",
-  "modified": "2023-01-26T20:55:34Z",
+  "modified": "2023-01-26T20:55:35Z",
   "published": "2017-10-24T18:33:35Z",
   "aliases": [
     "CVE-2017-5946"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/rubyzip/rubyzip/issues/315"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rubyzip/rubyzip/commit/ce4208fdecc2ad079b05d3c49d70fe6ed1d07016"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.2.1: https://github.com/rubyzip/rubyzip/commit/ce4208fdecc2ad079b05d3c49d70fe6ed1d07016

The commit patch message references the original issue: "Fix 315 and resolve relative path vulnerability"