### PR TITLE
[GHSA-gfhp-jgp6-838j] Orckestra C1 CMS's deserialization of untrusted data allows for arbitrary code execution.

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-gfhp-jgp6-838j/GHSA-gfhp-jgp6-838j.json
+++ b/advisories/github-reviewed/2022/09/GHSA-gfhp-jgp6-838j/GHSA-gfhp-jgp6-838j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gfhp-jgp6-838j",
-  "modified": "2022-11-01T12:56:34Z",
+  "modified": "2023-01-30T05:02:53Z",
   "published": "2022-09-30T04:54:06Z",
   "aliases": [
     "CVE-2022-39256"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/Orckestra/C1-CMS-Foundation/pull/814"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/Orckestra/C1-CMS-Foundation/commit/af856ab5a62d19acf6aea1b1f4c6c3c4985c9446"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v6.13: https://github.com/Orckestra/C1-CMS-Foundation/commit/af856ab5a62d19acf6aea1b1f4c6c3c4985c9446

This is the full merge of the original pull (https://github.com/Orckestra/C1-CMS-Foundation/pull/814)