### PR TITLE
[GHSA-gfhx-jjwq-63gv] Cross-site Scripting in Apereo CAS

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-gfhx-jjwq-63gv/GHSA-gfhx-jjwq-63gv.json
+++ b/advisories/github-reviewed/2021/12/GHSA-gfhx-jjwq-63gv/GHSA-gfhx-jjwq-63gv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gfhx-jjwq-63gv",
-  "modified": "2021-12-08T20:20:15Z",
+  "modified": "2023-02-01T05:07:00Z",
   "published": "2021-12-10T20:24:11Z",
   "aliases": [
     "CVE-2021-42567"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-42567"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apereo/cas/commit/376bf087d6d4267f61fc9f8028aa0d1ef407c3f0"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v6.4.2: https://github.com/apereo/cas/commit/376bf087d6d4267f61fc9f8028aa0d1ef407c3f0

As validation, the developer starts to sanitize the ticket-id/username described in the original reference link (https://apereo.github.io/2021/10/18/restvuln/): "Malicious scripts can be submitted to CAS via parameters such as the ticket id or the username."