### PR TITLE
[GHSA-gfv6-cj92-g3hx] Moderate severity vulnerability that affects pykmip

### DIFF
--- a/advisories/github-reviewed/2018/12/GHSA-gfv6-cj92-g3hx/GHSA-gfv6-cj92-g3hx.json
+++ b/advisories/github-reviewed/2018/12/GHSA-gfv6-cj92-g3hx/GHSA-gfv6-cj92-g3hx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gfv6-cj92-g3hx",
-  "modified": "2021-09-10T20:53:56Z",
+  "modified": "2023-01-09T05:02:54Z",
   "published": "2018-12-21T17:46:39Z",
   "aliases": [
     "CVE-2018-1000872"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/OpenKMIP/PyKMIP/issues/430"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/OpenKMIP/PyKMIP/commit/3a7b880bdf70d295ed8af3a5880bab65fa6b3932"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.8.0: https://github.com/OpenKMIP/PyKMIP/commit/3a7b880bdf70d295ed8af3a5880bab65fa6b3932

The commit patch closes the original issue (430): "Fix a denial-of-service bug by setting the server socket timeout. Closes 430"