### PR TITLE
[GHSA-gjh4-fcv3-whpq] Cross-Site Scripting in webtorrent

### DIFF
--- a/advisories/github-reviewed/2019/09/GHSA-gjh4-fcv3-whpq/GHSA-gjh4-fcv3-whpq.json
+++ b/advisories/github-reviewed/2019/09/GHSA-gjh4-fcv3-whpq/GHSA-gjh4-fcv3-whpq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gjh4-fcv3-whpq",
-  "modified": "2021-08-17T22:20:20Z",
+  "modified": "2023-01-09T05:01:55Z",
   "published": "2019-09-04T10:02:50Z",
   "aliases": [
     "CVE-2019-15782"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/webtorrent/webtorrent/pull/1714"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/webtorrent/webtorrent/commit/7e829b5d52c32d2e6d8f5fbcf0f8f418fffde083"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.107.6: https://github.com/webtorrent/webtorrent/commit/7e829b5d52c32d2e6d8f5fbcf0f8f418fffde083

This is the complete merge of the original pull (https://github.com/webtorrent/webtorrent/pull/1714) to resolve the cross-site scripting issue. 