### PR TITLE
[GHSA-gq5r-cc4w-g8xf] gosaml2 is vulnerable to NULL Pointer Dereference

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-gq5r-cc4w-g8xf/GHSA-gq5r-cc4w-g8xf.json
+++ b/advisories/github-reviewed/2021/06/GHSA-gq5r-cc4w-g8xf/GHSA-gq5r-cc4w-g8xf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gq5r-cc4w-g8xf",
-  "modified": "2022-11-15T19:04:51Z",
+  "modified": "2023-01-27T05:00:54Z",
   "published": "2021-06-23T17:25:08Z",
   "aliases": [
 
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/russellhaering/gosaml2/issues/59"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/russellhaering/gosaml2/commit/66e3b7affd622b8b24ea1e18845f045e46b23424"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.7.0: https://github.com/russellhaering/gosaml2/commit/66e3b7affd622b8b24ea1e18845f045e46b23424

Pull 90 (https://github.com/russellhaering/gosaml2/pull/90) closed the original issue 59 (https://github.com/russellhaering/gosaml2/issues/59), the patch I provided is the complete merge of pull 90.