### PR TITLE
[GHSA-grgm-pph5-j5h7] Exposure of Sensitive Information to an Unauthorized Actor in ansible

### DIFF
--- a/advisories/github-reviewed/2019/07/GHSA-grgm-pph5-j5h7/GHSA-grgm-pph5-j5h7.json
+++ b/advisories/github-reviewed/2019/07/GHSA-grgm-pph5-j5h7/GHSA-grgm-pph5-j5h7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-grgm-pph5-j5h7",
-  "modified": "2021-08-31T21:17:26Z",
+  "modified": "2023-02-01T05:02:22Z",
   "published": "2019-07-31T04:22:49Z",
   "aliases": [
     "CVE-2019-10156"
@@ -81,6 +81,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/ansible/ansible/pull/57188"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ansible/ansible/commit/04e94274fb92e116e9082cc9b86b1fd05c836922"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ansible/ansible/commit/3ff6505e8ff0e4655bab008886983476ef903375"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ansible/ansible/commit/a11c3edfa41e7e4a4db323cdabfc2eae1b61da2a"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.6.18: https://github.com/ansible/ansible/commit/3ff6505e8ff0e4655bab008886983476ef903375

Adding the patch link for v2.7.12: https://github.com/ansible/ansible/commit/a11c3edfa41e7e4a4db323cdabfc2eae1b61da2a

Adding the patch link for v2.8.2: https://github.com/ansible/ansible/commit/04e94274fb92e116e9082cc9b86b1fd05c836922

The patches are the complete merge of the original pull 57188 (https://github.com/ansible/ansible/pull/57188) for the corresponding patched versions. 