### PR TITLE
[GHSA-gv73-9mwv-fwgq] Out of bounds write in prost

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-gv73-9mwv-fwgq/GHSA-gv73-9mwv-fwgq.json
+++ b/advisories/github-reviewed/2021/08/GHSA-gv73-9mwv-fwgq/GHSA-gv73-9mwv-fwgq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gv73-9mwv-fwgq",
-  "modified": "2021-08-19T21:20:08Z",
+  "modified": "2023-01-11T05:06:01Z",
   "published": "2021-08-25T20:46:11Z",
   "aliases": [
     "CVE-2020-35858"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/danburkert/prost/issues/267"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/danburkert/prost/commit/04091d3e745c27590a5f1b7f581793e4159486b5"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.6.1: https://github.com/danburkert/prost/commit/04091d3e745c27590a5f1b7f581793e4159486b5

The original issue is linked in the commit patch message: "apply recursion limit when skipping fields. Fixes tokio-rs 267.