### PR TITLE
[GHSA-gvg7-pp82-cff3] Cross-Site Scripting in c3

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-gvg7-pp82-cff3/GHSA-gvg7-pp82-cff3.json
+++ b/advisories/github-reviewed/2020/09/GHSA-gvg7-pp82-cff3/GHSA-gvg7-pp82-cff3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gvg7-pp82-cff3",
-  "modified": "2021-09-23T21:36:05Z",
+  "modified": "2023-01-09T05:03:33Z",
   "published": "2020-09-01T15:59:11Z",
   "aliases": [
     "CVE-2016-1000240"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/c3js/c3/issues/1536"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/c3js/c3/commit/de3864650300488a63d0541620e9828b00e94b42"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.4.11: https://github.com/c3js/c3/commit/de3864650300488a63d0541620e9828b00e94b42

This is the merge of the pull 1675 (https://github.com/c3js/c3/pull/1675) that closed the original issue 1536 (https://github.com/c3js/c3/issues/1536): 'Sanitise string embedded in tooltip - 1536'