### PR TITLE
[GHSA-gwj5-wp6r-5q9f] Cronos vulnerable to DoS through unintended Contract Selfdestruct

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-gwj5-wp6r-5q9f/GHSA-gwj5-wp6r-5q9f.json
+++ b/advisories/github-reviewed/2022/08/GHSA-gwj5-wp6r-5q9f/GHSA-gwj5-wp6r-5q9f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gwj5-wp6r-5q9f",
-  "modified": "2022-08-11T18:08:57Z",
+  "modified": "2023-01-07T05:07:58Z",
   "published": "2022-08-11T18:08:57Z",
   "aliases": [
 
@@ -46,6 +46,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-35936"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/crypto-org-chain/cronos/commit/2f2cc88b501b47149690fdef05afbbbe5bc116c9"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.8.0: https://github.com/crypto-org-chain/cronos/commit/2f2cc88b501b47149690fdef05afbbbe5bc116c9

This is the only commit for v0.8.0 (https://github.com/crypto-org-chain/cronos/compare/v0.7.1...v0.8.0), and it's to apply the patch so selfdestruct doesn't delete bytecode of smart contracts, an aspect of the underlying DoS from the advisory. 