### PR TITLE
[GHSA-h39x-m55c-v55h] Eclipse Vert.x does not properly neutralize '' (forward slashes) sequences that can resolve to an external location

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-h39x-m55c-v55h/GHSA-h39x-m55c-v55h.json
+++ b/advisories/github-reviewed/2018/10/GHSA-h39x-m55c-v55h/GHSA-h39x-m55c-v55h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h39x-m55c-v55h",
-  "modified": "2022-04-26T21:49:59Z",
+  "modified": "2023-01-09T05:03:03Z",
   "published": "2018-10-17T16:20:45Z",
   "aliases": [
     "CVE-2018-12542"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/vert-x3/vertx-web/issues/1025"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vert-x3/vertx-web/commit/57a65dce6f4c5aa5e3ce7288685e7f3447eb8f3b"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.5.4: https://github.com/vert-x3/vertx-web/commit/57a65dce6f4c5aa5e3ce7288685e7f3447eb8f3b

The CVE and original issue 1025 is in the commit patch message: "CVE-2018-12542: The StaticHandler uses external input to construct a pathname that should be within a restricted directory, but it does not properly neutralize '\' (forward slashes) sequences that can resolve to a location that is outside of that directory when running on Windows Operating Systems. - fixes 1025"