### PR TITLE
[GHSA-h5f5-rj4r-42f6] Incorrect access control in Neo4j Enterprise Database Server via LDAP authentication

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-h5f5-rj4r-42f6/GHSA-h5f5-rj4r-42f6.json
+++ b/advisories/github-reviewed/2018/10/GHSA-h5f5-rj4r-42f6/GHSA-h5f5-rj4r-42f6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h5f5-rj4r-42f6",
-  "modified": "2022-04-27T14:23:03Z",
+  "modified": "2023-01-09T05:03:18Z",
   "published": "2018-10-17T17:31:26Z",
   "aliases": [
     "CVE-2018-18389"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/neo4j/neo4j/issues/12047"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/neo4j/neo4j/commit/46de5d01ae2741ffe04c36270fc62c6d490f65c9"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.4.9: https://github.com/neo4j/neo4j/commit/46de5d01ae2741ffe04c36270fc62c6d490f65c9

The fix was mentioned in the original issue 12047 (https://github.com/neo4j/neo4j/issues/12047): "The fix for that problem (46de5d0) will go in all upcoming releases from 3.4.9 onwards."