### PR TITLE
[GHSA-h6m7-j4h3-9rf5] Remote Code Execution in SyliusResourceBundle

### DIFF
--- a/advisories/github-reviewed/2020/08/GHSA-h6m7-j4h3-9rf5/GHSA-h6m7-j4h3-9rf5.json
+++ b/advisories/github-reviewed/2020/08/GHSA-h6m7-j4h3-9rf5/GHSA-h6m7-j4h3-9rf5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h6m7-j4h3-9rf5",
-  "modified": "2021-11-19T15:36:47Z",
+  "modified": "2023-02-01T05:04:32Z",
   "published": "2020-08-19T19:52:30Z",
   "aliases": [
     "CVE-2020-15146"
@@ -100,6 +100,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-15146"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/Sylius/SyliusResourceBundle/commit/73d9aba182947473a5935b31caf65ca263091e00"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.3.14 /v1.4.7/v1.5.2/v1.6.4: https://github.com/Sylius/SyliusResourceBundle/commit/73d9aba182947473a5935b31caf65ca263091e00

The GHSA-ID is mentioned in the commit patch message: "Merge pull request from GHSA-h6m7-j4h3-9rf5. Sanitize request input before passing it to expression language evaluator"