### PR TITLE
[GHSA-h6mq-3cj6-h738] Reverse Tabnabbing in showdown

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-h6mq-3cj6-h738/GHSA-h6mq-3cj6-h738.json
+++ b/advisories/github-reviewed/2020/09/GHSA-h6mq-3cj6-h738/GHSA-h6mq-3cj6-h738.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h6mq-3cj6-h738",
-  "modified": "2021-10-01T16:12:36Z",
+  "modified": "2023-01-09T05:04:23Z",
   "published": "2020-09-03T23:21:16Z",
   "aliases": [
 
@@ -39,6 +39,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/showdownjs/showdown/pull/670/files"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/showdownjs/showdown/commit/1cd281f0643ef613dc1d36847d4c6cbb22501d91"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.9.1: https://github.com/showdownjs/showdown/commit/1cd281f0643ef613dc1d36847d4c6cbb22501d91

The original pull 670 () is mentioned in the commit patch: "fix(openLinksInNewWindow): add rel="noopener noreferrer" to links
Add rel="noreferrer" to links when openLinksInNewWindow is on. Also add noopener when openLinksInNewWindow is on. target="_blank" without also adding rel="noopener noreferrer" creates a vulnerability (since the site you're linking to has access to the window.opener by default. This  adds rel="noopener noreferrer" to links generated by the makeHtml converter when openLinksInNewWindow is true.
Closes 670"