### PR TITLE
[GHSA-h9x2-5rm7-x4gm] Insecure Comparison in secure-compare

### DIFF
--- a/advisories/github-reviewed/2019/06/GHSA-h9x2-5rm7-x4gm/GHSA-h9x2-5rm7-x4gm.json
+++ b/advisories/github-reviewed/2019/06/GHSA-h9x2-5rm7-x4gm/GHSA-h9x2-5rm7-x4gm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h9x2-5rm7-x4gm",
-  "modified": "2020-08-31T18:09:18Z",
+  "modified": "2023-01-09T05:01:38Z",
   "published": "2019-06-03T17:28:23Z",
   "aliases": [
     "CVE-2015-9238"
@@ -40,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/vdemedes/secure-compare/pull/1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vadimdemedes/secure-compare/commit/dd1ff1ac0122de7e0af4f00c61ed73261062394a"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.0.1: https://github.com/vadimdemedes/secure-compare/commit/dd1ff1ac0122de7e0af4f00c61ed73261062394a

The original pull 1 (https://github.com/vadimdemedes/secure-compare/pull/1) is linked to the commit patch.