### PR TITLE
[GHSA-hc94-9v26-gxwv] Gluu Oxauth before v4.4.1 vulnerable to Server-Side Request Forgery attacks via a crafted request_uri parameter

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-hc94-9v26-gxwv/GHSA-hc94-9v26-gxwv.json
+++ b/advisories/github-reviewed/2022/09/GHSA-hc94-9v26-gxwv/GHSA-hc94-9v26-gxwv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hc94-9v26-gxwv",
-  "modified": "2022-09-16T17:41:00Z",
+  "modified": "2023-01-27T05:02:40Z",
   "published": "2022-09-07T00:01:50Z",
   "aliases": [
     "CVE-2022-36663"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36663"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/GluuFederation/oxAuth/commit/58c4ac9bbf2addf4b419bf155de99db57a202f5c"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v4.4.1: https://github.com/GluuFederation/oxAuth/commit/58c4ac9bbf2addf4b419bf155de99db57a202f5c

From an original reference link (https://gluu.org/gluu-4-4-1/): "To mitigate this risk, we’ve implemented both a request_uri blocklist and a request_uri allowlist that are configurable in the Gluu Server OpenID Provider JSON configuration."

The patch provided an "added restriction for request_uri parameter (blacklist/allowed list)" as described in the advisory. 