### PR TITLE
[GHSA-hcpj-qp55-gfph] GitPython vulnerable to Remote Code Execution due to improper user input validation

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-hcpj-qp55-gfph/GHSA-hcpj-qp55-gfph.json
+++ b/advisories/github-reviewed/2022/12/GHSA-hcpj-qp55-gfph/GHSA-hcpj-qp55-gfph.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hcpj-qp55-gfph",
-  "modified": "2022-12-06T14:33:52Z",
+  "modified": "2023-02-03T05:01:28Z",
   "published": "2022-12-06T06:30:17Z",
   "aliases": [
     "CVE-2022-24439"
@@ -46,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/gitpython-developers/GitPython/issues/1515"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/gitpython-developers/GitPython/commit/2625ed9fc074091c531c27ffcba7902771130261"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.1.30: https://github.com/gitpython-developers/GitPython/commit/2625ed9fc074091c531c27ffcba7902771130261

The CVE and issue are mentioned in the commit patch message: "Forbid unsafe protocol URLs in Repo.clone{,_from}() Since the URL is passed directly to git clone, and the remote-ext helper will happily execute shell commands, so by default disallow URLs that contain a "::" unless a new unsafe_protocols kwarg is passed. (CVE-2022-24439)
Fixes 1515"