### PR TITLE
[GHSA-hf9p-9r39-r2h3] Unrestricted Uploads in Concrete5

### DIFF
--- a/advisories/github-reviewed/2021/11/GHSA-hf9p-9r39-r2h3/GHSA-hf9p-9r39-r2h3.json
+++ b/advisories/github-reviewed/2021/11/GHSA-hf9p-9r39-r2h3/GHSA-hf9p-9r39-r2h3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hf9p-9r39-r2h3",
-  "modified": "2021-11-02T18:39:03Z",
+  "modified": "2023-02-01T05:06:14Z",
   "published": "2021-11-03T17:29:29Z",
   "aliases": [
     "CVE-2020-11476"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/concrete5/concrete5/pull/8713"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/commit/d296f4ba4f6ad94b199c21c1b16f0d185adab343"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v8.5.3: https://github.com/concretecms/concretecms/commit/d296f4ba4f6ad94b199c21c1b16f0d185adab343

This is the merge of the original pull (https://github.com/concretecms/concretecms/pull/8713) to resolve the issue