### PR TITLE
[GHSA-hfjr-m75m-wmh7] Jenkins Zulip Plugin vulnerable to Insufficiently Protected Credentials

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-hfjr-m75m-wmh7/GHSA-hfjr-m75m-wmh7.json
+++ b/advisories/github-reviewed/2022/05/GHSA-hfjr-m75m-wmh7/GHSA-hfjr-m75m-wmh7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hfjr-m75m-wmh7",
-  "modified": "2022-12-06T21:43:39Z",
+  "modified": "2023-01-31T05:02:35Z",
   "published": "2022-05-24T16:59:38Z",
   "aliases": [
     "CVE-2019-10476"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-10476"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/zulip-plugin/commit/2a9dd6c41c2d913b0414d015b3118e3ddb60bd90"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.1.1: https://github.com/jenkinsci/zulip-plugin/commit/2a9dd6c41c2d913b0414d015b3118e3ddb60bd90

The commit patch message mentioned the originating SECURITY-1621 reference link (https://www.jenkins.io/security/advisory/2019-10-23/#SECURITY-1621): "SECURITY-1621 Store global config API key as Secret"