### PR TITLE
[GHSA-hpv5-v8g5-c864] Cross-site Scripting in Mistune

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-hpv5-v8g5-c864/GHSA-hpv5-v8g5-c864.json
+++ b/advisories/github-reviewed/2022/05/GHSA-hpv5-v8g5-c864/GHSA-hpv5-v8g5-c864.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hpv5-v8g5-c864",
-  "modified": "2022-07-01T19:44:32Z",
+  "modified": "2023-01-29T05:01:56Z",
   "published": "2022-05-17T00:26:00Z",
   "aliases": [
     "CVE-2017-15612"
@@ -65,6 +65,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/lepture/mistune/pull/140"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/lepture/mistune/commit/d6f0b6402299bf5a380e7b4e77bd80e8736630fe"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.8: https://github.com/lepture/mistune/commit/d6f0b6402299bf5a380e7b4e77bd80e8736630fe

The original pull (140) is linked to the patch: "Fix bypassing XSS vulnerability."