### PR TITLE
[GHSA-hqc8-j86x-2764] Off-by-one error in simple-slab

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-hqc8-j86x-2764/GHSA-hqc8-j86x-2764.json
+++ b/advisories/github-reviewed/2021/08/GHSA-hqc8-j86x-2764/GHSA-hqc8-j86x-2764.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hqc8-j86x-2764",
-  "modified": "2021-08-19T21:06:47Z",
+  "modified": "2023-01-11T05:06:00Z",
   "published": "2021-08-25T20:48:33Z",
   "aliases": [
     "CVE-2020-35893"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/nathansizemore/simple-slab/issues/2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nathansizemore/simple-slab/commit/5e0524c1db836e2192e1cd818848d96937c0b587"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.3.3: https://github.com/nathansizemore/simple-slab/commit/5e0524c1db836e2192e1cd818848d96937c0b587

The original issue 2 (https://github.com/nathansizemore/simple-slab/issues/2) is mentioned in the message: "Fixes OOB access and off by one error. closes 2"