### PR TITLE
[GHSA-hrxv-694f-22g3] Exposure of Sensitive Information to an Unauthorized Actor in LemMinX

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-hrxv-694f-22g3/GHSA-hrxv-694f-22g3.json
+++ b/advisories/github-reviewed/2022/02/GHSA-hrxv-694f-22g3/GHSA-hrxv-694f-22g3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hrxv-694f-22g3",
-  "modified": "2022-03-02T21:57:30Z",
+  "modified": "2023-02-03T05:06:23Z",
   "published": "2022-02-19T00:01:28Z",
   "aliases": [
     "CVE-2022-0672"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/eclipse/lemminx/pull/1174"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/eclipse/lemminx/commit/076b88052c2a63f60a98ef4b45e3e38c217b70ae"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.19.0: https://github.com/eclipse/lemminx/commit/076b88052c2a63f60a98ef4b45e3e38c217b70ae

Other commits in the original pull (https://github.com/eclipse/lemminx/pull/1174) are for changelog/version updates. The patch provided is part of the pull and is the one to fix the insecure redirects. 