### PR TITLE
[GHSA-hv53-qjg6-5pm9] XSS vulnerability in Jenkins Gatling Plugin

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-hv53-qjg6-5pm9/GHSA-hv53-qjg6-5pm9.json
+++ b/advisories/github-reviewed/2022/05/GHSA-hv53-qjg6-5pm9/GHSA-hv53-qjg6-5pm9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hv53-qjg6-5pm9",
-  "modified": "2022-12-20T17:39:30Z",
+  "modified": "2023-01-29T05:01:03Z",
   "published": "2022-05-24T17:13:39Z",
   "aliases": [
     "CVE-2020-2173"
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2173"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/gatling-plugin/commit/8a9ae59c6b3328776d38af6596b35cef1ced05a7"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.3.0: https://github.com/jenkinsci/gatling-plugin/commit/8a9ae59c6b3328776d38af6596b35cef1ced05a7

The commit patch message mentions one of the original reference links SECURITY-1633 (https://jenkins.io/security/advisory/2020-04-07/#SECURITY-1633): "[SECURITY-1633] No longer display the Gatling html reports through Jenkins..."