### PR TITLE
[GHSA-hwhf-64mh-r662] ReDoS vulnerability in parser_apache2

### DIFF
--- a/advisories/github-reviewed/2021/11/GHSA-hwhf-64mh-r662/GHSA-hwhf-64mh-r662.json
+++ b/advisories/github-reviewed/2021/11/GHSA-hwhf-64mh-r662/GHSA-hwhf-64mh-r662.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hwhf-64mh-r662",
-  "modified": "2021-11-04T17:05:51Z",
+  "modified": "2023-02-01T05:06:24Z",
   "published": "2021-11-01T19:16:31Z",
   "aliases": [
     "CVE-2021-41186"
@@ -43,6 +43,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-41186"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/fluent/fluentd/commit/5482a3d049dab351de0be68f4b4bc562319d8511"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.14.2: https://github.com/fluent/fluentd/commit/5482a3d049dab351de0be68f4b4bc562319d8511

The commit patch message mentions the GHSA-ID: "Merge pull request from GHSA-hwhf-64mh-r662. parser_apache2: Fix too wide matching regexp"