### PR TITLE
[GHSA-hwhh-2fwm-cfgw] Doorkeeper is vulnerable to stored XSS and code execution

### DIFF
--- a/advisories/github-reviewed/2018/03/GHSA-hwhh-2fwm-cfgw/GHSA-hwhh-2fwm-cfgw.json
+++ b/advisories/github-reviewed/2018/03/GHSA-hwhh-2fwm-cfgw/GHSA-hwhh-2fwm-cfgw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hwhh-2fwm-cfgw",
-  "modified": "2022-04-26T17:36:10Z",
+  "modified": "2023-01-09T05:03:04Z",
   "published": "2018-03-13T20:44:48Z",
   "aliases": [
     "CVE-2018-1000088"
@@ -54,6 +54,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/rubysec/ruby-advisory-db/pull/328/files"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/doorkeeper-gem/doorkeeper/commit/7b1a8373ecd69768c896000c7971dbf48948c1b5"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v4.2.6: https://github.com/doorkeeper-gem/doorkeeper/commit/7b1a8373ecd69768c896000c7971dbf48948c1b5

This is the complete merge of the pull (970) that closed the original issue (969) for the XSS vulnerability: "Fix XSS issues in default views"