### PR TITLE
[GHSA-jgqf-hwc5-hh37] Root Path Disclosure in send

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-jgqf-hwc5-hh37/GHSA-jgqf-hwc5-hh37.json
+++ b/advisories/github-reviewed/2017/10/GHSA-jgqf-hwc5-hh37/GHSA-jgqf-hwc5-hh37.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jgqf-hwc5-hh37",
-  "modified": "2021-09-14T19:42:25Z",
+  "modified": "2023-01-09T05:03:20Z",
   "published": "2017-10-24T18:33:36Z",
   "aliases": [
     "CVE-2015-8859"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/pillarjs/send/pull/70"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pillarjs/send/commit/98a5b89982b38e79db684177cf94730ce7fc7aed"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.11.1: https://github.com/pillarjs/send/commit/98a5b89982b38e79db684177cf94730ce7fc7aed

This commit patch was mentioned in the original pull 70 (https://github.com/pillarjs/send/pull/70) to properly fix the root path disclosure issue: "Fix root path disclosure. fixes 70"