### PR TITLE
[GHSA-jjc5-fp7p-6f8w] Shescape prior to 1.5.8 vulnerable to insufficient escaping of line feeds for CMD

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-jjc5-fp7p-6f8w/GHSA-jjc5-fp7p-6f8w.json
+++ b/advisories/github-reviewed/2022/07/GHSA-jjc5-fp7p-6f8w/GHSA-jjc5-fp7p-6f8w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jjc5-fp7p-6f8w",
-  "modified": "2022-08-11T18:42:41Z",
+  "modified": "2023-01-31T05:01:24Z",
   "published": "2022-07-15T21:39:14Z",
   "aliases": [
     "CVE-2022-31179"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/ericcornelissen/shescape/pull/332"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ericcornelissen/shescape/commit/aceea7358f7222984e21260381ebc5ec4543b76f"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.5.8: https://github.com/ericcornelissen/shescape/commit/aceea7358f7222984e21260381ebc5ec4543b76f

This commit patch is the complete merge into main of the originally linked pull 332 (https://github.com/ericcornelissen/shescape/pull/332): "Improve testing and escaping of newlines (332)"