### PR TITLE
[GHSA-jrh2-hc4r-7jwx] Directory-traversal in Django

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-jrh2-hc4r-7jwx/GHSA-jrh2-hc4r-7jwx.json
+++ b/advisories/github-reviewed/2022/01/GHSA-jrh2-hc4r-7jwx/GHSA-jrh2-hc4r-7jwx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jrh2-hc4r-7jwx",
-  "modified": "2022-02-14T22:18:43Z",
+  "modified": "2023-02-03T05:04:07Z",
   "published": "2022-01-12T19:21:04Z",
   "aliases": [
     "CVE-2021-45452"
@@ -77,6 +77,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-45452"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/4cb35b384ceef52123fc66411a73c36a706825e1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/8d2f7cff76200cbd2337b2cf1707e383eb1fb54b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/e1592e0f26302e79856cc7f2218ae848ae19b0f6"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.2.26: https://github.com/django/django/commit/4cb35b384ceef52123fc66411a73c36a706825e1

Adding the patch link for v3.2.11: https://github.com/django/django/commit/8d2f7cff76200cbd2337b2cf1707e383eb1fb54b

Adding the patch link for v4.0.1: https://github.com/django/django/commit/e1592e0f26302e79856cc7f2218ae848ae19b0f6

The CVE is in the commit patch message: "Fixed CVE-2021-45452 -- Fixed potential path traversal in storage subsystem."