### PR TITLE
[GHSA-jrf8-cmgg-gv2m] Error on unsupported architectures in raw-cpuid

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-jrf8-cmgg-gv2m/GHSA-jrf8-cmgg-gv2m.json
+++ b/advisories/github-reviewed/2021/08/GHSA-jrf8-cmgg-gv2m/GHSA-jrf8-cmgg-gv2m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jrf8-cmgg-gv2m",
-  "modified": "2021-08-19T18:02:32Z",
+  "modified": "2023-01-27T05:02:18Z",
   "published": "2021-08-25T20:53:07Z",
   "aliases": [
     "CVE-2021-26307"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/RustSec/advisory-db/pull/614"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/gz/rust-cpuid/commit/91b676eecd01f2163e2984215e2c0ac89e30ce75"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v9.0.0: https://github.com/gz/rust-cpuid/commit/91b676eecd01f2163e2984215e2c0ac89e30ce75

The commit patch closes the original issue 40 (https://github.com/gz/rust-cpuid/issues/40): "Fix unsound transmutes (fixes 40)"