### PR TITLE
[GHSA-jv85-mqxj-3f9j] Sentry vulnerable to invite code reuse via cookie manipulation

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-jv85-mqxj-3f9j/GHSA-jv85-mqxj-3f9j.json
+++ b/advisories/github-reviewed/2022/12/GHSA-jv85-mqxj-3f9j/GHSA-jv85-mqxj-3f9j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jv85-mqxj-3f9j",
-  "modified": "2022-12-12T21:27:09Z",
+  "modified": "2023-01-28T05:05:52Z",
   "published": "2022-12-12T21:27:09Z",
   "aliases": [
     "CVE-2022-23485"
@@ -43,6 +43,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23485"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/getsentry/sentry/pull/40905"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/getsentry/sentry/commit/565f971da955d57c754a47f5802fe9f9f7c66b39"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v22.11.0: https://github.com/getsentry/sentry/commit/565f971da955d57c754a47f5802fe9f9f7c66b39

Adding the original pull: https://github.com/getsentry/sentry/pull/40905

In the pull, the description is very similar to the original advisory: "Moves the invite functionality from cookies to the session. This is to harden the security of the platform. With the cookie approach, a client can manipulate the cookie value for pending-invite resulting in situations where an invite code can be reused."