### PR TITLE
[GHSA-m836-gxwq-j2pm] Improper Access Control in github.com/treeverse/lakefs

### DIFF
--- a/advisories/github-reviewed/2021/10/GHSA-m836-gxwq-j2pm/GHSA-m836-gxwq-j2pm.json
+++ b/advisories/github-reviewed/2021/10/GHSA-m836-gxwq-j2pm/GHSA-m836-gxwq-j2pm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m836-gxwq-j2pm",
-  "modified": "2021-10-27T18:58:30Z",
+  "modified": "2023-01-09T05:05:03Z",
   "published": "2021-10-28T16:27:03Z",
   "aliases": [
 
@@ -39,6 +39,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/treeverse/lakeFS/security/advisories/GHSA-m836-gxwq-j2pm"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/treeverse/lakeFS/commit/f2117281cadb14fdf9ac7fe287f84d5c10308b88"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.53.1: https://github.com/treeverse/lakeFS/commit/f2117281cadb14fdf9ac7fe287f84d5c10308b88

The GHSA-ID is in the commit message: "Merge pull request from GHSA-m836-gxwq-j2pm"