### PR TITLE
[GHSA-m8r4-c7jm-w782] Jenkins Plugin Installation Manager Tool did not verify plugin downloads

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-m8r4-c7jm-w782/GHSA-m8r4-c7jm-w782.json
+++ b/advisories/github-reviewed/2022/05/GHSA-m8r4-c7jm-w782/GHSA-m8r4-c7jm-w782.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m8r4-c7jm-w782",
-  "modified": "2022-12-16T22:12:33Z",
+  "modified": "2023-02-01T05:06:35Z",
   "published": "2022-05-24T17:35:09Z",
   "aliases": [
     "CVE-2020-2320"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-2320"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/plugin-installation-manager-tool/commit/dfc745c3a97a3fea74a3fe2e92d8a4440cbbf867"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.2.0: https://github.com/jenkinsci/plugin-installation-manager-tool/commit/dfc745c3a97a3fea74a3fe2e92d8a4440cbbf867

Only three commits exist for v2.2.0 (https://github.com/jenkinsci/plugin-installation-manager-tool/compare/2.1.3...2.2.0), in which the commit above is related to verifying plugin downloads: "Check that downloads are correct"