### PR TITLE
[GHSA-mfpj-3qhm-976m] Uncontrolled Resource Consumption in asyncua and opcua

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-mfpj-3qhm-976m/GHSA-mfpj-3qhm-976m.json
+++ b/advisories/github-reviewed/2022/08/GHSA-mfpj-3qhm-976m/GHSA-mfpj-3qhm-976m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mfpj-3qhm-976m",
-  "modified": "2022-09-30T02:21:34Z",
+  "modified": "2023-01-28T05:07:54Z",
   "published": "2022-08-24T00:00:31Z",
   "aliases": [
     "CVE-2022-25304"
@@ -65,6 +65,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/FreeOpcUa/python-opcua/issues/1466"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FreeOpcUa/opcua-asyncio/commit/01c7acf047887b62d979cd4373d370e72a4b9057"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding the patch link for asyncua v0.9.96: https://github.com/FreeOpcUa/opcua-asyncio/commit/01c7acf047887b62d979cd4373d370e72a4b9057

CVE is in the commit message: "Check limits of messages (CVE-2022-25304) (1040)" 