### PR TITLE
[GHSA-776f-qx25-q3cc] xml2js is vulnerable to prototype pollution 

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-776f-qx25-q3cc/GHSA-776f-qx25-q3cc.json
+++ b/advisories/github-reviewed/2023/04/GHSA-776f-qx25-q3cc/GHSA-776f-qx25-q3cc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-776f-qx25-q3cc",
-  "modified": "2023-04-07T21:00:54Z",
+  "modified": "2023-04-07T21:00:55Z",
   "published": "2023-04-05T21:30:24Z",
   "aliases": [
     "CVE-2023-0842"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.4.23"
+              "fixed": "0.5.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.4.23"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
PR: https://github.com/Leonidas-from-XIV/node-xml2js/pull/603
Commit: https://github.com/Leonidas-from-XIV/node-xml2js/commit/50a492aef9729b8b9b291c5cb2746ec7dc1369db