### PR TITLE
[GHSA-mfv8-q39f-mgfg] Cross-site Scripting in invenio-communities

### DIFF
--- a/advisories/github-reviewed/2019/07/GHSA-mfv8-q39f-mgfg/GHSA-mfv8-q39f-mgfg.json
+++ b/advisories/github-reviewed/2019/07/GHSA-mfv8-q39f-mgfg/GHSA-mfv8-q39f-mgfg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mfv8-q39f-mgfg",
-  "modified": "2021-04-12T21:50:38Z",
+  "modified": "2023-01-09T05:03:09Z",
   "published": "2019-07-16T00:52:26Z",
   "aliases": [
     "CVE-2019-1020005"
@@ -46,6 +46,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-1020005"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/inveniosoftware/invenio-communities/commit/505da72c5acd7dfbd4148f884c73c9c3372b76f4"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.0.0.a20: https://github.com/inveniosoftware/invenio-communities/commit/505da72c5acd7dfbd4148f884c73c9c3372b76f4

The patch relates to the same XSS within the two Jinja templates in the invenio-communities module, where the developer starts to sanitize the HTML output. Very few commits exist for version 1.0.0.a20 (https://github.com/inveniosoftware/invenio-communities/compare/v1.0.0a19...v1.0.0a20): "views: sanitize HTML output in templates"