### PR TITLE
[GHSA-mh24-7wvg-v88g] CRLF Injection in pypiserver

### DIFF
--- a/advisories/github-reviewed/2019/01/GHSA-mh24-7wvg-v88g/GHSA-mh24-7wvg-v88g.json
+++ b/advisories/github-reviewed/2019/01/GHSA-mh24-7wvg-v88g/GHSA-mh24-7wvg-v88g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mh24-7wvg-v88g",
-  "modified": "2022-09-14T22:41:51Z",
+  "modified": "2023-02-01T05:04:07Z",
   "published": "2019-01-30T20:56:26Z",
   "aliases": [
     "CVE-2019-6802"
@@ -46,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/pypiserver/pypiserver/issues/237"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pypiserver/pypiserver/commit/1375a67c55a9b8d4619df30d2a1c0b239d7357e6"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.2.6: https://github.com/pypiserver/pypiserver/commit/1375a67c55a9b8d4619df30d2a1c0b239d7357e6

The patch resolves the original issue 237 from the advisory: "CRLF Injection Mitigation
Resolves 237" 