### PR TITLE
[GHSA-mhgm-52vg-pvvc] Privilege escalation in Strongbox

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-mhgm-52vg-pvvc/GHSA-mhgm-52vg-pvvc.json
+++ b/advisories/github-reviewed/2023/02/GHSA-mhgm-52vg-pvvc/GHSA-mhgm-52vg-pvvc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mhgm-52vg-pvvc",
-  "modified": "2023-02-16T14:12:04Z",
+  "modified": "2023-02-16T14:12:05Z",
   "published": "2023-02-16T14:12:04Z",
   "aliases": [
 
@@ -36,6 +36,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/schibsted/strongbox/security/advisories/GHSA-mhgm-52vg-pvvc"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/schibsted/strongbox/commit/e61f7c36efa898e8b44de6222cd66d2bcdd073e6"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.5.0: https://github.com/schibsted/strongbox/commit/e61f7c36efa898e8b44de6222cd66d2bcdd073e6

The patch updated the AWS Encryption SDK, which contains the underlying issue allowing privilege escalation in Strongbox. An additional note from the changelog (within the patch commit) that mentions another GHSA from the original reference link: "Upgrade AWS Encryption SDK dependency due to GHSA-55xh-53m6-936r"