### PR TITLE
[GHSA-mj4x-wcxf-hm8x] Json-jwt (RubyGems) did not verify, or incorrectly verifies, the cryptographic signature for data

### DIFF
--- a/advisories/github-reviewed/2018/07/GHSA-mj4x-wcxf-hm8x/GHSA-mj4x-wcxf-hm8x.json
+++ b/advisories/github-reviewed/2018/07/GHSA-mj4x-wcxf-hm8x/GHSA-mj4x-wcxf-hm8x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mj4x-wcxf-hm8x",
-  "modified": "2022-04-26T18:20:00Z",
+  "modified": "2023-01-09T05:03:32Z",
   "published": "2018-07-31T18:13:51Z",
   "aliases": [
     "CVE-2018-1000539"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/nov/json-jwt/pull/62"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nov/json-jwt/commit/a3b2147f0f6d9aca653e7a30e453d3a92b33413f"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.9.4: https://github.com/nov/json-jwt/commit/a3b2147f0f6d9aca653e7a30e453d3a92b33413f

The commit patch that closed the original pull (62): " Merge pull request #62 from bdewater/verify-gcm-auth-tag-length

Verify the GCM auth tag length"