### PR TITLE
[GHSA-mm33-5vfq-3mm3] Cross-site Scripting Vulnerability in Action Pack

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-mm33-5vfq-3mm3/GHSA-mm33-5vfq-3mm3.json
+++ b/advisories/github-reviewed/2022/04/GHSA-mm33-5vfq-3mm3/GHSA-mm33-5vfq-3mm3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mm33-5vfq-3mm3",
-  "modified": "2022-06-08T18:05:30Z",
+  "modified": "2023-01-29T05:00:51Z",
   "published": "2022-04-27T22:28:59Z",
   "aliases": [
     "CVE-2022-22577"
@@ -112,6 +112,22 @@
     {
       "type": "WEB",
       "url": "https://github.com/rails/rails/pull/44635"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/rails/commit/2b820a2a69fa50cffa74b4aedc57bf92ed6910ec"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/rails/commit/5299b57d596ea274f77f5ffee2b79c6ee0255508"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/rails/commit/8198d7c4accad0b6ba956b9d59528534a289866b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/rails/commit/d2253115ac2b30f5f7210670af906cebf79cf809"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v5.2.7.1: https://github.com/rails/rails/commit/d2253115ac2b30f5f7210670af906cebf79cf809

Adding the patch link for v6.0.4.8: https://github.com/rails/rails/commit/5299b57d596ea274f77f5ffee2b79c6ee0255508

Adding the patch link for v6.1.5.1: https://github.com/rails/rails/commit/2b820a2a69fa50cffa74b4aedc57bf92ed6910ec

Adding the patch link for v7.0.2.4: https://github.com/rails/rails/commit/8198d7c4accad0b6ba956b9d59528534a289866b

The commit patch for each version that closed the original pull (44635): "Merge pull request 44635 from imtayadeway/tjw/api-csp-i
Generate content security policy for non-HTML responses."