### PR TITLE
[GHSA-mm62-wxc8-cf7m] Code Execution Through IIFE in serialize-to-js

### DIFF
--- a/advisories/github-reviewed/2018/07/GHSA-mm62-wxc8-cf7m/GHSA-mm62-wxc8-cf7m.json
+++ b/advisories/github-reviewed/2018/07/GHSA-mm62-wxc8-cf7m/GHSA-mm62-wxc8-cf7m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mm62-wxc8-cf7m",
-  "modified": "2021-09-15T20:28:22Z",
+  "modified": "2023-01-09T05:03:18Z",
   "published": "2018-07-18T18:27:41Z",
   "aliases": [
     "CVE-2017-5954"
@@ -46,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/commenthol/serialize-to-js/issues/1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/commenthol/serialize-to-js/commit/1cd433960e5b9db4c0b537afb28366198a319429"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.0.0: https://github.com/commenthol/serialize-to-js/commit/1cd433960e5b9db4c0b537afb28366198a319429

The patch commit started to santize the input function as described in the PoC from the advisory: "harmful deserialization fix"