### PR TITLE
[GHSA-mm7v-vpv8-xfc3] Double free in smallvec

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-mm7v-vpv8-xfc3/GHSA-mm7v-vpv8-xfc3.json
+++ b/advisories/github-reviewed/2021/08/GHSA-mm7v-vpv8-xfc3/GHSA-mm7v-vpv8-xfc3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mm7v-vpv8-xfc3",
-  "modified": "2021-08-19T21:22:23Z",
+  "modified": "2023-01-11T05:05:45Z",
   "published": "2021-08-25T20:44:59Z",
   "aliases": [
     "CVE-2019-15551"
@@ -43,6 +43,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/servo/rust-smallvec/issues/148"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/servo/rust-smallvec/issues/149"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/servo/rust-smallvec/commit/c20cfa8584e649f00dc0767ab6fad63a3f59a296"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/servo/rust-smallvec/commit/f96322b9243405cc82701cc73f1b19313b413ab4"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch links for v0.6.10: 
https://github.com/servo/rust-smallvec/commit/c20cfa8584e649f00dc0767ab6fad63a3f59a296
https://github.com/servo/rust-smallvec/commit/f96322b9243405cc82701cc73f1b19313b413ab4

Adding additional issue: https://github.com/servo/rust-smallvec/issues/149 

The commit (https://github.com/servo/rust-smallvec/commit/c20cfa8584e649f00dc0767ab6fad63a3f59a296) closed the original issue 148 (https://github.com/servo/rust-smallvec/issues/148). In issue 148, developers also mentioned that 149 (https://github.com/servo/rust-smallvec/issues/149) was relevant. The commit (https://github.com/servo/rust-smallvec/commit/f96322b9243405cc82701cc73f1b19313b413ab4) closed 149, which was related to the original vulnerability. 