### PR TITLE
[GHSA-mpq4-rjj8-fjph] Uncontrolled Resource Consumption in github.com/google/fscrypt

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-mpq4-rjj8-fjph/GHSA-mpq4-rjj8-fjph.json
+++ b/advisories/github-reviewed/2022/02/GHSA-mpq4-rjj8-fjph/GHSA-mpq4-rjj8-fjph.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mpq4-rjj8-fjph",
-  "modified": "2022-03-07T13:42:34Z",
+  "modified": "2023-02-03T05:06:25Z",
   "published": "2022-02-26T00:00:44Z",
   "aliases": [
     "CVE-2022-25326"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/google/fscrypt/pull/346"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/google/fscrypt/commit/91aa3ebf42032ca783c41f9ec25d885875f66ddb"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch links for v0.3.3: https://github.com/google/fscrypt/commit/91aa3ebf42032ca783c41f9ec25d885875f66ddb

The patch commit is the complete merge of the original pull (346): "Merge pull request 346 from google/fixes
Metadata validation and other security improvements"