### PR TITLE
[GHSA-mwgj-7x7j-6966] Deserialization of Untrusted Data in ParlAI

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-mwgj-7x7j-6966/GHSA-mwgj-7x7j-6966.json
+++ b/advisories/github-reviewed/2021/09/GHSA-mwgj-7x7j-6966/GHSA-mwgj-7x7j-6966.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mwgj-7x7j-6966",
-  "modified": "2021-09-13T19:29:03Z",
+  "modified": "2023-02-01T05:06:06Z",
   "published": "2021-09-13T20:06:14Z",
   "aliases": [
     "CVE-2021-24040"
@@ -40,6 +40,22 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-24040"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/facebookresearch/ParlAI/pull/3402"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/facebookresearch/ParlAI/pull/3429"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/facebookresearch/ParlAI/commit/4374fa2aba383db6526ab36e939eb1cf8ef99879"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/facebookresearch/ParlAI/commit/507d066ef432ea27d3e201da08009872a2f37725"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch links for v1.1.0 (each closed the below pulls): https://github.com/facebookresearch/ParlAI/commit/507d066ef432ea27d3e201da08009872a2f37725

https://github.com/facebookresearch/ParlAI/commit/4374fa2aba383db6526ab36e939eb1cf8ef99879

Adding original pulls: https://github.com/facebookresearch/ParlAI/pull/3402

https://github.com/facebookresearch/ParlAI/pull/3429

From the release for v1.1.0: "[security] RCE fixed in chat services (3402, 3429)" -> 3402 & 3429 are in regards to the unsafe YAML that causes the RCE. 