### PR TITLE
[GHSA-p2g9-94wh-65c2] Space bug in `clean_text`

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-p2g9-94wh-65c2/GHSA-p2g9-94wh-65c2.json
+++ b/advisories/github-reviewed/2022/06/GHSA-p2g9-94wh-65c2/GHSA-p2g9-94wh-65c2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p2g9-94wh-65c2",
-  "modified": "2022-06-16T23:39:55Z",
+  "modified": "2023-01-12T05:01:00Z",
   "published": "2022-06-16T23:39:55Z",
   "aliases": [
 
@@ -36,6 +36,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/rust-ammonia/ammonia/pull/147"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rust-ammonia/ammonia/commit/6c7bf22907a75d1bbaed52e4f7dd9716f5e6f737"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.1.3: https://github.com/rust-ammonia/ammonia/commit/6c7bf22907a75d1bbaed52e4f7dd9716f5e6f737

The patch commit is from the original pull (147): "Fix a space bug in clean_text. I mixed up FF with CR when reading an ASCII table. Bug reported via email."