### PR TITLE
[GHSA-pf3p-x6qj-6j7q] mio invalidly assumes the memory layout of std::net::SocketAddr

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-pf3p-x6qj-6j7q/GHSA-pf3p-x6qj-6j7q.json
+++ b/advisories/github-reviewed/2021/08/GHSA-pf3p-x6qj-6j7q/GHSA-pf3p-x6qj-6j7q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pf3p-x6qj-6j7q",
-  "modified": "2021-08-19T18:54:14Z",
+  "modified": "2023-01-11T05:05:30Z",
   "published": "2021-08-25T20:50:33Z",
   "aliases": [
     "CVE-2020-35922"
@@ -43,6 +43,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/tokio-rs/mio/issues/1386"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/tokio-rs/mio/pull/1388"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/tokio-rs/mio/commit/152e0751f0be1c9b0cbd6778645b76bcb0eba93c"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.7.6: https://github.com/tokio-rs/mio/commit/152e0751f0be1c9b0cbd6778645b76bcb0eba93c

Adding the pull: https://github.com/tokio-rs/mio/pull/1388

The pull (1388) closed the original issue (1386): "Don't assume memory layout of std::net::SocketAddr. Fixes 1388."

1388 pull message: "Fixes 1386"