### PR TITLE
[GHSA-pgr8-jg6h-8gw6] Cross-Site Scripting in webpack-bundle-analyzer

### DIFF
--- a/advisories/github-reviewed/2019/05/GHSA-pgr8-jg6h-8gw6/GHSA-pgr8-jg6h-8gw6.json
+++ b/advisories/github-reviewed/2019/05/GHSA-pgr8-jg6h-8gw6/GHSA-pgr8-jg6h-8gw6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pgr8-jg6h-8gw6",
-  "modified": "2021-08-04T15:26:36Z",
+  "modified": "2023-01-09T05:01:21Z",
   "published": "2019-05-23T09:26:20Z",
   "aliases": [
 
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/264"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/webpack-contrib/webpack-bundle-analyzer/commit/20f2b4c553ee343f491faf63e39427fba9908c7c"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.3.2: https://github.com/webpack-contrib/webpack-bundle-analyzer/commit/20f2b4c553ee343f491faf63e39427fba9908c7c

The patch commit from the original pull (264) that closes the original issue (263): "Fix regression with escaping internal assets"