### PR TITLE
[GHSA-ph58-4vrj-w6hr] bootstrap Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2019/01/GHSA-ph58-4vrj-w6hr/GHSA-ph58-4vrj-w6hr.json
+++ b/advisories/github-reviewed/2019/01/GHSA-ph58-4vrj-w6hr/GHSA-ph58-4vrj-w6hr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ph58-4vrj-w6hr",
-  "modified": "2023-01-23T21:29:22Z",
+  "modified": "2023-01-23T21:29:23Z",
   "published": "2019-01-17T13:57:56Z",
   "aliases": [
     "CVE-2018-20677"
@@ -55,6 +55,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/twbs/bootstrap/pull/27047"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/twbs/bootstrap/commit/2a5ba23ce8f041f3548317acc992ed8a736b609d"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.4.0: https://github.com/twbs/bootstrap/commit/2a5ba23ce8f041f3548317acc992ed8a736b609d

This is the complete merge of 27047 that closed 27405. It fixes multiple CVEs: "* fix(affix): XSS on target config. Fixes #27045"