### PR TITLE
[GHSA-pmjg-52h9-72qv] Argo CD SSO users vulnerable to Cross-site Scripting

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-pmjg-52h9-72qv/GHSA-pmjg-52h9-72qv.json
+++ b/advisories/github-reviewed/2022/07/GHSA-pmjg-52h9-72qv/GHSA-pmjg-52h9-72qv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pmjg-52h9-72qv",
-  "modified": "2022-07-21T15:54:45Z",
+  "modified": "2023-01-27T05:05:43Z",
   "published": "2022-07-12T22:11:16Z",
   "aliases": [
     "CVE-2022-31102"
@@ -62,6 +62,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31102"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/argoproj/argo-cd/commit/3800a1e49d1d5a00a6692fee83396a37a6abe89a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/argoproj/argo-cd/commit/8d5119b1e3038a2c1d8b651cb242525e9e734c4c"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.3.6: https://github.com/argoproj/argo-cd/commit/8d5119b1e3038a2c1d8b651cb242525e9e734c4c

Adding the patch link for v2.4.5: https://github.com/argoproj/argo-cd/commit/3800a1e49d1d5a00a6692fee83396a37a6abe89a

The GHSA-ID is in the commit patch message: "Merge pull request from GHSA-pmjg-52h9-72qv"