### PR TITLE
[GHSA-pp3f-98qg-5g75] aws-iam-authenticator allow-listed IAM identity may be able to modify their username, escalate privileges before v0.5.9

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-pp3f-98qg-5g75/GHSA-pp3f-98qg-5g75.json
+++ b/advisories/github-reviewed/2022/07/GHSA-pp3f-98qg-5g75/GHSA-pp3f-98qg-5g75.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pp3f-98qg-5g75",
-  "modified": "2022-07-21T15:22:31Z",
+  "modified": "2023-01-27T05:05:09Z",
   "published": "2022-07-13T00:00:41Z",
   "aliases": [
     "CVE-2022-2385"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/469"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/kubernetes-sigs/aws-iam-authenticator/commit/029d1dcf2ec8d662d9b1c21260bb197404bc8218"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.5.9: https://github.com/kubernetes-sigs/aws-iam-authenticator/commit/029d1dcf2ec8d662d9b1c21260bb197404bc8218

This commit patch is specific for v0.5.9 (https://github.com/kubernetes-sigs/aws-iam-authenticator/compare/v0.5.8...v0.5.9), it's from the original pull (469): "Add query parameter validation for multiple parameters"