### PR TITLE
[GHSA-q27f-v3r6-9v77] Improper Certificate Validation in EM-HTTP-Request

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-q27f-v3r6-9v77/GHSA-q27f-v3r6-9v77.json
+++ b/advisories/github-reviewed/2021/05/GHSA-q27f-v3r6-9v77/GHSA-q27f-v3r6-9v77.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q27f-v3r6-9v77",
-  "modified": "2021-05-14T18:46:59Z",
+  "modified": "2023-02-01T05:05:32Z",
   "published": "2021-05-24T18:13:13Z",
   "aliases": [
     "CVE-2020-13482"
@@ -46,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/igrigorik/em-http-request/issues/339"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/igrigorik/em-http-request/commit/e5fa144f8d21050dd1fc15a4dc8aa34ac6f30602"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.1.6: https://github.com/igrigorik/em-http-request/commit/e5fa144f8d21050dd1fc15a4dc8aa34ac6f30602

The original issue and CVE are in the commit patch message: "Merge TLS verification patch from Faraday (340). Closes 339, CVE-2020-13482"