### PR TITLE
[GHSA-2367-c296-3mp2] Link following in tar

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-2367-c296-3mp2/GHSA-2367-c296-3mp2.json
+++ b/advisories/github-reviewed/2021/08/GHSA-2367-c296-3mp2/GHSA-2367-c296-3mp2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2367-c296-3mp2",
-  "modified": "2021-08-19T21:24:12Z",
+  "modified": "2023-01-11T05:06:01Z",
   "published": "2021-08-25T20:43:54Z",
   "aliases": [
     "CVE-2018-20990"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/alexcrichton/tar-rs/pull/156"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/alexcrichton/tar-rs/commit/54651a87ae6ba7d81fcc72ffdee2ea7eca2c7e85"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.4.16: https://github.com/alexcrichton/tar-rs/commit/54651a87ae6ba7d81fcc72ffdee2ea7eca2c7e85

This is the complete merge of the original pull (156): "Merge pull request 156 from alexcrichton/protect-hard-links. Don't allow hardlinks to overwrite existing files"