### PR TITLE
[GHSA-f8vr-r385-rh5r] hyper and h2 vulnerable to denial of service

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-f8vr-r385-rh5r/GHSA-f8vr-r385-rh5r.json
+++ b/advisories/github-reviewed/2023/04/GHSA-f8vr-r385-rh5r/GHSA-f8vr-r385-rh5r.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f8vr-r385-rh5r",
-  "modified": "2023-04-11T21:47:01Z",
+  "modified": "2023-04-11T21:47:04Z",
   "published": "2023-04-11T15:30:30Z",
   "aliases": [
     "CVE-2023-26964"
   ],
   "summary": "hyper and h2 vulnerable to denial of service",
-  "details": "Hyper is an HTTP library for Rust and h2 is an HTTP 2.0 client & server implementation for Rust. An issue was discovered in hyper v0.13.7 and h2 v0.2.4 when proessing header frames. Both packages incorrectly process the HTTP2 `RST_STREAM` frames by not always releasing the memory immediately upon receiving the reset frame, leading to stream stacking. As a result, the memory and CPU usage are high which can lead to a Denial of Service (DoS).\n\nAs of time of publication of this advisory, there is no evidence of a fix having been incorporated into hyper or h2.",
+  "details": "Hyper is an HTTP library for Rust and h2 is an HTTP 2.0 client & server implementation for Rust. An issue was discovered in hyper v0.13.7 and h2 v0.2.4 when processing header frames. Both packages incorrectly process the HTTP2 `RST_STREAM` frames by not always releasing the memory immediately upon receiving the reset frame, leading to stream stacking. As a result, the memory and CPU usage are high which can lead to a Denial of Service (DoS).\n\nAs of time of publication of this advisory, there is no evidence of a fix having been incorporated into hyper or h2.",
   "severity": [
 
   ],


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Correct a typo on `processing`