### PR TITLE
[GHSA-rgw9-2qv4-ghxq] The ShipStation.com plugin 1.1 and earlier for CS-Cart...

### DIFF
--- a/advisories/unreviewed/2023/04/GHSA-rgw9-2qv4-ghxq/GHSA-rgw9-2qv4-ghxq.json
+++ b/advisories/unreviewed/2023/04/GHSA-rgw9-2qv4-ghxq/GHSA-rgw9-2qv4-ghxq.json
@@ -1,22 +1,45 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rgw9-2qv4-ghxq",
-  "modified": "2023-04-11T21:31:08Z",
+  "modified": "2023-04-11T21:31:09Z",
   "published": "2023-04-11T21:31:08Z",
   "aliases": [
     "CVE-2020-9009"
   ],
-  "details": "The ShipStation.com plugin 1.1 and earlier for CS-Cart allows remote attackers to insert arbitrary information into the database (via action=shipnotify) because access to this endpoint is completely unchecked. The attacker must guess an order number.",
+  "summary": "ShipStation plugin for CS-Cart - incorrect access control, compromised database integrity",
+  "details": "The ShipStation.com plugin v1.0.10 at https://github.com/shipstation/plugin-cs-cart (internal plugin version 1.1 per https://github.com/shipstation/plugin-cs-cart/blob/v1.0.10/app/addons/shipstation/addon.xml) and earlier for CS-Cart allows remote attackers to insert arbitrary information into the database (via action=shipnotify) because access to this endpoint is completely unchecked. The attacker must guess an order number.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "GitHub Actions",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-9009"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/shipstation/plugin-cs-cart/blob/v1.0.10/app/addons/shipstation/controllers/frontend/shipstation.php"
     },
     {
       "type": "WEB",
@@ -31,7 +54,7 @@
     "cwe_ids": [
 
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-04-11T21:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Source code location
- Summary

**Comments**
Patched version of https://github.com/shipstation/plugin-cs-cart (tag v1.0.10) is available from fork at https://github.com/jerdiggity/plugin-cs-cart (tag 1.0.12). Pull requests have been submitted (see https://github.com/shipstation/plugin-cs-cart/pull/3, https://github.com/shipstation/plugin-cs-cart/pull/2) and multiple attempts to contact both Shipstation support and Github repo maintainers have been made but no corrective action has been taken. Private vulnerability reporting is not enabled for the repo and therefore all measures have been exhausted to remedy the code vulnerabilities while maintaining responsible disclosure practices.