### PR TITLE
[GHSA-9339-86wc-4qgf] Apache Xalan Java XSLT library integer truncation issue when processing malicious XSLT stylesheets

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-9339-86wc-4qgf/GHSA-9339-86wc-4qgf.json
+++ b/advisories/github-reviewed/2022/07/GHSA-9339-86wc-4qgf/GHSA-9339-86wc-4qgf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9339-86wc-4qgf",
-  "modified": "2022-09-22T19:16:28Z",
+  "modified": "2023-01-30T05:07:30Z",
   "published": "2022-07-20T00:00:18Z",
   "aliases": [
     "CVE-2022-34169"

--- a/advisories/github-reviewed/2022/07/GHSA-9339-86wc-4qgf/GHSA-9339-86wc-4qgf.json
+++ b/advisories/github-reviewed/2022/07/GHSA-9339-86wc-4qgf/GHSA-9339-86wc-4qgf.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
     }
   ],
   "affected": [
@@ -153,7 +153,7 @@
     "cwe_ids": [
       "CWE-681"
     ],
-    "severity": "CRITICAL",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2022-07-21T22:28:36Z",
     "nvd_published_at": "2022-07-19T18:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The Severity of this library is set at Critical with 9.8 CVSS in dependabot scans. However checking for cvss score of this vulnerabilty from multiple other sources shows it with less CVSS score. Can we get this updated to as lesser severity ?

https://nvd.nist.gov/vuln/detail/CVE-2022-34169
https://access.redhat.com/security/cve/cve-2022-34169#cve-cvss-v3
https://ossindex.sonatype.org/component/pkg:maven/xalan/xalan

Also the fix for this is not release in Sept 2022. There is a new version released recently and it still did not make it to Maven central repo. 
