### PR TITLE
[GHSA-f8vr-r385-rh5r] hyper and h2 vulnerable to denial of service

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-f8vr-r385-rh5r/GHSA-f8vr-r385-rh5r.json
+++ b/advisories/github-reviewed/2023/04/GHSA-f8vr-r385-rh5r/GHSA-f8vr-r385-rh5r.json
@@ -1,36 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f8vr-r385-rh5r",
-  "modified": "2023-04-11T21:47:01Z",
+  "modified": "2023-04-11T21:47:04Z",
   "published": "2023-04-11T15:30:30Z",
   "aliases": [
     "CVE-2023-26964"
   ],
   "summary": "hyper and h2 vulnerable to denial of service",
-  "details": "Hyper is an HTTP library for Rust and h2 is an HTTP 2.0 client & server implementation for Rust. An issue was discovered in hyper v0.13.7 and h2 v0.2.4 when proessing header frames. Both packages incorrectly process the HTTP2 `RST_STREAM` frames by not always releasing the memory immediately upon receiving the reset frame, leading to stream stacking. As a result, the memory and CPU usage are high which can lead to a Denial of Service (DoS).\n\nAs of time of publication of this advisory, there is no evidence of a fix having been incorporated into hyper or h2.",
+  "details": "Hyper is an HTTP library for Rust and h2 is an HTTP 2.0 client & server implementation for Rust. An issue was discovered in h2 v0.2.4 when proessing header frames. Both packages incorrectly process the HTTP2 `RST_STREAM` frames by not always releasing the memory immediately upon receiving the reset frame, leading to stream stacking. As a result, the memory and CPU usage are high which can lead to a Denial of Service (DoS).\n\nAs of time of publication of this advisory, there is no evidence of a fix having been incorporated into h2.",
   "severity": [
 
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "crates.io",
-        "name": "hyper"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "last_affected": "0.14.25"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "crates.io",
@@ -66,7 +47,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/hyperium/hyper"
+      "url": "https://github.com/hyperium/h2"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location

**Comments**
The code lives in the `h2` library, a fix will only require a new `h2` version. A `hyper` version will not need to be published, since hyper's dependency range allows the new version to be used once it exists.