### PR TITLE
[GHSA-f8vr-r385-rh5r] hyper and h2 vulnerable to denial of service

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-f8vr-r385-rh5r/GHSA-f8vr-r385-rh5r.json
+++ b/advisories/github-reviewed/2023/04/GHSA-f8vr-r385-rh5r/GHSA-f8vr-r385-rh5r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f8vr-r385-rh5r",
-  "modified": "2023-04-11T21:47:01Z",
+  "modified": "2023-04-11T21:47:04Z",
   "published": "2023-04-11T15:30:30Z",
   "aliases": [
     "CVE-2023-26964"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This CVE was opened before engaging with the project’s SECURITY process. This is a breach of trust.