### PR TITLE
[GHSA-2j79-8pqc-r7x6] react-native-reanimated vulnerable to ReDoS

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-2j79-8pqc-r7x6/GHSA-2j79-8pqc-r7x6.json
+++ b/advisories/github-reviewed/2022/09/GHSA-2j79-8pqc-r7x6/GHSA-2j79-8pqc-r7x6.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-2j79-8pqc-r7x6",
+  "modified": "2023-02-01T05:08:25Z",
+  "published": "2022-10-01T00:00:24Z",
+  "aliases": [
+    "CVE-2022-24373"
+  ],
+  "summary": "react-native-reanimated vulnerable to ReDoS",
+  "details": "The package react-native-reanimated before 2.10.0 is vulnerable to Regular Expression Denial of Service (ReDoS) due to improper usage of regular expression in the parser of Colors.js.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "react-native-reanimated"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.10.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24373"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/software-mansion/react-native-reanimated/pull/3382"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/software-mansion/react-native-reanimated/pull/3382/commits/7adf06d0c59382d884a04be86a96eede3d0432fa"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/software-mansion/react-native-reanimated/commit/8a927904366fa2d02df7a11553f8b0aa93471279"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/software-mansion/react-native-reanimated"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/software-mansion/react-native-reanimated/compare/2.9.1...2.10.0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/software-mansion/react-native-reanimated/releases/tag/3.0.0-rc.1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.snyk.io/vuln/SNYK-JS-REACTNATIVEREANIMATED-2949507"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-400"
+    ],
+    "severity": "HIGH",
+    "github_reviewed": true,
+    "github_reviewed_at": "2022-10-04T21:16:38Z",
+    "nvd_published_at": "2022-09-30T05:15:00Z"
+  }
+}


### PR DESCRIPTION
**Updates**
- Description

**Comments**
The current remediation and description texts are confusing/conflicting as it says that anything < 3.0.0-rc.1 is vulnerable but recommends upgrading to 2.10.0.

In reality, the fix is available in 2.10.0+ and 3.0.0-rc1+

The diff between version 2.9.1 and 2.10.0 has the fix:
https://github.com/software-mansion/react-native-reanimated/compare/2.9.1...2.10.0
https://github.com/software-mansion/react-native-reanimated/commit/49216791ff679dcbdb37dc4c60a58bd36c2592a7

The 3.0.0-rc1 tag also has the same commit:
https://github.com/software-mansion/react-native-reanimated/commit/6025581335f38e8117d321d6f2e0f73a8e6aa902
https://github.com/software-mansion/react-native-reanimated/releases/tag/3.0.0-rc.1