### PR TITLE
[GHSA-4pmp-38hf-rmwj] OpenStack Neutron allows remote authenticated users to cause a denial of service

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4pmp-38hf-rmwj/GHSA-4pmp-38hf-rmwj.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4pmp-38hf-rmwj/GHSA-4pmp-38hf-rmwj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4pmp-38hf-rmwj",
-  "modified": "2023-02-08T19:55:29Z",
+  "modified": "2023-02-08T19:55:31Z",
   "published": "2022-05-17T03:06:07Z",
   "aliases": [
     "CVE-2014-3555"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "PyPI",
-        "name": "neutron"
+        "name": ""
       },
       "ranges": [
         {
@@ -23,28 +23,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "2013.2.4"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "PyPI",
-        "name": "neutron"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2014.1.0"
-            },
-            {
-              "fixed": "2014.1.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The first available pypi package is from 2018: https://pypi.org/project/neutron/#history (predating the versions listed here), and none of them follow the calver versions specified. 

It seems likely this is a false match (at least for PyPI), and should be withdrawn