### PR TITLE
[GHSA-pfcc-3g6r-8rg8] Undertow client not checking server identity presented by server certificate in https connections

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-pfcc-3g6r-8rg8/GHSA-pfcc-3g6r-8rg8.json
+++ b/advisories/github-reviewed/2023/02/GHSA-pfcc-3g6r-8rg8/GHSA-pfcc-3g6r-8rg8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pfcc-3g6r-8rg8",
-  "modified": "2023-03-03T23:12:22Z",
+  "modified": "2023-03-24T20:05:55Z",
   "published": "2023-02-23T21:30:16Z",
   "aliases": [
     "CVE-2022-4492"
@@ -28,7 +28,26 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.3.4.Final"
+              "fixed": "2.3.5.Final"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.undertow:undertow-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.2.24.Final"
             }
           ]
         }
@@ -55,6 +74,10 @@
     {
       "type": "WEB",
       "url": "https://issues.redhat.com/browse/MTA-93"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.redhat.com/browse/UNDERTOW-2212"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
https://github.com/advisories/GHSA-pfcc-3g6r-8rg8 (CVE-2022-4492)

Updating patched versions:
* `2.3.5.Final` contains the patch for `2.3.x` versions.
* `2.2.24.Final` contains the back-ported patch for `2.2.x` versions.

**Relevant Links**
* Undertow tracking issue listing the fixed versions: https://issues.redhat.com/browse/UNDERTOW-2212
* PR with the fix for 2.3.x: https://github.com/undertow-io/undertow/pull/1447
* PR with the backport to 2.2.x: https://github.com/undertow-io/undertow/pull/1457