### PR TITLE
[GHSA-2f2w-349x-vrqm] Cross-site scripting (XSS) from field and configuration text displayed in the Panel

### DIFF
--- a/advisories/github-reviewed/2021/07/GHSA-2f2w-349x-vrqm/GHSA-2f2w-349x-vrqm.json
+++ b/advisories/github-reviewed/2021/07/GHSA-2f2w-349x-vrqm/GHSA-2f2w-349x-vrqm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2f2w-349x-vrqm",
-  "modified": "2021-10-21T14:13:46Z",
+  "modified": "2023-02-01T05:05:49Z",
   "published": "2021-07-02T19:18:43Z",
   "aliases": [
     "CVE-2021-32735"
@@ -46,6 +46,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-32735"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/getkirby/kirby/commit/f5ead62f8510158bed5baf58ca0e851875778a09"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.5.7: https://github.com/getkirby/kirby/commit/f5ead62f8510158bed5baf58ca0e851875778a09

The GHSA-ID is in the commit message: "Merge pull request from GHSA-2f2w-349x-vrqm. [3.5.7] `v-html` security fixes"