### PR TITLE
[GHSA-2p9h-ccw7-33gf] cleo is vulnerable to Regular Expression Denial of Service (ReDoS)

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-2p9h-ccw7-33gf/GHSA-2p9h-ccw7-33gf.json
+++ b/advisories/github-reviewed/2022/11/GHSA-2p9h-ccw7-33gf/GHSA-2p9h-ccw7-33gf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2p9h-ccw7-33gf",
-  "modified": "2022-11-10T18:52:40Z",
+  "modified": "2023-01-31T05:07:10Z",
   "published": "2022-11-10T12:01:17Z",
   "aliases": [
     "CVE-2022-42966"
@@ -46,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/python-poetry/cleo/pull/285"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python-poetry/cleo/commit/b5b9a04d2caf58bf7cf94eb7ae4a1ebbe60ea455"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.0.0: https://github.com/python-poetry/cleo/commit/b5b9a04d2caf58bf7cf94eb7ae4a1ebbe60ea455

This commit was the merge for the original pull (285) to resolve the ReDoS: "Change regex string to less permissive one"