### PR TITLE
[GHSA-2v78-j59h-fmpf] Heap overflow or corruption in safe-transmute

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-2v78-j59h-fmpf/GHSA-2v78-j59h-fmpf.json
+++ b/advisories/github-reviewed/2021/08/GHSA-2v78-j59h-fmpf/GHSA-2v78-j59h-fmpf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2v78-j59h-fmpf",
-  "modified": "2021-08-19T21:24:31Z",
+  "modified": "2023-01-11T05:06:02Z",
   "published": "2021-08-25T20:43:23Z",
   "aliases": [
     "CVE-2018-21000"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/nabijaczleweli/safe-transmute-rs/pull/36"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nabijaczleweli/safe-transmute-rs/commit/a134e06d740f9d7c287f74c0af2cd06206774364"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.10.1: https://github.com/nabijaczleweli/safe-transmute-rs/commit/a134e06d740f9d7c287f74c0af2cd06206774364

This commit was the original pull (36) merge to resolve the overflow: "Fix vec-to-vec conversion primitives - wrong function parameter order!"