### PR TITLE
[GHSA-32hw-3pvh-vcvc] XSS vulnerability on password reset page

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-32hw-3pvh-vcvc/GHSA-32hw-3pvh-vcvc.json
+++ b/advisories/github-reviewed/2021/09/GHSA-32hw-3pvh-vcvc/GHSA-32hw-3pvh-vcvc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-32hw-3pvh-vcvc",
-  "modified": "2021-08-30T18:03:34Z",
+  "modified": "2023-02-01T05:06:18Z",
   "published": "2021-09-01T18:40:56Z",
   "aliases": [
     "CVE-2021-27909"
@@ -43,6 +43,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-27909"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mautic/mautic/commit/942cb6992df619fdf1c181bfad9e25d5d4178b6f"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.3.4: https://github.com/mautic/mautic/commit/942cb6992df619fdf1c181bfad9e25d5d4178b6f

The GHSA-ID in the commit patch message: "Merge pull request from GHSA-32hw-3pvh-vcvc
* Fixing xss on common controller for Mautic 3.x branch.

* Add test cases to validate xss filteration."