### PR TITLE
[GHSA-363h-vj6q-3cmj] Rosetta-Flash JSONP Vulnerability in hapi

### DIFF
--- a/advisories/github-reviewed/2020/08/GHSA-363h-vj6q-3cmj/GHSA-363h-vj6q-3cmj.json
+++ b/advisories/github-reviewed/2020/08/GHSA-363h-vj6q-3cmj/GHSA-363h-vj6q-3cmj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-363h-vj6q-3cmj",
-  "modified": "2021-09-23T19:28:27Z",
+  "modified": "2023-01-09T05:03:42Z",
   "published": "2020-08-31T22:45:35Z",
   "aliases": [
     "CVE-2014-4671"
@@ -40,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/spumko/hapi/pull/1766"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hapijs/hapi/commit/d47f57abf23bdaa84f61aed2bac94ae5f358afb7"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v6.1.0: https://github.com/hapijs/hapi/commit/d47f57abf23bdaa84f61aed2bac94ae5f358afb7

This is the complete merge of the original pull (1766) from the advisory: "Merge pull request 1766 from patrickkettner/rosetta-flash prepend jsonp callbacks with a comment to prevent the rosetta-flash vulnerability"