### PR TITLE
[GHSA-37jj-wp7g-7wj4] Read of uninitialized memory in cdr

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-37jj-wp7g-7wj4/GHSA-37jj-wp7g-7wj4.json
+++ b/advisories/github-reviewed/2021/08/GHSA-37jj-wp7g-7wj4/GHSA-37jj-wp7g-7wj4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-37jj-wp7g-7wj4",
-  "modified": "2021-08-19T17:53:09Z",
+  "modified": "2023-01-11T05:05:29Z",
   "published": "2021-08-25T20:53:12Z",
   "aliases": [
     "CVE-2021-26305"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/hrektts/cdr-rs/issues/10"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hrektts/cdr-rs/commit/0e6006de464caa331643f86cd2d9ba3b32b09833"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.2.4: https://github.com/hrektts/cdr-rs/commit/0e6006de464caa331643f86cd2d9ba3b32b09833

The commit patch is from pull 11 (https://github.com/hrektts/cdr-rs/pull/11), which closed the original issue (10) from the advisory: "Fix not to use uninitialized memory"