### PR TITLE
[GHSA-3c67-gc48-983w] Path Traversal in Ansible

### DIFF
--- a/advisories/github-reviewed/2021/04/GHSA-3c67-gc48-983w/GHSA-3c67-gc48-983w.json
+++ b/advisories/github-reviewed/2021/04/GHSA-3c67-gc48-983w/GHSA-3c67-gc48-983w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3c67-gc48-983w",
-  "modified": "2021-04-05T14:22:26Z",
+  "modified": "2023-02-01T05:05:23Z",
   "published": "2021-04-20T16:44:37Z",
   "aliases": [
     "CVE-2020-10691"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/ansible/ansible/pull/68596"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ansible/ansible/commit/b2551bb6943eec078066aa3a923e0bb3ed85abe8"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.9.7: https://github.com/ansible/ansible/commit/b2551bb6943eec078066aa3a923e0bb3ed85abe8

The CVE is mentioned in the commit patch message: "ansible-galaxy - Fix tar path traversal issue during install - CVE-2020-10691 - 2.9 (68601)

* ansible-galaxy - Fix tar path traversal issue during install - CVE-2020-10691 (68596)"