### PR TITLE
[GHSA-3gfj-fxx4-f22w] OpenFGA Authorization Bypass

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-3gfj-fxx4-f22w/GHSA-3gfj-fxx4-f22w.json
+++ b/advisories/github-reviewed/2022/11/GHSA-3gfj-fxx4-f22w/GHSA-3gfj-fxx4-f22w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3gfj-fxx4-f22w",
-  "modified": "2022-11-10T14:32:09Z",
+  "modified": "2023-01-30T05:07:12Z",
   "published": "2022-11-08T22:31:25Z",
   "aliases": [
     "CVE-2022-39352"
@@ -46,6 +46,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-39352"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/openfga/openfga/commit/776e80505e8d184b2286acc8268d8d74f36a9984"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.2.5: https://github.com/openfga/openfga/commit/776e80505e8d184b2286acc8268d8d74f36a9984

The GHSA-ID is mentioned in the commit patch message: "Merge pull request from GHSA-3gfj-fxx4-f22w"