### PR TITLE
[GHSA-4262-wr7p-gpcj] Rundeck Community Edition vulnerable to Cross-site Scripting

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4262-wr7p-gpcj/GHSA-4262-wr7p-gpcj.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4262-wr7p-gpcj/GHSA-4262-wr7p-gpcj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4262-wr7p-gpcj",
-  "modified": "2022-11-22T18:46:01Z",
+  "modified": "2023-02-02T05:01:22Z",
   "published": "2022-05-13T01:06:55Z",
   "aliases": [
     "CVE-2019-6804"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/rundeck/rundeck/issues/4406"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rundeck/rundeck/commit/e992e94bba22d9fca3a669f0d02c85b80a19f848"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.0.13: https://github.com/rundeck/rundeck/commit/e992e94bba22d9fca3a669f0d02c85b80a19f848

This was from pull 4407 that was used to fix the original issue (4406): "Merge pull request 4407 from rundeck/issue/4406-stored-xss
Fix 4406: stored xss vulnerability"