### PR TITLE
[GHSA-42xw-2xvc-qx8m] Denial of Service in axios

### DIFF
--- a/advisories/github-reviewed/2019/05/GHSA-42xw-2xvc-qx8m/GHSA-42xw-2xvc-qx8m.json
+++ b/advisories/github-reviewed/2019/05/GHSA-42xw-2xvc-qx8m/GHSA-42xw-2xvc-qx8m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-42xw-2xvc-qx8m",
-  "modified": "2021-07-27T20:36:18Z",
+  "modified": "2023-02-01T05:02:00Z",
   "published": "2019-05-29T18:04:45Z",
   "aliases": [
     "CVE-2019-10742"
@@ -50,6 +50,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/axios/axios/pull/1485"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/axios/axios/commit/acabfbdf00a58bb866c9d070e8a10d1d0dbeb572"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.18.1: https://github.com/axios/axios/commit/acabfbdf00a58bb866c9d070e8a10d1d0dbeb572

This was from pull 1485 that was used to fix the original issue (1098): "Destroy stream on exceeding maxContentLength (fixes 1098) (1485)"