### PR TITLE
[GHSA-446m-mv8f-q348] Regular Expression Denial of Service in moment

### DIFF
--- a/advisories/github-reviewed/2018/03/GHSA-446m-mv8f-q348/GHSA-446m-mv8f-q348.json
+++ b/advisories/github-reviewed/2018/03/GHSA-446m-mv8f-q348/GHSA-446m-mv8f-q348.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-446m-mv8f-q348",
-  "modified": "2021-08-31T21:44:15Z",
+  "modified": "2023-02-01T05:03:23Z",
   "published": "2018-03-05T18:35:09Z",
   "aliases": [
     "CVE-2017-18214"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/moment/moment/pull/4326"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moment/moment/commit/69ed9d44957fa6ab12b73d2ae29d286a857b80eb"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.19.3: https://github.com/moment/moment/commit/69ed9d44957fa6ab12b73d2ae29d286a857b80eb

This is the complete merge of the original pull (4326) from the advisory: "[bugfix] Fix for ReDOS vulnerability (see 4163) (4326)
* Limiting regex match to 256 chars, fixing 4163

* Limiting regex match to 256 chars, fixing 4163

* Also limiting numbers to fix 4163"