### PR TITLE
[GHSA-49fq-pw77-6qxj] Use after free in string-interner

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-49fq-pw77-6qxj/GHSA-49fq-pw77-6qxj.json
+++ b/advisories/github-reviewed/2021/08/GHSA-49fq-pw77-6qxj/GHSA-49fq-pw77-6qxj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-49fq-pw77-6qxj",
-  "modified": "2021-08-19T21:23:01Z",
+  "modified": "2023-01-11T05:05:48Z",
   "published": "2021-08-25T20:44:15Z",
   "aliases": [
     "CVE-2019-16882"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/Robbepop/string-interner/issues/9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/Robbepop/string-interner/commit/d91dac0cfe42512526879cdfaac0b81beff54089"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.7.1: https://github.com/Robbepop/string-interner/commit/d91dac0cfe42512526879cdfaac0b81beff54089

This commit patch is from pull 10 that fixed the original issue (9): "Fix use after free bug around StringInterner::clone() (10) ..... Fixes 9."