### PR TITLE
[GHSA-4jm3-pfpf-h54p] espeak-ruby allows arbitrary command execution

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-4jm3-pfpf-h54p/GHSA-4jm3-pfpf-h54p.json
+++ b/advisories/github-reviewed/2017/10/GHSA-4jm3-pfpf-h54p/GHSA-4jm3-pfpf-h54p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4jm3-pfpf-h54p",
-  "modified": "2023-01-25T22:57:24Z",
+  "modified": "2023-01-25T22:57:25Z",
   "published": "2017-10-24T18:33:35Z",
   "aliases": [
     "CVE-2016-10193"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/dejan/espeak-ruby/issues/7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/dejan/espeak-ruby/commit/5251744b13bdd9fb0c72c612226e72d330bac143"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.0.3: https://github.com/dejan/espeak-ruby/commit/5251744b13bdd9fb0c72c612226e72d330bac143

The original issue (7) was mentioned in the commit patch message: "Replace sanitized_text method - Fix 7. Remove `sanitized_text` method and use `IO.popen` rather than `system` to prevent command injection."