### PR TITLE
[GHSA-53xv-c2hx-5w6q] Command Injection in node-windows

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-53xv-c2hx-5w6q/GHSA-53xv-c2hx-5w6q.json
+++ b/advisories/github-reviewed/2022/01/GHSA-53xv-c2hx-5w6q/GHSA-53xv-c2hx-5w6q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-53xv-c2hx-5w6q",
-  "modified": "2022-03-30T21:13:48Z",
+  "modified": "2023-01-30T05:07:49Z",
   "published": "2022-01-05T20:39:21Z",
   "aliases": [
     "CVE-2021-45459"
@@ -46,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/dwisiswant0/advisory/issues/4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/coreybutler/node-windows/commit/a379d31366edbd7a672a981e6c09e185ab448dd3"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.0.0-beta.6: https://github.com/coreybutler/node-windows/commit/a379d31366edbd7a672a981e6c09e185ab448dd3

It's the only related commit to the command injection fix: "prevent arbitrary command execution."