### PR TITLE
[GHSA-7jvx-f994-rfw2] materialize-css vulnerable to cross-site Scripting (XSS) due to improper escape of user input

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-7jvx-f994-rfw2/GHSA-7jvx-f994-rfw2.json
+++ b/advisories/github-reviewed/2022/05/GHSA-7jvx-f994-rfw2/GHSA-7jvx-f994-rfw2.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7jvx-f994-rfw2",
-  "modified": "2022-05-03T21:09:12Z",
+  "modified": "2023-02-01T05:00:55Z",
   "published": "2022-05-03T00:00:45Z",
   "aliases": [
     "CVE-2022-25349"
   ],
   "summary": "materialize-css vulnerable to cross-site Scripting (XSS) due to improper escape of user input",
-  "details": "All versions of package materialize-css are vulnerable to Cross-site Scripting (XSS) due to improper escape of user input (such as &lt;not-a-tag /&gt;) that is being parsed as HTML/JavaScript, and inserted into the Document Object Model (DOM). This vulnerability can be exploited when the user-input is provided to the autocomplete component.",
+  "details": "All versions of package materialize-css are vulnerable to Cross-site Scripting (XSS) due to improper escape of user input (such as &lt;not-a-tag /&gt;) that is being parsed as HTML/JavaScript, and inserted into the Document Object Model (DOM). This vulnerability can be exploited when the user input is provided to the autocomplete component.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/Dogfalo/materialize/blob/v1-dev/js/autocomplete.js%23L285%20"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.snyk.io/vuln/SNYK-JS-MATERIALIZECSS-2324800"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
https://security.snyk.io/vuln/SNYK-JS-MATERIALIZECSS-2324800
https://nvd.nist.gov/vuln/detail/CVE-2022-25349