### PR TITLE
[GHSA-rg3q-jxmp-pvjj] Materialize-css vulnerable to Improper Neutralization of Input During Web Page Generation

### DIFF
--- a/advisories/github-reviewed/2019/04/GHSA-rg3q-jxmp-pvjj/GHSA-rg3q-jxmp-pvjj.json
+++ b/advisories/github-reviewed/2019/04/GHSA-rg3q-jxmp-pvjj/GHSA-rg3q-jxmp-pvjj.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rg3q-jxmp-pvjj",
-  "modified": "2022-09-17T00:24:09Z",
+  "modified": "2023-01-11T05:04:08Z",
   "published": "2019-04-09T19:44:37Z",
   "aliases": [
     "CVE-2019-11004"
   ],
   "summary": "Materialize-css vulnerable to Improper Neutralization of Input During Web Page Generation",
-  "details": "In Materialize through 1.0.0, XSS is possible via the Toast feature.",
+  "details": "In Materialize through 1.0.0, XSS is possible via the Toast feature.\nIn Materialize through 1.0.0, XSS is possible via the Tooltip feature.\nIn Materialize through 1.0.0, XSS is possible via the Autocomplete feature.",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
References :
https://nvd.nist.gov/vuln/detail/CVE-2019-11002
https://nvd.nist.gov/vuln/detail/CVE-2019-11003