### PR TITLE
[GHSA-2chv-87wj-pjv2] OHDSI WebAPI vulnerable to SQL Injection

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-2chv-87wj-pjv2/GHSA-2chv-87wj-pjv2.json
+++ b/advisories/github-reviewed/2022/05/GHSA-2chv-87wj-pjv2/GHSA-2chv-87wj-pjv2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2chv-87wj-pjv2",
-  "modified": "2022-11-22T18:45:23Z",
+  "modified": "2023-02-02T05:03:37Z",
   "published": "2022-05-24T16:54:46Z",
   "aliases": [
     "CVE-2019-15563"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/OHDSI/WebAPI/pull/1101"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/OHDSI/WebAPI/commit/d7b12b2f5234e425e5bc76545e75de0d6eb3f8fd"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.7.2: https://github.com/OHDSI/WebAPI/commit/d7b12b2f5234e425e5bc76545e75de0d6eb3f8fd

This is the complete merge of the original pull (1101): "Fixes SQL injection vulnerability (1101)"