### PR TITLE
[GHSA-5c5f-7vfq-3732] JMESPath for Ruby uses unsafe JSON.load when safe JSON.parse is preferable

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-5c5f-7vfq-3732/GHSA-5c5f-7vfq-3732.json
+++ b/advisories/github-reviewed/2022/06/GHSA-5c5f-7vfq-3732/GHSA-5c5f-7vfq-3732.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5c5f-7vfq-3732",
-  "modified": "2022-07-05T21:24:30Z",
+  "modified": "2023-01-27T05:03:54Z",
   "published": "2022-06-07T00:00:31Z",
   "aliases": [
     "CVE-2022-32511"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/jmespath/jmespath.rb/pull/55"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jmespath/jmespath.rb/commit/e8841280053a9d9a0c90f36223f926c8b9e4ec49"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.6.1: https://github.com/jmespath/jmespath.rb/commit/e8841280053a9d9a0c90f36223f926c8b9e4ec49

This is the complete merge of the original pull (55): "Merge pull request 55 from jmespath/json-parse. Use JSON.parse instead of JSON.load"