### PR TITLE
[GHSA-5h7w-hmxc-99g5] Cross site scripting in safe-svg

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-5h7w-hmxc-99g5/GHSA-5h7w-hmxc-99g5.json
+++ b/advisories/github-reviewed/2022/04/GHSA-5h7w-hmxc-99g5/GHSA-5h7w-hmxc-99g5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5h7w-hmxc-99g5",
-  "modified": "2022-04-28T21:15:03Z",
+  "modified": "2023-01-27T05:01:42Z",
   "published": "2022-04-19T00:00:45Z",
   "aliases": [
     "CVE-2022-1091"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/10up/safe-svg/pull/28"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/10up/safe-svg/commit/00cb9a86d1bff2214714557d1901ec3896564e50"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.9.10: https://github.com/10up/safe-svg/commit/00cb9a86d1bff2214714557d1901ec3896564e50

This is the complete merge of the original pull (28): "Merge pull request 28 from 10up/fix/proper-type-checking. Better checking of the file type when determining which files are SVGs"