### PR TITLE
[GHSA-5v7r-jg9r-vq44] Insecure Cryptography Algorithm in simple-crypto-js

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-5v7r-jg9r-vq44/GHSA-5v7r-jg9r-vq44.json
+++ b/advisories/github-reviewed/2020/09/GHSA-5v7r-jg9r-vq44/GHSA-5v7r-jg9r-vq44.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5v7r-jg9r-vq44",
-  "modified": "2021-09-29T20:08:01Z",
+  "modified": "2023-01-09T05:04:00Z",
   "published": "2020-09-03T21:19:46Z",
   "aliases": [
 
@@ -39,6 +39,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/danang-id/simple-crypto-js/issues/12"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/danang-id/simple-crypto-js/pull/17"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/danang-id/simple-crypto-js/commit/416584369de1dad9b21ac3fe85df0b71cf5718b2"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.3.0: https://github.com/danang-id/simple-crypto-js/commit/416584369de1dad9b21ac3fe85df0b71cf5718b2

Adding the pull: https://github.com/danang-id/simple-crypto-js/pull/17

The original issue (12) referenced pull (17): "See 17 for a suggested fix."