### PR TITLE
[GHSA-5v9h-q3gj-c32x] SQL Injection via GeoJSON in sequelize

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-5v9h-q3gj-c32x/GHSA-5v9h-q3gj-c32x.json
+++ b/advisories/github-reviewed/2020/09/GHSA-5v9h-q3gj-c32x/GHSA-5v9h-q3gj-c32x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5v9h-q3gj-c32x",
-  "modified": "2021-09-23T21:29:13Z",
+  "modified": "2023-01-09T05:04:01Z",
   "published": "2020-09-01T15:27:40Z",
   "aliases": [
     "CVE-2016-1000225"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/sequelize/sequelize/issues/6194"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/sequelize/sequelize/commit/562d52585902090f4e53eb21c61314098c29d795"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.23.6 (https://github.com/sequelize/sequelize/compare/v3.23.5...v3.23.6): https://github.com/sequelize/sequelize/commit/562d52585902090f4e53eb21c61314098c29d795

The original issue (6194) referenced pull 6305, which was backported in pull 6306 for v3.23.6: "mysql case for GEOGRAPHY/GEOMETRY sql injection (6306)"