### PR TITLE
[GHSA-64wv-8vwp-xgw2] Use of Uninitialized Resource in ash.

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-64wv-8vwp-xgw2/GHSA-64wv-8vwp-xgw2.json
+++ b/advisories/github-reviewed/2022/01/GHSA-64wv-8vwp-xgw2/GHSA-64wv-8vwp-xgw2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-64wv-8vwp-xgw2",
-  "modified": "2022-01-07T17:19:25Z",
+  "modified": "2023-02-03T05:03:45Z",
   "published": "2022-01-06T22:13:02Z",
   "aliases": [
     "CVE-2021-45688"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-45688"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ash-rs/ash/commit/2c98b6f384a017de031698bd623551a45f24c8f9"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.33.1: https://github.com/ash-rs/ash/commit/2c98b6f384a017de031698bd623551a45f24c8f9

Only two commits for v0.33.1 (https://github.com/ash-rs/ash/compare/0.33.0...0.33.1), also the developers are fixing the same function read_spv as mentioned in the advisory: "util: Zero-initialize result to prevent possible uninit memory read (470)"