### PR TITLE
[GHSA-6757-jp84-gxfx] Improper Input Validation in PyYAML

### DIFF
--- a/advisories/github-reviewed/2021/04/GHSA-6757-jp84-gxfx/GHSA-6757-jp84-gxfx.json
+++ b/advisories/github-reviewed/2021/04/GHSA-6757-jp84-gxfx/GHSA-6757-jp84-gxfx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6757-jp84-gxfx",
-  "modified": "2022-07-29T18:40:16Z",
+  "modified": "2023-01-27T05:02:32Z",
   "published": "2021-04-20T16:14:24Z",
   "aliases": [
     "CVE-2020-1747"
@@ -19,13 +19,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "pyyaml"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "yaml.load",
-          "yaml.full_load",
-          "yaml.FullLoader"
-        ]
       },
       "ranges": [
         {
@@ -50,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/yaml/pyyaml/pull/386"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/yaml/pyyaml/commit/5080ba513377b6355a0502104846ee804656f1e0"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding the patch link for v5.3.1: https://github.com/yaml/pyyaml/commit/5080ba513377b6355a0502104846ee804656f1e0

This is the complete merge of the original pull (386): "Prevents arbitrary code execution during python/object/new constructor (386)"