### PR TITLE
[GHSA-6j63-35hj-vmcg] SQL injection in mysql-bunuuid-rails

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-6j63-35hj-vmcg/GHSA-6j63-35hj-vmcg.json
+++ b/advisories/github-reviewed/2018/10/GHSA-6j63-35hj-vmcg/GHSA-6j63-35hj-vmcg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6j63-35hj-vmcg",
-  "modified": "2022-09-14T21:58:59Z",
+  "modified": "2023-01-09T05:03:45Z",
   "published": "2018-10-30T20:34:06Z",
   "aliases": [
     "CVE-2018-18476"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/nedap/mysql-binuuid-rails/pull/18"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nedap/mysql-binuuid-rails/commit/9ae920951b46ff0163b16c55d744e89acb1036d4"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.1.1: https://github.com/nedap/mysql-binuuid-rails/commit/9ae920951b46ff0163b16c55d744e89acb1036d4

This is the complete merge of the original pull (18): "Fix possible SQL injection issue (18)"