### PR TITLE
[GHSA-7534-mm45-c74v] Buffer Overflow in Pillow

### DIFF
--- a/advisories/github-reviewed/2021/10/GHSA-7534-mm45-c74v/GHSA-7534-mm45-c74v.json
+++ b/advisories/github-reviewed/2021/10/GHSA-7534-mm45-c74v/GHSA-7534-mm45-c74v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7534-mm45-c74v",
-  "modified": "2021-10-05T18:52:50Z",
+  "modified": "2023-02-02T05:01:22Z",
   "published": "2021-10-05T20:24:41Z",
   "aliases": [
     "CVE-2021-34552"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/python-pillow/Pillow/pull/5567"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/commit/31c473898c29d1b7cb6555ce67d9503a4906b83f"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v8.3.0: https://github.com/python-pillow/Pillow/commit/31c473898c29d1b7cb6555ce67d9503a4906b83f

This is the complete merge of the original pull (5567): "Merge pull request 5567 from radarhere/sprintf. Limit sprintf modes to 10 characters"