### PR TITLE
[GHSA-4mgv-m5cm-f9h7] Vault GitHub Action did not correctly mask multi-line secrets in output

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4mgv-m5cm-f9h7/GHSA-4mgv-m5cm-f9h7.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4mgv-m5cm-f9h7/GHSA-4mgv-m5cm-f9h7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4mgv-m5cm-f9h7",
-  "modified": "2022-07-29T19:57:46Z",
+  "modified": "2023-01-27T05:03:38Z",
   "published": "2022-05-24T19:01:50Z",
   "aliases": [
     "CVE-2021-32074"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/hashicorp/vault-action/pull/208"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hashicorp/vault-action/commit/3526e1be65cf8faf42d6088bc5da8bff596c718a"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.2.0: https://github.com/hashicorp/vault-action/commit/3526e1be65cf8faf42d6088bc5da8bff596c718a

This is the complete merge of the original pull (208): "Mask each line of multi-line secrets (208)