### PR TITLE
[GHSA-69p3-xp37-f692] Improper Certificate Validation in kubeclient

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-69p3-xp37-f692/GHSA-69p3-xp37-f692.json
+++ b/advisories/github-reviewed/2022/03/GHSA-69p3-xp37-f692/GHSA-69p3-xp37-f692.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-69p3-xp37-f692",
-  "modified": "2022-04-08T21:45:06Z",
+  "modified": "2023-01-27T05:01:01Z",
   "published": "2022-03-26T00:00:29Z",
   "aliases": [
     "CVE-2022-0759"
@@ -51,6 +51,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/ManageIQ/kubeclient/pull/556"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ManageIQ/kubeclient/commit/109ea71de5a8881748f03ebbe103b49f0f1c7887"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v4.9.3: https://github.com/ManageIQ/kubeclient/commit/109ea71de5a8881748f03ebbe103b49f0f1c7887

This is the complete merge of the original pull (556): "Merge pull request 556 from cben/v4.y-security-config-ssl_verify [v4.y] SECURITY: Kubeclient::Config: return ssl_options[:verify_ssl] correctly"