### PR TITLE
[GHSA-6gcg-hp2x-q54h] Symlink following allows leaking out-of-bound manifests and JSON files from Argo CD repo-server

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-6gcg-hp2x-q54h/GHSA-6gcg-hp2x-q54h.json
+++ b/advisories/github-reviewed/2022/05/GHSA-6gcg-hp2x-q54h/GHSA-6gcg-hp2x-q54h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6gcg-hp2x-q54h",
-  "modified": "2022-05-23T21:13:57Z",
+  "modified": "2023-01-27T05:01:45Z",
   "published": "2022-05-23T21:13:57Z",
   "aliases": [
     "CVE-2022-24904"
@@ -81,6 +81,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24904"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/argoproj/argo-cd/commit/5e767a4b9e30983330c0fdec322192281a90eb84"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/argoproj/argo-cd/commit/7357cfdb58a560de70a0538c6e3bef6fe39505ea"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/argoproj/argo-cd/commit/d36d95dc9f71ec61c1a93794f81ece6d61a0d943"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.1.15: https://github.com/argoproj/argo-cd/commit/7357cfdb58a560de70a0538c6e3bef6fe39505ea

Adding the patch link for v2.2.9: https://github.com/argoproj/argo-cd/commit/5e767a4b9e30983330c0fdec322192281a90eb84

Adding the patch link for v2.3.4: https://github.com/argoproj/argo-cd/commit/d36d95dc9f71ec61c1a93794f81ece6d61a0d943

The GHSA-ID is the in the commit patch message: "Merge pull request from GHSA-6gcg-hp2x-q54h"