### PR TITLE
[GHSA-6hgr-2g6q-3rmc] Server session is not invalidated when logout() helper method of Authentication module is used in Vaadin 18-19

### DIFF
--- a/advisories/github-reviewed/2021/04/GHSA-6hgr-2g6q-3rmc/GHSA-6hgr-2g6q-3rmc.json
+++ b/advisories/github-reviewed/2021/04/GHSA-6hgr-2g6q-3rmc/GHSA-6hgr-2g6q-3rmc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6hgr-2g6q-3rmc",
-  "modified": "2021-10-08T21:22:21Z",
+  "modified": "2023-01-09T05:04:45Z",
   "published": "2021-04-22T16:11:26Z",
   "aliases": [
 
@@ -39,6 +39,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/vaadin/flow/security/advisories/GHSA-6hgr-2g6q-3rmc"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vaadin/flow/pull/10577"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vaadin/flow/commit/815b967fc84fefa8d3a4d72b9a036f48b0d96326"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v6.0.5: https://github.com/vaadin/flow/commit/815b967fc84fefa8d3a4d72b9a036f48b0d96326

Adding the pull: https://github.com/vaadin/flow/pull/10577

In the original reference link (https://vaadin.com/security/cve-2021-31408), the authors referenced pull 10577: "PR: https://github.com/vaadin/flow/pull/10577" The patch provided is the backport for v6.0.5 of the pull: "fix: store spring csrf to bootstrap page (10577)"