### PR TITLE
[GHSA-6hv3-7c34-4hx8] Hashicorp Nomad Information Exposure Through Environmental Variables

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-6hv3-7c34-4hx8/GHSA-6hv3-7c34-4hx8.json
+++ b/advisories/github-reviewed/2022/02/GHSA-6hv3-7c34-4hx8/GHSA-6hv3-7c34-4hx8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6hv3-7c34-4hx8",
-  "modified": "2023-01-09T22:28:26Z",
+  "modified": "2023-02-02T05:00:41Z",
   "published": "2022-02-15T01:57:18Z",
   "aliases": [
     "CVE-2019-14802"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/hashicorp/nomad/pull/6055"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hashicorp/nomad/commit/e8238305ef0b9ef37be3efd86a8d34bfbed5f63f"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.9.5: https://github.com/hashicorp/nomad/commit/e8238305ef0b9ef37be3efd86a8d34bfbed5f63f

The commit patch is the complete merge of the original pull (6055) for v0.9.5: "Render consul templates using task env only (6055)" 