### PR TITLE
[GHSA-683w-84m7-p8pw] User account enumeration via crafted URL

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-683w-84m7-p8pw/GHSA-683w-84m7-p8pw.json
+++ b/advisories/github-reviewed/2022/05/GHSA-683w-84m7-p8pw/GHSA-683w-84m7-p8pw.json
@@ -58,6 +58,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/plone/Products.CMFPlone/commit/a9479a5b38646fe0b0a9066ee46de9c18de32bfa"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/plone/Products.CMFPlone/commit/c3a98f4e6cf26501485de9c8354c49afdea21df8"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2014:1194"
     },
     {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v4.2.3: https://github.com/plone/Products.CMFPlone/commit/c3a98f4e6cf26501485de9c8354c49afdea21df8

Adding patch link for v4.3b1: https://github.com/plone/Products.CMFPlone/commit/a9479a5b38646fe0b0a9066ee46de9c18de32bfa

The commit patch message reads: "various security fixes based on PloneHotfix20121106," which is similar to the original link provided: https://plone.org/products/plone-hotfix/releases/20121106 (even though the original link doesn't work anymore, we can note the name of plone-hotfix 20121106)