### PR TITLE
[GHSA-68g5-8q7f-m384] Improper Limitation of a Pathname to a Restricted Directory in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-68g5-8q7f-m384/GHSA-68g5-8q7f-m384.json
+++ b/advisories/github-reviewed/2022/05/GHSA-68g5-8q7f-m384/GHSA-68g5-8q7f-m384.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-68g5-8q7f-m384",
-  "modified": "2022-06-30T21:21:47Z",
+  "modified": "2023-01-27T05:02:18Z",
   "published": "2022-05-14T00:58:29Z",
   "aliases": [
     "CVE-2017-7675"
@@ -64,6 +64,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-7675"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/cf181edc9a8c239cde704cffc3c503425bdcae2b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/dacb030b85fe0e0b3da87469e23d0f31252fdede"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v8.5.16: https://github.com/apache/tomcat/commit/dacb030b85fe0e0b3da87469e23d0f31252fdede

Adding patch link for v9.0.0-M22: https://github.com/apache/tomcat/commit/cf181edc9a8c239cde704cffc3c503425bdcae2b

From a different reference link(https://svn.apache.org/viewvc?view=revision&revision=1796090): "Fix https://bz.apache.org/bugzilla/show_bug.cgi?id=61120. Do not ignore path parameters when processing HTTP/2 requests. This is the fix for CVE-2017-7675"

Patch commit message: "Fix https://bz.apache.org/bugzilla/show_bug.cgi?id=61120 Do not ignore path parameters when processing HTTP/2 requests."