### PR TITLE
[GHSA-4cmx-hrq9-c23p] Improper Authorization in aedes

### DIFF
--- a/advisories/github-reviewed/2018/08/GHSA-4cmx-hrq9-c23p/GHSA-4cmx-hrq9-c23p.json
+++ b/advisories/github-reviewed/2018/08/GHSA-4cmx-hrq9-c23p/GHSA-4cmx-hrq9-c23p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4cmx-hrq9-c23p",
-  "modified": "2023-03-01T01:18:25Z",
+  "modified": "2023-03-01T01:18:28Z",
   "published": "2018-08-15T20:03:22Z",
   "aliases": [
     "CVE-2018-3778"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/mcollina/aedes/issues/212"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moscajs/aedes/commit/ffbc1702bb24b596afbb96407cc6db234a4044a8"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v0.35.1: https://github.com/moscajs/aedes/commit/ffbc1702bb24b596afbb96407cc6db234a4044a8

This is the complete merge of the original pull (212): "Fix211 (212) 
* Added test cases for 211.
* Fixed 211."