### PR TITLE
[GHSA-6qmf-fj6m-686c] Open Redirect in Flask-Security-Too

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-6qmf-fj6m-686c/GHSA-6qmf-fj6m-686c.json
+++ b/advisories/github-reviewed/2021/05/GHSA-6qmf-fj6m-686c/GHSA-6qmf-fj6m-686c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6qmf-fj6m-686c",
-  "modified": "2023-01-23T18:55:32Z",
+  "modified": "2023-01-23T18:55:33Z",
   "published": "2021-05-17T20:51:27Z",
   "aliases": [
     "CVE-2021-32618"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/Flask-Middleware/flask-security/issues/486"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/Flask-Middleware/flask-security/commit/e39bb04615050448c1b8ba4caa7dacc0edd3e405"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v4.1.0: https://github.com/Flask-Middleware/flask-security/commit/e39bb04615050448c1b8ba4caa7dacc0edd3e405

This is from the pull that closed the original issue (486): "A (hopeful) fix for possible open-redirect. (489) ..... Closes: 486"