### PR TITLE
[GHSA-7wq4-89xx-g62j] Password exposure in ShenYu

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-7wq4-89xx-g62j/GHSA-7wq4-89xx-g62j.json
+++ b/advisories/github-reviewed/2022/01/GHSA-7wq4-89xx-g62j/GHSA-7wq4-89xx-g62j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7wq4-89xx-g62j",
-  "modified": "2022-02-02T16:15:02Z",
+  "modified": "2023-02-03T05:04:57Z",
   "published": "2022-01-28T22:13:57Z",
   "aliases": [
     "CVE-2022-23223"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23223"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/shenyu/commit/0e826ceae97a1258cb15c73a3072118c920e8654"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v2.4.2: https://github.com/apache/shenyu/commit/0e826ceae97a1258cb15c73a3072118c920e8654

From an original reference link(https://www.openwall.com/lists/oss-security/2022/01/26/4): "Upgrade to Apache ShenYu (incubating) 2.4.2 or apply patch https://github.com/apache/incubator-shenyu/pull/2357."

The commit patch added is the complete merge of 2357: "fix shenyu-admin: add dashboard user permission (2357)"