### PR TITLE
[GHSA-7xfp-9c55-5vqj] Remote Memory Exposure in request

### DIFF
--- a/advisories/github-reviewed/2018/11/GHSA-7xfp-9c55-5vqj/GHSA-7xfp-9c55-5vqj.json
+++ b/advisories/github-reviewed/2018/11/GHSA-7xfp-9c55-5vqj/GHSA-7xfp-9c55-5vqj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7xfp-9c55-5vqj",
-  "modified": "2021-01-08T19:13:45Z",
+  "modified": "2023-01-09T05:02:36Z",
   "published": "2018-11-09T17:44:01Z",
   "aliases": [
     "CVE-2017-16026"
@@ -66,6 +66,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/request/request/pull/2018"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/request/request/commit/29d81814bc16bc79cb112b4face8be6fc00061dd"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v2.68.0: https://github.com/request/request/commit/29d81814bc16bc79cb112b4face8be6fc00061dd

From the original pull 2018: "Thanks I've added your commit here 2022 + a test case."

The commit patch added is the complete merge of 2022 that closed 2018: "Merge pull request 2022 from simov/fix-multipart. Convert numeric multipart bodies to string"