### PR TITLE
[GHSA-qgfr-5hqp-vrw9] Path Traversal in decompress

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-qgfr-5hqp-vrw9/GHSA-qgfr-5hqp-vrw9.json
+++ b/advisories/github-reviewed/2020/09/GHSA-qgfr-5hqp-vrw9/GHSA-qgfr-5hqp-vrw9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qgfr-5hqp-vrw9",
-  "modified": "2021-07-29T16:07:52Z",
+  "modified": "2023-02-01T05:04:44Z",
   "published": "2020-09-03T21:16:27Z",
   "aliases": [
     "CVE-2020-12265"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/kevva/decompress/pull/73"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/kevva/decompress/commit/967146e70f48be32ed1a69daa3941d681944d513"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v4.2.1: https://github.com/kevva/decompress/commit/967146e70f48be32ed1a69daa3941d681944d513

This is the complete merge of the original pull 73: "Prevent directory traversal (73)"