### PR TITLE
[GHSA-qj3v-q2vj-4c8h] Calculation error in ark-r1cs-std

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-qj3v-q2vj-4c8h/GHSA-qj3v-q2vj-4c8h.json
+++ b/advisories/github-reviewed/2021/08/GHSA-qj3v-q2vj-4c8h/GHSA-qj3v-q2vj-4c8h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qj3v-q2vj-4c8h",
-  "modified": "2021-08-18T21:27:27Z",
+  "modified": "2023-02-03T05:06:15Z",
   "published": "2021-08-25T20:55:58Z",
   "aliases": [
     "CVE-2021-38194"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "crates.io",
         "name": "ark-r1cs-std"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "ark_r1cs_std::FieldVar::mul_by_inverse"
-        ]
       },
       "ranges": [
         {
@@ -48,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/arkworks-rs/r1cs-std/pull/70"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/arkworks-rs/r1cs-std/commit/47ddbaa411afe7c499311a248a38135e5a192b67"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding patch link for v0.3.1: https://github.com/arkworks-rs/r1cs-std/commit/47ddbaa411afe7c499311a248a38135e5a192b67

This is the complete merge of the original pull 70: "Enforce mul_by_inverse (70)
* proposal to fix mul_by_inverse

* update CHANGELOG

* rollback to a secure impl

* update changelog"