### PR TITLE
[GHSA-q2qh-cgc2-qhr3] Directory Traversal in serve

### DIFF
--- a/advisories/github-reviewed/2018/07/GHSA-q2qh-cgc2-qhr3/GHSA-q2qh-cgc2-qhr3.json
+++ b/advisories/github-reviewed/2018/07/GHSA-q2qh-cgc2-qhr3/GHSA-q2qh-cgc2-qhr3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q2qh-cgc2-qhr3",
-  "modified": "2020-08-31T18:27:50Z",
+  "modified": "2023-01-09T05:03:12Z",
   "published": "2018-07-27T17:07:50Z",
   "aliases": [
     "CVE-2018-3712"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/zeit/serve/pull/316"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vercel/serve/commit/6adad6881c61991da61ebc857857c53409544575"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v6.4.9: https://github.com/vercel/serve/commit/6adad6881c61991da61ebc857857c53409544575

This is the complete merge of the original pull 316: "Scope to working directory correctly (316)
* Scope to working directory correctly

* Make it a little faster"