### PR TITLE
[GHSA-qq3j-44gw-cf6r] Eclipse Californium denial of service (DoS) via Datagram Transport Layer Security (DTLS) handshake on parameter mismatch

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-qq3j-44gw-cf6r/GHSA-qq3j-44gw-cf6r.json
+++ b/advisories/github-reviewed/2022/07/GHSA-qq3j-44gw-cf6r/GHSA-qq3j-44gw-cf6r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qq3j-44gw-cf6r",
-  "modified": "2022-08-10T15:41:24Z",
+  "modified": "2023-01-30T05:01:20Z",
   "published": "2022-07-30T00:00:35Z",
   "aliases": [
     "CVE-2022-2576"
@@ -64,6 +64,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-2576"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/eclipse/californium/pull/2039"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/eclipse-californium/californium/commit/0cc953a1dc071efc960130e229fcb4f8bda7f9df"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/eclipse-californium/californium/commit/8373db84b2d07f22c39ffc333ab881dba9401722"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v2.7.3: https://github.com/eclipse-californium/californium/commit/8373db84b2d07f22c39ffc333ab881dba9401722

Adding patch link for v3.6.0: https://github.com/eclipse-californium/californium/commit/0cc953a1dc071efc960130e229fcb4f8bda7f9df

Adding the pull: https://github.com/eclipse/californium/pull/2039

The commit patch message matches the advisory description: "Fix sending HelloVerifyRequest, if a fallback to a full-handshake is required." 

Also, in the original reference link (https://bugs.eclipse.org/bugs/show_bug.cgi?id=580018): "I prepared a PR to fix it.
https://github.com/eclipse/californium/pull/2039"