### PR TITLE
[GHSA-qrg7-hfx7-95c5] Command injection in Git package in Wrangler

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-qrg7-hfx7-95c5/GHSA-qrg7-hfx7-95c5.json
+++ b/advisories/github-reviewed/2023/01/GHSA-qrg7-hfx7-95c5/GHSA-qrg7-hfx7-95c5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qrg7-hfx7-95c5",
-  "modified": "2023-02-08T22:37:02Z",
+  "modified": "2023-02-23T16:36:07Z",
   "published": "2023-01-25T19:40:43Z",
   "aliases": [
     "CVE-2022-31249"
@@ -69,16 +69,13 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.0.0"
+              "introduced": "0.8.6"
             },
             {
-              "fixed": "1.0.1"
+              "fixed": "0.8.11"
             }
           ]
         }
-      ],
-      "versions": [
-        "1.0.0"
       ]
     },
     {
@@ -91,13 +88,16 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0.8.6"
+              "introduced": "1.0.0"
             },
             {
-              "fixed": "0.8.11"
+              "fixed": "1.0.1"
             }
           ]
         }
+      ],
+      "versions": [
+        "1.0.0"
       ]
     }
   ],
@@ -109,6 +109,22 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-31249"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rancher/wrangler/commit/12397eec50155cb2d24aa70bdf9e90c5f3b9a727"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rancher/wrangler/commit/341018c8fef3e12867c7cb2649bd2cecac75f287"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rancher/wrangler/commit/5a387e13e8d51e3340d9e5012a1951f0cca5fc90"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rancher/wrangler/commit/8649ecc062204f28764fd80157a621cbae89c9cf"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.7.4-security1 (https://github.com/rancher/wrangler/compare/v0.7.2...v0.7.4-security1): https://github.com/rancher/wrangler/commit/12397eec50155cb2d24aa70bdf9e90c5f3b9a727

Adding the patch link for v0.8.5-security1: https://github.com/rancher/wrangler/commit/8649ecc062204f28764fd80157a621cbae89c9cf

Adding the patch link for v0.8.11: https://github.com/rancher/wrangler/commit/5a387e13e8d51e3340d9e5012a1951f0cca5fc90

Adding the patch link for v1.0.1: https://github.com/rancher/wrangler/commit/341018c8fef3e12867c7cb2649bd2cecac75f287

In the patch, the developers added the '--' argument, which ensures that the g.URL argument is always treated as a URL and not an option to the ls-remote command. This would prevent the command injection possibility. Additionally, this was the only commit for some of the backports: https://github.com/rancher/wrangler/compare/v0.8.4...v0.8.5-security1