### PR TITLE
[GHSA-qx2j-85q5-ffp8] Query predicate bypass in Zalando Skipper

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-qx2j-85q5-ffp8/GHSA-qx2j-85q5-ffp8.json
+++ b/advisories/github-reviewed/2022/06/GHSA-qx2j-85q5-ffp8/GHSA-qx2j-85q5-ffp8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qx2j-85q5-ffp8",
-  "modified": "2022-07-07T17:14:28Z",
+  "modified": "2023-01-27T05:04:33Z",
   "published": "2022-06-24T00:00:32Z",
   "aliases": [
     "CVE-2022-34296"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/zalando/skipper/pull/2028"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/zalando/skipper/commit/998a658ce5a68a336a98f4e63e4371e200860dfc"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.13.218: https://github.com/zalando/skipper/commit/998a658ce5a68a336a98f4e63e4371e200860dfc

This is the complete merge of the original pull 2028: "
fix: Query predicate could be bypassed by prepared request, config is enabled by default and you can disable with -validate-query=false or (2028)"