### PR TITLE
[GHSA-r28h-x6hv-2fq3] Improper Verification of Cryptographic Signature in starkbank-ecdsa

### DIFF
--- a/advisories/github-reviewed/2021/11/GHSA-r28h-x6hv-2fq3/GHSA-r28h-x6hv-2fq3.json
+++ b/advisories/github-reviewed/2021/11/GHSA-r28h-x6hv-2fq3/GHSA-r28h-x6hv-2fq3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r28h-x6hv-2fq3",
-  "modified": "2021-11-15T14:43:04Z",
+  "modified": "2023-02-01T05:06:31Z",
   "published": "2021-11-10T20:48:00Z",
   "aliases": [
     "CVE-2021-43570"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43570"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/starkbank/ecdsa-java/commit/ed22e484186d6c66d3686bfe39d01bdbabf219b6"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.0.1: https://github.com/starkbank/ecdsa-java/commit/ed22e484186d6c66d3686bfe39d01bdbabf219b6

The developer started checking the signature range to ensure it wasn't non-zero, which is the same as the original advisory, and targeted the same ecdsa-java function: "Merge pull request #16 from starkbank/fix/signature-range. Fixed signature range"