### PR TITLE
[GHSA-r8f7-9pfq-mjmv] Improper Certificate Validation in node-sass

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-r8f7-9pfq-mjmv/GHSA-r8f7-9pfq-mjmv.json
+++ b/advisories/github-reviewed/2022/02/GHSA-r8f7-9pfq-mjmv/GHSA-r8f7-9pfq-mjmv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r8f7-9pfq-mjmv",
-  "modified": "2022-02-09T22:23:03Z",
+  "modified": "2023-02-01T05:05:18Z",
   "published": "2022-02-09T22:22:24Z",
   "aliases": [
     "CVE-2020-24025"
@@ -51,6 +51,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/sass/node-sass/pull/567#issuecomment-656609236"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/sass/node-sass/commit/0a21792803639851b480fbd8cbcb5540ef974387"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v7.0.0: https://github.com/sass/node-sass/commit/0a21792803639851b480fbd8cbcb5540ef974387

This is the complete merge of the original pull (3149): "Set rejectUnauthorized to true by default (3149). Resolve CVE-2020-240-25 by setting rejectUnauthorized to true by default." 