### PR TITLE
[GHSA-rjqq-98f6-6j3r] Improper Input Validation in sanitize-html

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-rjqq-98f6-6j3r/GHSA-rjqq-98f6-6j3r.json
+++ b/advisories/github-reviewed/2021/05/GHSA-rjqq-98f6-6j3r/GHSA-rjqq-98f6-6j3r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rjqq-98f6-6j3r",
-  "modified": "2022-04-27T19:14:02Z",
+  "modified": "2023-02-01T05:05:12Z",
   "published": "2021-05-06T16:10:05Z",
   "aliases": [
     "CVE-2021-26539"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/apostrophecms/sanitize-html/pull/458"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apostrophecms/sanitize-html/commit/bdf7836ef8f0e5b21f9a1aab0623ae8fcd09c1da"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.3.1: https://github.com/apostrophecms/sanitize-html/commit/bdf7836ef8f0e5b21f9a1aab0623ae8fcd09c1da

This is the complete merge of the original pull (458): "Merge pull request 458 from apostrophecms/stop-idna-iframe-attacks. Stop idna iframe attacks" 