### PR TITLE
[GHSA-rpcm-whqc-jfw8] Use after free in libflate

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-rpcm-whqc-jfw8/GHSA-rpcm-whqc-jfw8.json
+++ b/advisories/github-reviewed/2021/08/GHSA-rpcm-whqc-jfw8/GHSA-rpcm-whqc-jfw8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rpcm-whqc-jfw8",
-  "modified": "2021-08-19T21:22:31Z",
+  "modified": "2023-02-01T05:05:53Z",
   "published": "2021-08-25T20:44:53Z",
   "aliases": [
     "CVE-2019-15552"
@@ -43,6 +43,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/sile/libflate/issues/35"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/sile/libflate/pull/37"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/sile/libflate/commit/ffeff7c65deac5a6f886db2a59bcae4e420e4706"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.1.25: https://github.com/sile/libflate/commit/ffeff7c65deac5a6f886db2a59bcae4e420e4706

Adding the pull: https://github.com/sile/libflate/pull/37

From the original issue 35: "Fixed by 37." The patch link provided is the complete pull of 37: "Use take_mut instead of a bespoke unsafe block with mem::replace"