### PR TITLE
[GHSA-rvg8-pwq2-xj7q] Out-of-bounds Read in base64url

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-rvg8-pwq2-xj7q/GHSA-rvg8-pwq2-xj7q.json
+++ b/advisories/github-reviewed/2020/09/GHSA-rvg8-pwq2-xj7q/GHSA-rvg8-pwq2-xj7q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rvg8-pwq2-xj7q",
-  "modified": "2021-09-24T20:34:56Z",
+  "modified": "2023-01-09T05:03:45Z",
   "published": "2020-09-01T20:42:44Z",
   "aliases": [
 
@@ -36,6 +36,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/brianloveswords/base64url/pull/25"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/brianloveswords/base64url/commit/4fbd954a0a69e9d898de2146557cc6e893e79542"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.0.0: https://github.com/brianloveswords/base64url/commit/4fbd954a0a69e9d898de2146557cc6e893e79542

The patch link provided is the complete merge of the original pull 25: "Merge pull request 25 from MeirionHughes/master. fix: validate encode input and ensure zero-filled Buffer"