### PR TITLE
[GHSA-rvj9-8cvx-3vq9] Invalid Curve Attack in node-jose

### DIFF
--- a/advisories/github-reviewed/2018/07/GHSA-rvj9-8cvx-3vq9/GHSA-rvj9-8cvx-3vq9.json
+++ b/advisories/github-reviewed/2018/07/GHSA-rvj9-8cvx-3vq9/GHSA-rvj9-8cvx-3vq9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rvj9-8cvx-3vq9",
-  "modified": "2020-08-31T18:19:18Z",
+  "modified": "2023-01-09T05:03:14Z",
   "published": "2018-07-20T21:10:14Z",
   "aliases": [
     "CVE-2017-16007"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-16007"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cisco/node-jose/commit/f92cffb4a0398b4b1158be98423369233282e0af"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.9.3: https://github.com/cisco/node-jose/commit/f92cffb4a0398b4b1158be98423369233282e0af

The patch link message: "Fix: Validate EC public key is on configured curve" Very few commits for v0.9.3 (https://github.com/cisco/node-jose/compare/0.9.2...0.9.3), and this is the only commit related to fixing the invalid curve attack.