### PR TITLE
[GHSA-v633-x5vv-hqwc] Cross-Site Scripting in serve-index

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-v633-x5vv-hqwc/GHSA-v633-x5vv-hqwc.json
+++ b/advisories/github-reviewed/2017/10/GHSA-v633-x5vv-hqwc/GHSA-v633-x5vv-hqwc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v633-x5vv-hqwc",
-  "modified": "2021-09-20T15:12:25Z",
+  "modified": "2023-01-09T05:03:37Z",
   "published": "2017-10-24T18:33:36Z",
   "aliases": [
     "CVE-2015-8856"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/expressjs/serve-index/issues/28"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/expressjs/serve-index/commit/7381a1d1458959e57ee53ac932b06ff17904777e"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.6.3: https://github.com/expressjs/serve-index/commit/7381a1d1458959e57ee53ac932b06ff17904777e

The patch link fixes the original issue 28: "Properly escape file names in HTML. fixes 28."