### PR TITLE
[GHSA-v988-828w-xvf2] Authentication Bypass Using an Alternate Path or Channel and Authentication Bypass by Primary Weakness in rucio-webui

### DIFF
--- a/advisories/github-reviewed/2021/10/GHSA-v988-828w-xvf2/GHSA-v988-828w-xvf2.json
+++ b/advisories/github-reviewed/2021/10/GHSA-v988-828w-xvf2/GHSA-v988-828w-xvf2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v988-828w-xvf2",
-  "modified": "2021-10-21T21:36:22Z",
+  "modified": "2023-01-09T05:05:28Z",
   "published": "2021-10-22T16:21:07Z",
   "aliases": [
 
@@ -44,6 +44,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/rucio/rucio/issues/4928"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rucio/rucio/commit/8f832404ae88d6300e17d7e706b40fe58e0df90c"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.26.7: https://github.com/rucio/rucio/commit/8f832404ae88d6300e17d7e706b40fe58e0df90c

The patch link provided was referenced in the original issue 4928 and is the backport for v1.26.7: "WebUI: Fix privelege escalation; Fix 4928"