### PR TITLE
[GHSA-v9v4-7jp6-8c73] Moderate severity vulnerability that affects rails

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-v9v4-7jp6-8c73/GHSA-v9v4-7jp6-8c73.json
+++ b/advisories/github-reviewed/2017/10/GHSA-v9v4-7jp6-8c73/GHSA-v9v4-7jp6-8c73.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v9v4-7jp6-8c73",
-  "modified": "2021-09-20T21:18:52Z",
+  "modified": "2023-01-09T05:03:37Z",
   "published": "2017-10-24T18:33:38Z",
   "aliases": [
     "CVE-2011-2197"
@@ -61,6 +61,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2011-2197"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/rails/commit/53a2c0baf2b128dd4808eca313256f6f4bb8c4cd"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/rails/commit/ed3796434af6069ced6a641293cf88eef3b284da"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.0.8: https://github.com/rails/rails/commit/53a2c0baf2b128dd4808eca313256f6f4bb8c4cd

https://github.com/rails/rails/commit/ed3796434af6069ced6a641293cf88eef3b284da

The patches were noted from the original reference link(https://rubyonrails.org/2011/6/8/potential-xss-vulnerability-in-ruby-on-rails-applications) of the upgrading aspect -> https://gist.github.com/NZKoz/b2ceb626fc2bcdfe497f

Within the gist, two commits exist for the patch, which is provided above: "Ensure that the strings returned by SafeBuffer#gsub and friends aren't considered html_safe?" & "Do not modify a safe buffer in helpers"v