### PR TITLE
[GHSA-vcw4-8ph6-7vw8] Use after free in Rocket

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-vcw4-8ph6-7vw8/GHSA-vcw4-8ph6-7vw8.json
+++ b/advisories/github-reviewed/2021/08/GHSA-vcw4-8ph6-7vw8/GHSA-vcw4-8ph6-7vw8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vcw4-8ph6-7vw8",
-  "modified": "2021-08-19T17:09:45Z",
+  "modified": "2023-01-11T05:05:29Z",
   "published": "2021-08-25T20:54:20Z",
   "aliases": [
     "CVE-2021-29935"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/SergioBenitez/Rocket/issues/1534"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/SergioBenitez/Rocket/commit/b53a906a8e170fe9b151381c66a76a872c419f9e"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.4.7: https://github.com/SergioBenitez/Rocket/commit/b53a906a8e170fe9b151381c66a76a872c419f9e

The original issue (1534) is referenced in the commit patch message: "Fix soundness issue: make 'Formatter' panic-safe. Fixes 1534."