### PR TITLE
[GHSA-vx6v-2rg6-865h] Cross-site Scripting in django-js-reverse

### DIFF
--- a/advisories/github-reviewed/2019/08/GHSA-vx6v-2rg6-865h/GHSA-vx6v-2rg6-865h.json
+++ b/advisories/github-reviewed/2019/08/GHSA-vx6v-2rg6-865h/GHSA-vx6v-2rg6-865h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vx6v-2rg6-865h",
-  "modified": "2021-08-17T22:13:42Z",
+  "modified": "2023-02-01T05:02:35Z",
   "published": "2019-08-27T17:39:33Z",
   "aliases": [
     "CVE-2019-15486"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/ierror/django-js-reverse/pull/81"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ierror/django-js-reverse/commit/78d6aff2276f2d341f643b095515f8aaba5e67c2"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.9.1: https://github.com/ierror/django-js-reverse/commit/78d6aff2276f2d341f643b095515f8aaba5e67c2

This is the complete merge of the original pull 81: "avoid xss when using js_reverse_inline"