### PR TITLE
[GHSA-w7rc-rwvf-8q5r] The `size` option isn't honored after following a redirect in node-fetch

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-w7rc-rwvf-8q5r/GHSA-w7rc-rwvf-8q5r.json
+++ b/advisories/github-reviewed/2020/09/GHSA-w7rc-rwvf-8q5r/GHSA-w7rc-rwvf-8q5r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w7rc-rwvf-8q5r",
-  "modified": "2021-01-07T22:57:38Z",
+  "modified": "2023-01-09T05:04:27Z",
   "published": "2020-09-10T17:46:21Z",
   "aliases": [
     "CVE-2020-15168"
@@ -65,6 +65,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-15168"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/node-fetch/node-fetch/commit/2358a6c2563d1730a0cdaccc197c611949f6a334"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/node-fetch/node-fetch/commit/eaff0094c4dfdd5b78711a8c4f1b61e33d282072"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.6.1: https://github.com/node-fetch/node-fetch/commit/2358a6c2563d1730a0cdaccc197c611949f6a334

Adding the patch link for v3.0.0-beta.9: https://github.com/node-fetch/node-fetch/commit/eaff0094c4dfdd5b78711a8c4f1b61e33d282072

The developers started to honor the size option after following a redirect, which is related to the original advisory: "Fix: honor the `size` option after following a redirect."