### PR TITLE
[GHSA-6hrg-qmvc-2xh8] joblib vulnerable to arbitrary code execution

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-6hrg-qmvc-2xh8/GHSA-6hrg-qmvc-2xh8.json
+++ b/advisories/github-reviewed/2022/09/GHSA-6hrg-qmvc-2xh8/GHSA-6hrg-qmvc-2xh8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6hrg-qmvc-2xh8",
-  "modified": "2022-09-30T04:44:04Z",
+  "modified": "2023-03-30T22:18:54Z",
   "published": "2022-09-27T00:00:22Z",
   "aliases": [
     "CVE-2022-21797"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.2.0"
+              "fixed": "1.2.0, 1.1.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.1.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**

According to the commit log and release notes for joblib 1.1.1 the arbitrary code execution fix for 1.2.0 was backported into 1.1.1 released Oct 10, 2022.

- Affected products
joblib/joblib 

**Comments**
https://github.com/joblib/joblib/pull/1352
https://github.com/joblib/joblib/pull/1327

