### PR TITLE
[GHSA-wfrj-qqc2-83cm] Remote command injection when using sendmail email transport

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-wfrj-qqc2-83cm/GHSA-wfrj-qqc2-83cm.json
+++ b/advisories/github-reviewed/2021/09/GHSA-wfrj-qqc2-83cm/GHSA-wfrj-qqc2-83cm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wfrj-qqc2-83cm",
-  "modified": "2021-09-17T17:48:56Z",
+  "modified": "2023-01-09T05:05:40Z",
   "published": "2021-09-20T19:52:41Z",
   "aliases": [
 
@@ -39,6 +39,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/TryGhost/Ghost/security/advisories/GHSA-wfrj-qqc2-83cm"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/TryGhost/Ghost/commit/93e4b2eafd18bc8e4c17924e0824e73617e7940c"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v4.15.0: https://github.com/TryGhost/Ghost/commit/93e4b2eafd18bc8e4c17924e0824e73617e7940c

The GHSA-ID is referenced in the commit patch message: "Fixed remote command injection when using sendmail email transport
refs GHSA-wfrj-qqc2-83cm
refs GHSA-48ww-j4fc-435p"