### PR TITLE
[GHSA-q799-q27x-vp7w] Out-of-bounds Write in OpenCV

### DIFF
--- a/advisories/github-reviewed/2021/10/GHSA-q799-q27x-vp7w/GHSA-q799-q27x-vp7w.json
+++ b/advisories/github-reviewed/2021/10/GHSA-q799-q27x-vp7w/GHSA-q799-q27x-vp7w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q799-q27x-vp7w",
-  "modified": "2021-10-06T17:39:57Z",
+  "modified": "2023-02-01T05:06:08Z",
   "published": "2021-10-12T22:23:21Z",
   "aliases": [
     "CVE-2019-5064"
@@ -84,7 +84,7 @@
     {
       "package": {
         "ecosystem": "PyPI",
-        "name": "opencv-opencv-contrib-python-headless"
+        "name": "opencv-contrib-python-headless"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The package "opencv-opencv-contrib-python-headless" does not exist on PyPI. This should probably be "opencv-contrib-python-headless".