### PR TITLE
[GHSA-wmjf-jpjj-9f3j] Rubocop Exposure of Resource to Wrong Sphere

### DIFF
--- a/advisories/github-reviewed/2017/11/GHSA-wmjf-jpjj-9f3j/GHSA-wmjf-jpjj-9f3j.json
+++ b/advisories/github-reviewed/2017/11/GHSA-wmjf-jpjj-9f3j/GHSA-wmjf-jpjj-9f3j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wmjf-jpjj-9f3j",
-  "modified": "2023-03-13T23:58:08Z",
+  "modified": "2023-03-13T23:58:09Z",
   "published": "2017-11-15T20:39:47Z",
   "aliases": [
     "CVE-2017-8418"
@@ -46,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/bbatsov/rubocop/issues/4336"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rubocop/rubocop/commit/dcb258fabd5f2624c1ea0e1634763094590c09d7"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for 0.49.0: https://github.com/rubocop/rubocop/commit/dcb258fabd5f2624c1ea0e1634763094590c09d7

This commit closed the original issue 4336: "[Fix 4336] Store rubocop_cache in safer directories" 