### PR TITLE
[GHSA-wmrx-57hm-mw7r] Arbitrary file reads in HashiCorp Nomad

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-wmrx-57hm-mw7r/GHSA-wmrx-57hm-mw7r.json
+++ b/advisories/github-reviewed/2022/02/GHSA-wmrx-57hm-mw7r/GHSA-wmrx-57hm-mw7r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wmrx-57hm-mw7r",
-  "modified": "2022-03-24T22:47:39Z",
+  "modified": "2023-02-03T05:06:07Z",
   "published": "2022-02-18T00:00:34Z",
   "aliases": [
     "CVE-2022-24683"
@@ -77,6 +77,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24683"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hashicorp/nomad/commit/1aa46c3796e924b72eb45a7f02dae32df0c1179c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hashicorp/nomad/commit/b3c0e6a7a53d624003698b48b6c59739552c3721"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hashicorp/nomad/commit/fcb3a5d016a3dfcc63efcdb567373735a0703279"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.0.18: https://github.com/hashicorp/nomad/commit/1aa46c3796e924b72eb45a7f02dae32df0c1179c

Adding the patch link for v1.1.12: https://github.com/hashicorp/nomad/commit/fcb3a5d016a3dfcc63efcdb567373735a0703279

Adding the patch link for v1.2.6: https://github.com/hashicorp/nomad/commit/b3c0e6a7a53d624003698b48b6c59739552c3721

The CVE (CVE-2022-24683) was mentioned in the updated changelog during the patch: "Resolve symlinks to prevent unauthorized access to files outside the allocation directory. [CVE-2022-24683]"