### PR TITLE
[GHSA-wpjr-j57x-wxfw] Data leakage via cache key collision in Django

### DIFF
--- a/advisories/github-reviewed/2020/06/GHSA-wpjr-j57x-wxfw/GHSA-wpjr-j57x-wxfw.json
+++ b/advisories/github-reviewed/2020/06/GHSA-wpjr-j57x-wxfw/GHSA-wpjr-j57x-wxfw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wpjr-j57x-wxfw",
-  "modified": "2022-09-08T14:02:23Z",
+  "modified": "2023-01-29T05:01:55Z",
   "published": "2020-06-05T16:20:44Z",
   "aliases": [
     "CVE-2020-13254"
@@ -58,6 +58,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-13254"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/07e59caa02831c4569bbebb9eb773bdd9cb4b206"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/84b2da5552e100ae3294f564f6c862fef8d0e693"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.2.13: https://github.com/django/django/commit/07e59caa02831c4569bbebb9eb773bdd9cb4b206

Adding the patch link for v3.0.7: https://github.com/django/django/commit/84b2da5552e100ae3294f564f6c862fef8d0e693

The CVE (CVE-2020-13254) is mentioned in the commit patch message: "Fixed CVE-2020-13254 -- Enforced cache key validation in memcached backends."