### PR TITLE
[GHSA-wq5h-f9p5-q7fx] Improper validation of URLs ('Cross-site Scripting') in Wagtail rich text fields

### DIFF
--- a/advisories/github-reviewed/2021/04/GHSA-wq5h-f9p5-q7fx/GHSA-wq5h-f9p5-q7fx.json
+++ b/advisories/github-reviewed/2021/04/GHSA-wq5h-f9p5-q7fx/GHSA-wq5h-f9p5-q7fx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wq5h-f9p5-q7fx",
-  "modified": "2021-04-30T17:23:49Z",
+  "modified": "2023-02-01T05:05:36Z",
   "published": "2021-04-20T14:02:30Z",
   "aliases": [
     "CVE-2021-29434"
@@ -68,6 +68,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-29434"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/wagtail/wagtail/commit/5c7a60977cba478f6a35390ba98cffc2bd41c8a4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/wagtail/wagtail/commit/915f6ed2bd7d53154103cc4424a0f18695cdad6c"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.11.7 (https://github.com/wagtail/wagtail/compare/v2.11.6...v2.11.7), it's the only commit related to the fix: https://github.com/wagtail/wagtail/commit/5c7a60977cba478f6a35390ba98cffc2bd41c8a4

Adding the patch link for v2.12.4: https://github.com/wagtail/wagtail/commit/915f6ed2bd7d53154103cc4424a0f18695cdad6c

The patch links contain the same workaround provided in the original advisory: adding check_url within the function link_entity.