### PR TITLE
[GHSA-wqxw-8h5g-hq56] Switcher Client contains Regular Expression Denial of Service (ReDoS)

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-wqxw-8h5g-hq56/GHSA-wqxw-8h5g-hq56.json
+++ b/advisories/github-reviewed/2023/02/GHSA-wqxw-8h5g-hq56/GHSA-wqxw-8h5g-hq56.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wqxw-8h5g-hq56",
-  "modified": "2023-02-15T17:35:36Z",
+  "modified": "2023-02-15T17:35:37Z",
   "published": "2023-02-02T01:33:06Z",
   "aliases": [
     "CVE-2023-23925"
@@ -43,6 +43,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23925"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/switcherapi/switcher-client-master/commit/374752563d6ce9353ee592b40c809c8136f24930"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.1.4: https://github.com/switcherapi/switcher-client-master/commit/374752563d6ce9353ee592b40c809c8136f24930

The CVE and GHSA-ID are mentioned in the commit patch message: "Merge pull request from GHSA-wqxw-8h5g-hq56
Fixes CVE-2023-23925 - Added TimedMatch for safe REGEX execution" 