### PR TITLE
[GHSA-wrvr-8mpx-r7pp] mime Regular Expression Denial of Service when mime lookup performed on untrusted user input

### DIFF
--- a/advisories/github-reviewed/2018/07/GHSA-wrvr-8mpx-r7pp/GHSA-wrvr-8mpx-r7pp.json
+++ b/advisories/github-reviewed/2018/07/GHSA-wrvr-8mpx-r7pp/GHSA-wrvr-8mpx-r7pp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wrvr-8mpx-r7pp",
-  "modified": "2022-08-11T21:27:42Z",
+  "modified": "2023-01-07T05:02:54Z",
   "published": "2018-07-20T16:20:52Z",
   "aliases": [
     "CVE-2017-16138"
@@ -22,10 +22,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.0.0"
+              "introduced": "0"
             },
             {
-              "fixed": "2.0.3"
+              "fixed": "1.4.1"
             }
           ]
         }
@@ -41,10 +41,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0.0"
             },
             {
-              "fixed": "1.4.1"
+              "fixed": "2.0.3"
             }
           ]
         }
@@ -59,6 +59,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/broofa/node-mime/issues/167"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/broofa/mime/commit/1df903fdeb9ae7eaa048795b8d580ce2c98f40b0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/broofa/mime/commit/855d0c4b8b22e4a80b9401a81f2872058eae274d"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.4.1: https://github.com/broofa/mime/commit/855d0c4b8b22e4a80b9401a81f2872058eae274d

Adding the patch link for v2.0.3: https://github.com/broofa/mime/commit/1df903fdeb9ae7eaa048795b8d580ce2c98f40b0

The original issue (167) is mentioned in the commit patch message: "Fix 167"