### PR TITLE
[GHSA-4wp2-xw7p-2gfx] Issue summary: The AES-XTS cipher decryption...

### DIFF
--- a/advisories/unreviewed/2023/04/GHSA-4wp2-xw7p-2gfx/GHSA-4wp2-xw7p-2gfx.json
+++ b/advisories/unreviewed/2023/04/GHSA-4wp2-xw7p-2gfx/GHSA-4wp2-xw7p-2gfx.json
@@ -1,17 +1,33 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4wp2-xw7p-2gfx",
-  "modified": "2023-04-20T18:30:50Z",
+  "modified": "2023-04-20T21:33:27Z",
   "published": "2023-04-20T18:30:50Z",
   "aliases": [
     "CVE-2023-1255"
   ],
+  "summary": "OpenSSL input buffer over-read in AES-XTS implementation on 64 bit ARM",
   "details": "Issue summary: The AES-XTS cipher decryption implementation for 64 bit ARM\nplatform contains a bug that could cause it to read past the input buffer,\nleading to a crash.\n\nImpact summary: Applications that use the AES-XTS algorithm on the 64 bit ARM\nplatform can crash in rare circumstances. The AES-XTS algorithm is usually\nused for disk encryption.\n\nThe AES-XTS cipher decryption implementation for 64 bit ARM platform will read\npast the end of the ciphertext buffer if the ciphertext size is 4 mod 5, e.g.\n144 bytes or 1024 bytes. If the memory after the ciphertext buffer is\nunmapped, this will trigger a crash which results in a denial of service.\n\nIf an attacker can control the size and location of the ciphertext buffer\nbeing decrypted by an application using AES-XTS on 64 bit ARM, the\napplication is affected. This is fairly unlikely making this issue\na Low severity one.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "GitHub Actions",
+        "name": "openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -27,6 +43,10 @@
       "url": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=bc2f61ad70971869b242fc1cb445b98bad50074a"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/openssl/openssl"
+    },
+    {
       "type": "WEB",
       "url": "https://www.openssl.org/news/secadv/20230419.txt"
     },
@@ -37,9 +57,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-119"
     ],
-    "severity": null,
+    "severity": "LOW",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- Severity
- Source code location
- Summary

**Comments**
Set severity and title from upstream advisory, set CWE from Red Hat data

The package ecosystem is incorrect, but your edit form does not allow submitting improvements without selecting a package ecosystem. You should probably fix this.