### PR TITLE
[GHSA-qv62-xfj6-32xm] RubyGems 2.0.x before 2.0.17, 2.2.x before 2.2.5, and 2.4...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-qv62-xfj6-32xm/GHSA-qv62-xfj6-32xm.json
+++ b/advisories/unreviewed/2022/05/GHSA-qv62-xfj6-32xm/GHSA-qv62-xfj6-32xm.json
@@ -1,17 +1,83 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qv62-xfj6-32xm",
-  "modified": "2022-05-17T00:16:50Z",
+  "modified": "2023-02-03T05:01:21Z",
   "published": "2022-05-17T00:16:50Z",
   "aliases": [
     "CVE-2015-4020"
   ],
+  "summary": "Some RubyGems 2.0.x to 2.4.7 does not validate the hostname when fetching gems or making API",
   "details": "RubyGems 2.0.x before 2.0.17, 2.2.x before 2.2.5, and 2.4.x before 2.4.8 does not validate the hostname when fetching gems or making API requests, which allows remote attackers to redirect requests to arbitrary domains via a crafted DNS SRV record with a domain that is suffixed with the original domain name, aka a \"DNS hijack attack.\" NOTE: this vulnerability exists because to an incomplete fix for CVE-2015-3900.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "rubygems"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 2.0.17"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.0.17"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "rubygems"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 2.2.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.2.5"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "rubygems"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 2.4.8"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.4.8"
+      }
+    }
   ],
   "references": [
     {
@@ -19,7 +85,7 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-4020"
     },
     {
-      "type": "WEB",
+      "type": "PACKAGE",
       "url": "https://github.com/rubygems/rubygems/commit/5c7bfb5"
     },
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
Did some more research - to connect the existing dots.