### PR TITLE
[GHSA-228f-g3h7-3fj3] RubyGems before 1.8.23 can redirect HTTPS connections to...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-228f-g3h7-3fj3/GHSA-228f-g3h7-3fj3.json
+++ b/advisories/unreviewed/2022/05/GHSA-228f-g3h7-3fj3/GHSA-228f-g3h7-3fj3.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-228f-g3h7-3fj3",
-  "modified": "2022-05-17T04:54:56Z",
+  "modified": "2023-01-28T05:02:49Z",
   "published": "2022-05-17T04:54:56Z",
   "aliases": [
     "CVE-2012-2125"
   ],
+  "summary": "RubyGems before 1.8.23 can redirect HTTPS connections to HTTP",
   "details": "RubyGems before 1.8.23 can redirect HTTPS connections to HTTP, which makes it easier for remote attackers to observe or modify a gem during installation via a man-in-the-middle attack.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "rubygems"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">=  1.8.23"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -21,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=814718"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/rubygems/rubygems"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
Did more research to connect the dots. Reviewed all the URLs.