### PR TITLE
[GHSA-5mgj-mvv8-46mw] RubyGems before 1.8.23 does not verify an SSL certificate...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5mgj-mvv8-46mw/GHSA-5mgj-mvv8-46mw.json
+++ b/advisories/unreviewed/2022/05/GHSA-5mgj-mvv8-46mw/GHSA-5mgj-mvv8-46mw.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5mgj-mvv8-46mw",
-  "modified": "2022-05-17T04:54:47Z",
+  "modified": "2023-01-28T05:02:47Z",
   "published": "2022-05-17T04:54:47Z",
   "aliases": [
     "CVE-2012-2126"
   ],
+  "summary": "RubyGems before 1.8.23 does not verify an SSL certificate",
   "details": "RubyGems before 1.8.23 does not verify an SSL certificate, which allows remote attackers to modify a gem during installation via a man-in-the-middle attack.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "rubygems"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 1.8.23"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.8.23"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2012-2126"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/rubygems/rubygems/commit/d4c7eafb8efe1e13a7abf5be5a5b4548870b15b7"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
Filled in fields based on existing description and supplied URLs.