### PR TITLE
[GHSA-rc47-6667-2j5j] http-cache-semantics vulnerable to Regular Expression Denial of Service

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-rc47-6667-2j5j/GHSA-rc47-6667-2j5j.json
+++ b/advisories/github-reviewed/2023/01/GHSA-rc47-6667-2j5j/GHSA-rc47-6667-2j5j.json
@@ -60,6 +60,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25881"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/kornelski/http-cache-semantics/commit/560b2d8ef452bbba20ffed69dc155d63ac757b74"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/kornelski/http-cache-semantics"
     },


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v4.1.1: https://github.com/kornelski/http-cache-semantics/commit/560b2d8ef452bbba20ffed69dc155d63ac757b74#comments

The Snyk link from the advisory contained the patch link (https://security.snyk.io/vuln/SNYK-JS-HTTPCACHESEMANTICS-3248783): "Don't use regex to trim whitespace"