### PR TITLE
[GHSA-rcx6-7jp6-pqf2] ember-source Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-rcx6-7jp6-pqf2/GHSA-rcx6-7jp6-pqf2.json
+++ b/advisories/github-reviewed/2022/05/GHSA-rcx6-7jp6-pqf2/GHSA-rcx6-7jp6-pqf2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rcx6-7jp6-pqf2",
-  "modified": "2023-01-27T00:11:22Z",
+  "modified": "2023-01-27T00:11:23Z",
   "published": "2022-05-14T02:21:24Z",
   "aliases": [
     "CVE-2014-0014"
@@ -118,6 +118,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0014"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/emberjs/ember.js/commit/12fa46ba1c6efb9ddac7bfdef7f4f6909781c801"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link just for the latest version -> v1.4.0-beta.2: https://github.com/emberjs/ember.js/commit/12fa46ba1c6efb9ddac7bfdef7f4f6909781c801

The other versions were backported around this commit. The CVE is in the commit patch message: "[SECURITY CVE-2014-0014] Ensure {{group}} helper escapes properly."