### PR TITLE
[GHSA-rg6w-c352-p8pg] Concrete CMS vulnerable to Reflected Cross-site Scripting

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-rg6w-c352-p8pg/GHSA-rg6w-c352-p8pg.json
+++ b/advisories/github-reviewed/2022/11/GHSA-rg6w-c352-p8pg/GHSA-rg6w-c352-p8pg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rg6w-c352-p8pg",
-  "modified": "2022-11-22T00:11:13Z",
+  "modified": "2023-02-01T05:03:57Z",
   "published": "2022-11-15T12:00:19Z",
   "aliases": [
     "CVE-2022-43692"
@@ -58,6 +58,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43692"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/pull/10996"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/commit/0bd65388e5a6d455d8b2469fc166f1b6fdf1abbb"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/commit/5e353be6a12764dbc2338246f2c1b6058cdfd037"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v8.5.10: https://github.com/concretecms/concretecms/commit/0bd65388e5a6d455d8b2469fc166f1b6fdf1abbb

Adding the patch link for v9.1.3: https://github.com/concretecms/concretecms/commit/5e353be6a12764dbc2338246f2c1b6058cdfd037

Adding the pull: https://github.com/concretecms/concretecms/pull/10996

From the changelog in relation to the advisory CVE: "CVE-2022-43692 Sanitized output to prevent XSS in dashboard search pages."

The commit patch message: "Prevent browser blocked reflected XSS in dashboard search pages" 