### PR TITLE
[GHSA-vmhj-p9hw-vgrf] Podman has Files or Directories Accessible to External Parties

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-vmhj-p9hw-vgrf/GHSA-vmhj-p9hw-vgrf.json
+++ b/advisories/github-reviewed/2022/05/GHSA-vmhj-p9hw-vgrf/GHSA-vmhj-p9hw-vgrf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vmhj-p9hw-vgrf",
-  "modified": "2023-02-08T18:07:43Z",
+  "modified": "2023-02-08T18:08:34Z",
   "published": "2022-05-24T17:08:34Z",
   "aliases": [
     "CVE-2020-1726"
@@ -58,6 +58,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-1726"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/containers/podman/commit/c140ecdc9b416ab4efd4d21d14acd63b6adbdd42"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.0.6: https://github.com/containers/podman/commit/c140ecdc9b416ab4efd4d21d14acd63b6adbdd42

The CVE is mentioned in the commit patch message: "This resolves CVE-2020-1726." 