### PR TITLE
[GHSA-w267-m9c4-8555] Shopware user session is not logged out if the password is reset via password recovery

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-w267-m9c4-8555/GHSA-w267-m9c4-8555.json
+++ b/advisories/github-reviewed/2022/03/GHSA-w267-m9c4-8555/GHSA-w267-m9c4-8555.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w267-m9c4-8555",
-  "modified": "2022-03-18T20:12:59Z",
+  "modified": "2023-02-03T05:06:49Z",
   "published": "2022-03-10T17:37:43Z",
   "aliases": [
     "CVE-2022-24744"
@@ -68,6 +68,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-24744"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/shopware/platform/commit/47b4b094c13f62db860be2f431138bb45c0bd0b6"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v6.4.8.1: https://github.com/shopware/platform/commit/47b4b094c13f62db860be2f431138bb45c0bd0b6

The NEXT ID (NEXT-19820) is mentioned in one of the originally linked references (https://docs.shopware.com/en/shopware-6-en/security-updates/security-update-02-2022?category=security-updates): "NEXT-19820: User session is not logged out if the password is reset via password recovery"

Commit patch message: "NEXT-19820 - Improve session invalidation on customer updates"