### PR TITLE
[GHSA-w725-67p7-xv22] Command Injection in local-devices

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-w725-67p7-xv22/GHSA-w725-67p7-xv22.json
+++ b/advisories/github-reviewed/2020/09/GHSA-w725-67p7-xv22/GHSA-w725-67p7-xv22.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w725-67p7-xv22",
-  "modified": "2021-09-28T17:35:44Z",
+  "modified": "2023-01-09T05:03:49Z",
   "published": "2020-09-03T17:05:04Z",
   "aliases": [
 
@@ -36,6 +36,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/DylanPiercey/local-devices/pull/16"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/DylanPiercey/local-devices/commit/57b9a933c9d23d34bd5a055536db824de66db553"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.0.0: https://github.com/DylanPiercey/local-devices/commit/57b9a933c9d23d34bd5a055536db824de66db553

This is the complete merge of the original pull 16: "fix: validate ip address before executing command for 'find' (16)"