### PR TITLE
[GHSA-wwh7-4jw9-33x6] yajl-ruby vulnerable to Use of Externally-Controlled Format String

### DIFF
--- a/advisories/github-reviewed/2017/11/GHSA-wwh7-4jw9-33x6/GHSA-wwh7-4jw9-33x6.json
+++ b/advisories/github-reviewed/2017/11/GHSA-wwh7-4jw9-33x6/GHSA-wwh7-4jw9-33x6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wwh7-4jw9-33x6",
-  "modified": "2023-01-26T22:19:39Z",
+  "modified": "2023-01-26T22:19:40Z",
   "published": "2017-11-28T22:44:42Z",
   "aliases": [
     "CVE-2017-16516"
@@ -43,6 +43,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/brianmario/yajl-ruby/issues/176"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/brianmario/yajl-ruby/pull/178"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/brianmario/yajl-ruby/commit/a8ca8f476655adaa187eedc60bdc770fff3c51ce"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.3.1: https://github.com/brianmario/yajl-ruby/commit/a8ca8f476655adaa187eedc60bdc770fff3c51ce

Adding the pull: https://github.com/brianmario/yajl-ruby/pull/178

The original issue (176) was fixed by pull 178: "Don't advance our end pointer until we've checked we have enough buffer left and have peeked ahead to see that a unicode escape is approaching."