### PR TITLE
[GHSA-wx7c-8j35-mpg8] Fat Free CRM Cross-Site Request Forgery vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-wx7c-8j35-mpg8/GHSA-wx7c-8j35-mpg8.json
+++ b/advisories/github-reviewed/2022/05/GHSA-wx7c-8j35-mpg8/GHSA-wx7c-8j35-mpg8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wx7c-8j35-mpg8",
-  "modified": "2023-01-23T14:26:45Z",
+  "modified": "2023-01-23T19:52:18Z",
   "published": "2022-05-14T02:49:30Z",
   "aliases": [
     "CVE-2015-1585"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-1585"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/fatfreecrm/fat_free_crm/commit/86fd7f98c9583fd36384987282d1c086fdcecd7c"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.13.6: https://github.com/fatfreecrm/fat_free_crm/commit/86fd7f98c9583fd36384987282d1c086fdcecd7c

The CVE is mentioned in the commit patch message: "Fix for CVE-2015-1585 - CSRF vulnerability."