### PR TITLE
[GHSA-x4qm-mcjq-v2gf] Overflow in prost-types

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-x4qm-mcjq-v2gf/GHSA-x4qm-mcjq-v2gf.json
+++ b/advisories/github-reviewed/2021/08/GHSA-x4qm-mcjq-v2gf/GHSA-x4qm-mcjq-v2gf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x4qm-mcjq-v2gf",
-  "modified": "2021-08-18T21:29:54Z",
+  "modified": "2023-02-03T05:06:04Z",
   "published": "2021-08-25T20:55:53Z",
   "aliases": [
     "CVE-2021-38192"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "crates.io",
         "name": "prost-types"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "prost_types::Timestamp::Into<SystemTime>"
-        ]
       },
       "ranges": [
         {
@@ -48,6 +43,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/tokio-rs/prost/issues/438"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/tokio-rs/prost/pull/439"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/tokio-rs/prost/commit/59f2a7311dd6540696bfd0145f5281ce495f4385"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding the patch link for v0.8.0: https://github.com/tokio-rs/prost/commit/59f2a7311dd6540696bfd0145f5281ce495f4385

Adding the pull: https://github.com/tokio-rs/prost/pull/439

The original issue (438) was fixed by pull 439: "Fix 438: Check for overflow in Duration and Timestamp processing (439)"