### PR TITLE
[GHSA-x6jv-5vfg-gm7x] Path traversal in ServcieCenter

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-x6jv-5vfg-gm7x/GHSA-x6jv-5vfg-gm7x.json
+++ b/advisories/github-reviewed/2021/09/GHSA-x6jv-5vfg-gm7x/GHSA-x6jv-5vfg-gm7x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x6jv-5vfg-gm7x",
-  "modified": "2021-08-30T19:32:48Z",
+  "modified": "2023-02-01T05:06:18Z",
   "published": "2021-09-01T18:35:52Z",
   "aliases": [
     "CVE-2021-21501"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/servicecomb-service-center/pull/788"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/servicecomb-service-center/commit/f4f44fe5d4a7e530ca8ee7c6f2c9e891ae8353c9"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.0.0: https://github.com/apache/servicecomb-service-center/commit/f4f44fe5d4a7e530ca8ee7c6f2c9e891ae8353c9

This is the complete merge of the original pull 788: "SCB-2094 Fix Security Vulnerability - Directory Traversal (788)"