### PR TITLE
[GHSA-x7g2-wrrp-r6h3] Use of a Broken or Risky Cryptographic Algorithm

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-x7g2-wrrp-r6h3/GHSA-x7g2-wrrp-r6h3.json
+++ b/advisories/github-reviewed/2021/09/GHSA-x7g2-wrrp-r6h3/GHSA-x7g2-wrrp-r6h3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x7g2-wrrp-r6h3",
-  "modified": "2021-10-21T14:28:25Z",
+  "modified": "2023-02-01T05:06:24Z",
   "published": "2021-09-01T18:41:06Z",
   "aliases": [
     "CVE-2021-27913"
@@ -43,6 +43,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-27913"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mautic/mautic/commit/d1cad766a2de74e6c6b89d6d78c2a5f2e36ba91c"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.3.4: https://github.com/mautic/mautic/commit/d1cad766a2de74e6c6b89d6d78c2a5f2e36ba91c

The GHSA-ID is in the commit patch message: "Merge pull request from GHSA-x7g2-wrrp-r6h3"