### PR TITLE
[GHSA-x7rv-cr6v-4vm4] Cross-site Scripting in loofah

### DIFF
--- a/advisories/github-reviewed/2018/03/GHSA-x7rv-cr6v-4vm4/GHSA-x7rv-cr6v-4vm4.json
+++ b/advisories/github-reviewed/2018/03/GHSA-x7rv-cr6v-4vm4/GHSA-x7rv-cr6v-4vm4.json
@@ -45,6 +45,10 @@
       "url": "https://github.com/flavorjones/loofah/issues/144"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/flavorjones/loofah/commit/f739cf8eac5851f328b8044281d6653f74eff116"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-x7rv-cr6v-4vm4"
     },


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.2.1: https://github.com/flavorjones/loofah/commit/f739cf8eac5851f328b8044281d6653f74eff116

The CVE (CVE-2018-8048) is in the commit patch message: "tests and fix for CVE-2018-8048"