### PR TITLE
[GHSA-xcf7-q56x-78gh] Connection descriptor exhaustion in proxyproto

### DIFF
--- a/advisories/github-reviewed/2021/07/GHSA-xcf7-q56x-78gh/GHSA-xcf7-q56x-78gh.json
+++ b/advisories/github-reviewed/2021/07/GHSA-xcf7-q56x-78gh/GHSA-xcf7-q56x-78gh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xcf7-q56x-78gh",
-  "modified": "2023-02-15T00:44:40Z",
+  "modified": "2023-02-15T00:44:41Z",
   "published": "2021-07-26T21:23:49Z",
   "aliases": [
     "CVE-2021-23409"
@@ -55,6 +55,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/pires/go-proxyproto/pull/74/commits/cdc63867da24fc609b727231f682670d0d1cd346"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pires/go-proxyproto/pull/76"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pires/go-proxyproto/commit/2e44d7a76a851d66890ab341403253afae5caac2"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.6.1: https://github.com/pires/go-proxyproto/commit/2e44d7a76a851d66890ab341403253afae5caac2

Adding the pull: https://github.com/pires/go-proxyproto/pull/76

The original issue 75 was closed by pull 76: "Merge pull request 76 from pires/bugfix/reset_conn_read_deadline_after_successful_header"