### PR TITLE
[GHSA-xfqg-p48g-hh94] Login timing attack in ezsystems/ezpublish-kernel

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-xfqg-p48g-hh94/GHSA-xfqg-p48g-hh94.json
+++ b/advisories/github-reviewed/2022/06/GHSA-xfqg-p48g-hh94/GHSA-xfqg-p48g-hh94.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xfqg-p48g-hh94",
-  "modified": "2022-06-02T21:02:00Z",
+  "modified": "2023-01-11T05:07:18Z",
   "published": "2022-06-02T21:02:00Z",
   "aliases": [
 
@@ -36,6 +36,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/ezsystems/ezpublish-kernel/security/advisories/GHSA-xfqg-p48g-hh94"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ezsystems/ezpublish-kernel/commit/913fe17281536a91437d94e8267181ae8b57f5d5"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v7.5.29: https://github.com/ezsystems/ezpublish-kernel/commit/913fe17281536a91437d94e8267181ae8b57f5d5

IBX-1755 (https://issues.ibexa.co/browse/IBX-1755) was released as IBEXA-SA-2022-006, which is one of the originally linked references (https://developers.ibexa.co/security-advisories/ibexa-sa-2022-006-vulnerabilities-in-page-builder-login-and-commerce): "IBX-1755: Implemented constant time authentication" 