### PR TITLE
[GHSA-xr7r-88qv-q7hm] Out of bounds write in serde_cbor

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-xr7r-88qv-q7hm/GHSA-xr7r-88qv-q7hm.json
+++ b/advisories/github-reviewed/2021/08/GHSA-xr7r-88qv-q7hm/GHSA-xr7r-88qv-q7hm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xr7r-88qv-q7hm",
-  "modified": "2021-08-19T21:20:43Z",
+  "modified": "2023-01-11T05:05:45Z",
   "published": "2021-08-25T20:45:51Z",
   "aliases": [
     "CVE-2019-25001"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-25001"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pyfisch/cbor/pull/153"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pyfisch/cbor/commit/1aec4f9d71855dbfb223fa61ca60260400cc5d5f"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.10.2: https://github.com/pyfisch/cbor/commit/1aec4f9d71855dbfb223fa61ca60260400cc5d5f

Adding the pull: https://github.com/pyfisch/cbor/pull/153

The commit patch message is very similar to the original advisory: "Prevent stack overflow from nested tags" The developer also added a recursion check for nested tags. 