### PR TITLE
[GHSA-228f-g3h7-3fj3] RubyGems before 1.8.23 can redirect HTTPS connections to...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-228f-g3h7-3fj3/GHSA-228f-g3h7-3fj3.json
+++ b/advisories/unreviewed/2022/05/GHSA-228f-g3h7-3fj3/GHSA-228f-g3h7-3fj3.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-228f-g3h7-3fj3",
-  "modified": "2022-05-17T04:54:56Z",
+  "modified": "2023-01-28T05:02:49Z",
   "published": "2022-05-17T04:54:56Z",
   "aliases": [
     "CVE-2012-2125"
   ],
+  "summary": "\"CVE-2012-2125 CVE-2012-2126 rubygems: Two security fixes in v1.8.23\"",
   "details": "RubyGems before 1.8.23 can redirect HTTPS connections to HTTP, which makes it easier for remote attackers to observe or modify a gem during installation via a man-in-the-middle attack.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "rubygems-update"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 1.8.23"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,8 +42,16 @@
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=814718"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/rubygems/rubygems"
+    },
+    {
       "type": "WEB",
       "url": "https://github.com/rubygems/rubygems/blob/1.8/History.txt"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/20gems/rubygems-update/CVE-2012-2126.yml"
     },
     {
       "type": "WEB",

--- a/advisories/unreviewed/2022/05/GHSA-228f-g3h7-3fj3/GHSA-228f-g3h7-3fj3.json
+++ b/advisories/unreviewed/2022/05/GHSA-228f-g3h7-3fj3/GHSA-228f-g3h7-3fj3.json
@@ -42,16 +42,16 @@
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=814718"
     },
     {
-      "type": "PACKAGE",
-      "url": "https://github.com/rubygems/rubygems"
-    },
-    {
       "type": "WEB",
       "url": "https://github.com/rubygems/rubygems/blob/1.8/History.txt"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/20gems/rubygems-update/CVE-2012-2126.yml"
+      "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rubygems-update/CVE-2012-2125.yml"
+    },
+    {
+      "type": "PACKAGE",
+      "url": " https://github.com/rubygems/rubygems"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Added information (title, ecosystem, package name, patched_version, add URL) from github.com/ruby-advisory-db repo.
