### PR TITLE
[GHSA-5mgj-mvv8-46mw] RubyGems before 1.8.23 does not verify an SSL certificate...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5mgj-mvv8-46mw/GHSA-5mgj-mvv8-46mw.json
+++ b/advisories/unreviewed/2022/05/GHSA-5mgj-mvv8-46mw/GHSA-5mgj-mvv8-46mw.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5mgj-mvv8-46mw",
-  "modified": "2022-05-17T04:54:47Z",
+  "modified": "2023-01-28T05:02:47Z",
   "published": "2022-05-17T04:54:47Z",
   "aliases": [
     "CVE-2012-2126"
   ],
+  "summary": "\"CVE-2012-2125 CVE-2012-2126 rubygems: Two security fixes in v1.8.23\"",
   "details": "RubyGems before 1.8.23 does not verify an SSL certificate, which allows remote attackers to modify a gem during installation via a man-in-the-middle attack.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "rubygems-update"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 1.8.23"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -20,11 +39,23 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/rubygems/rubygems/commit/d4c7eafb8efe1e13a7abf5be5a5b4548870b15b7"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=814718"
     },
     {
       "type": "WEB",
       "url": "https://github.com/rubygems/rubygems/blob/1.8/History.txt"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rubygems-update/CVE-2012-2126.yml"
+    },
+    {
+      "type": "PACKAGE",
+      "url": " https://github.com/rubygems/rubygems/commit/d4c7eafb8efe1e13a7abf5be5a5b4548870b15b7"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Added information (title, ecosystem, package name, patched_version, source code location, added 2 URLs) from github.com/ruby-advisory-db repo plus additional research. Appears CWE-310 (Cryptographic Issues) does not show up in menu.

