### PR TITLE
[GHSA-qv62-xfj6-32xm] RubyGems 2.0.x before 2.0.17, 2.2.x before 2.2.5, and 2.4...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-qv62-xfj6-32xm/GHSA-qv62-xfj6-32xm.json
+++ b/advisories/unreviewed/2022/05/GHSA-qv62-xfj6-32xm/GHSA-qv62-xfj6-32xm.json
@@ -1,17 +1,74 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qv62-xfj6-32xm",
-  "modified": "2022-05-17T00:16:50Z",
+  "modified": "2023-02-03T05:01:21Z",
   "published": "2022-05-17T00:16:50Z",
   "aliases": [
     "CVE-2015-4020"
   ],
-  "details": "RubyGems 2.0.x before 2.0.17, 2.2.x before 2.2.5, and 2.4.x before 2.4.8 does not validate the hostname when fetching gems or making API requests, which allows remote attackers to redirect requests to arbitrary domains via a crafted DNS SRV record with a domain that is suffixed with the original domain name, aka a \"DNS hijack attack.\" NOTE: this vulnerability exists because to an incomplete fix for CVE-2015-3900.",
+  "summary": "RubyGems remote_fetcher.rb api_endpoint() Function Missin SRV Record Hostname Validation Request Hijacking",
+  "details": "  NOTE: ruby-advisory-db says: \n  RubyGems contains a flaw in the api_endpoint() function in remote_fetcher.rb\n  that is triggered when handling hostnames in SRV records. With a specially\n  crafted response, a context-dependent attacker may conduct DNS hijacking\n  attacks. This vulnerability is due to an incomplete fix for CVE-2015-3900,\n  which allowed redirection to an arbitrary gem server in any security domain.\n\n  NOTE Fro Trystware reference: Also Ruby versions before 2.2.3,\n        JRuby versions before 1.7.21 and before 9.0.0.0.rc1,\n        Rubinius versions before 1.4.9 and before 2.5.6\n\n  PREVIOUSLY:\n  RubyGems 2.0.x before 2.0.17, 2.2.x before 2.2.5, and \n  2.4.x before 2.4.8 does not validate the hostname when fetching\n  gems or making API requests, which allows remote attackers to \n  redirect requests to arbitrary domains via a crafted DNS SRV \n  record with a domain that is suffixed with the original domain\n  name, aka a \"DNS hijack attack.\"\n\n  NOTE: this vulnerability exists because to an incomplete   fix for CVE-2015-3900.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "rubygems-update"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 2.4.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "rubygems-update"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "~> 2.2.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "rubygems-update"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "~> 2.0.17"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -19,8 +76,12 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-4020"
     },
     {
-      "type": "WEB",
+      "type": "PACKAGE",
       "url": "https://github.com/rubygems/rubygems/commit/5c7bfb5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rubygems-update/CVE-2015-4020.yml"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Source code location
- Summary

**Comments**
Added information (title, description, ecosystem, package name, patched_version, source code location, added 2 URL) from github.com/ruby-advisory-db repo plus supported references.
