### PR TITLE
[GHSA-xrcv-f9gm-v42c] Out-of-bounds Read in Pillow

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-xrcv-f9gm-v42c/GHSA-xrcv-f9gm-v42c.json
+++ b/advisories/github-reviewed/2022/01/GHSA-xrcv-f9gm-v42c/GHSA-xrcv-f9gm-v42c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xrcv-f9gm-v42c",
-  "modified": "2022-02-17T23:26:14Z",
+  "modified": "2023-02-02T05:01:21Z",
   "published": "2022-01-12T20:07:41Z",
   "aliases": [
     "CVE-2022-22816"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-22816"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/pull/5920"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/commit/5543e4e2d409cd9e409bc64cdc77be0af007a31f"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v9.0.0: https://github.com/python-pillow/Pillow/commit/5543e4e2d409cd9e409bc64cdc77be0af007a31f

Adding the pull: https://github.com/python-pillow/Pillow/pull/5920

The pull has the CVE (CVE-2022-22816) in the title: "CVE-2022-22815, CVE-2022-22816: Fixed ImagePath.Path array handling 5920"