### PR TITLE
[GHSA-h835-75hw-pj89] activesupport Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-h835-75hw-pj89/GHSA-h835-75hw-pj89.json
+++ b/advisories/github-reviewed/2017/10/GHSA-h835-75hw-pj89/GHSA-h835-75hw-pj89.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h835-75hw-pj89",
-  "modified": "2023-01-23T17:34:24Z",
+  "modified": "2023-01-23T17:34:25Z",
   "published": "2017-10-24T18:33:37Z",
   "aliases": [
     "CVE-2012-3464"
@@ -74,6 +74,22 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2012-3464"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/rails/issues/7215"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/rails/commit/28f2c6f4037081da0a82104a3f473165ed4ed2ce"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/rails/commit/780a718723cf87b49cfe204d355948c4e0932d23"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/rails/commit/d0c9759d3aeb6327d68dd6c0de0fe2fed4e3c870"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.0.17: https://github.com/rails/rails/commit/780a718723cf87b49cfe204d355948c4e0932d23

Adding the patch link for v3.1.8: https://github.com/rails/rails/commit/d0c9759d3aeb6327d68dd6c0de0fe2fed4e3c870

Adding the patch link for v3.2.8: https://github.com/rails/rails/commit/28f2c6f4037081da0a82104a3f473165ed4ed2ce

Adding the issue: https://github.com/rails/rails/issues/7215

The issue references the original CVE (CVE-2012-3464): "html_escape should escape single quotes.....Closes 7215"