### PR TITLE
[GHSA-c25x-cm9x-qqgx] Deno improperly handles resizable ArrayBuffer

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-c25x-cm9x-qqgx/GHSA-c25x-cm9x-qqgx.json
+++ b/advisories/github-reviewed/2023/03/GHSA-c25x-cm9x-qqgx/GHSA-c25x-cm9x-qqgx.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c25x-cm9x-qqgx",
-  "modified": "2023-03-24T13:32:16Z",
+  "modified": "2023-03-24T13:32:17Z",
   "published": "2023-03-23T23:13:25Z",
   "aliases": [
     "CVE-2023-28445"
   ],
   "summary": "Deno improperly handles resizable ArrayBuffer",
-  "details": "### Impact\n\n[Resizable ArrayBuffers](https://github.com/tc39/proposal-resizablearraybuffer) passed to asynchronous native functions that are shrunk during the asynchronous operation could result in an out-of-bound read/write.\n\nIt is unlikely that this has been exploited in the wild, as the only version affected is Deno 1.32.0.\n\nDeno Deploy users are not affected.\n\n### Patches\n\nThe problem has been resolved by disabling resizable ArrayBuffers temporarily in Deno 1.32.1. Deno 1.32.2 will re-enable resizable ArrayBuffers with a proper fix.\n\n### Workarounds\n\nUpgrade to Deno 1.32.1, or run with `--v8-flags=--no-harmony-rab-gsab` to disable resizable ArrayBuffers.",
+  "details": "### Impact\n\n[Resizable ArrayBuffers](https://github.com/tc39/proposal-resizablearraybuffer) passed to asynchronous native functions that are shrunk during the asynchronous operation could result in an out-of-bound read/write.\n\nIt is unlikely that this has been exploited in the wild, as the only version affected is Deno 1.32.0.\n\nDeno Deploy users are not affected.\n\n### Patches\n\nThe problem has been resolved by disabling resizable ArrayBuffers temporarily in Deno 1.32.1. A future version of Deno will re-enable resizable ArrayBuffers with a proper fix.\n\n### Workarounds\n\nUpgrade to Deno 1.32.1, or run with `--v8-flags=--no-harmony-rab-gsab` to disable resizable ArrayBuffers.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -94,6 +94,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/denoland/deno/pull/18395"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/denoland/deno/pull/18452"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Description
- References

**Comments**
Deno 1.32.2 was released but it didn't re-enable the feature. The proper fix is being developed on https://github.com/denoland/deno/pull/18452 currently. Updated the description and reference accordingly.