### PR TITLE
[GHSA-f8vr-r385-rh5r] h2 vulnerable to denial of service

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-f8vr-r385-rh5r/GHSA-f8vr-r385-rh5r.json
+++ b/advisories/github-reviewed/2023/04/GHSA-f8vr-r385-rh5r/GHSA-f8vr-r385-rh5r.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f8vr-r385-rh5r",
-  "modified": "2023-04-13T15:58:41Z",
+  "modified": "2023-04-13T16:00:44Z",
   "published": "2023-04-11T15:30:30Z",
   "aliases": [
     "CVE-2023-26964"
   ],
   "summary": "h2 vulnerable to denial of service",
-  "details": "Hyper is an HTTP library for Rust and h2 is an HTTP 2.0 client & server implementation for Rust. An issue was discovered in h2 v0.2.4 when processing header frames. Both packages incorrectly process the HTTP2 `RST_STREAM` frames by not always releasing the memory immediately upon receiving the reset frame, leading to stream stacking. As a result, the memory and CPU usage are high which can lead to a Denial of Service (DoS).\n\nThis issue affects users only when dealing with http2 connections.",
+  "details": "h2 is an HTTP 2.0 client & server implementation for Rust. An issue was discovered in h2 v0.2.4 when processing header frames. It incorrectly processes the HTTP2 `RST_STREAM` frames by not always releasing the memory immediately upon receiving the reset frame, leading to stream stacking. As a result, the memory and CPU usage are high which can lead to a Denial of Service (DoS).\n\nThis issue affects users only when dealing with http2 connections.",
   "severity": [
 
   ],


### PR DESCRIPTION
**Updates**
- Description

**Comments**
Follow-up for https://github.com/github/advisory-database/pull/2057, that PR removed some mentions to hyper but not all. This PR removes the remaining (actually, the sentence "both packages incorrectly process..." is kinda confusing).