### PR TITLE
[GHSA-gmpq-xrxj-xh8m] Arches vulnerable to execution of arbitrary SQL

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-gmpq-xrxj-xh8m/GHSA-gmpq-xrxj-xh8m.json
+++ b/advisories/github-reviewed/2022/11/GHSA-gmpq-xrxj-xh8m/GHSA-gmpq-xrxj-xh8m.json
@@ -92,6 +92,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41892"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/archesproject/arches/commit/7ed53e23a616edf3301d95814d9d64de5e3072a9"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/archesproject/arches"
     },
@@ -102,6 +106,10 @@
     {
       "type": "WEB",
       "url": "https://pypi.org/project/arches/7.2.0/"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://securitylab.github.com/advisories/GHSL-2022-070_GHSL-2022-072_Arches/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v7.2.0: https://github.com/archesproject/arches/commit/7ed53e23a616edf3301d95814d9d64de5e3072a9

Adding the GHSL link: https://securitylab.github.com/advisories/GHSL-2022-070_GHSL-2022-072_Arches/

The GHSL link references the CVE: "GHSL-2022-070_GHSL-2022-072: SQL injection in Arches - CVE-2022-41892"

And the issues referenced in the commit patch reference GHSL-2022-070_GHSL-2022-072: "fixes9019, 9021, 9026 in stable/7.1.1"