### PR TITLE
[GHSA-gvpx-9459-w3mj] Cross-Site Scripting in @ckeditor/ckeditor5-link

### DIFF
--- a/advisories/github-reviewed/2018/05/GHSA-gvpx-9459-w3mj/GHSA-gvpx-9459-w3mj.json
+++ b/advisories/github-reviewed/2018/05/GHSA-gvpx-9459-w3mj/GHSA-gvpx-9459-w3mj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gvpx-9459-w3mj",
-  "modified": "2021-09-13T13:35:54Z",
+  "modified": "2023-01-09T05:03:07Z",
   "published": "2018-05-23T20:37:46Z",
   "aliases": [
     "CVE-2018-11093"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-11093"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ckeditor/ckeditor5-link/commit/8cb782eceba10fc481e4021cb5d25b2a85d1b04e"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v10.0.1: https://github.com/ckeditor/ckeditor5-link/commit/8cb782eceba10fc481e4021cb5d25b2a85d1b04e

The CVE is mentioned in the commit patch message: "Fix: Fixed a cross-site scripting (XSS) vulnerability which allowed remote attackers to inject arbitrary web script through a crafted href attribute of a link (A) element. [CVE-2018-11093]"