### PR TITLE
[GHSA-j8p3-8m69-2hqq] CakePHP allows remote attackers to spoof their IP

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-j8p3-8m69-2hqq/GHSA-j8p3-8m69-2hqq.json
+++ b/advisories/github-reviewed/2022/05/GHSA-j8p3-8m69-2hqq/GHSA-j8p3-8m69-2hqq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j8p3-8m69-2hqq",
-  "modified": "2023-01-14T05:30:42Z",
+  "modified": "2023-01-30T05:03:30Z",
   "published": "2022-05-14T02:19:19Z",
   "aliases": [
     "CVE-2016-4793"
@@ -134,6 +134,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-4793"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cakephp/cakephp/commit/908754649f70bab2b1093942e17c9a46a2fcf6c2"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.2.5: https://github.com/cakephp/cakephp/commit/908754649f70bab2b1093942e17c9a46a2fcf6c2

The developer started to get the client IP from REMOTE_ADDR. Additionally, this is the same code as referenced in the original reference link (https://legalhackers.com/advisories/CakePHP-IP-Spoofing-Vulnerability.txt) and targets the same function -> clientIp(): 

Commit message is also similar to advisory for spoofing: " Don't trust Client-IP header unless behind a proxy
REMOTE_ADDR is a far safer place to get an client's IP over the header
which is easily spoofed. If someone is trusting the proxy we'll prefer
x-forwarded-for and fallback to client-ip should that not exist."