### PR TITLE
[GHSA-jgm2-m5cg-f66g] Authentication Bypass in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-jgm2-m5cg-f66g/GHSA-jgm2-m5cg-f66g.json
+++ b/advisories/github-reviewed/2022/05/GHSA-jgm2-m5cg-f66g/GHSA-jgm2-m5cg-f66g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jgm2-m5cg-f66g",
-  "modified": "2022-07-13T21:29:14Z",
+  "modified": "2023-01-27T05:02:21Z",
   "published": "2022-05-17T00:59:04Z",
   "aliases": [
     "CVE-2012-3546"
@@ -55,6 +55,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2012-3546"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/f78c0cdfc8a3c2efdfe6df6b69e5e3daafa3f588"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v7.0.30: https://github.com/apache/tomcat/commit/f78c0cdfc8a3c2efdfe6df6b69e5e3daafa3f588

This is the commit patch link for the original Apache-SVN reference link (http://svn.apache.org/viewvc?view=revision&revision=1377892): "Merged revision 1377887 from tomcat/trunk:
Remove unneeded handling of FORM authentication in RealmBase.

The login and error pages are handled via forward, so processing completes before this code is ever reached.
The action page is handled elsewhere.

git-svn-id: https://svn.apache.org/repos/asf/tomcat/tc7.0.x/trunk@1377892"