### PR TITLE
[GHSA-m69r-9g56-7mv8] HashiCorp Consul vulnerable to authorization bypass

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-m69r-9g56-7mv8/GHSA-m69r-9g56-7mv8.json
+++ b/advisories/github-reviewed/2022/09/GHSA-m69r-9g56-7mv8/GHSA-m69r-9g56-7mv8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m69r-9g56-7mv8",
-  "modified": "2022-09-29T14:39:58Z",
+  "modified": "2023-01-28T05:07:41Z",
   "published": "2022-09-25T00:00:27Z",
   "aliases": [
     "CVE-2022-40716"
@@ -77,6 +77,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-40716"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hashicorp/consul/pull/14579"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hashicorp/consul/commit/8f6fb4f6fe9488b8ec37da71ac503081d7d3760b"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.13.2: https://github.com/hashicorp/consul/commit/8f6fb4f6fe9488b8ec37da71ac503081d7d3760b

Adding the pull: https://github.com/hashicorp/consul/pull/14579

The developer starts to check that only one SAN URI value is present, similar to the original vulnerability: "Added URI length checks to ConnectCA CSR requests. Prior to this change, it was possible for a malicious actor to designate multiple SAN URI values in a call to the `ConnectCA.Sign` endpoint. The endpoint now only allows for exactly one SAN URI to be specified."