### PR TITLE
[GHSA-mhp6-pxh8-r675] Cross site scripting in Angular

### DIFF
--- a/advisories/github-reviewed/2020/06/GHSA-mhp6-pxh8-r675/GHSA-mhp6-pxh8-r675.json
+++ b/advisories/github-reviewed/2020/06/GHSA-mhp6-pxh8-r675/GHSA-mhp6-pxh8-r675.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mhp6-pxh8-r675",
-  "modified": "2021-09-22T18:31:00Z",
+  "modified": "2023-01-09T05:03:30Z",
   "published": "2020-06-18T14:19:58Z",
   "aliases": [
     "CVE-2020-7676"
@@ -46,7 +46,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/angular/angular.js/pull/17028,"
+      "url": "https://github.com/angular/angular.js/commit/2df43c07779137d1bddf7f3b282a1287a8634acd"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.8.0: https://github.com/angular/angular.js/commit/2df43c07779137d1bddf7f3b282a1287a8634acd

This is the complete merge of the original pull 17028: "fix(jqLite): prevent possible XSS due to regex-based HTML replacement"

Also, removing the extra pull link that had a comma after it...