### PR TITLE
[GHSA-q56r-mw39-944g] Concrete CMS vulnerable to Improper Authentication

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-q56r-mw39-944g/GHSA-q56r-mw39-944g.json
+++ b/advisories/github-reviewed/2022/11/GHSA-q56r-mw39-944g/GHSA-q56r-mw39-944g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q56r-mw39-944g",
-  "modified": "2022-11-22T00:12:39Z",
+  "modified": "2023-02-01T05:04:02Z",
   "published": "2022-11-15T12:00:16Z",
   "aliases": [
     "CVE-2022-43690"
@@ -58,6 +58,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43690"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/commit/a4dc73a4a47823373d4b4824534bb9b7d251f72c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/commit/d5dd12c40efed326b26862391b7e1e6f414cdd55"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v8.5.10: https://github.com/concretecms/concretecms/commit/d5dd12c40efed326b26862391b7e1e6f414cdd55

Adding the patch link for v9.1.3: https://github.com/concretecms/concretecms/commit/a4dc73a4a47823373d4b4824534bb9b7d251f72c

Commit patch message matches the description of the advisory: "Make the legacy_salt functionality easier to read and use strict comparison"