### PR TITLE
[GHSA-q73f-vjc2-3gqf] OpenStack Image Service (Glance) allows remote authenticated users to read arbitrary file

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-q73f-vjc2-3gqf/GHSA-q73f-vjc2-3gqf.json
+++ b/advisories/github-reviewed/2022/05/GHSA-q73f-vjc2-3gqf/GHSA-q73f-vjc2-3gqf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q73f-vjc2-3gqf",
-  "modified": "2023-02-08T18:01:32Z",
+  "modified": "2023-02-08T18:01:33Z",
   "published": "2022-05-17T03:44:51Z",
   "aliases": [
     "CVE-2015-5163"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5163"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/openstack/glance/commit/eb99e45829a1b4c93db5692bdbf636a86faa56c4"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2015.1.2: https://github.com/openstack/glance/commit/eb99e45829a1b4c93db5692bdbf636a86faa56c4

The patch closed the original bug (https://bugs.launchpad.net/glance/+bug/1471912): "Don't import files with backed files.....Closes-bug: 1471912"