### PR TITLE
[GHSA-q9h2-4xhf-23xx] Data races in im

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-q9h2-4xhf-23xx/GHSA-q9h2-4xhf-23xx.json
+++ b/advisories/github-reviewed/2021/08/GHSA-q9h2-4xhf-23xx/GHSA-q9h2-4xhf-23xx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q9h2-4xhf-23xx",
-  "modified": "2022-06-07T21:31:41Z",
+  "modified": "2023-01-27T05:00:32Z",
   "published": "2021-08-25T20:51:36Z",
   "aliases": [
     "CVE-2020-36204"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/bodil/im-rs/pull/158"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/bodil/im-rs/commit/0b3a7b228b0fe70446393f55c8b893f349f3f6bd"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v15.1.0: https://github.com/bodil/im-rs/commit/0b3a7b228b0fe70446393f55c8b893f349f3f6bd

This is the complete merge of the originally linked pull 158: "Add Send and Sync bounds for TreeFocus"