### PR TITLE
[GHSA-6mqr-q86q-6gwr] Authentication Bypass by CSRF Weakness

### DIFF
--- a/advisories/github-reviewed/2021/11/GHSA-6mqr-q86q-6gwr/GHSA-6mqr-q86q-6gwr.json
+++ b/advisories/github-reviewed/2021/11/GHSA-6mqr-q86q-6gwr/GHSA-6mqr-q86q-6gwr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6mqr-q86q-6gwr",
-  "modified": "2021-11-18T19:52:03Z",
+  "modified": "2023-01-09T05:05:06Z",
   "published": "2021-11-18T20:15:09Z",
   "aliases": [
 
@@ -46,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/spree/spree_auth_devise/security/advisories/GHSA-6mqr-q86q-6gwr"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spree/spree_auth_devise/commit/50bf2444a851f10dff926eb4ea3674976d9d279d"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v4.2.1: https://github.com/spree/spree_auth_devise/commit/50bf2444a851f10dff926eb4ea3674976d9d279d

The commit patch message is very similar to the original advisory: "[PATCH] Fix account takeover through CSRF attack" 