### PR TITLE
[GHSA-h3r8-h5qw-4r35] sidekiq vulnerable to cross-site scripting 

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-h3r8-h5qw-4r35/GHSA-h3r8-h5qw-4r35.json
+++ b/advisories/github-reviewed/2023/04/GHSA-h3r8-h5qw-4r35/GHSA-h3r8-h5qw-4r35.json
@@ -30,22 +30,6 @@
           ]
         }
       ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "sidekiq"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ]
     }
   ],
   "references": [

--- a/advisories/github-reviewed/2023/04/GHSA-h3r8-h5qw-4r35/GHSA-h3r8-h5qw-4r35.json
+++ b/advisories/github-reviewed/2023/04/GHSA-h3r8-h5qw-4r35/GHSA-h3r8-h5qw-4r35.json
@@ -7,7 +7,7 @@
     "CVE-2023-1892"
   ],
   "summary": "sidekiq vulnerable to cross-site scripting ",
-  "details": "sidekiq prior to 7.0.8 is vulnerable to reflected cross-site scripting.",
+  "details": "sidekiq from 7.0.4 to 7.0.7 is vulnerable to reflected cross-site scripting.",
   "severity": [
 
   ],
@@ -22,10 +22,26 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.4"
             },
             {
               "fixed": "7.0.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "sidekiq"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
From the upstream [changelog](https://github.com/sidekiq/sidekiq/blob/main/Changes.md#708):
> SECURITY Sanitize period input parameter on Metrics pages. Specially crafted values can lead to XSS. This functionality was introduced in 7.0.4. 

But currently the advisory applies to all versions < 7.0.8.