### PR TITLE
[GHSA-6m9f-pj6w-w87g] Rancher Webhook is misconfigured during upgrade process

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-6m9f-pj6w-w87g/GHSA-6m9f-pj6w-w87g.json
+++ b/advisories/github-reviewed/2023/04/GHSA-6m9f-pj6w-w87g/GHSA-6m9f-pj6w-w87g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6m9f-pj6w-w87g",
-  "modified": "2023-04-25T18:09:03Z",
+  "modified": "2023-04-25T18:09:04Z",
   "published": "2023-04-24T22:34:59Z",
   "aliases": [
     "CVE-2023-22651"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.6.0"
+              "introduced": "2.7.2"
             },
             {
               "fixed": "2.7.3"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The affected versions is incorrect, as per original advisory: https://github.com/rancher/rancher/security/advisories/GHSA-6m9f-pj6w-w87g