### PR TITLE
[GHSA-35jh-r3h4-6jhm] Command Injection in lodash

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-35jh-r3h4-6jhm/GHSA-35jh-r3h4-6jhm.json
+++ b/advisories/github-reviewed/2021/05/GHSA-35jh-r3h4-6jhm/GHSA-35jh-r3h4-6jhm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-35jh-r3h4-6jhm",
-  "modified": "2022-02-08T21:35:09Z",
+  "modified": "2023-02-28T22:27:17Z",
   "published": "2021-05-06T16:05:51Z",
   "aliases": [
     "CVE-2021-23337"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "lodash"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "lodash.template"
-        ]
       },
       "ranges": [
         {
@@ -44,10 +39,24 @@
         "ecosystem": "npm",
         "name": "lodash-es"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "lodash.template"
-        ]
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.17.21"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "lodash.template"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
as seen both in the CVE description and in the reference commits the vulnerability is in the _.template function
this function can be installed independently though the npm package manager https://www.npmjs.com/package/lodash.template 