### PR TITLE
[GHSA-29mw-wpgm-hmr9] Regular Expression Denial of Service (ReDoS) in lodash

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-29mw-wpgm-hmr9/GHSA-29mw-wpgm-hmr9.json
+++ b/advisories/github-reviewed/2022/01/GHSA-29mw-wpgm-hmr9/GHSA-29mw-wpgm-hmr9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-29mw-wpgm-hmr9",
-  "modified": "2022-02-08T21:35:28Z",
+  "modified": "2023-01-27T05:07:54Z",
   "published": "2022-01-06T20:30:46Z",
   "aliases": [
     "CVE-2020-28500"
@@ -38,6 +38,44 @@
       "package": {
         "ecosystem": "npm",
         "name": "lodash-es"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.17.21"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "lodash.trimend"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.17.21"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "lodash.trim"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
as seen both in the CVE description and in the reference commits the vulnerability is in the _.trim and _.trimEnd functions
these functions can be installed independently though the npm package manager https://www.npmjs.com/package/lodash.trim https://www.npmjs.com/package/lodash.trimend