### PR TITLE
[GHSA-776f-qx25-q3cc] xml2js is vulnerable to prototype pollution 

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-776f-qx25-q3cc/GHSA-776f-qx25-q3cc.json
+++ b/advisories/github-reviewed/2023/04/GHSA-776f-qx25-q3cc/GHSA-776f-qx25-q3cc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-776f-qx25-q3cc",
-  "modified": "2023-04-10T19:01:29Z",
+  "modified": "2023-04-10T19:01:30Z",
   "published": "2023-04-05T21:30:24Z",
   "aliases": [
     "CVE-2023-0842"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
     }
   ],
   "affected": [
@@ -61,7 +61,7 @@
     "cwe_ids": [
       "CWE-1321"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2023-04-07T21:00:54Z",
     "nvd_published_at": "2023-04-05T20:15:00Z"


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
The NVD gives this CVE a Medium severity based on a CVSS 3 score of 5.3. Please see https://nvd.nist.gov/vuln/detail/CVE-2023-0842. I updated the vector based on what the NVD contains. Can the severity be updated accordingly? Thanks!