### PR TITLE
[GHSA-6m9f-pj6w-w87g] Rancher Webhook is misconfigured during upgrade process

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-6m9f-pj6w-w87g/GHSA-6m9f-pj6w-w87g.json
+++ b/advisories/github-reviewed/2023/04/GHSA-6m9f-pj6w-w87g/GHSA-6m9f-pj6w-w87g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6m9f-pj6w-w87g",
-  "modified": "2023-04-25T18:09:03Z",
+  "modified": "2023-04-26T17:54:41Z",
   "published": "2023-04-24T22:34:59Z",
   "aliases": [
     "CVE-2023-22651"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This change has already been submitted yesterday, and was merged:

![image](https://user-images.githubusercontent.com/5452977/234807643-8081fd4e-e2db-4475-9db0-75b9094db215.png)

However, the affected versions in the page still remains incorrect:

![image](https://user-images.githubusercontent.com/5452977/234807773-d3121756-dbaf-4e6c-ad1d-34d8c4aa59f2.png)