### PR TITLE
[GHSA-rc2q-x9mf-w3vf] TestNG is vulnerable to Path Traversal

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-rc2q-x9mf-w3vf/GHSA-rc2q-x9mf-w3vf.json
+++ b/advisories/github-reviewed/2022/11/GHSA-rc2q-x9mf-w3vf/GHSA-rc2q-x9mf-w3vf.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rc2q-x9mf-w3vf",
-  "modified": "2023-01-18T18:46:58Z",
+  "modified": "2023-02-03T05:04:25Z",
   "published": "2022-11-19T21:30:25Z",
   "aliases": [
     "CVE-2022-4065"
   ],
   "summary": "TestNG is vulnerable to Path Traversal",
-  "details": "A vulnerability was found in cbeust testng. It has been declared as critical. Affected by this vulnerability is the function `testngXmlExistsInJar` of the file `testng-core/src/main/java/org/testng/JarFileUtils.java` of the component `XML File Parser`. The manipulation leads to path traversal. The attack can be launched remotely. A patch is available in [version 7.7.0](https://github.com/cbeust/testng/releases/tag/7.7.0) at commit 9150736cd2c123a6a3b60e6193630859f9f0422b. It is recommended to apply a patch to fix this issue. The patch was pushed into the master branch but no releases have yet been made with the patch included.",
+  "details": "A vulnerability was found in cbeust testng.\n\n### Impact\n\nAffected by this vulnerability is the function `testngXmlExistsInJar` of the file `testng-core/src/main/java/org/testng/JarFileUtils.java` of the component `XML File Parser`.\n\nThe manipulation leads to path traversal only for `.xml`, `.yaml` and `.yml` files by default. The attack implies running an unsafe test JAR. However since that JAR can also contain executable code itself, the path traversal is unlikely to be the main attack.\n\n### Patches\n\nA patch is available in [version 7.7.0](https://github.com/cbeust/testng/releases/tag/7.7.0) at commit 9150736cd2c123a6a3b60e6193630859f9f0422b. It is recommended to apply a patch to fix this issue. The patch was pushed into the master branch but no releases have yet been made with the patch included.\n\n### Workaround\n\n* Specify which tests to run when invoking TestNG by configuring them on the CLI or in the build tool controlling the run.\n* Do not run tests with untrusted JARs on the classpath, this includes pull requests on open source projects.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "6.13"
             },
             {
               "fixed": "7.7.0"


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
See analysis done in the context of the Gradle Build tool report - https://github.com/gradle/gradle/issues/24062#issuecomment-1525631857
*  introduced a lower bound, as there are older versions that are not affected.
* I reformatted and clarified the description as well.

I did not attempt to update the CVE score, as I do not master the meaning of all fields. But the level seems highly inflated, as if TestNG could be used in a webapp accepting uploads. But that's not the case at all. Not sure how to represent this in the CVE score.
And if a user runs test with an infected JAR, there are much more serious risks simply from code execution _directly_.