### PR TITLE
[GHSA-4r6j-fwcx-94cf] snowflake-connector-python is vulnerable to Regular Expression Denial of Service (ReDoS)

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-4r6j-fwcx-94cf/GHSA-4r6j-fwcx-94cf.json
+++ b/advisories/github-reviewed/2022/11/GHSA-4r6j-fwcx-94cf/GHSA-4r6j-fwcx-94cf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4r6j-fwcx-94cf",
-  "modified": "2022-11-10T20:09:27Z",
+  "modified": "2023-03-14T14:11:10Z",
   "published": "2022-11-10T12:01:17Z",
   "aliases": [
     "CVE-2022-42965"
@@ -32,10 +32,7 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 2.8.0"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Just updating the affected version range to correspond to the patch version being 2.8.2 (so 2.8.1 would also be flagged as vulnerable)