### PR TITLE
[GHSA-3mgp-fx93-9xv5] XSS vulnerability that affects bootstrap

### DIFF
--- a/advisories/github-reviewed/2019/01/GHSA-3mgp-fx93-9xv5/GHSA-3mgp-fx93-9xv5.json
+++ b/advisories/github-reviewed/2019/01/GHSA-3mgp-fx93-9xv5/GHSA-3mgp-fx93-9xv5.json
@@ -58,6 +58,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/twbs/bootstrap/commit/2a5ba23ce8f041f3548317acc992ed8a736b609d"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHBA-2019:1076"
     },
     {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v3.4.0: https://github.com/twbs/bootstrap/commit/2a5ba23ce8f041f3548317acc992ed8a736b609d

The commit here is the squashed merge of the original pull (27047), it fixes a lot of different CVEs in one - but the original issue 27044 is mentioned: "* fix(tooltip): XSS on data-viewport attribute. Fixes 27044"