### PR TITLE
[GHSA-46r5-59fg-2fjc] Deserialization of Untrusted Data in Infinispan

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-46r5-59fg-2fjc/GHSA-46r5-59fg-2fjc.json
+++ b/advisories/github-reviewed/2022/05/GHSA-46r5-59fg-2fjc/GHSA-46r5-59fg-2fjc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-46r5-59fg-2fjc",
-  "modified": "2022-07-01T19:46:46Z",
+  "modified": "2023-01-27T05:02:11Z",
   "published": "2022-05-14T00:59:30Z",
   "aliases": [
     "CVE-2017-15089"
@@ -46,6 +46,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/infinispan/infinispan/pull/5639"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/infinispan/infinispan/commit/1deadcb1c74ea0337abd5382c0150b000f6b106f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/infinispan/infinispan/commit/2944b0d1369a230bde88392b222921537c99331e"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch links for v9.2.0.CR1: https://github.com/infinispan/infinispan/commit/1deadcb1c74ea0337abd5382c0150b000f6b106f

https://github.com/infinispan/infinispan/commit/2944b0d1369a230bde88392b222921537c99331e

The developer didn't squash the merge, so the patches appear as two separate patch links from the original 5639 pull: 

"ISPN-8624 White list unmarshalling for GenericJBossMarshaller "

"ISPN-8624 Custom marshaller implementors should verify class names"