### PR TITLE
[GHSA-4936-rj25-6wm6] nori contains Improper Input Validation

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-4936-rj25-6wm6/GHSA-4936-rj25-6wm6.json
+++ b/advisories/github-reviewed/2017/10/GHSA-4936-rj25-6wm6/GHSA-4936-rj25-6wm6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4936-rj25-6wm6",
-  "modified": "2023-01-20T22:08:42Z",
+  "modified": "2023-01-20T22:08:43Z",
   "published": "2017-10-24T18:33:37Z",
   "aliases": [
     "CVE-2013-0285"
@@ -74,6 +74,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-0285"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/savonrb/nori/commit/818f5263b1d597b603d46cbe1702cd2717259e32"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/savonrb/nori/commit/c5e07f5c32e615f0a4a7ee2782d37f7a33261be4"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch links for the latest v2.0.2: https://github.com/savonrb/nori/commit/818f5263b1d597b603d46cbe1702cd2717259e32

https://github.com/savonrb/nori/commit/c5e07f5c32e615f0a4a7ee2782d37f7a33261be4

In the changelog, the developers mention the Rails CVE-2013-0156, which was mentioned in the advisory: "Fix for remote code execution bug. For more in-depth information, read about the recent [Rails hotfix](https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-security/61bkgvnSGTQ)."

Additionally, the developer targets the YAML and symbol type conversion aspect: "fixed YAML remote code execution vulnerability"