### PR TITLE
[GHSA-4pv3-63jw-4jw2] Missing Release of Memory after Effective Lifetime in Apache Tika

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-4pv3-63jw-4jw2/GHSA-4pv3-63jw-4jw2.json
+++ b/advisories/github-reviewed/2021/05/GHSA-4pv3-63jw-4jw2/GHSA-4pv3-63jw-4jw2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4pv3-63jw-4jw2",
-  "modified": "2022-10-07T20:41:22Z",
+  "modified": "2023-01-28T05:05:15Z",
   "published": "2021-05-07T15:53:40Z",
   "aliases": [
     "CVE-2020-9489"
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-9489"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tika/commit/0f4d5de0f85455e91433fb0b464ea0461d7c891d"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch links for the latest v1.24.1: https://github.com/apache/tika/commit/0f4d5de0f85455e91433fb0b464ea0461d7c891d

From comments in the patch that relate to the original advisory: "TikaInputStream includes a few safety features to protect against parsers that may fail to check for an EOF or may incorrectly rely on the unreliable value returned from {link FileInputStream#skip}.  These parser failures can lead to infinite loops."

Additionally, System.exit was removed in the last file, an aspect of what could be triggered from the original vulnerability.