### PR TITLE
[GHSA-5jp2-vwrj-99rf] Team scope authorization bypass when Post/Put request with :team_name in body, allows HTTP parameter pollution 

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-5jp2-vwrj-99rf/GHSA-5jp2-vwrj-99rf.json
+++ b/advisories/github-reviewed/2022/10/GHSA-5jp2-vwrj-99rf/GHSA-5jp2-vwrj-99rf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5jp2-vwrj-99rf",
-  "modified": "2022-12-27T22:03:26Z",
+  "modified": "2023-01-27T05:06:22Z",
   "published": "2022-10-19T20:26:05Z",
   "aliases": [
     "CVE-2022-31683"
@@ -70,6 +70,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/concourse/concourse/pull/8580"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concourse/concourse/commit/57e06711b0d861775a5a6bd078a34abeb0e2638e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concourse/concourse/commit/ba885834d9bcbb9d1ccb9964faa7af0e78a72205"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch links for v6.7.9: https://github.com/concourse/concourse/commit/ba885834d9bcbb9d1ccb9964faa7af0e78a72205

Adding the patch links for v7.8.3: https://github.com/concourse/concourse/commit/57e06711b0d861775a5a6bd078a34abeb0e2638e

Adding the commit patch link directly into the advisory for their respective versions. They are from the original pull 8566: "fix team_name overwritten bug"