### PR TITLE
[GHSA-6278-2q4m-cmf3] ZK Framework vulnerable to malicious POST

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-6278-2q4m-cmf3/GHSA-6278-2q4m-cmf3.json
+++ b/advisories/github-reviewed/2022/08/GHSA-6278-2q4m-cmf3/GHSA-6278-2q4m-cmf3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6278-2q4m-cmf3",
-  "modified": "2022-09-16T18:37:18Z",
+  "modified": "2023-03-01T01:56:00Z",
   "published": "2022-08-27T00:00:43Z",
   "aliases": [
     "CVE-2022-36537"
@@ -115,6 +115,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36537"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/zkoss/zk/commit/92a29aa9b1daf1fd2d9d188cb6545f0441d54e84"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch links for the latest versions of v9.X: https://github.com/zkoss/zk/commit/92a29aa9b1daf1fd2d9d188cb6545f0441d54e84

The same tracker id from the original reference links (ZK-5150) is mentioned in the commit patch message: "ZK-5150: uploading issue"