### PR TITLE
[GHSA-6q49-35h6-rq2p] Browsershot version 3.57.3 vulnerable to improper input validation

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-6q49-35h6-rq2p/GHSA-6q49-35h6-rq2p.json
+++ b/advisories/github-reviewed/2022/11/GHSA-6q49-35h6-rq2p/GHSA-6q49-35h6-rq2p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6q49-35h6-rq2p",
-  "modified": "2022-12-02T22:32:45Z",
+  "modified": "2023-02-03T05:01:31Z",
   "published": "2022-11-25T18:30:25Z",
   "aliases": [
     "CVE-2022-43984"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43984"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spatie/browsershot/commit/554c3e566fde8c47ad1ac9be47eaeb9a84c4dfe2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spatie/browsershot/commit/92cf16fc098211731f80d21687abeafbe2c457ad"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch links for the latest versions of v3.57.4: https://github.com/spatie/browsershot/commit/92cf16fc098211731f80d21687abeafbe2c457ad

https://github.com/spatie/browsershot/commit/554c3e566fde8c47ad1ac9be47eaeb9a84c4dfe2

We can see the developer no longer allows file:// in the Browsershot::html method: "do not allow file urls"

An additional commit was later added to allow users to explicitly enable files for HTML content, which I believe would be helpful for the advisory: "Allow user to explicitly use a local file for html content."