### PR TITLE
[GHSA-6v39-p2xq-g5c3] Missing authentication in ShenYu

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-6v39-p2xq-g5c3/GHSA-6v39-p2xq-g5c3.json
+++ b/advisories/github-reviewed/2022/01/GHSA-6v39-p2xq-g5c3/GHSA-6v39-p2xq-g5c3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6v39-p2xq-g5c3",
-  "modified": "2022-02-02T16:16:05Z",
+  "modified": "2023-02-03T05:05:20Z",
   "published": "2022-01-28T22:13:44Z",
   "aliases": [
     "CVE-2022-23944"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23944"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/incubator-shenyu/pull/2462"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/shenyu/pull/2462/commits/50e4b5e626ad94b415e26ef4fbe584bd51fd1b77"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding patch link for v2.4.2: https://github.com/apache/shenyu/pull/2462/commits/50e4b5e626ad94b415e26ef4fbe584bd51fd1b77

Adding PR: https://github.com/apache/incubator-shenyu/pull/2462

The PR was referenced in an original reference (https://www.openwall.com/lists/oss-security/2022/01/26/2)

"Upgrade to Apache ShenYu (incubating) 2.4.2 or apply patch
https://github.com/apache/incubator-shenyu/pull/2462."