### PR TITLE
[GHSA-5pm2-9mr2-3frq] Component takeover in Oracle Data Provider for .NET

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-5pm2-9mr2-3frq/GHSA-5pm2-9mr2-3frq.json
+++ b/advisories/github-reviewed/2023/01/GHSA-5pm2-9mr2-3frq/GHSA-5pm2-9mr2-3frq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5pm2-9mr2-3frq",
-  "modified": "2023-04-13T17:39:27Z",
+  "modified": "2023-04-13T17:39:30Z",
   "published": "2023-01-18T00:30:16Z",
   "aliases": [
     "CVE-2023-21893"
@@ -48,6 +48,44 @@
             },
             {
               "fixed": "3.21.90"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Oracle.ManagedDataAccess"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "19.18.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Oracle.ManagedDataAccess.Core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.19.80"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The CVE was fixed in ODP.NET 19c lines as well, starting with Oracle.ManagedDataAccess 19.18 and Oracle.ManagedDataAccess.Core 2.19.80. Here are the excerpts from these two product NuGet READMEs.


Bug Fixes since Oracle.ManagedDataAccess.Core NuGet Package 2.19.170
====================================================================
...
Bug 34617083 RESOLVE CVE-2023-21893


Bug Fixes since Oracle.ManagedDataAccess NuGet Package 19.17.0
===================================================================
...
Bug 34617083 RESOLVE CVE-2023-21893