### PR TITLE
[GHSA-gv7g-x59x-wf8f] SvelteKit framework has Insufficient CSRF protection for CORS requests

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-gv7g-x59x-wf8f/GHSA-gv7g-x59x-wf8f.json
+++ b/advisories/github-reviewed/2023/04/GHSA-gv7g-x59x-wf8f/GHSA-gv7g-x59x-wf8f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gv7g-x59x-wf8f",
-  "modified": "2023-04-14T20:30:47Z",
+  "modified": "2023-04-14T20:30:48Z",
   "published": "2023-04-07T19:23:31Z",
   "aliases": [
     "CVE-2023-29008"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:A/AC:L/PR:N/UI:R/S:C/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -55,10 +55,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-352",
-      "CWE-918"
+
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2023-04-07T19:23:31Z",
     "nvd_published_at": "2023-04-06T17:15:00Z"


### PR DESCRIPTION
**Updates**
- CVSS
- CWEs
- Severity

**Comments**
This has to be a mistake 