### PR TITLE
[GHSA-m2qf-hxjv-5gpq] Flask vulnerable to possible disclosure of permanent session cookie due to missing Vary: Cookie header

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-m2qf-hxjv-5gpq/GHSA-m2qf-hxjv-5gpq.json
+++ b/advisories/github-reviewed/2023/05/GHSA-m2qf-hxjv-5gpq/GHSA-m2qf-hxjv-5gpq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m2qf-hxjv-5gpq",
-  "modified": "2023-05-01T19:22:20Z",
+  "modified": "2023-05-01T19:22:46Z",
   "published": "2023-05-01T19:22:20Z",
   "aliases": [
     "CVE-2023-30861"
@@ -20,11 +20,6 @@
         "ecosystem": "PyPI",
         "name": "flask"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "flask.sessions.SecureCookieSessionInterface.save_session"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.3.2"
+              "fixed": "2.2.5, 2.3.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.3.2"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The fix was backported to the 2.2.x branch, released in Flask 2.2.5.