### PR TITLE
[GHSA-h3qr-39j9-4r5v] Data written to GitHub Actions Cache may expose secrets

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-h3qr-39j9-4r5v/GHSA-h3qr-39j9-4r5v.json
+++ b/advisories/github-reviewed/2023/05/GHSA-h3qr-39j9-4r5v/GHSA-h3qr-39j9-4r5v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h3qr-39j9-4r5v",
-  "modified": "2023-05-01T13:42:44Z",
+  "modified": "2023-05-01T13:42:45Z",
   "published": "2023-05-01T13:42:44Z",
   "aliases": [
     "CVE-2023-30853"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.4.2"
+              "fixed": "2.4.2, 2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.4.2"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
I'm the original author of this security advisory. 
Using the floating `v2` version will result in using the latest `v2.x` version of the action, so this version is also effectively patched.
Ideally, the Dependabot alert could be updated with this information, so that users aren't forced to either dismiss the alert or switch to the pinned `v2.4.2` version.
