### PR TITLE
[GHSA-5pm2-9mr2-3frq] Component takeover in Oracle Data Provider for .NET

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-5pm2-9mr2-3frq/GHSA-5pm2-9mr2-3frq.json
+++ b/advisories/github-reviewed/2023/01/GHSA-5pm2-9mr2-3frq/GHSA-5pm2-9mr2-3frq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5pm2-9mr2-3frq",
-  "modified": "2023-04-13T17:39:27Z",
+  "modified": "2023-05-01T19:29:38Z",
   "published": "2023-01-18T00:30:16Z",
   "aliases": [
     "CVE-2023-21893"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "20.0.0"
+              "introduced": "21.0.0"
             },
             {
               "fixed": "21.9.0"
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.0.0"
+              "introduced": "3.21.0"
             },
             {
               "fixed": "3.21.90"
@@ -63,7 +63,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "19.0.0"
             },
             {
               "fixed": "19.18.0"
@@ -82,10 +82,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.19.0"
             },
             {
-              "fixed": "2.19.80"
+              "fixed": "2.19.180"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Corrected the affected versions. Specifically, later ODP.NET 19.x versions have the CVE fix. Versions earlier than 19.x are not stated as affected in the CVE.