### PR TITLE
[GHSA-c25x-cm9x-qqgx] Deno improperly handles resizable ArrayBuffer

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-c25x-cm9x-qqgx/GHSA-c25x-cm9x-qqgx.json
+++ b/advisories/github-reviewed/2023/03/GHSA-c25x-cm9x-qqgx/GHSA-c25x-cm9x-qqgx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c25x-cm9x-qqgx",
-  "modified": "2023-05-01T21:25:28Z",
+  "modified": "2023-05-01T21:25:29Z",
   "published": "2023-03-23T23:13:25Z",
   "aliases": [
     "CVE-2023-28445"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.32.0"
             },
             {
               "fixed": "1.32.1"
@@ -33,9 +33,9 @@
           ]
         }
       ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 1.32.0"
-      }
+      "versions": [
+        "1.32.0"
+      ]
     },
     {
       "package": {
@@ -47,7 +47,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.87.0"
             },
             {
               "fixed": "0.88.0"
@@ -55,9 +55,9 @@
           ]
         }
       ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 0.87.0"
-      }
+      "versions": [
+        "0.87.0"
+      ]
     },
     {
       "package": {
@@ -69,7 +69,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.102.0"
             },
             {
               "fixed": "0.103.0"
@@ -77,9 +77,9 @@
           ]
         }
       ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 0.102.0"
-      }
+      "versions": [
+        "0.102.0"
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The change only affects a single specific rev - not the wide range specified previously.

See the source advisory here.
https://github.com/denoland/deno/security/advisories/GHSA-c25x-cm9x-qqgx
