### PR TITLE
[GHSA-5pm2-9mr2-3frq] Component takeover in Oracle Data Provider for .NET

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-5pm2-9mr2-3frq/GHSA-5pm2-9mr2-3frq.json
+++ b/advisories/github-reviewed/2023/01/GHSA-5pm2-9mr2-3frq/GHSA-5pm2-9mr2-3frq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5pm2-9mr2-3frq",
-  "modified": "2023-04-13T17:39:27Z",
+  "modified": "2023-05-04T21:13:11Z",
   "published": "2023-01-18T00:30:16Z",
   "aliases": [
     "CVE-2023-21893"
@@ -85,7 +85,7 @@
               "introduced": "2.19.0"
             },
             {
-              "fixed": "2.19.80"
+              "fixed": "2.19.180"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Updated the patched version for Oracle.ManagedDataAccess.Core. It was mistakenly marked as fixed in 2.19.80. The actual fixed version is 2.19.180. From the Oracle.ManagedDataAccess.Core 2.19.180 README:

===
Bug Fixes since Oracle.ManagedDataAccess.Core NuGet Package 2.19.170
====================================================================
...
Bug 34617083 RESOLVE CVE-2023-21893
