### PR TITLE
[GHSA-22fx-6r9m-r8h9] A Segmentation fault caused by a floating point exception...

### DIFF
--- a/advisories/unreviewed/2023/05/GHSA-22fx-6r9m-r8h9/GHSA-22fx-6r9m-r8h9.json
+++ b/advisories/unreviewed/2023/05/GHSA-22fx-6r9m-r8h9/GHSA-22fx-6r9m-r8h9.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-22fx-6r9m-r8h9",
-  "modified": "2023-05-05T18:30:17Z",
+  "modified": "2023-05-05T18:30:22Z",
   "published": "2023-05-05T18:30:17Z",
   "aliases": [
     "CVE-2023-29659"
   ],
+  "summary": "libheif: segfault caused by divide-by-zero",
   "details": "A Segmentation fault caused by a floating point exception exists in libheif 1.15.1 using crafted heif images via the heif::Fraction::round() function in box.cc, which causes a denial of service.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "GitHub Actions",
+        "name": "libheif"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.15.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
https://github.com/strukturag/libheif/commit/e05e15b57a38ec411cb9acb38512a1c36ff62991 is tagged for 1.15.2+