### PR TITLE
[GHSA-rc2q-x9mf-w3vf] TestNG is vulnerable to Path Traversal

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-rc2q-x9mf-w3vf/GHSA-rc2q-x9mf-w3vf.json
+++ b/advisories/github-reviewed/2022/11/GHSA-rc2q-x9mf-w3vf/GHSA-rc2q-x9mf-w3vf.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rc2q-x9mf-w3vf",
-  "modified": "2023-05-01T20:10:56Z",
+  "modified": "2023-05-01T20:10:57Z",
   "published": "2022-11-19T21:30:25Z",
   "aliases": [
     "CVE-2022-4065"
   ],
   "summary": "TestNG is vulnerable to Path Traversal",
-  "details": "### Impact\n\nAffected by this vulnerability is the function `testngXmlExistsInJar` of the file `testng-core/src/main/java/org/testng/JarFileUtils.java` of the component `XML File Parser`.\n\nThe manipulation leads to path traversal only for `.xml`, `.yaml` and `.yml` files by default. The attack implies running an unsafe test JAR. However since that JAR can also contain executable code itself, the path traversal is unlikely to be the main attack.\n\n### Patches\n\nA patch is available in [version 7.7.0](https://github.com/cbeust/testng/releases/tag/7.7.0) at commit 9150736cd2c123a6a3b60e6193630859f9f0422b. It is recommended to apply a patch to fix this issue. The patch was pushed into the master branch but no releases have yet been made with the patch included.\n\n### Workaround\n\n* Specify which tests to run when invoking TestNG by configuring them on the CLI or in the build tool controlling the run.\n* Do not run tests with untrusted JARs on the classpath, this includes pull requests on open source projects.",
+  "details": "### Impact\n\nAffected by this vulnerability is the function `testngXmlExistsInJar` of the file `testng-core/src/main/java/org/testng/JarFileUtils.java` of the component `XML File Parser`.\n\nThe manipulation leads to path traversal only for `.xml`, `.yaml` and `.yml` files by default. The attack implies running an unsafe test JAR. However since that JAR can also contain executable code itself, the path traversal is unlikely to be the main attack.\n\n### Patches\n\nA patch is available in [version 7.7.0](https://github.com/cbeust/testng/releases/tag/7.7.0) at commit 9150736cd2c123a6a3b60e6193630859f9f0422b. It is recommended to apply a patch to fix this issue. The patch was pushed into the master branch but no releases have yet been made with the patch included.\n\nA backport of the fix is available in [version 7.5.1]((https://github.com/cbeust/testng/releases/tag/7.5.1) for Java 8 projects.\n\n### Workaround\n\n* Specify which tests to run when invoking TestNG by configuring them on the CLI or in the build tool controlling the run.\n* Do not run tests with untrusted JARs on the classpath, this includes pull requests on open source projects.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,11 +28,14 @@
               "introduced": "6.13"
             },
             {
-              "fixed": "7.7.0"
+              "fixed": "7.7.0, 7.5.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 7.7.0"
+      }
     }
   ],
   "references": [
@@ -50,11 +53,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/testng-team/testng/pull/2899"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/cbeust/testng/commit/9150736cd2c123a6a3b60e6193630859f9f0422b"
     },
     {
       "type": "PACKAGE",
       "url": "https://github.com/cbeust/testng"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cbeust/testng/releases/tag/7.5.1"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
Include information about the fixversion testng 7.5.1 because the fix was backported, see https://github.com/testng-team/testng/pull/2899 and https://github.com/testng-team/testng/releases/tag/7.5.1.

See also https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4065.
