### PR TITLE
[GHSA-4r6h-8v6p-xvw6] Prototype Pollution in sheetJS

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-4r6h-8v6p-xvw6/GHSA-4r6h-8v6p-xvw6.json
+++ b/advisories/github-reviewed/2023/04/GHSA-4r6h-8v6p-xvw6/GHSA-4r6h-8v6p-xvw6.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4r6h-8v6p-xvw6",
-  "modified": "2023-05-02T21:53:21Z",
+  "modified": "2023-05-02T21:53:23Z",
   "published": "2023-04-24T09:30:19Z",
   "aliases": [
     "CVE-2023-30533"
   ],
   "summary": "Prototype Pollution in sheetJS",
-  "details": "All versions of SheetJS CE through 0.19.2 are vulnerable to \"Prototype Pollution\" when reading specially crafted files. Workflows that do not read arbitrary files (for example, exporting data to spreadsheet files) are unaffected. ",
+  "details": "All versions of SheetJS CE through 0.19.2 are vulnerable to \"Prototype Pollution\" when reading specially crafted files. Workflows that do not read arbitrary files (for example, exporting data to spreadsheet files) are unaffected. \n\nNote that a non-vulnerable version cannot be found via NPM, as the repository hosted on Github.com and the NPM package `xlxs` are no longer maintained.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://cdn.sheetjs.com/advisories/CVE-2023-30533"
+    },
+    {
+      "type": "WEB",
+      "url": "https://git.sheetjs.com/sheetjs/sheetjs/issues/2667"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Description
- References

**Comments**
The NPM package `xlxs`and the repository hosted on Github.com are no longer maintained by SheetJS, see https://git.sheetjs.com/sheetjs/sheetjs/issues/2667. Hence, no fixed version will be released via NPM.