### PR TITLE
[GHSA-vg27-hr3v-3cqv] open redirect in pollbot

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-vg27-hr3v-3cqv/GHSA-vg27-hr3v-3cqv.json
+++ b/advisories/github-reviewed/2022/02/GHSA-vg27-hr3v-3cqv/GHSA-vg27-hr3v-3cqv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vg27-hr3v-3cqv",
-  "modified": "2023-02-28T16:49:36Z",
+  "modified": "2023-02-28T16:49:39Z",
   "published": "2022-02-16T23:02:09Z",
   "aliases": [
     "CVE-2022-0637"
@@ -43,6 +43,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-0637"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mozilla/PollBot/pull/360"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mozilla/PollBot/commit/e39d8bec2df582ba525bb2e2f33c3ebc584d7ff8"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.4.6: https://github.com/mozilla/PollBot/commit/e39d8bec2df582ba525bb2e2f33c3ebc584d7ff8

Adding the PR: https://github.com/mozilla/PollBot/pull/360

The commit patch message matches the original BugZilla ID (https://bugzilla.mozilla.org/show_bug.cgi?id=1753838). This is also the squashed commit from pull 360: "[Bug 1753838] Harden trailing slashes redirect" 