### PR TITLE
[GHSA-vrv8-v4w8-f95h] Cross-site scripting vulnerability in TinyMCE

### DIFF
--- a/advisories/github-reviewed/2020/08/GHSA-vrv8-v4w8-f95h/GHSA-vrv8-v4w8-f95h.json
+++ b/advisories/github-reviewed/2020/08/GHSA-vrv8-v4w8-f95h/GHSA-vrv8-v4w8-f95h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vrv8-v4w8-f95h",
-  "modified": "2020-08-11T16:24:30Z",
+  "modified": "2023-02-01T05:04:23Z",
   "published": "2020-08-11T14:55:01Z",
   "aliases": [
 
@@ -55,6 +55,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/tinymce/tinymce/security/advisories/GHSA-vrv8-v4w8-f95h"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/tinymce/tinymce/pull/5843"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/tinymce/tinymce/pull/5843/commits/696e43658dc9750ec24fdc4650bd2be9653daf5b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/tinymce/tinymce/commit/2b71c922214d388838d930806207a66c14e80f63"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v4.9.11: https://github.com/tinymce/tinymce/commit/2b71c922214d388838d930806207a66c14e80f63

Adding the patch link for v5.4.1: https://github.com/tinymce/tinymce/pull/5843/commits/696e43658dc9750ec24fdc4650bd2be9653daf5b

Adding the PR: https://github.com/tinymce/tinymce/pull/5843

The security release text (https://www.tiny.cloud/docs/release-notes/release-notes54/#securityfixes):
"TinyMCE 5.4 provides fixes for the following security issues:
Fixed content in an iframe element parsing as DOM elements instead of text content."

Matches the updated changelog in the patch commit: "Fixed content in an iframe element parsing as dom elements instead of text content #TINY-5943"