### PR TITLE
[GHSA-v9j4-cp63-qv62] Tarslip in go-unarr

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-v9j4-cp63-qv62/GHSA-v9j4-cp63-qv62.json
+++ b/advisories/github-reviewed/2021/09/GHSA-v9j4-cp63-qv62/GHSA-v9j4-cp63-qv62.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v9j4-cp63-qv62",
-  "modified": "2021-08-30T21:24:59Z",
+  "modified": "2023-02-01T05:06:18Z",
   "published": "2021-09-01T18:32:02Z",
   "aliases": [
     "CVE-2021-38197"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.1.1"
+              "fixed": "0.1.4"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.1.3"
+      }
     }
   ],
   "references": [
@@ -43,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/gen2brain/go-unarr/issues/21"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/gen2brain/go-unarr/commit/239ec404d348280b50bbf671327709e8857fc5f4"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Reference : 

https://github.com/gen2brain/go-unarr/commit/239ec404d348280b50bbf671327709e8857fc5f4
https://pkg.go.dev/github.com/gen2brain/go-unarr?tab=versions