### PR TITLE
[GHSA-98g7-rxmf-rrxm] fabric8 kubernetes-client vulnerable 

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-98g7-rxmf-rrxm/GHSA-98g7-rxmf-rrxm.json
+++ b/advisories/github-reviewed/2022/07/GHSA-98g7-rxmf-rrxm/GHSA-98g7-rxmf-rrxm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-98g7-rxmf-rrxm",
-  "modified": "2022-09-08T14:19:24Z",
+  "modified": "2023-01-31T05:03:35Z",
   "published": "2022-07-15T05:17:35Z",
   "aliases": [
     "CVE-2021-4178"
@@ -157,6 +157,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/fabric8io/kubernetes-client/issues/3653"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/fabric8io/kubernetes-client/commit/445103004d1ed3153d5abb272473451d05891e39"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v5.X: https://github.com/fabric8io/kubernetes-client/commit/445103004d1ed3153d5abb272473451d05891e39

Within the original reference link (https://bugzilla.redhat.com/show_bug.cgi?id=2034388), a developer mentions: "A flaw was found in kubernetes-client. An insecure deserialization issue due to the use of the SnakeYAML library may lead to arbitrary code execution."

The following commit patch fixes the issue with SnakeYAML: "fix: SnakeYAML uses only standard Java types"