### PR TITLE
[GHSA-f683-35w9-28g5] Multiple vulnerabilities in extension "Newsletter subscriber management" (fp_newsletter)

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-f683-35w9-28g5/GHSA-f683-35w9-28g5.json
+++ b/advisories/github-reviewed/2022/12/GHSA-f683-35w9-28g5/GHSA-f683-35w9-28g5.json
@@ -80,6 +80,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/bihor/fp_newsletter/commit/bc673cd9ab04f3fdd1225303f2ccb378b11a3747"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/FriendsOfPHP/security-advisories/blob/master/fixpunkt/fp-newsletter/CVE-2022-47408.yaml"
     },
     {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for the latest v3.2.6: https://github.com/bihor/fp_newsletter/commit/bc673cd9ab04f3fdd1225303f2ccb378b11a3747

As the advisory describes, "multiple vulnerabilities" and multiple were fixed related to the advisory (CAPTCHA bypass, arbitrary subscriptions, and information disclosures):"
Security fix: default password for fe_users set to a random password.	 
  
Security fix: mathematical captcha check enhanced (it was possible to cheat).	 
  
Security fix: settings.doubleOptOut set from 0 to 1. You can set it to 0 if you don't want a double opt out subscription.	 
  
Security fix: additional check added to the delete-action (it was possible to unsubscribe all users).	 
  
Security fix: Information Disclosure in the new- and unsubscribe-action."