### PR TITLE
[GHSA-vwjc-q9px-r9vq] Denial of Service in ecstatic

### DIFF
--- a/advisories/github-reviewed/2018/06/GHSA-vwjc-q9px-r9vq/GHSA-vwjc-q9px-r9vq.json
+++ b/advisories/github-reviewed/2018/06/GHSA-vwjc-q9px-r9vq/GHSA-vwjc-q9px-r9vq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vwjc-q9px-r9vq",
-  "modified": "2020-08-31T18:09:49Z",
+  "modified": "2023-01-09T05:03:26Z",
   "published": "2018-06-07T19:43:11Z",
   "aliases": [
     "CVE-2015-9242"
@@ -40,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/jfhbrook/node-ecstatic/pull/179"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jfhbrook/node-ecstatic/commit/0d0a2779ac5e5843d3745920212dfac9b69440e2"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for the v1.4.0: https://github.com/jfhbrook/node-ecstatic/commit/0d0a2779ac5e5843d3745920212dfac9b69440e2

This is from the original pull 179 to do the actual fix by adding checks: "put modifiedDate check in a block, check for Invalid Date case"