### PR TITLE
[GHSA-w9vv-q986-vj7x] Out of bounds read in uu_od

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-w9vv-q986-vj7x/GHSA-w9vv-q986-vj7x.json
+++ b/advisories/github-reviewed/2021/08/GHSA-w9vv-q986-vj7x/GHSA-w9vv-q986-vj7x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w9vv-q986-vj7x",
-  "modified": "2021-08-19T17:09:13Z",
+  "modified": "2023-02-03T05:05:57Z",
   "published": "2021-08-25T20:54:24Z",
   "aliases": [
     "CVE-2021-29934"
@@ -43,6 +43,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/uutils/coreutils/issues/1729"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/uutils/coreutils/commit/39d62c6c1f809022c903180471c10fde6ecd12d1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/uutils/coreutils/commit/5935876f38498b0c1f657d031171eb17028def6f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/uutils/coreutils/commit/7341a1a033aa5980ac59bc9d4df978b396de4fad"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch links for the v0.0.4: https://github.com/uutils/coreutils/commit/39d62c6c1f809022c903180471c10fde6ecd12d1

https://github.com/uutils/coreutils/commit/7341a1a033aa5980ac59bc9d4df978b396de4fad

https://github.com/uutils/coreutils/commit/5935876f38498b0c1f657d031171eb17028def6f

This took three different pulls (1730, 1738, and 1739) to resolve the vulnerability as described in the original issue (1729): "This should be resolved now that the linked PRs have been merged." Each of the commits added is the squash from each pull. 