### PR TITLE
[GHSA-7mvr-5x2g-wfc8] Bootstrap Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2018/09/GHSA-7mvr-5x2g-wfc8/GHSA-7mvr-5x2g-wfc8.json
+++ b/advisories/github-reviewed/2018/09/GHSA-7mvr-5x2g-wfc8/GHSA-7mvr-5x2g-wfc8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7mvr-5x2g-wfc8",
-  "modified": "2023-01-23T20:48:55Z",
+  "modified": "2023-01-23T20:48:57Z",
   "published": "2018-09-13T15:50:32Z",
   "aliases": [
     "CVE-2018-14042"
@@ -51,6 +51,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/twbs/bootstrap/pull/26630"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/twbs/bootstrap/commit/2d90d369bbc2bd2647620246c55cec8c4705e3d0"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch links for the v4.1.2: https://github.com/twbs/bootstrap/commit/2d90d369bbc2bd2647620246c55cec8c4705e3d0

The original pull (26630) fixed three CVEs. The commit patch link added is specifically for CVE-2018-14042, which is for the XSS in tooltip: "fix(tooltip): xss in container option" 