### PR TITLE
[GHSA-2c7v-qcjp-4mg2] .NET Remote Code Execution Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-2c7v-qcjp-4mg2/GHSA-2c7v-qcjp-4mg2.json
+++ b/advisories/github-reviewed/2022/12/GHSA-2c7v-qcjp-4mg2/GHSA-2c7v-qcjp-4mg2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2c7v-qcjp-4mg2",
-  "modified": "2022-12-14T21:42:00Z",
+  "modified": "2023-01-07T05:05:08Z",
   "published": "2022-12-14T21:42:00Z",
   "aliases": [
     "CVE-2022-41089"
@@ -197,6 +197,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/dotnet/announcements/issues/242"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/dotnet/wpf/commit/5f4c0f7763a06b024c8a517616e0fc0194e997a4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/dotnet/wpf/commit/7b0be4d41c33ce8525d8160bf8869cac10f8a8cd"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/dotnet/wpf/commit/c08825a9889e6c798fe95ed5ec1f6a9f517ab5a0"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for the v3.1.32: https://github.com/dotnet/wpf/commit/7b0be4d41c33ce8525d8160bf8869cac10f8a8cd

Adding the patch link for the v6.0.12: https://github.com/dotnet/wpf/commit/c08825a9889e6c798fe95ed5ec1f6a9f517ab5a0

Adding the patch link for the v7.0.1: https://github.com/dotnet/wpf/commit/5f4c0f7763a06b024c8a517616e0fc0194e997a4

The CVE is in the commit message: "Change RestrictiveXamlXmlReader to use an allow list
- Removes the old deny list logic used by RestrictiveXamlXmlReader
- Provides an extensible (via registry) allow list mechanism

Fixes CVE-2022-41089."