### PR TITLE
[GHSA-f865-m6cq-j9vx] ReDOS in Mpmath

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-f865-m6cq-j9vx/GHSA-f865-m6cq-j9vx.json
+++ b/advisories/github-reviewed/2021/08/GHSA-f865-m6cq-j9vx/GHSA-f865-m6cq-j9vx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f865-m6cq-j9vx",
-  "modified": "2021-10-08T20:45:06Z",
+  "modified": "2023-01-27T05:02:27Z",
   "published": "2021-08-09T20:44:51Z",
   "aliases": [
     "CVE-2021-29063"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.0.0"
+              "fixed": "1.3.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.0.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
There is a patched version released 1.3.0