### PR TITLE
[GHSA-9jxw-cfrh-jxq6] Cachet vulnerable to new line injection during configuration edition

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-9jxw-cfrh-jxq6/GHSA-9jxw-cfrh-jxq6.json
+++ b/advisories/github-reviewed/2021/08/GHSA-9jxw-cfrh-jxq6/GHSA-9jxw-cfrh-jxq6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9jxw-cfrh-jxq6",
-  "modified": "2022-08-11T00:16:20Z",
+  "modified": "2023-01-29T05:02:54Z",
   "published": "2021-08-30T16:11:24Z",
   "aliases": [
     "CVE-2021-39172"
@@ -43,6 +43,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-39172"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/fiveai/Cachet/commit/6442976c25930cb370c65a22784b9caee7ed1de2"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for the v2.5.1: https://github.com/fiveai/Cachet/commit/6442976c25930cb370c65a22784b9caee7ed1de2

The GHSA-ID is in the commit message: "Prevent new lines and variables in settings values GHSA-88f9-7xxh-c688 and GHSA-9jxw-cfrh-jxq6"