### PR TITLE
[GHSA-3wqf-4x89-9g79] Bootstrap vulnerable to Cross-Site Scripting (XSS)

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-3wqf-4x89-9g79/GHSA-3wqf-4x89-9g79.json
+++ b/advisories/github-reviewed/2022/05/GHSA-3wqf-4x89-9g79/GHSA-3wqf-4x89-9g79.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3wqf-4x89-9g79",
-  "modified": "2023-01-24T15:59:21Z",
+  "modified": "2023-03-31T18:12:49Z",
   "published": "2022-05-13T01:07:54Z",
   "aliases": [
     "CVE-2018-14040"
@@ -51,6 +51,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/twbs/bootstrap/pull/26630"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/twbs/bootstrap/commit/149096016f70fd815540d62c0989fd99cdc809e0"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for the v4.1.2: https://github.com/twbs/bootstrap/commit/149096016f70fd815540d62c0989fd99cdc809e0

The original pull (26630) fixed three CVEs. The commit patch link added is specifically for CVE-2018-14040, which is for the XSS in collapse: "fix(collapse): xss in parent option"