### PR TITLE
[GHSA-3jqw-vv45-mjhh] XSS/Script injection vulnerability in matestack

### DIFF
--- a/advisories/github-reviewed/2020/02/GHSA-3jqw-vv45-mjhh/GHSA-3jqw-vv45-mjhh.json
+++ b/advisories/github-reviewed/2020/02/GHSA-3jqw-vv45-mjhh/GHSA-3jqw-vv45-mjhh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3jqw-vv45-mjhh",
-  "modified": "2021-01-08T20:29:59Z",
+  "modified": "2023-05-04T19:56:51Z",
   "published": "2020-02-12T23:37:46Z",
   "aliases": [
     "CVE-2020-5241"
@@ -43,6 +43,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-5241"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/matestack/matestack-ui-core/commit/5c61571739e860db9ca578fe09ab4733878cb0fc"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/matestack/matestack-ui-core/commit/e96915cf20c4fa0571df7fa21e9b09a69be19107"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch links for the v0.7.4: https://github.com/matestack/matestack-ui-core/commit/e96915cf20c4fa0571df7fa21e9b09a69be19107

https://github.com/matestack/matestack-ui-core/commit/5c61571739e860db9ca578fe09ab4733878cb0fc

Here the developers started to escape the incoming argument in the Plain class to avoid any potentially malicious inputs: "Fix basic XSS vector, check with more of them" 

"Explicitly define html_escape In async actions the view context doesn't seem to be available, from where html_escape was called before."