### PR TITLE
[GHSA-7774-7vr3-cc8j] Authorization Policy Bypass Due to Case Insensitive Host Comparison

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-7774-7vr3-cc8j/GHSA-7774-7vr3-cc8j.json
+++ b/advisories/github-reviewed/2021/08/GHSA-7774-7vr3-cc8j/GHSA-7774-7vr3-cc8j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7774-7vr3-cc8j",
-  "modified": "2021-12-13T13:09:54Z",
+  "modified": "2023-01-27T05:02:08Z",
   "published": "2021-08-30T16:15:56Z",
   "aliases": [
     "CVE-2021-39155"
@@ -84,6 +84,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-39155"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/istio/istio/commit/084b417a486dbe9b9024d4812877016a484572b1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/istio/istio/commit/76ed51413ddd2a7fa253a368ab20a9cec5fb1cbe"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/istio/istio/commit/90b00bdf891e6c770cb3235c14a9b1fda96cc7c5"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.9.8: https://github.com/istio/istio/commit/084b417a486dbe9b9024d4812877016a484572b1

Adding the patch link for v1.10.4: https://github.com/istio/istio/commit/76ed51413ddd2a7fa253a368ab20a9cec5fb1cbe

Adding the patch link for v1.11.1: https://github.com/istio/istio/commit/90b00bdf891e6c770cb3235c14a9b1fda96cc7c5

The patch links apply a case-insensitive match for host fields, which is similar to the original advisory description: "use case-insensitive match for host field in authz"