### PR TITLE
[GHSA-7wg4-8m5p-hrfg] HashiCorp Nomad vulnerable to non-sensitive metadata exposure

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-7wg4-8m5p-hrfg/GHSA-7wg4-8m5p-hrfg.json
+++ b/advisories/github-reviewed/2022/11/GHSA-7wg4-8m5p-hrfg/GHSA-7wg4-8m5p-hrfg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7wg4-8m5p-hrfg",
-  "modified": "2022-11-10T23:51:44Z",
+  "modified": "2023-01-30T05:07:49Z",
   "published": "2022-11-10T12:01:03Z",
   "aliases": [
     "CVE-2022-3866"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-3866"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hashicorp/nomad/commit/3b24f26603e2b116ba324101afa8a7e3a7a769a5"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v1.4.2: https://github.com/hashicorp/nomad/commit/3b24f26603e2b116ba324101afa8a7e3a7a769a5

The updated changelog during the patch link is very similar to the advisory: "Fixed a bug where non-sensitive variable metadata (paths and raft indexes) was exposed via the template `nomadVarList` function to other jobs in the same namespace."