### PR TITLE
[GHSA-r773-pmw3-f4mr] Open Redirect in koa-remove-trailing-slashes

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-r773-pmw3-f4mr/GHSA-r773-pmw3-f4mr.json
+++ b/advisories/github-reviewed/2022/02/GHSA-r773-pmw3-f4mr/GHSA-r773-pmw3-f4mr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r773-pmw3-f4mr",
-  "modified": "2021-05-19T17:57:27Z",
+  "modified": "2023-02-01T05:05:42Z",
   "published": "2022-02-10T23:47:27Z",
   "aliases": [
     "CVE-2021-23384"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-23384"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vgno/koa-remove-trailing-slashes/commit/e7ce4000e9fe4d957332df1056640a22ebea28ee"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v2.0.2: https://github.com/vgno/koa-remove-trailing-slashes/commit/e7ce4000e9fe4d957332df1056640a22ebea28ee

The developer removed the ability to redirect from relative URLs. Additionally, the patched code is in the same location as the advisory (index.js::removeTrailingSlashes()): "fix: only redirect for current origin"