### PR TITLE
[GHSA-m589-mv4q-p7rj] webbrowser-rs allows attackers to access arbitrary files via supplying a crafted URL

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-m589-mv4q-p7rj/GHSA-m589-mv4q-p7rj.json
+++ b/advisories/github-reviewed/2023/01/GHSA-m589-mv4q-p7rj/GHSA-m589-mv4q-p7rj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m589-mv4q-p7rj",
-  "modified": "2023-01-23T18:49:42Z",
+  "modified": "2023-01-23T18:49:44Z",
   "published": "2023-01-13T21:30:26Z",
   "aliases": [
     "CVE-2022-45299"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-45299"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/amodm/webbrowser-rs/commit/431b5139e274b7e456bea27e768aaa121b97be4c"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.8.3: https://github.com/amodm/webbrowser-rs/commit/431b5139e274b7e456bea27e768aaa121b97be4c

The commit message is very similar to the original tag comment for the advisory (The guarantee of web browser being opened (instead of local file association), now solves for the scenario where the URL is crafted to be an executable.): "define consistent behavior to include opening web browser even for local files" "This library guarantees that it's a browser that is opened (as determined by `http` scheme association, not local file association)."