### PR TITLE
[GHSA-mh33-7rrq-662w] Improper Certificate Validation

### DIFF
--- a/advisories/github-reviewed/2019/04/GHSA-mh33-7rrq-662w/GHSA-mh33-7rrq-662w.json
+++ b/advisories/github-reviewed/2019/04/GHSA-mh33-7rrq-662w/GHSA-mh33-7rrq-662w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mh33-7rrq-662w",
-  "modified": "2021-06-16T19:56:57Z",
+  "modified": "2023-02-01T05:01:41Z",
   "published": "2019-04-19T16:55:10Z",
   "aliases": [
     "CVE-2019-11324"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2019:3590"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/urllib3/urllib3"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Source code location

**Comments**
Adding the source link: https://github.com/urllib3/urllib3

Also, adding a cleaner patch link 1.24.2: https://github.com/urllib3/urllib3/commit/1efadf43dc63317cd9eaa3e0fdb9e05ab07254b1

This was the only commit for v1.24.2: "Don't load system certificates by default when any other ``ca_certs``, ``ca_certs_dir`` or ``ssl_context`` parameters are specified." 