### PR TITLE
[GHSA-c4r9-r8fh-9vj2] snakeYAML before 1.31 vulnerable to Denial of Service due to Out-of-bounds Write

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-c4r9-r8fh-9vj2/GHSA-c4r9-r8fh-9vj2.json
+++ b/advisories/github-reviewed/2022/09/GHSA-c4r9-r8fh-9vj2/GHSA-c4r9-r8fh-9vj2.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c4r9-r8fh-9vj2",
-  "modified": "2022-09-15T03:27:43Z",
+  "modified": "2023-01-27T05:08:37Z",
   "published": "2022-09-06T00:00:27Z",
   "aliases": [
     "CVE-2022-38749"
   ],
   "summary": "snakeYAML before 1.31 vulnerable to Denial of Service due to Out-of-bounds Write",
-  "details": "Using snakeYAML to parse untrusted YAML files may be vulnerable to Denial of Service attacks (DOS). If the parser is running on user supplied input, an attacker may supply content that causes the parser to crash by stackoverflow.",
+  "details": "Using snakeYAML to parse untrusted YAML files may be vulnerable to Denial of Service attacks (DOS). If the parser is running on user supplied input, an attacker may supply content that causes the parser to crash by StackOverflow.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -29,6 +29,99 @@
             },
             {
               "fixed": "1.31"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "be.cylab:snakeyaml"
+      },
+      "versions": [
+        "1.25.1"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.alipay.sofa.acts:acts-common-util"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.prometheus.jmx:jmx_prometheus_httpserver"
+      },
+      "versions": [
+        "0.17.0"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.prometheus.jmx:jmx_prometheus_httpserver_java6"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "0.18.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.testifyproject.external:external-snakeyaml"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.0.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "pl.droidsonroids.yaml:snakeyaml"
+      },
+      "versions": [
+        "1.18-android"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "pl.droidsonroids.yaml:snakeyaml"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.18.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Several other components are also affected as a result of cloning or shading. Proof-of-Vulnerability projects with tests to verify the presence of the CVE can be found here: https://github.com/jensdietrich/xshady-release/ . Those projects were detected with a research tool  our team has developed.  