### PR TITLE
[GHSA-jmxr-w2jc-qp7w] Promotion names in Jenkins promoted builds Plugin are not validated when using Job DSL

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-jmxr-w2jc-qp7w/GHSA-jmxr-w2jc-qp7w.json
+++ b/advisories/github-reviewed/2022/04/GHSA-jmxr-w2jc-qp7w/GHSA-jmxr-w2jc-qp7w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jmxr-w2jc-qp7w",
-  "modified": "2022-12-01T23:45:18Z",
+  "modified": "2023-01-27T05:01:35Z",
   "published": "2022-04-13T00:00:16Z",
   "aliases": [
     "CVE-2022-29049"
@@ -47,7 +47,7 @@
               "introduced": "3.11"
             },
             {
-              "last_affected": "873.v6149db"
+              "fixed": "876.v99d29788b"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
updating to include fix as 876.v99d29788b per https://www.jenkins.io/security/advisory/2022-04-12/#SECURITY-2655 and based on the version range used in https://github.com/advisories/GHSA-v98r-gjgc-m9pf not including the `_36b_` suffix
