### PR TITLE
[GHSA-85rq-hp8x-ghjq] Cross-Site Request Forgery in Jenkins Mailer Plugin

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-85rq-hp8x-ghjq/GHSA-85rq-hp8x-ghjq.json
+++ b/advisories/github-reviewed/2022/01/GHSA-85rq-hp8x-ghjq/GHSA-85rq-hp8x-ghjq.json
@@ -25,10 +25,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.35"
             },
             {
               "fixed": "408.vd726a_1130320"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:mailer"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.34.2"
             }
           ]
         }

--- a/advisories/github-reviewed/2022/01/GHSA-85rq-hp8x-ghjq/GHSA-85rq-hp8x-ghjq.json
+++ b/advisories/github-reviewed/2022/01/GHSA-85rq-hp8x-ghjq/GHSA-85rq-hp8x-ghjq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-85rq-hp8x-ghjq",
-  "modified": "2022-11-29T18:22:40Z",
+  "modified": "2023-02-01T05:07:17Z",
   "published": "2022-01-13T00:01:04Z",
   "aliases": [
     "CVE-2022-20613"
@@ -32,10 +32,7 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 391.ve4a38c1bcf4b"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Updating affected version range to extend up to excluding the fix version.  ~~Also I see in https://nvd.nist.gov/vuln/detail/CVE-2022-20613 that it has version 1.34.2 as excluded but I don't see any mention of that in the Jenkins announcement at https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-2163 so have left that out for the moment~~

Added 1.34.2 in based on https://github.com/github/advisory-database/issues/771#issuecomment-1549355480