### PR TITLE
[GHSA-558x-h7rg-997v] Incorrect Permission Assignment for Critical Resource in Jenkins Mailer Plugin

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-558x-h7rg-997v/GHSA-558x-h7rg-997v.json
+++ b/advisories/github-reviewed/2022/01/GHSA-558x-h7rg-997v/GHSA-558x-h7rg-997v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-558x-h7rg-997v",
-  "modified": "2022-06-20T22:50:04Z",
+  "modified": "2023-01-30T05:03:37Z",
   "published": "2022-01-13T00:01:04Z",
   "aliases": [
     "CVE-2022-20614"
@@ -25,17 +25,33 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.35"
             },
             {
               "fixed": "408.vd726a_1130320"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 391.ve4a38c1bcf4b"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:mailer"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.34.2"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adds separate version range for 1.34.2 based on CVE range info from https://nvd.nist.gov/vuln/detail/CVE-2022-20614