### PR TITLE
[GHSA-6fr3-286q-q3cr] Improper Validation of Certificate with Host Mismatch in Jenkins Mailer Plugin

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-6fr3-286q-q3cr/GHSA-6fr3-286q-q3cr.json
+++ b/advisories/github-reviewed/2022/05/GHSA-6fr3-286q-q3cr/GHSA-6fr3-286q-q3cr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6fr3-286q-q3cr",
-  "modified": "2022-06-23T23:19:44Z",
+  "modified": "2023-01-27T05:02:37Z",
   "published": "2022-05-24T17:28:25Z",
   "aliases": [
     "CVE-2020-2252"
@@ -25,17 +25,52 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.32"
             },
             {
               "fixed": "1.32.1"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 1.32"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:mailer"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.30"
+            },
+            {
+              "fixed": "1.31.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:mailer"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.29.1"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Add backports based on cve.org data from https://github.com/CVEProject/cvelist/blob/16860a328d970faa6e4350b0fa446f64a52e52ca/2020/2xxx/CVE-2020-2252.json