### PR TITLE
[GHSA-599f-7c49-w659] Arbitrary code execution in Apache Commons Text

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-599f-7c49-w659/GHSA-599f-7c49-w659.json
+++ b/advisories/github-reviewed/2022/10/GHSA-599f-7c49-w659/GHSA-599f-7c49-w659.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-599f-7c49-w659",
-  "modified": "2022-10-17T17:34:05Z",
+  "modified": "2023-02-15T22:00:19Z",
   "published": "2022-10-13T19:00:17Z",
   "aliases": [
     "CVE-2022-42889"
@@ -29,6 +29,34 @@
             },
             {
               "fixed": "1.10.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.guicedee.services:commons-text"
+      },
+      "versions": [
+        "1.2.2.1"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.guicedee.services:commons-text"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.2.2.1-jre17"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Several other components are also affected as a result of cloning or shading. Proof-of-Vulnerability projects with tests to verify the presence of the CVE can be found here: https://github.com/jensdietrich/xshady-release/. 