### PR TITLE
[GHSA-gqm2-2gcx-p88w] Incorrect Permission Assignment for Critical Resource in Jenkins Credentials Binding Plugin

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-gqm2-2gcx-p88w/GHSA-gqm2-2gcx-p88w.json
+++ b/advisories/github-reviewed/2022/01/GHSA-gqm2-2gcx-p88w/GHSA-gqm2-2gcx-p88w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gqm2-2gcx-p88w",
-  "modified": "2022-11-29T18:40:17Z",
+  "modified": "2023-02-01T05:07:17Z",
   "published": "2022-01-13T00:01:03Z",
   "aliases": [
     "CVE-2022-20616"
@@ -25,10 +25,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.25"
             },
             {
               "fixed": "1.27.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:credentials"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.24.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
add backports per https://github.com/CVEProject/cvelist/blob/2d78eb36f4d084db7fb35f1535d8d84fdcb7d859/2022/20xxx/CVE-2022-20616.json