### PR TITLE
[GHSA-9wxh-jjj5-67cv] Missing permission checks in SSH Agent Plugin allow enumerating credentials IDs

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-9wxh-jjj5-67cv/GHSA-9wxh-jjj5-67cv.json
+++ b/advisories/github-reviewed/2022/01/GHSA-9wxh-jjj5-67cv/GHSA-9wxh-jjj5-67cv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9wxh-jjj5-67cv",
-  "modified": "2022-07-27T21:24:04Z",
+  "modified": "2023-01-30T05:03:38Z",
   "published": "2022-01-13T00:00:58Z",
   "aliases": [
     "CVE-2022-20620"
@@ -25,10 +25,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.23"
             },
             {
               "fixed": "1.23.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:ssh-agent"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.22.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
add backports per https://github.com/CVEProject/cvelist/blob/2d78eb36f4d084db7fb35f1535d8d84fdcb7d859/2022/20xxx/CVE-2022-20620.json