### PR TITLE
[GHSA-gg9m-x3cg-69vh] Access key stored in plain text by Jenkins Metrics Plugin

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-gg9m-x3cg-69vh/GHSA-gg9m-x3cg-69vh.json
+++ b/advisories/github-reviewed/2022/01/GHSA-gg9m-x3cg-69vh/GHSA-gg9m-x3cg-69vh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gg9m-x3cg-69vh",
-  "modified": "2022-05-04T20:59:58Z",
+  "modified": "2023-02-03T05:04:35Z",
   "published": "2022-01-13T00:00:57Z",
   "aliases": [
     "CVE-2022-20621"
@@ -22,17 +22,33 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.0.2.8"
             },
             {
               "fixed": "4.0.2.8.1"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 4.0.2.8"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:metrics"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.0.2.7.1"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
add backports per https://github.com/CVEProject/cvelist/blob/2d78eb36f4d084db7fb35f1535d8d84fdcb7d859/2022/20xxx/CVE-2022-20621.json