### PR TITLE
[GHSA-j664-qhh4-hpf8] Cross-site Scripting vulnerability in Jenkins

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-j664-qhh4-hpf8/GHSA-j664-qhh4-hpf8.json
+++ b/advisories/github-reviewed/2023/03/GHSA-j664-qhh4-hpf8/GHSA-j664-qhh4-hpf8.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -61,6 +61,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://blog.aquasec.com/jenkins-server-vulnerabilities"
+    },
+    {
+      "type": "WEB",
       "url": "https://www.jenkins.io/security/advisory/2023-03-08/#SECURITY-3037"
     }
   ],
@@ -68,7 +72,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2023-03-17T14:45:14Z",
     "nvd_published_at": "2023-03-10T21:15:00Z"


### PR DESCRIPTION
**Updates**
- CVSS
- References
- Severity

**Comments**
The score mentioned earlier is incorrect. You can view the correct score on the Jenkins Security Advisory 2023-03-08 (https://www.jenkins.io/security/advisory/2023-03-08/)  at the following link: https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
I have also added a blog post about this research.