### PR TITLE
[GHSA-pqg3-xfx2-fmqp] Cross site scripting vulnerability in update-center2 

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-pqg3-xfx2-fmqp/GHSA-pqg3-xfx2-fmqp.json
+++ b/advisories/github-reviewed/2023/03/GHSA-pqg3-xfx2-fmqp/GHSA-pqg3-xfx2-fmqp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pqg3-xfx2-fmqp",
-  "modified": "2023-03-16T16:00:42Z",
+  "modified": "2023-03-16T16:00:46Z",
   "published": "2023-03-10T21:30:19Z",
   "aliases": [
     "CVE-2023-27905"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27905"
+    },
+    {
+      "type": "WEB",
+      "url": "https://blog.aquasec.com/jenkins-server-vulnerabilities"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- CVSS
- References

**Comments**
The score mentioned earlier is incorrect. You can view the correct score on the Jenkins Security Advisory 2023-03-08 (https://www.jenkins.io/security/advisory/2023-03-08/) at the following link: https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
I have also added a blog post about this research.