### PR TITLE
[GHSA-prp9-9gxw-38j8] A deserialization flaw was found in Apache Chainsaw...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-prp9-9gxw-38j8/GHSA-prp9-9gxw-38j8.json
+++ b/advisories/unreviewed/2022/05/GHSA-prp9-9gxw-38j8/GHSA-prp9-9gxw-38j8.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-prp9-9gxw-38j8",
-  "modified": "2022-05-24T19:05:32Z",
+  "modified": "2023-01-29T05:06:34Z",
   "published": "2022-05-24T19:05:32Z",
   "aliases": [
     "CVE-2020-9493"
   ],
-  "details": "A deserialization flaw was found in Apache Chainsaw versions prior to 2.1.0 which could lead to malicious code execution.",
+  "summary": "Deserialization of Untrusted Data in Apache Log4j",
+  "details": "A deserialization flaw was found in Apache Chainsaw versions prior to 2.1.0 which could lead to malicious code execution. Prior to Chainsaw V2.0 Chainsaw was a component of Apache Log4j 1.2.x where the same issue exists.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,12 +15,34 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "log4j:log4j"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.2.17"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-9493"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23307"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Summary

**Comments**
No package/affected version metadata was provided before this. This combines the report for CVE-2020-9493 with information from CVE-2022-23307 that informs on the presence of Apache Chainsaw within Apache Log4j.