### PR TITLE
[GHSA-whpj-8f3w-67p5] vm2 Sandbox Escape vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-whpj-8f3w-67p5/GHSA-whpj-8f3w-67p5.json
+++ b/advisories/github-reviewed/2023/05/GHSA-whpj-8f3w-67p5/GHSA-whpj-8f3w-67p5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-whpj-8f3w-67p5",
-  "modified": "2023-05-15T20:50:51Z",
+  "modified": "2023-05-15T21:39:13Z",
   "published": "2023-05-15T20:50:51Z",
   "aliases": [
     "CVE-2023-32314"
@@ -39,6 +39,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/patriksimek/vm2/security/advisories/GHSA-whpj-8f3w-67p5"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-36067"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Added additional scope for CVE-2022-36067 via NIST