### PR TITLE
[GHSA-2qrg-x229-3v8q] Deserialization of Untrusted Data in Log4j

### DIFF
--- a/advisories/github-reviewed/2020/01/GHSA-2qrg-x229-3v8q/GHSA-2qrg-x229-3v8q.json
+++ b/advisories/github-reviewed/2020/01/GHSA-2qrg-x229-3v8q/GHSA-2qrg-x229-3v8q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2qrg-x229-3v8q",
-  "modified": "2022-11-17T18:28:14Z",
+  "modified": "2023-01-28T05:00:54Z",
   "published": "2020-01-06T18:43:49Z",
   "aliases": [
     "CVE-2019-17571"
@@ -28,7 +28,7 @@
               "introduced": "1.2"
             },
             {
-              "last_affected": "1.2.27"
+              "last_affected": "1.2.17"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The latest version of log4j 1.x is 1.2.17 not 1.2.27.