### PR TITLE
[GHSA-r23g-3qw4-gfh2] RedCloth Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-r23g-3qw4-gfh2/GHSA-r23g-3qw4-gfh2.json
+++ b/advisories/github-reviewed/2017/10/GHSA-r23g-3qw4-gfh2/GHSA-r23g-3qw4-gfh2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r23g-3qw4-gfh2",
-  "modified": "2023-01-24T14:55:19Z",
+  "modified": "2023-02-01T05:06:41Z",
   "published": "2017-10-24T18:33:37Z",
   "aliases": [
     "CVE-2012-6684"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Fix package name's case (s/redcloth/RedCloth). To verify change, see https://rubygems.org/gems/RedCloth web site.