### PR TITLE
[GHSA-gpqc-4pp7-5954] Authentication Bypass by CSRF Weakness

### DIFF
--- a/advisories/github-reviewed/2021/11/GHSA-gpqc-4pp7-5954/GHSA-gpqc-4pp7-5954.json
+++ b/advisories/github-reviewed/2021/11/GHSA-gpqc-4pp7-5954/GHSA-gpqc-4pp7-5954.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gpqc-4pp7-5954",
-  "modified": "2021-11-18T19:51:48Z",
+  "modified": "2023-01-09T05:05:27Z",
   "published": "2021-11-18T20:15:35Z",
   "aliases": [
 
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/spree/spree_auth_devise/security/advisories/GHSA-gpqc-4pp7-5954"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/spree_auth_devise/CVE-2021-41275.yml"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add CVE-2021-41275 to this advisory. Reference: 
https://github.com/rubysec/ruby-advisory-db/blob/master/gems/spree_auth_devise/CVE-2021-41275.yml