### PR TITLE
[GHSA-8xfw-5q82-3652] Authentication Bypass by CSRF Weakness

### DIFF
--- a/advisories/github-reviewed/2021/11/GHSA-8xfw-5q82-3652/GHSA-8xfw-5q82-3652.json
+++ b/advisories/github-reviewed/2021/11/GHSA-8xfw-5q82-3652/GHSA-8xfw-5q82-3652.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8xfw-5q82-3652",
-  "modified": "2021-11-18T19:51:58Z",
+  "modified": "2023-01-09T05:05:31Z",
   "published": "2021-11-18T20:15:23Z",
   "aliases": [
 
@@ -46,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/spree/spree_auth_devise/security/advisories/GHSA-8xfw-5q82-3652"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/spree_auth_devise/CVE-2021-41275.yml"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Please add CVE-2021-41275 to this advisory. Referece: https://github.com/rubysec/ruby-advisory-db/blob/master/gems/spree_auth_devise/CVE-2021-41275.yml