### PR TITLE
[GHSA-6mqr-q86q-6gwr] Authentication Bypass by CSRF Weakness

### DIFF
--- a/advisories/github-reviewed/2021/11/GHSA-6mqr-q86q-6gwr/GHSA-6mqr-q86q-6gwr.json
+++ b/advisories/github-reviewed/2021/11/GHSA-6mqr-q86q-6gwr/GHSA-6mqr-q86q-6gwr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6mqr-q86q-6gwr",
-  "modified": "2023-05-01T20:29:57Z",
+  "modified": "2023-05-01T20:29:58Z",
   "published": "2021-11-18T20:15:09Z",
   "aliases": [
 
@@ -50,6 +50,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/spree/spree_auth_devise/commit/50bf2444a851f10dff926eb4ea3674976d9d279d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/spree_auth_devise/CVE-2021-41275.yml"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Please add CVE-2021-41275 to this advisory. Reference: https://github.com/rubysec/ruby-advisory-db/blob/master/gems/spree_auth_devise/CVE-2021-41275.yml