### PR TITLE
[GHSA-75w6-p6mg-vh8j] rails vulnerable to Cross-site Scripting

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-75w6-p6mg-vh8j/GHSA-75w6-p6mg-vh8j.json
+++ b/advisories/github-reviewed/2017/10/GHSA-75w6-p6mg-vh8j/GHSA-75w6-p6mg-vh8j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-75w6-p6mg-vh8j",
-  "modified": "2023-05-12T17:02:41Z",
+  "modified": "2023-05-12T17:02:42Z",
   "published": "2017-10-24T18:33:38Z",
   "aliases": [
     "CVE-2011-0446"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "actionview"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Changed package name from "rails" to "actionview". Reference; https://github.com/rubysec/ruby-advisory-db/blob/master/gems/actionview/CVE-2011-0446.yml