### PR TITLE
[GHSA-xf96-32q2-9rw2] rails vulnerable to SQL injection

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-xf96-32q2-9rw2/GHSA-xf96-32q2-9rw2.json
+++ b/advisories/github-reviewed/2017/10/GHSA-xf96-32q2-9rw2/GHSA-xf96-32q2-9rw2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xf96-32q2-9rw2",
-  "modified": "2023-05-11T13:59:57Z",
+  "modified": "2023-05-20T05:00:37Z",
   "published": "2017-10-24T18:33:38Z",
   "aliases": [
     "CVE-2008-4094"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "activerecord"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Change package name from rails to activerecord. Reference: https://github.com/rubysec/ruby-advisory-db/blob/master/gems/activerecord/CVE-2008-4094.yml