### PR TITLE
[GHSA-gjxw-5w2q-7grf] rails Improper Input Validation vulnerability

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-gjxw-5w2q-7grf/GHSA-gjxw-5w2q-7grf.json
+++ b/advisories/github-reviewed/2017/10/GHSA-gjxw-5w2q-7grf/GHSA-gjxw-5w2q-7grf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gjxw-5w2q-7grf",
-  "modified": "2023-05-12T17:12:21Z",
+  "modified": "2023-05-12T17:12:22Z",
   "published": "2017-10-24T18:33:38Z",
   "aliases": [
     "CVE-2010-3933"
@@ -34,7 +34,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "activerecord"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Change package name from rails to activerecord. Reference: https://github.com/rubysec/ruby-advisory-db/blob/master/gems/activerecord/CVE-2010-3933.yml

