### PR TITLE
[GHSA-xxr8-833v-c7wc] Cross-site Scripting vulnerability in  i18n translations helper method

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-xxr8-833v-c7wc/GHSA-xxr8-833v-c7wc.json
+++ b/advisories/github-reviewed/2017/10/GHSA-xxr8-833v-c7wc/GHSA-xxr8-833v-c7wc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xxr8-833v-c7wc",
-  "modified": "2023-01-18T21:56:51Z",
+  "modified": "2023-01-18T21:56:52Z",
   "published": "2017-10-24T18:33:38Z",
   "aliases": [
     "CVE-2011-4319"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "actionpack"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Change package name from rails to actionpack. Reference: https://github.com/rubysec/ruby-advisory-db/blob/master/gems/actionpack/CVE-2011-4319.yml