### PR TITLE
[GHSA-j4rf-7357-f4cg] Unpatched extfs vulnerabilities are exploitable through suid-mode Apptainer and Singularity

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-j4rf-7357-f4cg/GHSA-j4rf-7357-f4cg.json
+++ b/advisories/github-reviewed/2023/04/GHSA-j4rf-7357-f4cg/GHSA-j4rf-7357-f4cg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j4rf-7357-f4cg",
-  "modified": "2023-04-25T19:48:35Z",
+  "modified": "2023-04-25T21:48:30Z",
   "published": "2023-04-25T19:48:35Z",
   "aliases": [
     "CVE-2023-30549"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:H"
+      "score": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- CVSS

**Comments**
The CVSS scores in this copy of the advisory were what they were when I originally created it, not what I ended up publishing in https://github.com/apptainer/apptainer/security/advisories/GHSA-j4rf-7357-f4cg.  Please update this one to match.  The NVD vector matched the published one except they said the attack complexity was low.