### PR TITLE
[GHSA-6hgm-866r-3cjv] Insecure Deserialization in Apache Commons Collection

### DIFF
--- a/advisories/github-reviewed/2020/06/GHSA-6hgm-866r-3cjv/GHSA-6hgm-866r-3cjv.json
+++ b/advisories/github-reviewed/2020/06/GHSA-6hgm-866r-3cjv/GHSA-6hgm-866r-3cjv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6hgm-866r-3cjv",
-  "modified": "2020-06-11T15:58:44Z",
+  "modified": "2023-02-03T05:06:03Z",
   "published": "2020-06-15T20:36:20Z",
   "aliases": [
     "CVE-2015-6420"
@@ -45,6 +45,63 @@
             },
             {
               "fixed": "3.2.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "net.sourceforge.collections:collections-generic"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "4.01"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.servicemix.bundles:org.apache.servicemix.bundles.collections-generic"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "4.01_1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.servicemix.bundles:org.apache.servicemix.bundles.commons-collections"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.2.1_3"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Several other components are also affected as a result of cloning or shading. Proof-of-Vulnerability projects with tests to verify the presence of the CVE can be found here: https://github.com/jensdietrich/xshady-release/. 