### PR TITLE
[GHSA-gxg6-rc6c-v673] Improper Input Validation in BeanShell

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-gxg6-rc6c-v673/GHSA-gxg6-rc6c-v673.json
+++ b/advisories/github-reviewed/2022/05/GHSA-gxg6-rc6c-v673/GHSA-gxg6-rc6c-v673.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gxg6-rc6c-v673",
-  "modified": "2022-07-06T19:57:52Z",
+  "modified": "2023-01-27T05:02:09Z",
   "published": "2022-05-13T01:14:25Z",
   "aliases": [
     "CVE-2016-2510"
@@ -36,6 +36,25 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 2.0b5"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache-extras.beanshell:bsh"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.0b5"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Several other components are also affected as a result of cloning or shading. Proof-of-Vulnerability projects with tests to verify the presence of the CVE can be found here: https://github.com/jensdietrich/xshady-release/.