### PR TITLE
[GHSA-6xx3-rg99-gc3p] Timing based private key exposure in Bouncy Castle

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-6xx3-rg99-gc3p/GHSA-6xx3-rg99-gc3p.json
+++ b/advisories/github-reviewed/2021/08/GHSA-6xx3-rg99-gc3p/GHSA-6xx3-rg99-gc3p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6xx3-rg99-gc3p",
-  "modified": "2021-05-21T17:50:36Z",
+  "modified": "2023-02-01T05:06:03Z",
   "published": "2021-08-13T15:22:31Z",
   "aliases": [
     "CVE-2020-15522"
@@ -165,6 +165,25 @@
             },
             {
               "fixed": "1.66"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "BouncyCastle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.8.7"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Added NuGet's BouncyCastle to affected products based on https://github.com/bcgit/bc-csharp/wiki/CVE-2020-15522