### PR TITLE
Improve GHSA-hmhg-95wh-r699: add affected artifacts

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-hmhg-95wh-r699/GHSA-hmhg-95wh-r699.json
+++ b/advisories/unreviewed/2022/05/GHSA-hmhg-95wh-r699/GHSA-hmhg-95wh-r699.json
@@ -11,7 +11,63 @@
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.wicket:wicket-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.0"
+            },
+            {
+              "last_affected": "9.2.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.wicket:wicket-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.0.0"
+            },
+            {
+              "last_affected": "8.11.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.wicket:wicket-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "7.0.0"
+            },
+            {
+              "last_affected": "7.17.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
Verified the affected artifact is wicket-core
(fix in 84f62a5cff462eaa3bfaf171b0638c7e7feea30d).