### PR TITLE
[GHSA-2c4m-59x9-fr2g] Gin Web Framework does not properly sanitize filename parameter of Context.FileAttachment function

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-2c4m-59x9-fr2g/GHSA-2c4m-59x9-fr2g.json
+++ b/advisories/github-reviewed/2023/05/GHSA-2c4m-59x9-fr2g/GHSA-2c4m-59x9-fr2g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2c4m-59x9-fr2g",
-  "modified": "2023-05-12T20:19:25Z",
+  "modified": "2023-05-24T18:33:08Z",
   "published": "2023-05-12T20:19:25Z",
   "aliases": [
     "CVE-2023-29401"
@@ -23,6 +23,9 @@
           "events": [
             {
               "introduced": "1.3.1-0.20190301021747-ccb9e902956d"
+            },
+            {
+              "fixed": "1.9.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Patched in https://github.com/gin-gonic/gin/pull/3556, released in 1.9.1