### PR TITLE
Update GHSA-7x94-jx75-3gh6.json

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-7x94-jx75-3gh6/GHSA-7x94-jx75-3gh6.json
+++ b/advisories/github-reviewed/2023/05/GHSA-7x94-jx75-3gh6/GHSA-7x94-jx75-3gh6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7x94-jx75-3gh6",
-  "modified": "2023-06-02T22:17:57Z",
+  "modified": "2023-06-05T17:27:50Z",
   "published": "2023-05-26T18:30:21Z",
   "aliases": [
     "CVE-2023-2817"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.0.0-RC1"
             },
             {
               "fixed": "4.4.12"


### PR DESCRIPTION
This does not affect anything < Craft 4.0.0. Updated "introduced" to limit the affected scope.