### PR TITLE
[GHSA-7vx2-5349-qj99] ConcreteCMS vulnerable to Xpath injection attacks

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-7vx2-5349-qj99/GHSA-7vx2-5349-qj99.json
+++ b/advisories/github-reviewed/2022/12/GHSA-7vx2-5349-qj99/GHSA-7vx2-5349-qj99.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7vx2-5349-qj99",
-  "modified": "2022-12-06T22:13:21Z",
+  "modified": "2023-01-31T05:03:27Z",
   "published": "2022-12-06T00:30:16Z",
   "aliases": [
     "CVE-2022-46464"
   ],
   "summary": "ConcreteCMS vulnerable to Xpath injection attacks",
-  "details": "ConcreteCMS v9.1.3 was discovered to be vulnerable to Xpath injection attacks. This vulnerability allows attackers to access sensitive XML data via a crafted payload injected into the URL path folder \"3\".",
+  "details": "[This CVE](https://nvd.nist.gov/vuln/detail/CVE-2022-46464) has been found invalid.]",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -53,7 +53,7 @@
     "cwe_ids": [
       "CWE-91"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2022-12-06T15:35:16Z",
     "nvd_published_at": "2022-12-05T23:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity

**Comments**
[This CVE has been refuted by the founders/maintainers of Concrete CMS. It has been found invalid. MITRE and NIST concurred. Reporter created his/her own public advisory (this one) and then used it to obtain a CVE without informing the open source project Concrete CMS. ](https://nvd.nist.gov/vuln/detail/CVE-2022-46464)