### PR TITLE
[GHSA-58xm-mxjf-254g] Multiple vulnerabilities allow bypassing path filtering of agent-to-controller access control in Jenkins

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-58xm-mxjf-254g/GHSA-58xm-mxjf-254g.json
+++ b/advisories/github-reviewed/2022/05/GHSA-58xm-mxjf-254g/GHSA-58xm-mxjf-254g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-58xm-mxjf-254g",
-  "modified": "2022-12-16T20:19:52Z",
+  "modified": "2023-02-01T05:06:55Z",
   "published": "2022-05-24T19:19:44Z",
   "aliases": [
     "CVE-2021-21685"
@@ -28,14 +28,11 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.319"
+              "fixed": "2.303.3"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 2.303.2"
-      }
+      ]
     },
     {
       "package": {
@@ -54,10 +51,7 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 2.318"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adjust the affected ranges to reflect 2.303.3 being the fix for the LTS release per https://www.jenkins.io/security/advisory/2021-11-04/#SECURITY-2455