### PR TITLE
[GHSA-x5x7-3v85-wpc4]  Apache Struts allows entering a custom URL in a form field if built-in URLValidator is used

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-x5x7-3v85-wpc4/GHSA-x5x7-3v85-wpc4.json
+++ b/advisories/github-reviewed/2018/10/GHSA-x5x7-3v85-wpc4/GHSA-x5x7-3v85-wpc4.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x5x7-3v85-wpc4",
-  "modified": "2022-04-26T19:02:51Z",
+  "modified": "2023-01-09T05:03:39Z",
   "published": "2018-10-16T19:37:33Z",
   "aliases": [
     "CVE-2017-9804"
   ],
-  "summary": " Apache Struts allows entering a custom URL in a form field if built-in URLValidator is used",
+  "summary": "Apache Struts allows entering a custom URL in a form field if built-in URLValidator is used",
   "details": "In Apache Struts 2.3.7 through 2.3.33 and 2.5 through 2.5.12, if an application allows entering a URL in a form field and built-in URLValidator is used, it is possible to prepare a special URL which will be used to overload server process when performing validation of the URL.  NOTE: this vulnerability exists because of an incomplete fix for S2-047 / CVE-2017-7672.",
   "severity": [
     {


### PR DESCRIPTION
**Updates**
- Summary

**Comments**
Remove leading whitespace from summary