### PR TITLE
[GHSA-gvhx-gj42-m28v] Cross-site scripting (XSS) vulnerability in Wiki content...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-gvhx-gj42-m28v/GHSA-gvhx-gj42-m28v.json
+++ b/advisories/unreviewed/2022/05/GHSA-gvhx-gj42-m28v/GHSA-gvhx-gj42-m28v.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gvhx-gj42-m28v",
-  "modified": "2022-05-01T07:00:37Z",
+  "modified": "2023-01-31T05:01:17Z",
   "published": "2022-05-01T07:00:37Z",
   "aliases": [
     "CVE-2006-2581"
   ],
+  "summary": "RWiki before 2.1.0 has cross-site scripting vulnerability",
   "details": "Cross-site scripting (XSS) vulnerability in Wiki content in RWiki 2.1.0pre1 through 2.1.0 allows remote attackers to inject arbitrary web script or HTML via unknown attack vectors.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "rwiki"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.1.0pre1"
+            },
+            {
+              "fixed": ">= 2.1.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,12 +42,32 @@
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/26664"
     },
     {
-      "type": "WEB",
-      "url": "http://secunia.com/advisories/20264"
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-gvhx-gj42-m28v"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-wwmf-6p58-6vj2"
     },
     {
       "type": "WEB",
-      "url": "http://www.vupen.com/english/advisories/2006/1949"
+      "url": "https://rubygems.org/gems/rwiki"
+    },
+    {
+      "type": "WEB",
+      "url": "https://web.archive.org/web/20081201080215/http://secunia.com/advisories/20264"
+    },
+    {
+      "type": "WEB",
+      "url": "https://web.archive.org/web/20090501134922/http://www2a.biglobe.ne.jp/~seki/ruby/rwiki.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://web.archive.org/web/20090504061152/http://pub.cozmixng.org/~the-rwiki/rw-cgi.rb?cmd=view;name=top"
+    },
+    {
+      "type": "WEB",
+      "url": "https://web.archive.org/web/20090524010623/http://www.vupen.com/english/advisories/2006/1949"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Summary

**Comments**
Trying to add it to ruby-advisory-db repo so I decide to add the data here too.
Unclear about source code location.
Initial advisory (in Japanese) was: https://web.archive.org/web/20090501134922/http://www2a.biglobe.ne.jp/~seki/ruby/rwiki.html