### PR TITLE
[GHSA-mmrq-6999-72v8] Incorrect value comparison in Ruby openssl

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-mmrq-6999-72v8/GHSA-mmrq-6999-72v8.json
+++ b/advisories/github-reviewed/2022/05/GHSA-mmrq-6999-72v8/GHSA-mmrq-6999-72v8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mmrq-6999-72v8",
-  "modified": "2023-06-09T22:57:50Z",
+  "modified": "2023-06-09T22:57:51Z",
   "published": "2022-05-13T01:50:20Z",
   "aliases": [
     "CVE-2018-16395"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.0.9"
+              "fixed": "2.1.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The official [blog post](https://www.ruby-lang.org/en/news/2018/10/17/openssl-x509-name-equality-check-does-not-work-correctly-cve-2018-16395/) states:

> The openssl 2.1.2 gem or later includes a fix for the vulnerability, so upgrade the openssl gem to the latest version if you are using Ruby 2.4 or a later series.