### PR TITLE
[GHSA-95xq-v4m2-fq3r] GitLab Grit Gem for Ruby contains a flaw allowing arbitrary commands to be executed

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-95xq-v4m2-fq3r/GHSA-95xq-v4m2-fq3r.json
+++ b/advisories/github-reviewed/2022/05/GHSA-95xq-v4m2-fq3r/GHSA-95xq-v4m2-fq3r.json
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "grit"
+        "name": "gitlab-grit"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The [grit gem](https://rubygems.org/gems/grit) has no version 2.6.1. I believe the advisory is referring to [gitlab-grit](https://rubygems.org/gems/gitlab-grit), who's ChangeLog mentions 2.6.1 included various security fixes:
https://gitlab.com/gitlab-org/gitlab-grit/-/blob/v2.6.1/History.txt?ref_type=tags#L2