### PR TITLE
[GHSA-282v-666c-3fvg] transformers has Insecure Temporary File

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-282v-666c-3fvg/GHSA-282v-666c-3fvg.json
+++ b/advisories/github-reviewed/2023/05/GHSA-282v-666c-3fvg/GHSA-282v-666c-3fvg.json
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "4.29.2"
+              "fixed": "4.30.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.29.2"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
4.30.0 has been released.  NVD updated to show fixed (https://nvd.nist.gov/vuln/detail/CVE-2023-2800).  4.30.0 released 4 days ago (https://github.com/huggingface/transformers/releases)