### PR TITLE
[GHSA-7gf7-jv65-wjmh] xml-rs vulnerable to denial of service via invalid token in XML document

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-7gf7-jv65-wjmh/GHSA-7gf7-jv65-wjmh.json
+++ b/advisories/github-reviewed/2023/06/GHSA-7gf7-jv65-wjmh/GHSA-7gf7-jv65-wjmh.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7gf7-jv65-wjmh",
-  "modified": "2023-06-12T20:09:47Z",
+  "modified": "2023-06-12T20:09:48Z",
   "published": "2023-06-05T06:30:15Z",
   "aliases": [
     "CVE-2023-34411"
   ],
   "summary": "xml-rs vulnerable to denial of service via invalid token in XML document",
-  "details": "The xml-rs crate before 0.8.14 for Rust and Crab allows a denial of service (panic) via an invalid <! token (such as <!DOCTYPEs/%<!A nesting) in an XML document.",
+  "details": "The xml-rs crate >= 0.8.9 and < 0.8.14 for Rust and Crab allows a denial of service (panic) via an invalid <! token (such as <!DOCTYPEs/%<!A nesting) in an XML document.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.8.9"
             },
             {
               "fixed": "0.8.14"
@@ -50,6 +50,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/netvl/xml-rs/commit/014d808be900c85a0afc5ccdfe668be040d175aa"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/netvl/xml-rs/commit/c09549a187e62d39d40467f129e64abf32efc35c"
     },
     {
@@ -63,7 +67,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-611"
+      "CWE-617"
     ],
     "severity": "HIGH",
     "github_reviewed": true,


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- Description
- References

**Comments**
Update affected versions, add more accurate CWE.