### PR TITLE
[GHSA-p26g-97m4-6q7c] Eclipse Jetty's cookie parsing of quoted values can exfiltrate values from other cookies

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-p26g-97m4-6q7c/GHSA-p26g-97m4-6q7c.json
+++ b/advisories/github-reviewed/2023/04/GHSA-p26g-97m4-6q7c/GHSA-p26g-97m4-6q7c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p26g-97m4-6q7c",
-  "modified": "2023-04-18T22:19:57Z",
+  "modified": "2023-05-26T21:48:51Z",
   "published": "2023-04-18T22:19:57Z",
   "aliases": [
     "CVE-2023-26049"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "9.4.51"
+              "fixed": "9.4.51.v20230217"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Similar fix as https://github.com/github/advisory-database/pull/2393; The correct version is already specified in the details markdown.