### PR TITLE
[GHSA-c77j-p484-h84m] In Elasticsearch before 7.9.0 and 6.8.12 a field...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-c77j-p484-h84m/GHSA-c77j-p484-h84m.json
+++ b/advisories/unreviewed/2022/05/GHSA-c77j-p484-h84m/GHSA-c77j-p484-h84m.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c77j-p484-h84m",
-  "modified": "2023-01-27T21:31:11Z",
+  "modified": "2023-02-04T05:05:46Z",
   "published": "2022-05-24T17:26:07Z",
   "aliases": [
     "CVE-2020-7019"
   ],
+  "summary": "Improper privilege management in elasticsearch",
   "details": "In Elasticsearch before 7.9.0 and 6.8.12 a field disclosure flaw was found when running a scrolling search with Field Level Security. If a user runs the same query another more privileged user recently ran, the scrolling search can leak fields that should be hidden. This could result in an attacker gaining additional permissions against a restricted index.",
   "severity": [
     {
@@ -14,7 +15,44 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.elasticsearch:elasticsearch"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "7.0.0"
+            },
+            {
+              "fixed": "7.9.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.elasticsearch:elasticsearch"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "6.8.12"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -24,6 +62,10 @@
     {
       "type": "WEB",
       "url": "https://discuss.elastic.co/t/elastic-stack-7-9-0-and-6-8-12-security-update/245456"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/elastic/elasticsearch"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
adding affected version ranges for org.elasticsearch:elasticsearch per data from https://nvd.nist.gov/vuln/detail/CVE-2020-7019