### PR TITLE
[GHSA-6qmf-mmc7-6c2p] NuGet Client Remote Code Execution Vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-6qmf-mmc7-6c2p/GHSA-6qmf-mmc7-6c2p.json
+++ b/advisories/github-reviewed/2023/06/GHSA-6qmf-mmc7-6c2p/GHSA-6qmf-mmc7-6c2p.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6qmf-mmc7-6c2p",
-  "modified": "2023-06-14T16:44:21Z",
+  "modified": "2023-06-14T16:44:23Z",
   "published": "2023-06-14T16:44:21Z",
   "aliases": [
     "CVE-2023-29337"
   ],
   "summary": "NuGet Client Remote Code Execution Vulnerability",
-  "details": "### Description\nMicrosoft is releasing this security advisory to provide information about a vulnerability in .NET and NuGet on Linux. This advisory also provides guidance on what developers can do to update their applications to remove this vulnerability.\n\nA vulnerability exists in .NET 6.0, .NET 7.0 and NuGet(nuget.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement) where a potential race condition that can lead to a symlink attack on Linux. Non-Linux platforms are not affected.\n\n### Affected software\nThis issue only affects Linux systems.\n\n#### NuGet & NuGet Packages\n\n- Any NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement 6.6.0 version or earlier.\n- Any NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement 6.5.0 version or earlier.\n- Any NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement 6.4.1 version or earlier.\n- Any NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement 6.3.2 version or earlier.\n- Any NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement 6.2.3 version or earlier.\n- Any NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement 6.0.4 version or earlier.\n\n#### .NET SDK(s)\n\n- Any .NET SDK 7.0.106 or earlier, or 7.0.303 or earlier\n- Any .NET SDK 6.0.117 or earlier, or 6.0.312 or earlier, or 6.0.409 or earlier.\n\n\n### Patches\nTo fix the issue, please install the latest version of .NET 6.0 or .NET 7.0 and NuGet (NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, NuGet.PackageManagement  versions). If you have installed one or more .NET SDKs through Visual Studio, Visual Studio will prompt you to update Visual Studio, which will also update your .NET SDKs.\n\n- If you're using NuGet.exe 6.6.0 or lower, you should download and install 6.6.1 from https://dist.nuget.org/win-x86-commandline/v6.6.1/nuget.exe.\n- If you're using NuGet.exe 6.5.0 or lower, you should download and install 6.5.1 from https://dist.nuget.org/win-x86-commandline/v6.5.1/nuget.exe.\n- If you're using NuGet.exe 6.4.1 or lower, you should download and install 6.4.2 from https://dist.nuget.org/win-x86-commandline/v6.4.2/nuget.exe.\n- If you're using NuGet.exe 6.3.2 or lower, you should download and install 6.3.3 from https://dist.nuget.org/win-x86-commandline/v6.3.3/nuget.exe.\n- If you're using NuGet.exe 6.2.3 or lower, you should download and install 6.2.4 from https://dist.nuget.org/win-x86-commandline/v6.2.4/nuget.exe.\n- If you're using NuGet.exe 6.0.4 or lower, you should download and install 6.0.5 from https://dist.nuget.org/win-x86-commandline/v6.0.5/nuget.exe.\n\n- If you're using .NET 7.0, you should download and install Runtime 7.0.7 or SDK 7.0.107 or SDK 7.0.304 from https://dotnet.microsoft.com/download/dotnet-core/7.0.\n- If you're using .NET 6.0, you should download and install Runtime 6.0.18 or SDK 6.0.118 or SDK 6.0.312 from https://dotnet.microsoft.com/download/dotnet-core/6.0.\n\n\n### Other details\nAnnouncement for this issue can be found at https://github.com/NuGet/Announcements/issues/69\n\nMSRC details for this can be found at https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-29337\n",
+  "details": "### Description\nMicrosoft is releasing this security advisory to provide information about a vulnerability in .NET and NuGet on Linux. This advisory also provides guidance on what developers can do to update their applications to remove this vulnerability.\n\nA vulnerability exists in .NET 6.0, .NET 7.0 and NuGet(nuget.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement) where a potential race condition that can lead to a symlink attack on Linux. Non-Linux platforms are not affected.\n\n### Affected software\nThis issue only affects Linux systems.\n\n#### NuGet & NuGet Packages\n\n- Any NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement 6.6.0 version or earlier.\n- Any NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement 6.5.0 version or earlier.\n- Any NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement 6.4.1 version or earlier.\n- Any NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement 6.3.2 version or earlier.\n- Any NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement 6.2.3 version or earlier.\n- Any NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement 6.0.4 version or earlier.\n- Any NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, Microsoft.Build.NuGetSdkResolver, NuGet.PackageManagement 5.11.4 version or earlier.\n\n#### .NET SDK(s)\n\n- Any .NET SDK 7.0.106 or earlier, or 7.0.303 or earlier\n- Any .NET SDK 6.0.117 or earlier, or 6.0.312 or earlier, or 6.0.409 or earlier.\n\n\n### Patches\nTo fix the issue, please install the latest version of .NET 6.0 or .NET 7.0 and NuGet (NuGet.exe, NuGet.Protocol, NuGet.Common, NuGet.CommandLine, NuGet.Commands, NuGet.PackageManagement  versions). If you have installed one or more .NET SDKs through Visual Studio, Visual Studio will prompt you to update Visual Studio, which will also update your .NET SDKs.\n\n- If you're using NuGet.exe 6.6.0 or lower, you should download and install 6.6.1 from https://dist.nuget.org/win-x86-commandline/v6.6.1/nuget.exe.\n- If you're using NuGet.exe 6.5.0 or lower, you should download and install 6.5.1 from https://dist.nuget.org/win-x86-commandline/v6.5.1/nuget.exe.\n- If you're using NuGet.exe 6.4.1 or lower, you should download and install 6.4.2 from https://dist.nuget.org/win-x86-commandline/v6.4.2/nuget.exe.\n- If you're using NuGet.exe 6.3.2 or lower, you should download and install 6.3.3 from https://dist.nuget.org/win-x86-commandline/v6.3.3/nuget.exe.\n- If you're using NuGet.exe 6.2.3 or lower, you should download and install 6.2.4 from https://dist.nuget.org/win-x86-commandline/v6.2.4/nuget.exe.\n- If you're using NuGet.exe 6.0.4 or lower, you should download and install 6.0.5 from https://dist.nuget.org/win-x86-commandline/v6.0.5/nuget.exe.\n- If you're using NuGet.exe 5.11.4 or lower, you should download and install 5.11.5 from https://dist.nuget.org/win-x86-commandline/v5.11.5/nuget.exe.\n\n- If you're using .NET 7.0, you should download and install Runtime 7.0.7 or SDK 7.0.107 or SDK 7.0.304 from https://dotnet.microsoft.com/download/dotnet-core/7.0.\n- If you're using .NET 6.0, you should download and install Runtime 6.0.18 or SDK 6.0.118 or SDK 6.0.312 from https://dotnet.microsoft.com/download/dotnet-core/6.0.\n\n\n### Other details\nAnnouncement for this issue can be found at https://github.com/NuGet/Announcements/issues/69\n\nMSRC details for this can be found at https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-29337\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -34,7 +34,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.6.0"
+              "introduced": "6.0.0"
             },
             {
               "fixed": "6.0.5"
@@ -172,7 +172,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.6.0"
+              "introduced": "6.0.0"
             },
             {
               "fixed": "6.0.5"
@@ -292,7 +292,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.6.0"
+              "introduced": "6.0.0"
             },
             {
               "fixed": "6.0.5"
@@ -412,7 +412,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.6.0"
+              "introduced": "6.0.0"
             },
             {
               "fixed": "6.0.5"
@@ -520,6 +520,202 @@
       ],
       "versions": [
         "6.6.0"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Protocol"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.0.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Protocol"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.2.0"
+            },
+            {
+              "fixed": "6.2.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Protocol"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.3.0"
+            },
+            {
+              "fixed": "6.3.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Protocol"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.4.0"
+            },
+            {
+              "fixed": "6.4.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Protocol"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.5.0"
+            },
+            {
+              "fixed": "6.5.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "6.5.0"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Protocol"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.6.0"
+            },
+            {
+              "fixed": "6.6.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "6.6.0"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.CommandLine"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.6.0"
+            },
+            {
+              "fixed": "5.11.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Commands"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.6.0"
+            },
+            {
+              "fixed": "5.11.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.Common"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.6.0"
+            },
+            {
+              "fixed": "5.11.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "NuGet.PackageManagement"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.6.0"
+            },
+            {
+              "fixed": "5.11.5"
+            }
+          ]
+        }
       ]
     },
     {
@@ -535,111 +731,10 @@
               "introduced": "4.7.0"
             },
             {
-              "fixed": "6.0.5"
+              "fixed": "5.11.5"
             }
           ]
         }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "NuGet",
-        "name": "NuGet.Protocol"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "6.2.0"
-            },
-            {
-              "fixed": "6.2.4"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "NuGet",
-        "name": "NuGet.Protocol"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "6.3.0"
-            },
-            {
-              "fixed": "6.3.3"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "NuGet",
-        "name": "NuGet.Protocol"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "6.4.0"
-            },
-            {
-              "fixed": "6.4.2"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "NuGet",
-        "name": "NuGet.Protocol"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "6.5.0"
-            },
-            {
-              "fixed": "6.5.1"
-            }
-          ]
-        }
-      ],
-      "versions": [
-        "6.5.0"
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "NuGet",
-        "name": "NuGet.Protocol"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "6.6.0"
-            },
-            {
-              "fixed": "6.6.1"
-            }
-          ]
-        }
-      ],
-      "versions": [
-        "6.6.0"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
NuGet team published a new patched version 5.11.5 for the following packages:
NuGet.CommandLine
NuGet.Commands
NuGet.Common
NuGet.PackageManagement
NuGet.Protocol 