### PR TITLE
[GHSA-gpv5-7x3g-ghjv] fast-xml-parser regex vulnerability patch could be improved from a safety perspective

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-gpv5-7x3g-ghjv/GHSA-gpv5-7x3g-ghjv.json
+++ b/advisories/github-reviewed/2023/06/GHSA-gpv5-7x3g-ghjv/GHSA-gpv5-7x3g-ghjv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gpv5-7x3g-ghjv",
-  "modified": "2023-06-15T19:05:13Z",
+  "modified": "2023-06-15T19:05:26Z",
   "published": "2023-06-15T19:05:13Z",
   "aliases": [
 
@@ -17,14 +17,19 @@
         "ecosystem": "npm",
         "name": "fast-xml-parser"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "fast-xml-parser.XMLParser"
-        ]
-      },
-      "versions": [
-        "4.2.4"
-      ]
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.2.4"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The referenced link [GHSA-6w63-h3fj-q4vw](https://github.com/NaturalIntelligence/fast-xml-parser/security/advisories/GHSA-6w63-h3fj-q4vw) states that the affected version is `<4.2.4` and it is patched on `4.2.4` **BUT** this [advisory record](https://github.com/advisories/GHSA-gpv5-7x3g-ghjv) tells affected version is `4.2.4`. :confused: It seems like there is an error here. My apologies if I'm missing something.

I see patch has been applied to [v4.2.4](https://github.com/NaturalIntelligence/fast-xml-parser/releases/tag/v4.2.4) release.

----

[Advisory record](https://github.com/advisories/GHSA-gpv5-7x3g-ghjv) tells affected version is 4.2.4:

![image](https://github.com/github/advisory-database/assets/673349/909c0e98-85d6-44c1-86e1-2b0a85733558)

----

[GHSA-6w63-h3fj-q4vw](https://github.com/NaturalIntelligence/fast-xml-parser/security/advisories/GHSA-6w63-h3fj-q4vw) tells affected versions are < 4.2.4:

![image](https://github.com/github/advisory-database/assets/673349/e36f1c96-f71c-4453-a966-6cd8bf62e635)
