### PR TITLE
[GHSA-r7wr-4w5q-55m6] Update introduced version

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-r7wr-4w5q-55m6/GHSA-r7wr-4w5q-55m6.json
+++ b/advisories/github-reviewed/2023/06/GHSA-r7wr-4w5q-55m6/GHSA-r7wr-4w5q-55m6.json
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.13.0"
             },
             {
               "fixed": "1.13.4"


### PR DESCRIPTION
https://github.com/cilium/cilium/security/advisories/GHSA-r7wr-4w5q-55m6 states that Cilium versions <1.13 are not affected. 
Update introduced version accordingly