### PR TITLE
[GHSA-8qrh-h9m2-5fvf] Moderate severity vulnerability that affects rails

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-8qrh-h9m2-5fvf/GHSA-8qrh-h9m2-5fvf.json
+++ b/advisories/github-reviewed/2017/10/GHSA-8qrh-h9m2-5fvf/GHSA-8qrh-h9m2-5fvf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8qrh-h9m2-5fvf",
-  "modified": "2020-06-16T21:26:29Z",
+  "modified": "2023-05-11T13:33:30Z",
   "published": "2017-10-24T18:33:38Z",
   "aliases": [
     "CVE-2009-3009"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "actionpack"
       },
       "ranges": [
         {
@@ -34,7 +34,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "actionpack"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This GHSA advisory (GHSA-8qrh-h9m2-5fvf) was split to ruby-advisory-db:
 * gems/actionpack/CVE-2009-3009.yml
 * gems/activesupport/CVE-2009-3009.yml
This is a change-package-name PR plus clone-advisory for 2nd package-name.

