### PR TITLE
[GHSA-v9v4-7jp6-8c73] rails Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-v9v4-7jp6-8c73/GHSA-v9v4-7jp6-8c73.json
+++ b/advisories/github-reviewed/2017/10/GHSA-v9v4-7jp6-8c73/GHSA-v9v4-7jp6-8c73.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v9v4-7jp6-8c73",
-  "modified": "2023-04-20T21:47:18Z",
+  "modified": "2023-05-12T17:24:09Z",
   "published": "2017-10-24T18:33:38Z",
   "aliases": [
     "CVE-2011-2197"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "actionpack"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "actionpack"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This GHSA advisory (GHSA-v9v4-7jp6-8c73) was split to ruby-advisory-db:
 * gems/actionpack/CVE-2011-2197.yml
 * gems/activesupport/CVE-2011-2197.yml
This is a change-package-name PR plus clone-advisory for 2nd package-name.- activesupport.