### PR TITLE
[GHSA-77rv-6vfw-x4gc] Critical severity vulnerability that affects org.springframework.security.oauth:spring-security-oauth and org.springframework.security.oauth:spring-security-oauth2

### DIFF
--- a/advisories/github-reviewed/2019/03/GHSA-77rv-6vfw-x4gc/GHSA-77rv-6vfw-x4gc.json
+++ b/advisories/github-reviewed/2019/03/GHSA-77rv-6vfw-x4gc/GHSA-77rv-6vfw-x4gc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-77rv-6vfw-x4gc",
-  "modified": "2021-01-08T19:16:39Z",
+  "modified": "2023-02-01T05:03:21Z",
   "published": "2019-03-14T15:39:30Z",
   "aliases": [
     "CVE-2019-3778"
@@ -195,7 +195,7 @@
     "cwe_ids": [
       "CWE-601"
     ],
-    "severity": "CRITICAL",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2020-06-16T21:22:03Z",
     "nvd_published_at": "2019-03-07T18:29:00Z"


### PR DESCRIPTION
**Updates**
- Severity

**Comments**
The score is not updated, please review https://nvd.nist.gov/vuln/detail/CVE-2019-3778, based on NVD its recommended to update the CVE score.