### PR TITLE
[GHSA-x3cc-x39p-42qx] fast-xml-parser vulnerable to Prototype Pollution through tag or attribute name

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-x3cc-x39p-42qx/GHSA-x3cc-x39p-42qx.json
+++ b/advisories/github-reviewed/2023/06/GHSA-x3cc-x39p-42qx/GHSA-x3cc-x39p-42qx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x3cc-x39p-42qx",
-  "modified": "2023-06-13T12:44:34Z",
+  "modified": "2023-06-13T12:44:35Z",
   "published": "2023-06-13T12:44:34Z",
   "aliases": [
     "CVE-2023-26920"
@@ -16,11 +16,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "fast-xml-parser"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "fast-xml-parser.XMLParser.parse"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Can all `fast-xml-parser` vulnerabilities be published together at once? We get commits blocked in our repos with every new detailed feature found. (I understand this might not be easy though)