### PR TITLE
[GHSA-cjjg-rvc7-5p7r] NocoDB through 0.106.0 (or 0.109.1) has a path traversal...

### DIFF
--- a/advisories/unreviewed/2023/06/GHSA-cjjg-rvc7-5p7r/GHSA-cjjg-rvc7-5p7r.json
+++ b/advisories/unreviewed/2023/06/GHSA-cjjg-rvc7-5p7r/GHSA-cjjg-rvc7-5p7r.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cjjg-rvc7-5p7r",
-  "modified": "2023-06-19T18:30:48Z",
+  "modified": "2023-06-19T18:30:59Z",
   "published": "2023-06-19T18:30:48Z",
   "aliases": [
     "CVE-2023-35843"
   ],
+  "summary": "NocoDB version <= 0.106.0 (or 0.109.1) Arbitrary File Read",
   "details": "NocoDB through 0.106.0 (or 0.109.1) has a path traversal vulnerability that allows an unauthenticated attacker to access arbitrary files on the server by manipulating the path parameter of the /download route. This vulnerability could allow an attacker to access sensitive files and data on the server, including configuration files, source code, and other sensitive information.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "nocodb"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "0.109.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,7 +42,7 @@
       "url": "https://advisory.dw1.io/60"
     },
     {
-      "type": "WEB",
+      "type": "PACKAGE",
       "url": "https://github.com/nocodb/nocodb/blob/6decfa2b20c28db9946bddce0bcb1442b683ecae/packages/nocodb/src/lib/controllers/attachment.ctl.ts#L62-L74"
     },
     {
@@ -33,9 +52,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-27"
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": null

--- a/advisories/unreviewed/2023/06/GHSA-cjjg-rvc7-5p7r/GHSA-cjjg-rvc7-5p7r.json
+++ b/advisories/unreviewed/2023/06/GHSA-cjjg-rvc7-5p7r/GHSA-cjjg-rvc7-5p7r.json
@@ -6,8 +6,8 @@
   "aliases": [
     "CVE-2023-35843"
   ],
-  "summary": "NocoDB version <= 0.106.0 (or 0.109.1) Arbitrary File Read",
-  "details": "NocoDB through 0.106.0 (or 0.109.1) has a path traversal vulnerability that allows an unauthenticated attacker to access arbitrary files on the server by manipulating the path parameter of the /download route. This vulnerability could allow an attacker to access sensitive files and data on the server, including configuration files, source code, and other sensitive information.",
+  "summary": "NocoDB version <= 0.106.1 Arbitrary File Read",
+  "details": "NocoDB through 0.106.1 has a path traversal vulnerability that allows an unauthenticated attacker to access arbitrary files on the server by manipulating the path parameter of the /download route. This vulnerability could allow an attacker to access sensitive files and data on the server, including configuration files, source code, and other sensitive information.",
   "severity": [
 
   ],
@@ -25,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.109.1"
+              "fixed": ">= 0.107.0-beta.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.106.1"
+      }
     }
   ],
   "references": [
@@ -42,7 +45,7 @@
       "url": "https://advisory.dw1.io/60"
     },
     {
-      "type": "PACKAGE",
+      "type": "WEB",
       "url": "https://github.com/nocodb/nocodb/blob/6decfa2b20c28db9946bddce0bcb1442b683ecae/packages/nocodb/src/lib/controllers/attachment.ctl.ts#L62-L74"
     },
     {


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- Severity
- Source code location
- Summary

**Comments**
My CVE.