### PR TITLE
[GHSA-j79j-cx3h-g27h] Out of bounds write in traitobject

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-j79j-cx3h-g27h/GHSA-j79j-cx3h-g27h.json
+++ b/advisories/github-reviewed/2021/08/GHSA-j79j-cx3h-g27h/GHSA-j79j-cx3h-g27h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j79j-cx3h-g27h",
-  "modified": "2021-08-19T21:07:57Z",
+  "modified": "2023-01-09T05:05:35Z",
   "published": "2021-08-25T20:48:02Z",
   "aliases": [
     "CVE-2020-35881"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This is not a criti,al vulnerability. There will never be a rust 2.0. When the layout changes, this will be communicated way ahead of time. This CVE is frivolous 