### PR TITLE
[GHSA-4348-x292-h437] GoBase Race Condition vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-4348-x292-h437/GHSA-4348-x292-h437.json
+++ b/advisories/github-reviewed/2022/12/GHSA-4348-x292-h437/GHSA-4348-x292-h437.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4348-x292-h437",
-  "modified": "2023-01-06T03:19:36Z",
+  "modified": "2023-01-29T05:01:23Z",
   "published": "2022-12-28T00:30:23Z",
   "aliases": [
     "CVE-2022-2583"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/ntbosscher/gobase"
+        "name": "github.com/ntbosscher/gobase/auth/httpauth"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Accurate the package name instead of the module name. The package is listed in https://pkg.go.dev/vuln/GO-2022-0400. 