### PR TITLE
[GHSA-776f-qx25-q3cc] xml2js is vulnerable to prototype pollution 

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-776f-qx25-q3cc/GHSA-776f-qx25-q3cc.json
+++ b/advisories/github-reviewed/2023/04/GHSA-776f-qx25-q3cc/GHSA-776f-qx25-q3cc.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-776f-qx25-q3cc",
-  "modified": "2023-04-27T14:07:13Z",
+  "modified": "2023-04-27T14:07:15Z",
   "published": "2023-04-05T21:30:24Z",
   "aliases": [
     "CVE-2023-0842"
   ],
-  "summary": "xml2js is vulnerable to prototype pollution ",
+  "summary": "xml2js is vulnerable to prototype pollution",
   "details": "xml2js versions before 0.5.0 allows an external attacker to edit or add new properties to an object. This is possible because the application does not properly validate incoming JSON keys, thus allowing the `__proto__` property to be edited.",
   "severity": [
     {


### PR DESCRIPTION
**Updates**
- Summary

**Comments**
Removed trailing space