### PR TITLE
[GHSA-3x74-v64j-qc3f] CraftCMS Server-Side Template Injection vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-3x74-v64j-qc3f/GHSA-3x74-v64j-qc3f.json
+++ b/advisories/github-reviewed/2023/06/GHSA-3x74-v64j-qc3f/GHSA-3x74-v64j-qc3f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3x74-v64j-qc3f",
-  "modified": "2023-06-14T16:47:17Z",
+  "modified": "2023-06-14T16:47:19Z",
   "published": "2023-06-13T18:30:39Z",
   "aliases": [
     "CVE-2023-30179"
@@ -22,10 +22,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.0.0-RC1"
             },
             {
               "fixed": "4.4.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "craftcms/cms"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.0.0"
+            },
+            {
+              "fixed": "3.7.60"
             }
           ]
         }
@@ -44,6 +63,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/craftcms/cms"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/craftcms/cms/blob/3.8/CHANGELOG.md#L180---2022-11-16"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The affected version was way too broad and was including every Craft 3 release, which is incorrect.