### PR TITLE
[GHSA-mvr2-9pj6-7w5j] Denial of Service in Google Guava

### DIFF
--- a/advisories/github-reviewed/2020/06/GHSA-mvr2-9pj6-7w5j/GHSA-mvr2-9pj6-7w5j.json
+++ b/advisories/github-reviewed/2020/06/GHSA-mvr2-9pj6-7w5j/GHSA-mvr2-9pj6-7w5j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mvr2-9pj6-7w5j",
-  "modified": "2021-06-09T23:19:54Z",
+  "modified": "2023-01-27T05:04:56Z",
   "published": "2020-06-15T20:35:11Z",
   "aliases": [
     "CVE-2018-10237"
@@ -32,6 +32,126 @@
             }
           ]
         }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.google.guava:guava-jdk5"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "17.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.googlecode.guava-osgi:guava-osgi"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "11.0.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "de.mhus.ports:vaadin-shared-deps"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "7.4.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.servicemix.bundles:org.apache.servicemix.bundles.guava"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "11_1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.hudsonci.lib.guava:guava"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "14.0.1-h-3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.hudsonci.lib.guava:guava"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.sonatype.sisu:sisu-guava"
+      },
+      "versions": [
+        "0.11.1"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Several other components are also affected as a result of cloning or shading. Proof-of-Vulnerability projects with tests to verify the presence of the CVE can be found here: https://github.com/jensdietrich/xshady-release/ , the process was the same used for #2258 . 