### PR TITLE
[GHSA-jfh8-c2jp-5v3q] Remote code injection in Log4j

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-jfh8-c2jp-5v3q/GHSA-jfh8-c2jp-5v3q.json
+++ b/advisories/github-reviewed/2021/12/GHSA-jfh8-c2jp-5v3q/GHSA-jfh8-c2jp-5v3q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jfh8-c2jp-5v3q",
-  "modified": "2022-03-25T20:56:18Z",
+  "modified": "2023-04-04T21:46:32Z",
   "published": "2021-12-10T00:40:56Z",
   "aliases": [
     "CVE-2021-44228"
@@ -70,6 +70,43 @@
             }
           ]
         }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.guicedee.services:log4j-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.2.1.2-jre17"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.xbib.elasticsearch:log4j"
+      },
+      "versions": [
+        "6.3.2.1"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "uk.co.nichesolutions.logging.log4j:log4j-core"
+      },
+      "versions": [
+        "2.6.3-CUSTOM"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Several other components are also affected as a result of cloning or shading. Proof-of-Vulnerability projects with tests to verify the presence of the CVE can be found here: https://github.com/jensdietrich/xshady-release/ , the process was the same used for #2258 . 