### PR TITLE
[GHSA-g753-ghr7-q33w] cyfs-base vulnerable to misaligned pointer dereference in `ChunkId::new`

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-g753-ghr7-q33w/GHSA-g753-ghr7-q33w.json
+++ b/advisories/github-reviewed/2023/06/GHSA-g753-ghr7-q33w/GHSA-g753-ghr7-q33w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g753-ghr7-q33w",
-  "modified": "2023-06-22T20:01:55Z",
+  "modified": "2023-06-22T20:01:57Z",
   "published": "2023-06-22T20:01:55Z",
   "aliases": [
 


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
read.me