### PR TITLE
[GHSA-p2fh-2h23-6grg] antfu/utils vulnerable to prototype pollution

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-p2fh-2h23-6grg/GHSA-p2fh-2h23-6grg.json
+++ b/advisories/github-reviewed/2023/05/GHSA-p2fh-2h23-6grg/GHSA-p2fh-2h23-6grg.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p2fh-2h23-6grg",
-  "modified": "2023-06-02T17:11:18Z",
+  "modified": "2023-06-02T17:11:19Z",
   "published": "2023-05-30T12:30:17Z",
   "aliases": [
     "CVE-2023-2972"
   ],
   "summary": "antfu/utils vulnerable to prototype pollution",
-  "details": "Prototype Pollution in GitHub repository antfu/utils prior to 0.7.3.",
+  "details": "Prototype Pollution in GitHub repository antfu/utils prior to and including 0.7.4.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.7.3"
+              "last_affected": "0.7.4"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
The Sonatype Security Research team discovered that the fix was published in 0.7.3 only in the `index.mjs` and `index.cjs` files. The `index.js` file remains vulnerable.

You can validate this by installing the latest version of the package (presently 0.7.4) and comparing the `deepMerge` implementation for `index.js` and `index.mjs`.

```sh
npm i @antfu/utils
cd node_modules/@antfu/utils/dist
```