### PR TITLE
[GHSA-6jvc-q2x7-pchv] AWS S3 Crypto SDK sends an unencrypted hash of the plaintext alongside the ciphertext as a metadata field

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-6jvc-q2x7-pchv/GHSA-6jvc-q2x7-pchv.json
+++ b/advisories/github-reviewed/2022/12/GHSA-6jvc-q2x7-pchv/GHSA-6jvc-q2x7-pchv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6jvc-q2x7-pchv",
-  "modified": "2023-01-06T03:20:04Z",
+  "modified": "2023-02-09T16:52:06Z",
   "published": "2022-12-28T00:30:23Z",
   "aliases": [
     "CVE-2022-2582"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/aws/aws-sdk-go/service/s3/s3crypto"
+        "name": "github.com/aws/aws-sdk-go"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to the OSV spec, the name field should be a Go module path.

>The Go ecosystem; the name field is a Go module path.

https://ossf.github.io/osv-schema/#affectedpackage-field

It should be `github.com/aws/aws-sdk-go` in this case.