### PR TITLE
[GHSA-3f7h-mf4q-vrm4] Denial of Service due to parser crash

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-3f7h-mf4q-vrm4/GHSA-3f7h-mf4q-vrm4.json
+++ b/advisories/github-reviewed/2022/09/GHSA-3f7h-mf4q-vrm4/GHSA-3f7h-mf4q-vrm4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3f7h-mf4q-vrm4",
-  "modified": "2022-10-25T22:11:08Z",
+  "modified": "2023-01-30T05:02:55Z",
   "published": "2022-09-17T00:00:41Z",
   "aliases": [
     "CVE-2022-40152"
@@ -9,7 +9,10 @@
   "summary": "Denial of Service due to parser crash",
   "details": "Those using FasterXML/woodstox to seralize XML data may be vulnerable to Denial of Service attacks (DOS). If the parser is running on user supplied input, an attacker may supply content that causes the parser to crash by stackoverflow. This effect may support a denial of service attack.\n\nThis vulnerability is only relevant for users making use of the DTD parsing functionality. ",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
   ],
   "affected": [
     {
@@ -85,7 +88,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2022-09-20T21:21:07Z",
     "nvd_published_at": "2022-09-16T10:15:00Z"


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
Based on https://nvd.nist.gov/vuln/detail/CVE-2022-40152 the Severity should be 7.5 (NVD). Or at least 6.5 (Google).
Low seems to be the wrong Severity for this advisory.