### PR TITLE
[GHSA-6c3j-c64m-qhgq] XSS in jQuery as used in Drupal, Backdrop CMS, and other products

### DIFF
--- a/advisories/github-reviewed/2019/04/GHSA-6c3j-c64m-qhgq/GHSA-6c3j-c64m-qhgq.json
+++ b/advisories/github-reviewed/2019/04/GHSA-6c3j-c64m-qhgq/GHSA-6c3j-c64m-qhgq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6c3j-c64m-qhgq",
-  "modified": "2022-02-08T22:08:08Z",
+  "modified": "2023-06-30T19:44:52Z",
   "published": "2019-04-26T16:29:11Z",
   "aliases": [
     "CVE-2019-11358"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.1.4"
             },
             {
               "fixed": "3.4.0"
@@ -63,7 +63,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.1.4"
             },
             {
               "fixed": "3.4.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Issue 4333 here https://research.insecurelabs.org/jquery/test/ is a test for this. Does not affect versions below 1.1.4. Those packages does not appear to exist for npm or nuget though, but for jQuery itself, this holds, so I think it would make sense to set it at >= 1.1.4, as there is no non-npm js library ecosystem.
The jquery-rails versioning scheme does not follow jQuery versioning, and the initial version uses jQuery 1.4.2, so it makes sense to leave it at < 4.3.4 as that was the version that started using jQuery 3.4.0