### PR TITLE
[GHSA-fmrf-p77g-vv5c] MediaWiki Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-fmrf-p77g-vv5c/GHSA-fmrf-p77g-vv5c.json
+++ b/advisories/github-reviewed/2023/06/GHSA-fmrf-p77g-vv5c/GHSA-fmrf-p77g-vv5c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fmrf-p77g-vv5c",
-  "modified": "2023-06-30T20:25:26Z",
+  "modified": "2023-06-30T20:25:28Z",
   "published": "2023-06-30T18:31:02Z",
   "aliases": [
     "CVE-2023-37302"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Packagist",
-        "name": "mediawiki/core"
+        "name": ""
       },
       "ranges": [
         {
@@ -23,9 +23,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "1.39.3"
             }
           ]
         }
@@ -47,7 +44,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/wikimedia/mediawiki"
+      "url": "https://github.com/wikimedia/mediawiki-extensions-Wikibase"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
This is a vulnerability in the Wikibase extension, not in MediaWiki core.