### PR TITLE
[GHSA-9w5j-4mwv-2wj8] Remote code execution in simple-git

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-9w5j-4mwv-2wj8/GHSA-9w5j-4mwv-2wj8.json
+++ b/advisories/github-reviewed/2023/01/GHSA-9w5j-4mwv-2wj8/GHSA-9w5j-4mwv-2wj8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9w5j-4mwv-2wj8",
-  "modified": "2023-02-03T20:33:15Z",
+  "modified": "2023-02-03T20:33:16Z",
   "published": "2023-01-26T21:30:25Z",
   "aliases": [
     "CVE-2022-25860"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -57,7 +57,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "CRITICAL",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2023-01-27T01:01:27Z",
     "nvd_published_at": "2023-01-26T21:15:00Z"


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
Versions of the package simple-git before 3.16.0 are vulnerable to Remote Code Execution (RCE) via the clone(), pull(), push() and listRemote() methods, due to improper input sanitization. This vulnerability exists due to an incomplete fix of CVE-2022-25912.

References

https://nvd.nist.gov/vuln/detail/CVE-2022-25860
steveukx/git-js@9545931
steveukx/git-js@ec97a39
https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-3177391