### PR TITLE
[GHSA-cwcx-rxgc-cmw3] Prototype pollution in 101

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-cwcx-rxgc-cmw3/GHSA-cwcx-rxgc-cmw3.json
+++ b/advisories/github-reviewed/2021/05/GHSA-cwcx-rxgc-cmw3/GHSA-cwcx-rxgc-cmw3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cwcx-rxgc-cmw3",
-  "modified": "2021-05-25T20:45:15Z",
+  "modified": "2023-02-01T05:05:38Z",
   "published": "2021-05-17T20:57:40Z",
   "aliases": [
     "CVE-2021-25943"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Description
Prototype pollution vulnerability in '101' versions 1.0.0 through 1.6.3 allows an attacker to cause a denial of service and may lead to remote code execution.

References

https://nvd.nist.gov/vuln/detail/CVE-2021-25943
https://github.com/tjmehta/101/blob/d87f63ce2a4cbdc476e8287abd78327c3144d646/set.js#L52
https://www.whitesourcesoftware.com/vulnerability-database/CVE-2021-25943