### PR TITLE
[GHSA-hxxf-q3w9-4xgw] Malicious Package in eslint-scope

### DIFF
--- a/advisories/github-reviewed/2018/07/GHSA-hxxf-q3w9-4xgw/GHSA-hxxf-q3w9-4xgw.json
+++ b/advisories/github-reviewed/2018/07/GHSA-hxxf-q3w9-4xgw/GHSA-hxxf-q3w9-4xgw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hxxf-q3w9-4xgw",
-  "modified": "2021-09-14T17:35:41Z",
+  "modified": "2023-01-12T05:07:35Z",
   "published": "2018-07-12T19:52:02Z",
   "aliases": [
 
@@ -28,7 +28,7 @@
               "introduced": "3.7.2"
             },
             {
-              "fixed": "4.0.0"
+              "fixed": "3.7.3"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
For eslint-scope pathced version must be 3.7.3.

Postmortem (https://eslint.org/blog/2018/07/postmortem-for-malicious-package-publishes/) says:
2018-07-12 17:41 UTC: The ESLint team published eslint-scope@3.7.3 with the code from eslint-scope@3.7.1 so that caches could pick up the new version.

