### PR TITLE
[GHSA-72xf-g2v4-qvf3] Versions of the package tough-cookie before 4.1.3 are...

### DIFF
--- a/advisories/unreviewed/2023/07/GHSA-72xf-g2v4-qvf3/GHSA-72xf-g2v4-qvf3.json
+++ b/advisories/unreviewed/2023/07/GHSA-72xf-g2v4-qvf3/GHSA-72xf-g2v4-qvf3.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-72xf-g2v4-qvf3",
-  "modified": "2023-07-01T06:30:16Z",
+  "modified": "2023-07-01T06:30:23Z",
   "published": "2023-07-01T06:30:16Z",
   "aliases": [
     "CVE-2023-26136"
   ],
+  "summary": "Add affected package npm < 4.1.3",
   "details": "Versions of the package tough-cookie before 4.1.3 are vulnerable to Prototype Pollution due to improper handling of Cookies when using CookieJar in rejectPublicSuffixes=false mode. This issue arises from the manner in which the objects are initialized.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "tough-cookie"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.1.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -42,7 +61,7 @@
     "cwe_ids": [
 
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Summary

**Comments**
I add the npm package in affected products, hope that was correct.