### PR TITLE
[GHSA-cfgp-2977-2fmm] Connection confusion in gRPC

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-cfgp-2977-2fmm/GHSA-cfgp-2977-2fmm.json
+++ b/advisories/github-reviewed/2023/07/GHSA-cfgp-2977-2fmm/GHSA-cfgp-2977-2fmm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cfgp-2977-2fmm",
-  "modified": "2023-07-05T20:26:48Z",
+  "modified": "2023-07-05T20:26:49Z",
   "published": "2023-07-05T19:12:51Z",
   "aliases": [
     "CVE-2023-32731"
@@ -74,25 +74,6 @@
     },
     {
       "package": {
-        "ecosystem": "Go",
-        "name": "google.golang.org/grpc"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.53.0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
         "ecosystem": "Maven",
         "name": "io.grpc:grpc-protobuf"
       },
@@ -113,7 +94,7 @@
     {
       "package": {
         "ecosystem": "npm",
-        "name": "@grpc/grpc-js"
+        "name": "@grpc/grpc"
       },
       "ranges": [
         {
@@ -123,7 +104,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.8.8"
+              "fixed": "0.0.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
After a thorough analysis, we believe that those 2 ecosystems are not impacted as they don't wrap the vulnerable C++ implementation of gRPC:
* Go, cf https://go-review.googlesource.com/c/vulndb/+/503837/3/data/excluded/GO-2023-1847.yaml#2 and https://github.com/grpc/grpc-go
* npm, grpc-js is a pure javascript implementation according to https://www.npmjs.com/package/@grpc/grpc-js.
The deprecatd grpc package (https://www.npmjs.com/package/grpc) is probably the one that is vulnerable (versions to be defined)