### PR TITLE
[GHSA-cfgp-2977-2fmm] Connection confusion in gRPC

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-cfgp-2977-2fmm/GHSA-cfgp-2977-2fmm.json
+++ b/advisories/github-reviewed/2023/07/GHSA-cfgp-2977-2fmm/GHSA-cfgp-2977-2fmm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cfgp-2977-2fmm",
-  "modified": "2023-07-05T20:26:48Z",
+  "modified": "2023-07-05T20:26:49Z",
   "published": "2023-07-05T19:12:51Z",
   "aliases": [
     "CVE-2023-32731"
@@ -67,25 +67,6 @@
             },
             {
               "fixed": "3.2.0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Go",
-        "name": "google.golang.org/grpc"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.53.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The Go Vuln DB team has clarified this vulnerability doesn't impact the Go gRPC implementation. The related issues for the advisory (https://github.com/grpc/grpc/pull/32309 and https://github.com/grpc/grpc/pull/33005) impact the C++ code, but Go's gRPC implementation uses its own Go-based HTTP/2 stack.

Additional information:
- https://github.com/golang/vulndb/issues/1847
- https://cloud.google.com/support/bulletins#gcp-2023-010