### PR TITLE
[GHSA-w44m-8mv2-v78h] Cosmos "Barberry" vulnerability in github.com/cosmos/cosmos-sdk

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-w44m-8mv2-v78h/GHSA-w44m-8mv2-v78h.json
+++ b/advisories/github-reviewed/2023/06/GHSA-w44m-8mv2-v78h/GHSA-w44m-8mv2-v78h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w44m-8mv2-v78h",
-  "modified": "2023-06-22T20:01:48Z",
+  "modified": "2023-06-22T20:01:55Z",
   "published": "2023-06-22T20:01:48Z",
   "aliases": [
 
@@ -22,14 +22,17 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.46.0"
             },
             {
               "fixed": "0.46.13"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.46.12"
+      }
     },
     {
       "package": {
@@ -48,7 +51,10 @@
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.47.2"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Wrong version mentioned here now breaks builds for cosmos-sdk v0.45.x branches which are NOT affected by this vulnerability. Corrected version numbers.