### PR TITLE
Fix function name in GHSA-3288-cwgw-ch86

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-3288-cwgw-ch86/GHSA-3288-cwgw-ch86.json
+++ b/advisories/github-reviewed/2021/08/GHSA-3288-cwgw-ch86/GHSA-3288-cwgw-ch86.json
@@ -22,7 +22,7 @@
       },
       "ecosystem_specific": {
         "affected_functions": [
-          "xcb::xproto::GetAtomNameReply::name()"
+          "xcb::xproto::GetAtomNameReply::name"
         ]
       },
       "ranges": [


### PR DESCRIPTION
This attribute should contain the function name without parenthesis (see https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2021/08/GHSA-vhfr-v4w9-45v8/GHSA-vhfr-v4w9-45v8.json#L24 for example)