### PR TITLE
[GHSA-g98v-hv3f-hcfr] atty potential unaligned read

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-g98v-hv3f-hcfr/GHSA-g98v-hv3f-hcfr.json
+++ b/advisories/github-reviewed/2023/06/GHSA-g98v-hv3f-hcfr/GHSA-g98v-hv3f-hcfr.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g98v-hv3f-hcfr",
-  "modified": "2023-06-30T20:21:59Z",
+  "modified": "2023-06-30T20:22:03Z",
   "published": "2023-06-30T20:21:59Z",
   "aliases": [
 
   ],
   "summary": "atty potential unaligned read",
-  "details": "On windows, `atty` dereferences a potentially unaligned pointer.\n\nIn practice however, the pointer won't be unaligned unless a custom global allocator is used.\n\nIn particular, the `System` allocator on windows uses `HeapAlloc`, which guarantees a large enough alignment.\n\n# atty is Unmaintained\n\nA Pull Request with a fix has been provided over a year ago but the maintainer seems to be unreachable.\n\nLast release of `atty` was almost 3 years ago.\n\n## Possible Alternative(s)\n\nThe below list has not been vetted in any way and may or may not contain alternatives;\n\n - [is-terminal](https://crates.io/crates/is-terminal)\n - std::io::IsTerminal *nightly-only experimental*\n",
+  "details": "On windows, `atty` dereferences a potentially unaligned pointer.\n\nIn practice however, the pointer won't be unaligned unless a custom global allocator is used.\n\nIn particular, the `System` allocator on windows uses `HeapAlloc`, which guarantees a large enough alignment.\n\n# atty is Unmaintained\n\nA Pull Request with a fix has been provided over a year ago but the maintainer seems to be unreachable.\n\nLast release of `atty` was almost 3 years ago.\n\n## Possible Alternative(s)\n\nThe below list has not been vetted in any way and may or may not contain alternatives;\n\n - [std::io::IsTerminal](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html) - Stable since Rust 1.70.0\n - [is-terminal](https://crates.io/crates/is-terminal) - Standalone crate supporting Rust older than 1.70.0",
   "severity": [
 
   ],


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Rust v1.70 released the `IsTerminal` trait as stable.

The updated text is copied from the RUSTSEC security advisory.