### PR TITLE
[GHSA-22wj-vf5f-wrvj] Password exposure in H2 Database 

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-22wj-vf5f-wrvj/GHSA-22wj-vf5f-wrvj.json
+++ b/advisories/github-reviewed/2022/11/GHSA-22wj-vf5f-wrvj/GHSA-22wj-vf5f-wrvj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-22wj-vf5f-wrvj",
-  "modified": "2022-11-30T23:34:15Z",
+  "modified": "2023-07-07T21:14:46Z",
   "published": "2022-11-23T21:30:31Z",
   "aliases": [
     "CVE-2022-45868"
@@ -9,10 +9,7 @@
   "summary": "Password exposure in H2 Database ",
   "details": "The web-based admin console in H2 Database Engine through 2.1.214 can be started via the CLI with the argument -webAdminPassword, which allows the user to specify the password in cleartext for the web admin console. Consequently, a local user (or an attacker that has obtained local access through some means) would be able to discover the password by listing processes and their arguments. NOTE: the vendor states \"This is not a vulnerability of H2 Console ... Passwords should never be passed on the command line and every qualified DBA or system administrator is expected to know that.\"",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
-    }
+
   ],
   "affected": [
     {
@@ -66,7 +63,7 @@
       "CWE-200",
       "CWE-312"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2022-11-23T22:31:05Z",
     "nvd_published_at": "2022-11-23T21:15:00Z"


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
Please for the love of god stop sending me these alerts. This isn't a vulnerability that anyone should care about. If an attacker already has access to your local machine you are screwed. 

"This is not a vulnerability of H2 Console ... Passwords should never be passed on the command line and every qualified DBA or system administrator is expected to know that."