### PR TITLE
[GHSA-58qw-p7qm-5rvh] Eclipse Jetty XmlParser allows arbitrary DOCTYPE declarations

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-58qw-p7qm-5rvh/GHSA-58qw-p7qm-5rvh.json
+++ b/advisories/github-reviewed/2023/07/GHSA-58qw-p7qm-5rvh/GHSA-58qw-p7qm-5rvh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-58qw-p7qm-5rvh",
-  "modified": "2023-07-10T21:52:39Z",
+  "modified": "2023-07-10T21:52:40Z",
   "published": "2023-07-10T21:52:39Z",
   "aliases": [
 
@@ -28,14 +28,11 @@
               "introduced": "0"
             },
             {
-              "fixed": "10.0.16"
+              "last_affected": "10.0.15"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 10.0.15"
-      }
+      ]
     },
     {
       "package": {
@@ -50,14 +47,11 @@
               "introduced": "11.0.0-alpha0"
             },
             {
-              "fixed": "11.0.16"
+              "last_affected": "11.0.15"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 11.0.15"
-      }
+      ]
     },
     {
       "package": {
@@ -72,14 +66,11 @@
               "introduced": "12.0.0.beta0"
             },
             {
-              "fixed": "12.0.0"
+              "last_affected": "12.0.0.beta3"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 12.0.0.beta3"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
There are no patched versions of the `jetty-xml` artifacts that fix or address this Advisory.