### PR TITLE
[GHSA-wgvx-9rh5-4g4m] Jenkins Benchmark Evaluator Plugin vulnerable to cross-site request forgery

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-wgvx-9rh5-4g4m/GHSA-wgvx-9rh5-4g4m.json
+++ b/advisories/github-reviewed/2023/07/GHSA-wgvx-9rh5-4g4m/GHSA-wgvx-9rh5-4g4m.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wgvx-9rh5-4g4m",
-  "modified": "2023-07-12T22:30:15Z",
+  "modified": "2023-07-12T22:30:18Z",
   "published": "2023-07-12T18:30:39Z",
   "aliases": [
     "CVE-2023-37962"
   ],
   "summary": "Jenkins Benchmark Evaluator Plugin vulnerable to cross-site request forgery",
-  "details": "Jenkins Benchmark Evaluator Plugin 1.0.1 and earlier does not perform a permission check in a method implementing form validation.\n\nThis allows attackers with Overall/Read permission to connect to an attacker-specified URL and to check for the existence of directories, `.csv`, and `.ycsb` files on the Jenkins controller file system.\n\nAdditionally, this form validation method does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.",
+  "details": "Jenkins Benchmark Evaluator Plugin 1.0.1 and earlier does not perform a permission check in a method implementing form validation.\n\nThis allows attackers with Overall/Read permission to connect to an attacker-specified URL and to check for the existence of directories, `.csv`, and `.ycsb` files on the Jenkins controller file system.\n\nAdditionally, this form validation method does not require POST requests, resulting in a cross-site request forgery (CSRF) vulnerability.\n\nCaptcha can be added by embedding a random `csrf_token` value in the form, or by checking the `Referer` field in the request header to see if the request was sent from the same domain.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-37962"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://plugins.jenkins.io/benchmark-evaluator/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location

**Comments**
Captcha can be added by embedding a random `csrf_token` value in the form, or by checking the `Referer` field in the request header to see if the request was sent from the same domain.