### PR TITLE
[GHSA-257q-pv89-v3xv] jQuery Cross Site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-257q-pv89-v3xv/GHSA-257q-pv89-v3xv.json
+++ b/advisories/github-reviewed/2023/06/GHSA-257q-pv89-v3xv/GHSA-257q-pv89-v3xv.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-257q-pv89-v3xv",
-  "modified": "2023-07-07T15:07:56Z",
+  "modified": "2023-07-10T13:07:18Z",
   "published": "2023-06-26T21:30:58Z",
   "aliases": [
     "CVE-2020-23064"
   ],
   "summary": "jQuery Cross Site Scripting vulnerability",
-  "details": "Cross Site Scripting vulnerability in jQuery v.2.2.0 until v.3.5.0 allows a remote attacker to execute arbitrary code via the `<options>` element.",
+  "details": "Cross Site Scripting vulnerability in jQuery v.1.0.3 until v.3.5.0 allows a remote attacker to execute arbitrary code via the `<option>` element.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -20,17 +20,12 @@
         "ecosystem": "npm",
         "name": "jquery"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "jquery.htmlPrefilter"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.2.0"
+              "introduced": "1.0.3"
             },
             {
               "fixed": "3.5.0"
@@ -49,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.2.0"
+              "introduced": "1.0.3"
             },
             {
               "fixed": "3.5.0"
@@ -68,7 +63,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.1.0"
+              "introduced": "0"
             },
             {
               "fixed": "4.4.0"


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
CVE-2020-23064 is a duplicate of CVE-2020-11023. This is also mentioned on Snyk's page: https://security.snyk.io/vuln/SNYK-JS-JQUERY-565129.
For npm and nuget it should thus have the same lower bound as GHSA-jpcq-cgw6-v4j6. 
For jquery-rails the first version is using 1.4.2, so all versions below 4.4.0 (which uses jQuery 3.5.1) are vulnerable.
The links for these advisories (GHSA-jpcq-cgw6-v4j6 and GHSA-257q-pv89-v3xv) should be merged, and probably also the Affected products listing.
For testing, see https://research.insecurelabs.org/jquery/test/ issue 4647.