### PR TITLE
[GHSA-p8p7-x288-28g6] Server-Side Request Forgery in Request

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-p8p7-x288-28g6/GHSA-p8p7-x288-28g6.json
+++ b/advisories/github-reviewed/2023/03/GHSA-p8p7-x288-28g6/GHSA-p8p7-x288-28g6.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p8p7-x288-28g6",
-  "modified": "2023-03-22T21:49:04Z",
+  "modified": "2023-04-14T20:24:55Z",
   "published": "2023-03-16T15:30:19Z",
   "aliases": [
     "CVE-2023-28155"
   ],
   "summary": "Server-Side Request Forgery in Request",
-  "details": "The Request package through 2.88.2 for Node.js allows a bypass of SSRF mitigations via an attacker-controller server that does a cross-protocol redirect (HTTP to HTTPS, or HTTPS to HTTP). NOTE: This vulnerability only affects products that are no longer supported by the maintainer.",
+  "details": "The Request package through 2.88.1 for Node.js allows a bypass of SSRF mitigations via an attacker-controller server that does a cross-protocol redirect (HTTP to HTTPS, or HTTPS to HTTP). NOTE: This vulnerability only affects products that are no longer supported by the maintainer.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.88.2"
+              "fixed": "2.88.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.88.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
The NVD states that the vulnerability is for versions up to and including 2.88.1 (not 2.88.2), see source here:
https://nvd.nist.gov/vuln/detail/CVE-2023-28155