### PR TITLE
[GHSA-257q-pv89-v3xv] jQuery Cross Site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-257q-pv89-v3xv/GHSA-257q-pv89-v3xv.json
+++ b/advisories/github-reviewed/2023/06/GHSA-257q-pv89-v3xv/GHSA-257q-pv89-v3xv.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-257q-pv89-v3xv",
-  "modified": "2023-07-07T15:07:56Z",
+  "modified": "2023-07-13T20:49:59Z",
   "published": "2023-06-26T21:30:58Z",
   "aliases": [
     "CVE-2020-23064"
   ],
   "summary": "jQuery Cross Site Scripting vulnerability",
-  "details": "Cross Site Scripting vulnerability in jQuery v.2.2.0 until v.3.5.0 allows a remote attacker to execute arbitrary code via the `<options>` element.",
+  "details": "> Cross Site Scripting vulnerability in jQuery v.2.2.0 until v.3.5.0 allows a remote attacker to execute arbitrary code via the `<options>` element.\n\nThis is nice, but I already updated to v3.7.0, and Dependabot keeps issuing alerts.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "jquery"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "jquery.htmlPrefilter"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Dependabot keeps issuing alerts after I fixed the vuln. The link to the vulnerable file in the alert 404s, because that file no longer exists on HEAD of my default branch.