### PR TITLE
[GHSA-7gj7-224w-vpr3] Thymeleaf allows sandbox bypass via crafted HTML

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-7gj7-224w-vpr3/GHSA-7gj7-224w-vpr3.json
+++ b/advisories/github-reviewed/2023/07/GHSA-7gj7-224w-vpr3/GHSA-7gj7-224w-vpr3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7gj7-224w-vpr3",
-  "modified": "2023-07-14T21:50:50Z",
+  "modified": "2023-07-14T21:50:52Z",
   "published": "2023-07-14T06:31:00Z",
   "aliases": [
     "CVE-2023-38286"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.thymeleaf:thymeleaf-parent"
+        "name": "de.codecentric:spring-boot-admin-starter-server"
       },
       "ranges": [
         {
@@ -25,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.1.1.RELEASE"
+              "fixed": "3.1.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.1.1"
+      }
     }
   ],
   "references": [
@@ -38,12 +41,12 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-38286"
     },
     {
-      "type": "WEB",
-      "url": "https://github.com/p1n93r/SpringBootAdmin-thymeleaf-SSTI"
+      "type": "PACKAGE",
+      "url": "https://github.com/codecentric/spring-boot-admin"
     },
     {
-      "type": "PACKAGE",
-      "url": "https://github.com/thymeleaf/thymeleaf"
+      "type": "WEB",
+      "url": "https://github.com/p1n93r/SpringBootAdmin-thymeleaf-SSTI"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
Vulnerable and fixed product is Spring Boot Admin, not thymeleaf.
https://github.com/codecentric/spring-boot-admin/commit/f1f6ac6f613e1c0afc121c8989f28b4155a6797a#diff-1ea8b144c29588e08221597d56d8be10b4b4a210f248a83f2e837152a3d2e0d7