### PR TITLE
Reporting Inaccurate Affected Components in GHSA-gfwj-fwqj-fp3v

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-gfwj-fwqj-fp3v/GHSA-gfwj-fwqj-fp3v.json
+++ b/advisories/github-reviewed/2022/05/GHSA-gfwj-fwqj-fp3v/GHSA-gfwj-fwqj-fp3v.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.springframework:spring-core"
+        "name": "org.springframework:spring-web"
       },
       "ranges": [
         {
@@ -92,6 +92,14 @@
     {
       "type": "WEB",
       "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+    },
+    {
+      "type": "DISCUSSION",
+      "url": "https://github.com/spring-projects/spring-framework/issues/26931"
+    },
+    {
+      "type": "FIX",
+      "url": "https://github.com/spring-projects/spring-framework/commit/0d0d75e25322d8161002d861fff3ec04ba8be5ac"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
the true affected components may contain org.springframework:spring-web. There are the advisory and patch: https://spring.io/security/cve-2021-22118/, https://github.com/spring-projects/spring-framework/commit/cce60c479c22101f24b2b4abebb6d79440b120d1.
The affected version may be checked as well.