### PR TITLE
[GHSA-257q-pv89-v3xv] jQuery Cross Site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-257q-pv89-v3xv/GHSA-257q-pv89-v3xv.json
+++ b/advisories/github-reviewed/2023/06/GHSA-257q-pv89-v3xv/GHSA-257q-pv89-v3xv.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-257q-pv89-v3xv",
-  "modified": "2023-07-07T15:07:56Z",
+  "modified": "2023-07-13T20:49:59Z",
   "published": "2023-06-26T21:30:58Z",
   "aliases": [
     "CVE-2020-23064"
   ],
   "summary": "jQuery Cross Site Scripting vulnerability",
-  "details": "Cross Site Scripting vulnerability in jQuery v.2.2.0 until v.3.5.0 allows a remote attacker to execute arbitrary code via the `<options>` element.",
+  "details": "Cross Site Scripting vulnerability in jQuery v.2.2.0 until v.3.5.0 allows a remote attacker to execute arbitrary code via the `<options>` element.\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "jquery"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "jquery.htmlPrefilter"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**

false positive '__') it's already 3.5.0

Upgrade jquery to fix [2 Dependabot alerts](https://github.com/kokizzu/gotro/security/dependabot?q=is%3Aopen+package%3Ajquery+manifest%3AW%2Fexample-simplified%2Fpublic%2Flib%2Fjquery.js+has%3Apatch) in [W/example-simplified/public/lib/jquery.js](https://github.com/kokizzu/gotro/blob/-/W/example-simplified/public/lib/jquery.js)

Upgrade jquery to version 3.5.0 or later.