### PR TITLE
[GHSA-rfvw-5848-gxc5] Silverstripe Flash Clipboard Reflected XSS

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-rfvw-5848-gxc5/GHSA-rfvw-5848-gxc5.json
+++ b/advisories/github-reviewed/2022/05/GHSA-rfvw-5848-gxc5/GHSA-rfvw-5848-gxc5.json
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.3.5"
+              "fixed": "4.3.5, 4.4.4"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.3.5"
+      }
     },
     {
       "package": {
@@ -47,11 +50,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.0"
+              "fixed": "1.3.5, 1.4.4"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.3.5"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The versions listed were incorrect - especially for silverstripe/admin which doesn't even have a version 3 at the moment.
There was a historical precedent for just calling all related core modules by the version number that silverstripe/framework was on. But 1.x on silverstripe/admin is in-step with 4.x of silverstripe/framework.

Note that this is causing issues for anyone running `composer audit`, or any other composer command that triggers an audit, in projects that use `silverstripe/admin`. This needs to be fixed ASAP.