### PR TITLE
[GHSA-w49p-h6v2-88hr] D-Link DIR_878_FW1.30B08 was discovered to contain a...

### DIFF
--- a/advisories/unreviewed/2023/01/GHSA-w49p-h6v2-88hr/GHSA-w49p-h6v2-88hr.json
+++ b/advisories/unreviewed/2023/01/GHSA-w49p-h6v2-88hr/GHSA-w49p-h6v2-88hr.json
@@ -1,20 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w49p-h6v2-88hr",
-  "modified": "2023-02-07T21:30:26Z",
+  "modified": "2023-02-15T05:06:31Z",
   "published": "2023-01-27T21:31:10Z",
   "aliases": [
     "CVE-2022-48107"
   ],
-  "details": "D-Link DIR_878_FW1.30B08 was discovered to contain a command injection vulnerability via the component /setnetworksettings/IPAddress. This vulnerability allows attackers to escalate privileges to root via a crafted payload.",
+  "summary": "CVE incorrectly rated",
+  "details": "D-Link DIR_878_FW1.30B08 was discovered to contain a command injection vulnerability via the component /setnetworksettings/IPAddress. This vulnerability allows attackers to escalate privileges to root via a crafted payload. However, the attackers would need to be on the same network as the router as well as have administrative access to the web portal.\n\n![image](https://user-images.githubusercontent.com/103917304/254802701-5e41309e-be8b-4e97-8731-d365ac82487b.png)\n",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:A/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -34,7 +50,7 @@
     "cwe_ids": [
       "CWE-77"
     ],
-    "severity": "CRITICAL",
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-01-27T21:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Summary

**Comments**
CVE is incorrectly rated. In order for the exploit to work, the user needs to have administrative access to the router first in order to receive the cookie which authenticates the POST request.

The user also needs to be on the same logical network as the router. 

Therefore the Attack Vector has been adjusted to Adjacent and the Privileges required adjusted to High.
