### PR TITLE
[GHSA-6hvf-xvwm-vrw4] XMLTooling Library Incorrectly Handles Some Exceptions

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-6hvf-xvwm-vrw4/GHSA-6hvf-xvwm-vrw4.json
+++ b/advisories/github-reviewed/2022/05/GHSA-6hvf-xvwm-vrw4/GHSA-6hvf-xvwm-vrw4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6hvf-xvwm-vrw4",
-  "modified": "2023-07-18T23:18:21Z",
+  "modified": "2023-07-18T23:18:22Z",
   "published": "2022-05-13T01:02:16Z",
   "aliases": [
     "CVE-2019-9628"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.opensaml:xmltooling"
+        "name": ""
       },
       "ranges": [
         {
@@ -29,10 +29,7 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 3.0.4"
-      }
+      ]
     }
   ],
   "references": [
@@ -45,8 +42,16 @@
       "url": "https://bugs.launchpad.net/ubuntu/+source/xmltooling/+bug/1819912"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://git.shibboleth.net/view/?p=cpp-xmltooling.git"
+    },
+    {
       "type": "WEB",
       "url": "https://security.netapp.com/advisory/ntap-20190611-0003/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://shibboleth.atlassian.net/browse/CPPXT-143"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
## Changes

* Added additional references and source code location
* Removed affected ecosystem information (wrong ecosystem/unsupported)

## Reasons for the change

The CVE concerns the C++ version of the xmltooling library, not the Java library.

Per the advisory (https://shibboleth.net/community/advisories/secadv_20190311.txt), we can trace back the commit and tickets here:

* https://git.shibboleth.net/view/?p=cpp-xmltooling.git;a=commit;h=af27c422f551e16989ff6f1722d83614c8550eb5
* https://shibboleth.atlassian.net/browse/CPPXT-143

Where we can see the actual component is "XMLTooling - C++" - not the Java library. Version 3.0.4 does not exist in the Java library - releases stop at 1.4.6:

* https://git.shibboleth.net/view/?p=java-xmltooling.git;a=summary
* https://build.shibboleth.net/maven/releases/org/opensaml/xmltooling/
