### PR TITLE
Reporting Inaccurate Affected Components in GHSA-pr5m-4w22-8483

### DIFF
--- a/advisories/github-reviewed/2021/02/GHSA-pr5m-4w22-8483/GHSA-pr5m-4w22-8483.json
+++ b/advisories/github-reviewed/2021/02/GHSA-pr5m-4w22-8483/GHSA-pr5m-4w22-8483.json
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.nanohttpd:nanohttpd"
+        "name": "org.nanohttpd:nanohttpd-nanolets"
       },
       "ranges": [
         {


### PR DESCRIPTION
affected package change to org.nanohttpd:nanohttpd, according to the cve desc: 'An issue was discovered in RouterNanoHTTPD.java in NanoHTTPD through 2.3.1.', and the RouterNanoHTTPD is located in org.nanohttpd:nanohttpd-nanolets (https://github.com/NanoHttpd/nanohttpd/blob/efb2ebf85a2b06f7c508aba9eaad5377e3a01e81/nanolets/src/main/java/org/nanohttpd/router/RouterNanoHTTPD.java#L64), the pom.xml (https://github.com/NanoHttpd/nanohttpd/blob/efb2ebf85a2b06f7c508aba9eaad5377e3a01e81/nanolets/pom.xml) shows the coordiante of this component.