### PR TITLE
Reporting Inaccurate Affected Components in GHSA-7q8g-gpfp-v8gx

### DIFF
--- a/advisories/github-reviewed/2021/02/GHSA-pr5m-4w22-8483/GHSA-pr5m-4w22-8483.json
+++ b/advisories/github-reviewed/2021/02/GHSA-pr5m-4w22-8483/GHSA-pr5m-4w22-8483.json
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.nanohttpd:nanohttpd"
+        "name": "org.nanohttpd:nanohttpd-nanolets"
       },
       "ranges": [
         {

--- a/advisories/github-reviewed/2022/01/GHSA-7q8g-gpfp-v8gx/GHSA-7q8g-gpfp-v8gx.json
+++ b/advisories/github-reviewed/2022/01/GHSA-7q8g-gpfp-v8gx/GHSA-7q8g-gpfp-v8gx.json
@@ -18,24 +18,18 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.nifi:nifi"
+        "name": "org.apache.nifi:nifi-framework-core"
       },
       "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0.0.1"
-            },
-            {
-              "fixed": "1.12.0-RC1"
-            }
-          ]
-        }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 1.11.0"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.nifi:nifi-security-utils"
+      },
+      "ranges": [
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
According to the advisory(https://nifi.apache.org/security.html#CVE-2020-1942) and patch in this advisory(https://github.com/apache/nifi/pull/4028/files) ,the affected component is org.apache.nifi:nifi-framework-core and org.apache.nifi:nifi-security-utils. 
The affected versions should be rechecked.