### PR TITLE
Reporting Inaccurate Affected Components in GHSA-grc3-8q8m-4j7c

### DIFF
--- a/advisories/github-reviewed/2021/02/GHSA-pr5m-4w22-8483/GHSA-pr5m-4w22-8483.json
+++ b/advisories/github-reviewed/2021/02/GHSA-pr5m-4w22-8483/GHSA-pr5m-4w22-8483.json
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.nanohttpd:nanohttpd"
+        "name": "org.nanohttpd:nanohttpd-nanolets"
       },
       "ranges": [
         {


### PR DESCRIPTION
According to this patch: https://github.com/apache/accumulo/pull/1828/files, when accumulo-manager do not throw exceptions, allowing an authenticated user flushing a table, shutting down Accumulo or an individual tablet server, and setting or removing system-wide Accumulo configuration properties without permission.