### PR TITLE
[GHSA-cf7p-gm2m-833m] cryptography mishandles SSH certificates

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-cf7p-gm2m-833m/GHSA-cf7p-gm2m-833m.json
+++ b/advisories/github-reviewed/2023/07/GHSA-cf7p-gm2m-833m/GHSA-cf7p-gm2m-833m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cf7p-gm2m-833m",
-  "modified": "2023-07-14T22:14:26Z",
+  "modified": "2023-07-14T22:14:27Z",
   "published": "2023-07-14T21:31:08Z",
   "aliases": [
     "CVE-2023-38325"
@@ -17,17 +17,12 @@
         "ecosystem": "PyPI",
         "name": "cryptography"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "cryptography.hazmat.primitives.serialization.ssh.SSHCertificateBuilder.sign"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "40.0.0"
             },
             {
               "fixed": "41.0.2"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
SSH certificate parsing was added in 40.0.0 by https://github.com/pyca/cryptography/commit/aca8de845e751dd45fe4e48f8492f357d34d1861