### PR TITLE
[GHSA-65j5-vpm7-6xp4] Smarty Path Traversal Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-65j5-vpm7-6xp4/GHSA-65j5-vpm7-6xp4.json
+++ b/advisories/github-reviewed/2022/05/GHSA-65j5-vpm7-6xp4/GHSA-65j5-vpm7-6xp4.json
@@ -32,10 +32,7 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 3.1.33-dev-4"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This version range is not composer-compliant, and is unusable in the composer ecosystem: `< 3.1.33-dev-4` therefore becomes `<3.1.33` (which is the patched version anyway).

Ref: https://github.com/Roave/SecurityAdvisoriesBuilder/actions/runs/5661243781

 > Could not parse version constraint < 3.1.33-dev-4: Invalid version string "3.1.33-dev-4"

Ref: https://github.com/Roave/SecurityAdvisoriesBuilder/actions/runs/5661243781/job/15338734912#step:7:20

Note that `3.1.33-dev-4` is not published to packagist anyway: https://packagist.org/packages/smarty/smarty