### PR TITLE
[GHSA-x5m7-rwfx-w7qm] Remote Code Execution in Apache Flume

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-x5m7-rwfx-w7qm/GHSA-x5m7-rwfx-w7qm.json
+++ b/advisories/github-reviewed/2022/06/GHSA-x5m7-rwfx-w7qm/GHSA-x5m7-rwfx-w7qm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x5m7-rwfx-w7qm",
-  "modified": "2022-06-17T01:15:00Z",
+  "modified": "2023-01-27T05:04:00Z",
   "published": "2022-06-15T00:00:24Z",
   "aliases": [
     "CVE-2022-25167"
@@ -9,13 +9,16 @@
   "summary": "Remote Code Execution in Apache Flume",
   "details": "Apache Flume versions 1.4.0 through 1.9.0 are vulnerable to a remote code execution (RCE) attack when a configuration uses a JMS Source with a JNDI LDAP data source URI when an attacker has control of the target LDAP server. This issue is fixed by limiting JNDI to allow only the use of the java protocol or no protocol.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.flume:flume-parent"
+        "name": "org.apache.flume.flume-ng-sources:flume-jms-source"
       },
       "ranges": [
         {
@@ -60,9 +63,10 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-20",
+      "CWE-74"
     ],
-    "severity": "HIGH",
+    "severity": "CRITICAL",
     "github_reviewed": true,
     "github_reviewed_at": "2022-06-17T01:15:00Z",
     "nvd_published_at": "2022-06-14T08:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity

**Comments**
Looking at the linked commit https://github.com/apache/flume/commit/dafb26ccb172141c6e14e95447e1b6ae38e9a7d0 it appears that the affected artifact should be org.apache.flume.flume-ng-sources:flume-jms-source similar to https://github.com/advisories/GHSA-h9mh-mgpv-gqmv