### PR TITLE
[GHSA-9w4g-fp9h-3q2v] Apache Flume vulnerable to remote code execution via deserialization of unsafe providerURL

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-9w4g-fp9h-3q2v/GHSA-9w4g-fp9h-3q2v.json
+++ b/advisories/github-reviewed/2022/10/GHSA-9w4g-fp9h-3q2v/GHSA-9w4g-fp9h-3q2v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9w4g-fp9h-3q2v",
-  "modified": "2022-10-31T15:53:07Z",
+  "modified": "2023-01-30T05:03:15Z",
   "published": "2022-10-26T19:00:38Z",
   "aliases": [
     "CVE-2022-42468"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.flume:flume-parent"
+        "name": "org.apache.flume.flume-ng-sources:flume-jms-source"
       },
       "ranges": [
         {
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-42468"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/flume/commit/eee179a09df405c1ab55ae25a53b76ca1050bb97"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Looking at the commit https://github.com/apache/flume/commit/eee179a09df405c1ab55ae25a53b76ca1050bb97 that seems to correspond to this, it appears that the affected artifact should be org.apache.flume.flume-ng-sources:flume-jms-source similar to https://github.com/advisories/GHSA-h9mh-mgpv-gqmv