### PR TITLE
[GHSA-q9w4-w667-qqj4] ckeditor-wordcount-plugin vulnerable to Cross-site Scripting in Source Mode of Editor

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-q9w4-w667-qqj4/GHSA-q9w4-w667-qqj4.json
+++ b/advisories/github-reviewed/2023/07/GHSA-q9w4-w667-qqj4/GHSA-q9w4-w667-qqj4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q9w4-w667-qqj4",
-  "modified": "2023-07-21T17:59:43Z",
+  "modified": "2023-07-21T21:34:16Z",
   "published": "2023-07-10T21:54:03Z",
   "aliases": [
     "CVE-2023-37905"
@@ -36,9 +36,70 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 1.17.11"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "typo3/cms-rte-ckeditor"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.5.0"
+            },
+            {
+              "fixed": "9.5.42"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "typo3/cms-rte-ckeditor"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.0.0"
+            },
+            {
+              "fixed": "10.4.39"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "typo3/cms-rte-ckeditor"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "11.0.0"
+            },
+            {
+              "fixed": "11.5.30"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/TYPO3/typo3/security/advisories/GHSA-m8fw-p3cr-6jqc"
+    },
     {
       "type": "WEB",
       "url": "https://github.com/w8tcha/CKEditor-WordCount-Plugin/security/advisories/GHSA-q9w4-w667-qqj4"


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Additional affected software configurations