### PR TITLE
[GHSA-369m-2gv6-mw28] WEBrick RCE Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
+++ b/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-369m-2gv6-mw28",
-  "modified": "2023-07-26T20:26:17Z",
+  "modified": "2023-07-26T20:26:18Z",
   "published": "2022-05-14T02:03:29Z",
   "aliases": [
     "CVE-2017-10784"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
I'm not quite sure what to change here.  The affected versions being used here are the RUBY versions, but dependabot is matching against the gem version (latest webrick gem is 1.8.1).

So someone with ruby version 3.1 and webrick gem 1.8.1 is getting caught by this detection, even though they aren't subject to the CVE (which affects ruby < 2.2.8, etc)