### PR TITLE
[GHSA-369m-2gv6-mw28] WEBrick RCE Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
+++ b/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-369m-2gv6-mw28",
-  "modified": "2023-07-26T20:26:17Z",
+  "modified": "2023-07-26T20:26:18Z",
   "published": "2022-05-14T02:03:29Z",
   "aliases": [
     "CVE-2017-10784"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This advisory is incorrectly flagging the ruby-gem `webrick` and not Ruby (the language interpreter).

The Gem `webrick` has a current version of 1.8.1.

This advisory mistakenly suggests updating to:

```ruby


gem "webrick", ">= 2.2.8"
```

which does not exist.

This advisory should instead "target" the Ruby language version, not the version of the ruby-gem `webrick`