### PR TITLE
[GHSA-369m-2gv6-mw28] WEBrick RCE Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
+++ b/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-369m-2gv6-mw28",
-  "modified": "2023-07-26T20:26:17Z",
+  "modified": "2023-07-26T20:26:18Z",
   "published": "2022-05-14T02:03:29Z",
   "aliases": [
     "CVE-2017-10784"
   ],
   "summary": "WEBrick RCE Vulnerability",
-  "details": "The Basic authentication code in WEBrick library in Ruby before 2.2.8, 2.3.x before 2.3.5, and 2.4.x through 2.4.1 allows remote attackers to inject terminal emulator escape sequences into its log and possibly execute arbitrary commands via a crafted user name.",
+  "details": "The Basic authentication code in the WEBrick library when bundled with Ruby, before 2.2.8, 2.3.x before 2.3.5, and 2.4.x through 2.4.1, or when used as a gem before 1.4.0 allows remote attackers to inject terminal emulator escape sequences into its log and possibly execute arbitrary commands via a crafted user name.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,45 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.2.8"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "webrick"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.3"
-            },
-            {
-              "fixed": "2.3.5"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "webrick"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.4"
-            },
-            {
-              "last_affected": "2.4.1"
+              "fixed": "1.4.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
The 1.4.0 gem release contains this commit:
https://github.com/ruby/webrick/commit/4ac0f3843ab82d1c31e1cfc719409208adef7813
This commit references this other commit:
https://github.com/ruby/ruby/commit/6617c41292
whose description says:
> It had failed to sanitize some type of exception messages.  Reported and
patched by Yusuke Endoh (mame) at https://hackerone.com/reports/223363

So this clearly fixes CVE-2017-10784 (you can verify by matching the CVE/name with the hackerone report for example)

The previously provided versions were for the version of **Ruby** itself.
As far as I am aware, the advisory database can not model this constraint.
Currently, I think this causes false dependabot alerts for potentially every Jekyll user.