### PR TITLE
[GHSA-369m-2gv6-mw28] WEBrick RCE Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
+++ b/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-369m-2gv6-mw28",
-  "modified": "2023-07-26T20:26:17Z",
+  "modified": "2023-07-26T20:26:18Z",
   "published": "2022-05-14T02:03:29Z",
   "aliases": [
     "CVE-2017-10784"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This is not quite right. 
Dependabot is advising to `Upgrade webrick to version 2.2.8 or later`, which is not correct, as that webrick version does not exist https://rubygems.org/gems/webrick/versions
What it must be done is to upgrade RUBY itself to the mentioned versions, as in that moment webrick was part of the base ruby code.
This is mentioned like for example here https://www.ruby-lang.org/en/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784 which is one of the articles already referenced.