### PR TITLE
[GHSA-369m-2gv6-mw28] WEBrick RCE Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
+++ b/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-369m-2gv6-mw28",
-  "modified": "2023-07-26T20:26:17Z",
+  "modified": "2023-07-26T20:26:18Z",
   "published": "2022-05-14T02:03:29Z",
   "aliases": [
     "CVE-2017-10784"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "webrick"
+        "name": "ruby"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "webrick"
+        "name": "ruby"
       },
       "ranges": [
         {
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "webrick"
+        "name": "ruby"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
These is no such webricks 2.2.8, 2.3.x, and 2.4.x, these are ruby versions. recent update on this create wrong dependentbot alerts.