### PR TITLE
[GHSA-369m-2gv6-mw28] WEBrick RCE Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
+++ b/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-369m-2gv6-mw28",
-  "modified": "2023-07-26T20:26:17Z",
+  "modified": "2023-07-26T20:26:18Z",
   "published": "2022-05-14T02:03:29Z",
   "aliases": [
     "CVE-2017-10784"
@@ -26,47 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "2.2.8"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "webrick"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.3"
-            },
-            {
-              "fixed": "2.3.5"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "webrick"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.4"
-            },
-            {
-              "last_affected": "2.4.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
There _is_ [no version of webrick beyond 1.8.1](https://rubygems.org/gems/webrick). The advisory is misleading - it suggests we need to update webrick to a newer version of webrick (2.4.2 or above) but I believe the advisory is actually referring to versions of `ruby`, _not_ `webrick`. So this should only be alerting on repos that have a `.ruby-version` below 2.4.2.