### PR TITLE
[GHSA-369m-2gv6-mw28] WEBrick RCE Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
+++ b/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-369m-2gv6-mw28",
-  "modified": "2023-07-26T20:26:17Z",
+  "modified": "2023-07-26T20:26:18Z",
   "published": "2022-05-14T02:03:29Z",
   "aliases": [
     "CVE-2017-10784"
@@ -28,45 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.2.8"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "webrick"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.3"
-            },
-            {
-              "fixed": "2.3.5"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "webrick"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.4"
-            },
-            {
-              "last_affected": "2.4.1"
+              "fixed": "1.4.0"
             }
           ]
         }
@@ -77,6 +39,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-10784"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ruby/ruby/commit/6617c41292b7d1e097abb8fdb0cab9ddd83c77e7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ruby/webrick/commit/4ac0f3843ab82d1c31e1cfc719409208adef7813"
+    },
+    {
+      "type": "WEB",
+      "url": "https://hackerone.com/reports/223363"
     },
     {
       "type": "WEB",
@@ -93,6 +67,10 @@
     {
       "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2018:0585"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/ruby/webrick"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
The current version range are ruby versions, not from the gem. Current webrick only goes up to 1.8.1 and it's not possible to update my dependencies to get rid of the advisory. Dependabot also fails to create a security update for this.

1.4.0 got released with the fix. https://github.com/ruby/webrick/commit/4ac0f3843ab82d1c31e1cfc719409208adef7813 is the combined webrick commit and https://github.com/ruby/ruby/commit/6617c41292b7d1e097abb8fdb0cab9ddd83c77e7 is where it got fixed in ruby. The previously specified ruby versions are still vulnerable because they contain the code but it's not possible to make advisories for default gems like this.