### PR TITLE
[GHSA-6hvf-xvwm-vrw4] XMLTooling Library Incorrectly Handles Some Exceptions

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-6hvf-xvwm-vrw4/GHSA-6hvf-xvwm-vrw4.json
+++ b/advisories/github-reviewed/2022/05/GHSA-6hvf-xvwm-vrw4/GHSA-6hvf-xvwm-vrw4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6hvf-xvwm-vrw4",
-  "modified": "2023-07-18T23:18:21Z",
+  "modified": "2023-07-18T23:18:22Z",
   "published": "2022-05-13T01:02:16Z",
   "aliases": [
     "CVE-2019-9628"
@@ -26,13 +26,13 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "3.0.4"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 3.0.4"
-      }
+      ]
     }
   ],
   "references": [

--- a/advisories/github-reviewed/2022/05/GHSA-6hvf-xvwm-vrw4/GHSA-6hvf-xvwm-vrw4.json
+++ b/advisories/github-reviewed/2022/05/GHSA-6hvf-xvwm-vrw4/GHSA-6hvf-xvwm-vrw4.json
@@ -17,7 +17,7 @@
   "affected": [
     {
       "package": {
-        "ecosystem": "Maven",
+        "ecosystem": "Go",
         "name": "org.opensaml:xmltooling"
       },
       "ranges": [
@@ -26,19 +26,23 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "3.0.4"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 3.0.4"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-9628"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/unofficial-shibboleth-mirror/cpp-xmltooling/commit/af27c422f551e16989ff6f1722d83614c8550eb5"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It is documented to affect versions < 3.0.4. There exists a version 3.0.4 which should be set as patched version.