### PR TITLE
[GHSA-369m-2gv6-mw28] WEBrick RCE Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
+++ b/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-369m-2gv6-mw28",
-  "modified": "2023-07-26T20:26:17Z",
+  "modified": "2023-07-26T20:26:18Z",
   "published": "2022-05-14T02:03:29Z",
   "aliases": [
     "CVE-2017-10784"
@@ -28,45 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.2.8"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "webrick"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.3"
-            },
-            {
-              "fixed": "2.3.5"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "webrick"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.4"
-            },
-            {
-              "last_affected": "2.4.1"
+              "fixed": "1.4.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The version specified was the **ruby** version this library was shipped with, not the version of the library itself. It has been removed from the standard library and currently the webrick version is 1.8.1.

The specification as is leads to false positives as every project using webrick will be flagged as affected although it uses a patched version.