### PR TITLE
[GHSA-369m-2gv6-mw28] WEBrick RCE Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
+++ b/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-369m-2gv6-mw28",
-  "modified": "2023-07-26T20:26:17Z",
+  "modified": "2023-07-26T20:26:18Z",
   "published": "2022-05-14T02:03:29Z",
   "aliases": [
     "CVE-2017-10784"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
I can't change this above, but this one is a false positive for us.

Referenced CVE databases mention that you are affected when using Ruby before v2.2.8. But this entry triggers an alert if your WebRick is pre v2.2.8 (which is always the case, given the latest Webrick is v.1.8.1).. so for us and others this will be a false positive.

With other words, entry needs to be modified to look at people using any version of webrick with Ruby pre v.2.2.8 but don't see a way to do this.