### PR TITLE
[GHSA-369m-2gv6-mw28] WEBrick RCE Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
+++ b/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-369m-2gv6-mw28",
-  "modified": "2023-07-26T20:26:17Z",
+  "modified": "2023-07-26T20:26:18Z",
   "published": "2022-05-14T02:03:29Z",
   "aliases": [
     "CVE-2017-10784"
@@ -28,45 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.2.8"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "webrick"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.3"
-            },
-            {
-              "fixed": "2.3.5"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "RubyGems",
-        "name": "webrick"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.4"
-            },
-            {
-              "last_affected": "2.4.1"
+              "fixed": "1.4.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The CVE describes vulnerable _Ruby_ versions rather than vulnerable Gem versions from back when `webrick` was primarily bundled with Ruby and not as a standalone gem. The GitHub advisory, as updated yesterday, however, now seems to link to the Gem versions, which is not aligned with the Ruby version. The latest gem version is 1.8.1, so this alert started re-appearing for applications long-since patched and is unresolvable with the version constraints specified. It's not clear to me when/whether the standalone gem was vulnerable to this, but 1.4.0 post-dates the CVE and is probably the first version used by most applications, so updated the range to use that instead.