### PR TITLE
[GHSA-369m-2gv6-mw28] WEBrick RCE Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
+++ b/advisories/github-reviewed/2022/05/GHSA-369m-2gv6-mw28/GHSA-369m-2gv6-mw28.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-369m-2gv6-mw28",
-  "modified": "2023-07-26T20:26:17Z",
+  "modified": "2023-07-26T20:26:18Z",
   "published": "2022-05-14T02:03:29Z",
   "aliases": [
     "CVE-2017-10784"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "webrick"
+        "name": "ruby"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "webrick"
+        "name": "ruby"
       },
       "ranges": [
         {
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "webrick"
+        "name": "ruby"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
What's being referenced is the webrick bundled gem, not the externalized webrick gem. The way this is written is causing it to pick up that external webrick gem that was pulled out of ruby. The vulnerability can't be fixed because the above versions are ruby versions, not webrick versions (latest webrick is only 1.8.1). I'm not sure if referencing ruby versions like this works or not...