### PR TITLE
[GHSA-7gj7-224w-vpr3] Thymeleaf, as used in Spring Boot Admin, allows sandbox bypass via crafted HTML

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-7gj7-224w-vpr3/GHSA-7gj7-224w-vpr3.json
+++ b/advisories/github-reviewed/2023/07/GHSA-7gj7-224w-vpr3/GHSA-7gj7-224w-vpr3.json
@@ -9,10 +9,7 @@
   "summary": "Thymeleaf, as used in Spring Boot Admin, allows sandbox bypass via crafted HTML",
   "details": "Thymeleaf through 3.1.1.RELEASE, as used in spring-boot-admin (aka Spring Boot Admin) through 3.1.1 and other products, allows sandbox bypass via crafted HTML. This may be relevant for SSTI (Server Side Template Injection) and code execution in spring-boot-admin if MailNotifier is enabled and there is write access to environment variables via the UI.\n\nSpring Boot Admin 3.1.2 contains a [patch](https://github.com/codecentric/spring-boot-admin/pull/2615) for this issue.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
-    }
+
   ],
   "affected": [
     {
@@ -46,6 +43,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/thymeleaf/thymeleaf/issues/966"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/codecentric/spring-boot-admin/pull/2615"
     },
     {
@@ -73,7 +74,7 @@
     "cwe_ids": [
       "CWE-77"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2023-07-14T21:50:50Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- References

**Comments**
Modifications performed in Thymeleaf for 3.1.2 securing the scenario of CVE-2023-38286 further, from the standpoint of Thymeleaf.