### PR TITLE
[GHSA-qm95-pgcg-qqfq] Insufficient validation when decoding a Socket.IO packet

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-qm95-pgcg-qqfq/GHSA-qm95-pgcg-qqfq.json
+++ b/advisories/github-reviewed/2022/10/GHSA-qm95-pgcg-qqfq/GHSA-qm95-pgcg-qqfq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qm95-pgcg-qqfq",
-  "modified": "2022-11-14T20:01:32Z",
+  "modified": "2023-03-13T23:27:28Z",
   "published": "2022-10-26T12:00:28Z",
   "aliases": [
     "CVE-2022-2421"
@@ -20,10 +20,27 @@
         "ecosystem": "npm",
         "name": "socket.io-parser"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "socket.io-parser.Decoder"
-        ]
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.1.0"
+            },
+            {
+              "fixed": "4.2.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.2.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "socket.io-parser"
       },
       "ranges": [
         {
@@ -44,35 +61,6 @@
         "ecosystem": "npm",
         "name": "socket.io-parser"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "socket.io-parser.Decoder"
-        ]
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "4.1.0"
-            },
-            {
-              "fixed": "4.2.1"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "socket.io-parser"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "socket.io-parser.Decoder"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -91,11 +79,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "socket.io-parser"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "socket.io-parser.Decoder"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Improve: "Insufficient validation when decoding a Socket.IO packet"
https://security.snyk.io/package/npm/socket.io-parser/4.2.1 - Upgrade socket.io-parser to version 3.4.3, 4.2.3 or higher.