### PR TITLE
[GHSA-6hvf-xvwm-vrw4] XMLTooling Library Incorrectly Handles Some Exceptions

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-6hvf-xvwm-vrw4/GHSA-6hvf-xvwm-vrw4.json
+++ b/advisories/github-reviewed/2022/05/GHSA-6hvf-xvwm-vrw4/GHSA-6hvf-xvwm-vrw4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6hvf-xvwm-vrw4",
-  "modified": "2023-07-18T23:18:21Z",
+  "modified": "2023-07-31T20:31:07Z",
   "published": "2022-05-13T01:02:16Z",
   "aliases": [
     "CVE-2019-9628"
@@ -17,8 +17,8 @@
   "affected": [
     {
       "package": {
-        "ecosystem": "Maven",
-        "name": "org.opensaml:xmltooling"
+        "ecosystem": "Go",
+        "name": "xmltooling-cpp"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This is affects the cpp version not the java version. I am not sure why the correct ecosystem should be in this case.
See also https://github.com/github/advisory-database/pull/2509