### PR TITLE
[GHSA-r4h9-gv2m-9x97] Croogo XSS

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-r4h9-gv2m-9x97/GHSA-r4h9-gv2m-9x97.json
+++ b/advisories/github-reviewed/2022/05/GHSA-r4h9-gv2m-9x97/GHSA-r4h9-gv2m-9x97.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r4h9-gv2m-9x97",
-  "modified": "2023-07-26T22:37:30Z",
+  "modified": "2023-07-26T22:37:31Z",
   "published": "2022-05-14T03:41:55Z",
   "aliases": [
     "CVE-2017-1000510"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.3.1-17-g6f82e6c"
+              "fixed": "4.0.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The dependency range `< 2.3.1-17-g6f82e6c` is not valid in the packagist ecosystem.

As mentioned in https://github.com/croogo/croogo/issues/847, the security issue is fixed in 4.x.