### PR TITLE
[GHSA-pv7r-9vjg-g3f9] Duplicate advisory: swift-nio-http2 vulnerable to denial of service via invalid HTTP/2 HEADERS frame length

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-pv7r-9vjg-g3f9/GHSA-pv7r-9vjg-g3f9.json
+++ b/advisories/github-reviewed/2022/02/GHSA-pv7r-9vjg-g3f9/GHSA-pv7r-9vjg-g3f9.json
@@ -8,7 +8,7 @@
 
   ],
   "summary": "Duplicate advisory: swift-nio-http2 vulnerable to denial of service via invalid HTTP/2 HEADERS frame length",
-  "details": "## Duplicate Advisory\n\nThis advisory has been withdrawn because it is a duplicate of GHSA-pgfx-g6rc-8cjv. This link is maintained to preserve external references.\n\n## Original Description\n\nA program using swift-nio-http2 is vulnerable to a denial of service attack, caused by a network peer sending a specially crafted HTTP/2 frame. This attack affects all swift-nio-http2 versions from 1.0.0 to 1.19.1. This vulnerability is caused by a logical error when parsing a HTTP/2 HEADERS frame where the frame contains priority information without any other data. This logical error caused confusion about the size of the frame, leading to a parsing error. This parsing error immediately crashes the entire process. Sending a HEADERS frame with HTTP/2 priority information does not require any special permission, so any HTTP/2 connection peer may send such a frame. For clients, this means any server to which they connect may launch this attack. For servers, anyone they allow to connect to them may launch such an attack. The attack is low-effort: it takes very little resources to send an appropriately crafted frame. The impact on availability is high: receiving the frame immediately crashes the server, dropping all in-flight connections and causing the service to need to restart. It is straightforward for an attacker to repeatedly send appropriately crafted frames, so attackers require very few resources to achieve a substantial denial of service. The attack does not have any confidentiality or integrity risks in and of itself: swift-nio-http2 is parsing the frame in memory-safe code, so the crash is safe. However, sudden process crashes can lead to violations of invariants in services, so it is possible that this attack can be used to trigger an error condition that has confidentiality or integrity risks. The risk can be mitigated if untrusted peers can be prevented from communicating with the service. This mitigation is not available to many services. The issue is fixed by rewriting the parsing code to correctly handle the condition. The issue was found by automated fuzzing by oss-fuzz.",
+  "details": " Duplicate Advisory\n\nThis advisory has been withdrawn because it is a duplicate of GHSA-pgfx-g6rc-8cjv. This link is maintained to preserve external references.\n\n## Original Description\n\nA program using swift-nio-http2 is vulnerable to a denial of service attack, caused by a network peer sending a specially crafted HTTP/2 frame. This attack affects all swift-nio-http2 versions from 1.0.0 to 1.19.1. This vulnerability is caused by a logical error when parsing a HTTP/2 HEADERS frame where the frame contains priority information without any other data. This logical error caused confusion about the size of the frame, leading to a parsing error. This parsing error immediately crashes the entire process. Sending a HEADERS frame with HTTP/2 priority information does not require any special permission, so any HTTP/2 connection peer may send such a frame. For clients, this means any server to which they connect may launch this attack. For servers, anyone they allow to connect to them may launch such an attack. The attack is low-effort: it takes very little resources to send an appropriately crafted frame. The impact on availability is high: receiving the frame immediately crashes the server, dropping all in-flight connections and causing the service to need to restart. It is straightforward for an attacker to repeatedly send appropriately crafted frames, so attackers require very few resources to achieve a substantial denial of service. The attack does not have any confidentiality or integrity risks in and of itself: swift-nio-http2 is parsing the frame in memory-safe code, so the crash is safe. However, sudden process crashes can lead to violations of invariants in services, so it is possible that this attack can be used to trigger an error condition that has confidentiality or integrity risks. The risk can be mitigated if untrusted peers can be prevented from communicating with the service. This mitigation is not available to many services. The issue is fixed by rewriting the parsing code to correctly handle the condition. The issue was found by automated fuzzing by oss-fuzz.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -18,7 +18,7 @@
   "affected": [
     {
       "package": {
-        "ecosystem": "purl-type:swift",
+        "ecosystem": "GitHub Actions",
         "name": "github.com/apple/swift-nio-http2"
       },
       "ranges": [
@@ -52,7 +52,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-130"
+
     ],
     "severity": "HIGH",
     "github_reviewed": true,

--- a/advisories/github-reviewed/2022/02/GHSA-pv7r-9vjg-g3f9/GHSA-pv7r-9vjg-g3f9.json
+++ b/advisories/github-reviewed/2022/02/GHSA-pv7r-9vjg-g3f9/GHSA-pv7r-9vjg-g3f9.json
@@ -18,7 +18,7 @@
   "affected": [
     {
       "package": {
-        "ecosystem": "GitHub Actions",
+        "ecosystem": "purl-type:swift",
         "name": "github.com/apple/swift-nio-http2"
       },
       "ranges": [


### PR DESCRIPTION
**Updates**
- CWEs
- Description

**Comments**
Take down the tab links and codes js
