### PR TITLE
[GHSA-h896-mx9x-g32g] XML External Entity injection in Apache Camel

### DIFF
--- a/advisories/github-reviewed/2019/05/GHSA-h896-mx9x-g32g/GHSA-h896-mx9x-g32g.json
+++ b/advisories/github-reviewed/2019/05/GHSA-h896-mx9x-g32g/GHSA-h896-mx9x-g32g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h896-mx9x-g32g",
-  "modified": "2022-11-17T17:55:41Z",
+  "modified": "2023-01-28T05:00:56Z",
   "published": "2019-05-29T18:15:50Z",
   "aliases": [
     "CVE-2019-0188"
@@ -15,25 +15,6 @@
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.apache.camel:camel-core"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "2.24.0"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "Maven",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This only affects the camel-xmljson component according to the announcement

https://www.openwall.com/lists/oss-security/2019/05/24/2