### PR TITLE
Add swift to the list of supported ecosystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Our supported ecosystems are:
 - Pub (registry: https://pub.dev/)
 - RubyGems (registry: https://rubygems.org/)
 - Rust (registry: https://crates.io/)
+- Swift (registry: [namespaced by dns](https://datatracker.ietf.org/doc/html/rfc1035))
 
 If you have a suggestion for a new ecosystem we should support, please open an [issue](https://github.com/github/advisory-database/issues) for discussion.
 


### PR DESCRIPTION
PR to add swift as a supported ecosystem and links out to the dns rfc to explain the namespace constraint in place of a file server based registry

Closes #2447