### PR TITLE
[GHSA-hmx6-gc2p-5p82] Nablarch Incomplete Cryptography

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-hmx6-gc2p-5p82/GHSA-hmx6-gc2p-5p82.json
+++ b/advisories/github-reviewed/2022/05/GHSA-hmx6-gc2p-5p82/GHSA-hmx6-gc2p-5p82.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hmx6-gc2p-5p82",
-  "modified": "2023-07-19T18:05:17Z",
+  "modified": "2023-07-19T18:05:18Z",
   "published": "2022-05-13T01:08:15Z",
   "aliases": [
     "CVE-2019-5919"
@@ -18,14 +18,17 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "com.nablarch.framework:nablarch-core"
+        "name": "com.nablarch.framework:nablarch-fw-web"
       },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.5.1"
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.5.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The target artifact of the vulnerability is nablarch-fw-web, not nablarch-core.
The modifications to this vulnerability can be found in the following PR.
https://github.com/nablarch/nablarch-fw-web/pull/53
https://github.com/nablarch/nablarch-fw-web/pull/54

Affected versions was specified as a lower limit, but should correctly be specified as an upper limit.