### PR TITLE
[GHSA-wj7q-gjg8-3cpm] league/oauth2-server key exposed in exception message when passing as a string and providing an invalid pass phrase

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-wj7q-gjg8-3cpm/GHSA-wj7q-gjg8-3cpm.json
+++ b/advisories/github-reviewed/2023/07/GHSA-wj7q-gjg8-3cpm/GHSA-wj7q-gjg8-3cpm.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wj7q-gjg8-3cpm",
-  "modified": "2023-07-06T21:07:27Z",
+  "modified": "2023-07-06T21:07:29Z",
   "published": "2023-07-06T21:07:27Z",
   "aliases": [
     "CVE-2023-37260"
   ],
   "summary": "league/oauth2-server key exposed in exception message when passing as a string and providing an invalid pass phrase",
-  "details": "### Impact\nServers that passed their keys to the CryptKey constructor as as string instead of a file path will have had that key included in a LogicException message if they did not provide a valid pass phrase for the key where required. \n\n### Patches\nThis issue has been patched so that the provided key is no longer exposed in the exception message in the scenario outlined above. Users should upgrade to version 8.5.3 to receive the patch\n\n### Workarounds\nWe recommend upgrading the oauth2-server to the latest version. If you are unable to upgrade you can avoid this security issue by passing your key as a file instead of a string.\n\n### References\n[Pull request](https://github.com/thephpleague/oauth2-server/pull/1353) for the applied fix.\n",
+  "details": "### Impact\nServers that passed their keys to the CryptKey constructor as as string instead of a file path will have had that key included in a LogicException message if they did not provide a valid pass phrase for the key where required. \n\n### Patches\nThis issue has been patched so that the provided key is no longer exposed in the exception message in the scenario outlined above. Users should upgrade to version 8.5.3 or 8.4.2 to receive the patch\n\n### Workarounds\nWe recommend upgrading the oauth2-server to the latest version. If you are unable to upgrade you can avoid this security issue by passing your key as a file instead of a string.\n\n### References\n[Pull request](https://github.com/thephpleague/oauth2-server/pull/1353) for the applied fix.\n[Pull request](https://github.com/thephpleague/oauth2-server/pull/1359) for the applied fix for php 7.x version.\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -25,10 +25,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "8.3.2"
+              "introduced": "8.5.0"
             },
             {
               "fixed": "8.5.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "league/oauth2-server"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.3.2"
+            },
+            {
+              "fixed": "8.4.2"
             }
           ]
         }
@@ -47,6 +66,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/thephpleague/oauth2-server/pull/1353"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/thephpleague/oauth2-server/pull/1359"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
Fixed for php7.x versions, see https://github.com/thephpleague/oauth2-server/pull/1359