### PR TITLE
[GHSA-7rx6-4vwv-432g] Missing permission check in CloudBees CD Plugin allows scheduling builds

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-7rx6-4vwv-432g/GHSA-7rx6-4vwv-432g.json
+++ b/advisories/github-reviewed/2022/05/GHSA-7rx6-4vwv-432g/GHSA-7rx6-4vwv-432g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7rx6-4vwv-432g",
-  "modified": "2022-12-13T19:28:45Z",
+  "modified": "2023-01-29T05:04:56Z",
   "published": "2022-05-24T17:48:06Z",
   "aliases": [
     "CVE-2021-21647"
@@ -25,17 +25,33 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.1.19"
             },
             {
               "fixed": "1.1.22"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 1.1.21"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:electricflow"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.1.18.1"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adjusts affected version ranges to account for Jenkins backported fix per https://github.com/CVEProject/cvelist/blob/1f5ffa2118d4a1c833c50a6d03eda5bd0aac005c/2021/21xxx/CVE-2021-21647.json#L22-L25