### PR TITLE
[GHSA-xfv3-rrfm-f2rv] Information Exposure in Netty

### DIFF
--- a/advisories/github-reviewed/2020/06/GHSA-xfv3-rrfm-f2rv/GHSA-xfv3-rrfm-f2rv.json
+++ b/advisories/github-reviewed/2020/06/GHSA-xfv3-rrfm-f2rv/GHSA-xfv3-rrfm-f2rv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xfv3-rrfm-f2rv",
-  "modified": "2021-09-22T18:45:29Z",
+  "modified": "2023-01-09T05:03:31Z",
   "published": "2020-06-30T21:01:21Z",
   "aliases": [
     "CVE-2015-2156"
@@ -32,10 +32,45 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 4.0.2.7"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jboss.netty:netty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.9.8.Final"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jboss.netty:netty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.10"
+            },
+            {
+              "fixed": "3.10.3.Final"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adds the affected version ranges for netty 3.x, which was packaged as a single artifact `netty` under the `org.jboss.netty` namespace: https://central.sonatype.com/namespace/org.jboss.netty