### PR TITLE
[GHSA-p979-4mfw-53vg] HTTP Request Smuggling in Netty

### DIFF
--- a/advisories/github-reviewed/2019/10/GHSA-p979-4mfw-53vg/GHSA-p979-4mfw-53vg.json
+++ b/advisories/github-reviewed/2019/10/GHSA-p979-4mfw-53vg/GHSA-p979-4mfw-53vg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p979-4mfw-53vg",
-  "modified": "2022-04-01T18:11:58Z",
+  "modified": "2023-02-01T05:02:38Z",
   "published": "2019-10-11T18:41:23Z",
   "aliases": [
     "CVE-2019-16869"
@@ -36,6 +36,25 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 4.1.41.Final"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jboss.netty:netty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.2.10.Final"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Netty prior to v4 was under a different groupid https://central.sonatype.com/namespace/org.jboss.netty, so this adds the necessary ranges to include all prior versions