### PR TITLE
[GHSA-cqqj-4p63-rrmm] HTTP Request Smuggling in Netty

### DIFF
--- a/advisories/github-reviewed/2020/02/GHSA-cqqj-4p63-rrmm/GHSA-cqqj-4p63-rrmm.json
+++ b/advisories/github-reviewed/2020/02/GHSA-cqqj-4p63-rrmm/GHSA-cqqj-4p63-rrmm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cqqj-4p63-rrmm",
-  "modified": "2021-08-25T17:26:45Z",
+  "modified": "2023-03-22T20:57:16Z",
   "published": "2020-02-21T18:55:24Z",
   "aliases": [
     "CVE-2019-20444"
@@ -29,6 +29,25 @@
             },
             {
               "fixed": "4.1.44"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jboss.netty:netty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.2.10.Final"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adding ranges to include netty 3.x which was distributed as a single artifact `netty` under a different groupid: https://central.sonatype.com/namespace/org.jboss.netty