### PR TITLE
[GHSA-p2v9-g2qv-p635] HTTP Request Smuggling in Netty

### DIFF
--- a/advisories/github-reviewed/2020/02/GHSA-p2v9-g2qv-p635/GHSA-p2v9-g2qv-p635.json
+++ b/advisories/github-reviewed/2020/02/GHSA-p2v9-g2qv-p635/GHSA-p2v9-g2qv-p635.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p2v9-g2qv-p635",
-  "modified": "2021-08-25T17:37:42Z",
+  "modified": "2023-02-01T05:02:46Z",
   "published": "2020-02-21T18:55:04Z",
   "aliases": [
     "CVE-2019-20445"
@@ -26,6 +26,25 @@
             },
             {
               "fixed": "4.1.45"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jboss.netty:netty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.2.10.Final"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adding ranges to include netty 3.x which was distributed as a single artifact `netty` under a different groupid: https://central.sonatype.com/namespace/org.jboss.netty