### PR TITLE
[GHSA-5mcr-gq6c-3hq2] Local Information Disclosure Vulnerability in Netty on Unix-Like systems

### DIFF
--- a/advisories/github-reviewed/2021/02/GHSA-5mcr-gq6c-3hq2/GHSA-5mcr-gq6c-3hq2.json
+++ b/advisories/github-reviewed/2021/02/GHSA-5mcr-gq6c-3hq2/GHSA-5mcr-gq6c-3hq2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5mcr-gq6c-3hq2",
-  "modified": "2022-04-19T15:19:08Z",
+  "modified": "2023-02-01T05:05:06Z",
   "published": "2021-02-08T21:17:48Z",
   "aliases": [
     "CVE-2021-21290"
@@ -36,6 +36,25 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 4.1.58.Final"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jboss.netty:netty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.2.10.Final"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adding ranges to include netty 3.x which was distributed as a single artifact `netty` under a different groupid: https://central.sonatype.com/namespace/org.jboss.netty