### PR TITLE
[GHSA-wm47-8v5p-wjpj] Possible request smuggling in HTTP/2 due missing validation

### DIFF
--- a/advisories/github-reviewed/2021/03/GHSA-wm47-8v5p-wjpj/GHSA-wm47-8v5p-wjpj.json
+++ b/advisories/github-reviewed/2021/03/GHSA-wm47-8v5p-wjpj/GHSA-wm47-8v5p-wjpj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wm47-8v5p-wjpj",
-  "modified": "2021-08-31T21:19:12Z",
+  "modified": "2023-02-01T05:05:17Z",
   "published": "2021-03-09T18:49:49Z",
   "aliases": [
     "CVE-2021-21295"
@@ -36,6 +36,25 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 4.1.59.Final"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jboss.netty:netty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.2.10.Final"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adding ranges to include netty 3.x which was distributed as a single artifact `netty` under a different groupid: https://central.sonatype.com/namespace/org.jboss.netty