### PR TITLE
[GHSA-f256-j965-7f32] Possible request smuggling in HTTP/2 due missing validation of content-length

### DIFF
--- a/advisories/github-reviewed/2021/03/GHSA-f256-j965-7f32/GHSA-f256-j965-7f32.json
+++ b/advisories/github-reviewed/2021/03/GHSA-f256-j965-7f32/GHSA-f256-j965-7f32.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f256-j965-7f32",
-  "modified": "2022-02-08T21:31:25Z",
+  "modified": "2023-02-01T05:05:21Z",
   "published": "2021-03-30T15:10:38Z",
   "aliases": [
     "CVE-2021-21409"
@@ -36,6 +36,25 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 4.1.60.Final"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jboss.netty:netty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.2.10.Final"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adding ranges to include netty 3.x which was distributed as a single artifact `netty` under a different groupid: https://central.sonatype.com/namespace/org.jboss.netty