### PR TITLE
[GHSA-grg4-wf29-r9vv] Bzip2Decoder doesn't allow setting size restrictions for decompressed data

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-grg4-wf29-r9vv/GHSA-grg4-wf29-r9vv.json
+++ b/advisories/github-reviewed/2021/09/GHSA-grg4-wf29-r9vv/GHSA-grg4-wf29-r9vv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-grg4-wf29-r9vv",
-  "modified": "2022-02-08T20:39:51Z",
+  "modified": "2023-01-28T05:03:13Z",
   "published": "2021-09-09T17:11:21Z",
   "aliases": [
     "CVE-2021-37136"
@@ -36,6 +36,25 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 4.1.67"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jboss.netty:netty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.2.10.Final"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adding ranges to include netty 3.x which was distributed as a single artifact `netty` under a different groupid: https://central.sonatype.com/namespace/org.jboss.netty