### PR TITLE
[GHSA-9vjp-v76f-g363]  SnappyFrameDecoder doesn't restrict chunk length any may buffer skippable chunks in an unnecessary way

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-9vjp-v76f-g363/GHSA-9vjp-v76f-g363.json
+++ b/advisories/github-reviewed/2021/09/GHSA-9vjp-v76f-g363/GHSA-9vjp-v76f-g363.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9vjp-v76f-g363",
-  "modified": "2022-02-08T20:35:49Z",
+  "modified": "2023-01-28T05:03:19Z",
   "published": "2021-09-09T17:11:31Z",
   "aliases": [
     "CVE-2021-37137"
@@ -36,6 +36,25 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 4.1.67"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jboss.netty:netty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.2.10.Final"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adding ranges to include netty 3.x which was distributed as a single artifact `netty` under a different groupid: https://central.sonatype.com/namespace/org.jboss.netty