### PR TITLE
[GHSA-wx5j-54mm-rqqq] HTTP request smuggling in io.netty:netty-codec-http

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-wx5j-54mm-rqqq/GHSA-wx5j-54mm-rqqq.json
+++ b/advisories/github-reviewed/2021/12/GHSA-wx5j-54mm-rqqq/GHSA-wx5j-54mm-rqqq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wx5j-54mm-rqqq",
-  "modified": "2022-02-23T22:16:26Z",
+  "modified": "2023-01-28T05:03:32Z",
   "published": "2021-12-09T19:09:17Z",
   "aliases": [
     "CVE-2021-43797"
@@ -36,6 +36,25 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 4.1.70.Final"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jboss.netty:netty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.2.10.Final"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adding ranges to include netty 3.x which was distributed as a single artifact `netty` under a different groupid: https://central.sonatype.com/namespace/org.jboss.netty