### PR TITLE
[GHSA-57qw-cc2g-pv5p] Incomplete blacklist vulnerability in the lxml.html.clean...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-57qw-cc2g-pv5p/GHSA-57qw-cc2g-pv5p.json
+++ b/advisories/unreviewed/2022/05/GHSA-57qw-cc2g-pv5p/GHSA-57qw-cc2g-pv5p.json
@@ -1,22 +1,52 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-57qw-cc2g-pv5p",
-  "modified": "2022-05-14T04:01:59Z",
+  "modified": "2023-02-03T05:01:06Z",
   "published": "2022-05-14T04:01:59Z",
   "aliases": [
     "CVE-2014-3146"
   ],
+  "summary": "Incomplete blacklist vulnerability in the lxml clean module",
   "details": "Incomplete blacklist vulnerability in the lxml.html.clean module in lxml before 3.3.5 allows remote attackers to conduct cross-site scripting (XSS) attacks via control characters in the link scheme to the clean_html function.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "lxml"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.3.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.3.4"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-3146"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/lxml/lxml/commit/e86b294f1f81b899a59925123560ff924a72f1cc"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/lxml/lxml"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Missing ecosystem and package versions