### PR TITLE
[GHSA-5q63-jvc9-qphv] A cross-site request forgery vulnerability in Jenkins...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5q63-jvc9-qphv/GHSA-5q63-jvc9-qphv.json
+++ b/advisories/unreviewed/2022/05/GHSA-5q63-jvc9-qphv/GHSA-5q63-jvc9-qphv.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5q63-jvc9-qphv",
-  "modified": "2022-05-13T01:25:41Z",
+  "modified": "2023-02-01T05:07:25Z",
   "published": "2022-05-13T01:25:41Z",
   "aliases": [
     "CVE-2019-1003092"
   ],
+  "summary": "XSS forgery vulnerability in Jenkins Nomad Plugin",
   "details": "A cross-site request forgery vulnerability in Jenkins Nomad Plugin in the NomadCloud.DescriptorImpl#doTestConnection form validation method allows attackers to initiate a connection to an attacker-specified server.",
   "severity": [
     {
@@ -14,12 +15,38 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:nomad"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.5.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-1003092"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/nomad-plugin/pull/42"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/nomad-plugin"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Missing package details. The version is tough to find, you can the version bump that contains this fix
https://github.com/jenkinsci/nomad-plugin/commit/460e9824454a43c033f55afd823a34a2036703d5