### PR TITLE
[GHSA-j249-ghv5-7mxv] In Docker CE and EE before 18.09.8 (as well as Docker EE...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-j249-ghv5-7mxv/GHSA-j249-ghv5-7mxv.json
+++ b/advisories/unreviewed/2022/05/GHSA-j249-ghv5-7mxv/GHSA-j249-ghv5-7mxv.json
@@ -1,17 +1,55 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j249-ghv5-7mxv",
-  "modified": "2022-05-24T16:50:40Z",
+  "modified": "2023-01-28T05:06:19Z",
   "published": "2022-05-24T16:50:40Z",
   "aliases": [
     "CVE-2019-13509"
   ],
+  "summary": "Docker Engine debug log secrets disclosure",
   "details": "In Docker CE and EE before 18.09.8 (as well as Docker EE before 17.06.2-ee-23 and 18.x before 18.03.1-ee-10), Docker Engine in debug mode may sometimes add secrets to the debug log. This applies to a scenario where docker stack deploy is run to redeploy a stack that includes (non external) secrets. It potentially applies to other API users of the stack API if they resend the secret.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/docker/docker"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "17.06.2-ee-23"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/docker/docker"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "18.0.0"
+            },
+            {
+              "fixed": "18.03.1-ee-10"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
I'm trusting the versions in the description, it's rough trying to find details on this one