### PR TITLE
[GHSA-5949-rw7g-wx7w] Deserialization of untrusted data in jackson-databind

### DIFF
--- a/advisories/github-reviewed/2021/01/GHSA-5949-rw7g-wx7w/GHSA-5949-rw7g-wx7w.json
+++ b/advisories/github-reviewed/2021/01/GHSA-5949-rw7g-wx7w/GHSA-5949-rw7g-wx7w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5949-rw7g-wx7w",
-  "modified": "2022-06-06T18:07:24Z",
+  "modified": "2023-01-29T05:06:23Z",
   "published": "2021-01-20T21:20:15Z",
   "aliases": [
     "CVE-2021-20190"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.7.0-rc1"
             },
             {
               "fixed": "2.9.10.7"
@@ -36,6 +36,25 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 2.9.10.6"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.fasterxml.jackson.core:jackson-databind"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.6.7.5"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
By https://github.com/FasterXML/jackson-databind/issues/2854 a fix was released in 2.6.7.5 (released 22-Jun-2021)