### PR TITLE
[GHSA-xfv3-rrfm-f2rv] Information Exposure in Netty

### DIFF
--- a/advisories/github-reviewed/2020/06/GHSA-xfv3-rrfm-f2rv/GHSA-xfv3-rrfm-f2rv.json
+++ b/advisories/github-reviewed/2020/06/GHSA-xfv3-rrfm-f2rv/GHSA-xfv3-rrfm-f2rv.json
@@ -75,7 +75,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "netty.io:netty"
+        "name": "io.netty:netty"
       },
       "ranges": [
         {
@@ -94,7 +94,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "netty.io:netty"
+        "name": "io.netty:netty"
       },
       "ranges": [
         {

--- a/advisories/github-reviewed/2020/06/GHSA-xfv3-rrfm-f2rv/GHSA-xfv3-rrfm-f2rv.json
+++ b/advisories/github-reviewed/2020/06/GHSA-xfv3-rrfm-f2rv/GHSA-xfv3-rrfm-f2rv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xfv3-rrfm-f2rv",
-  "modified": "2021-09-22T18:45:29Z",
+  "modified": "2023-08-04T19:13:42Z",
   "published": "2020-06-30T21:01:21Z",
   "aliases": [
     "CVE-2015-2156"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "io.netty:netty-parent"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,11 +39,6 @@
         "ecosystem": "Maven",
         "name": "org.jboss.netty:netty"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -68,10 +58,43 @@
         "ecosystem": "Maven",
         "name": "org.jboss.netty:netty"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.10.0"
+            },
+            {
+              "fixed": "3.10.3.Final"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "netty.io:netty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.9.8.Final"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "netty.io:netty"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It seems all of the 3.x netty artifacts were also published to the io.netty namespace, so I need to go back and include those for all of my previous updates