### PR TITLE
[GHSA-p979-4mfw-53vg] HTTP Request Smuggling in Netty

### DIFF
--- a/advisories/github-reviewed/2019/10/GHSA-p979-4mfw-53vg/GHSA-p979-4mfw-53vg.json
+++ b/advisories/github-reviewed/2019/10/GHSA-p979-4mfw-53vg/GHSA-p979-4mfw-53vg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p979-4mfw-53vg",
-  "modified": "2022-04-01T18:11:58Z",
+  "modified": "2023-08-04T19:23:00Z",
   "published": "2019-10-11T18:41:23Z",
   "aliases": [
     "CVE-2019-16869"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "io.netty:netty-all"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,10 +39,24 @@
         "ecosystem": "Maven",
         "name": "org.jboss.netty:netty"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.2.10.Final"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "netty.io:netty"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It seems all of the 3.x netty artifacts were also published to the netty.io namespace, so I need to go back and include those for all of my previous updates