### PR TITLE
[GHSA-cqqj-4p63-rrmm] HTTP Request Smuggling in Netty

### DIFF
--- a/advisories/github-reviewed/2020/02/GHSA-cqqj-4p63-rrmm/GHSA-cqqj-4p63-rrmm.json
+++ b/advisories/github-reviewed/2020/02/GHSA-cqqj-4p63-rrmm/GHSA-cqqj-4p63-rrmm.json
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "netty.io:netty"
+        "name": "io.netty:netty"
       },
       "ranges": [
         {

--- a/advisories/github-reviewed/2020/02/GHSA-cqqj-4p63-rrmm/GHSA-cqqj-4p63-rrmm.json
+++ b/advisories/github-reviewed/2020/02/GHSA-cqqj-4p63-rrmm/GHSA-cqqj-4p63-rrmm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cqqj-4p63-rrmm",
-  "modified": "2021-08-25T17:26:45Z",
+  "modified": "2023-08-04T19:24:07Z",
   "published": "2020-02-21T18:55:24Z",
   "aliases": [
     "CVE-2019-20444"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "io.netty:netty-codec-http"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,10 +39,24 @@
         "ecosystem": "Maven",
         "name": "org.jboss.netty:netty"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.2.10.Final"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "netty.io:netty"
       },
       "ranges": [
         {

--- a/advisories/github-reviewed/2020/02/GHSA-cqqj-4p63-rrmm/GHSA-cqqj-4p63-rrmm.json
+++ b/advisories/github-reviewed/2020/02/GHSA-cqqj-4p63-rrmm/GHSA-cqqj-4p63-rrmm.json
@@ -45,13 +45,13 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "3.2.10.Final"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.0.0"
+      }
     },
     {
       "package": {
@@ -64,13 +64,13 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "3.2.10.Final"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.0.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Prior to netty v4, there was a single artifact `netty` distributed, bother under the `io.netty` and the `org.jboss.netty` namespaces.  This should hopefully ensure that versions of netty prior to v4 are identified as affected.  For some reason setting `<= 3.2.10.Final` in the previous attempt got changed to `< 3.2.10.Final` with a fix of `3.2.10.Final` which I believe is incorrect in this case as there is no fix for the 3.x series.  Also, the 3.x series extended further under the `io.netty` namespace, so here I’ve just used < 4.0.0 to cap these.