### PR TITLE
[GHSA-5mcr-gq6c-3hq2] Local Information Disclosure Vulnerability in Netty on Unix-Like systems

### DIFF
--- a/advisories/github-reviewed/2021/02/GHSA-5mcr-gq6c-3hq2/GHSA-5mcr-gq6c-3hq2.json
+++ b/advisories/github-reviewed/2021/02/GHSA-5mcr-gq6c-3hq2/GHSA-5mcr-gq6c-3hq2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5mcr-gq6c-3hq2",
-  "modified": "2022-04-19T15:19:08Z",
+  "modified": "2023-08-04T19:39:05Z",
   "published": "2021-02-08T21:17:48Z",
   "aliases": [
     "CVE-2021-21290"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "io.netty:netty-codec-http"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,10 +39,24 @@
         "ecosystem": "Maven",
         "name": "org.jboss.netty:netty"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.2.10.Final"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.netty:netty"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It seems all of the 3.x netty artifacts were also published to the io.netty namespace, so I need to go back and include those for all of my previous updates