### PR TITLE
[GHSA-f256-j965-7f32] Possible request smuggling in HTTP/2 due missing validation of content-length

### DIFF
--- a/advisories/github-reviewed/2021/03/GHSA-f256-j965-7f32/GHSA-f256-j965-7f32.json
+++ b/advisories/github-reviewed/2021/03/GHSA-f256-j965-7f32/GHSA-f256-j965-7f32.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f256-j965-7f32",
-  "modified": "2022-02-08T21:31:25Z",
+  "modified": "2023-08-04T19:55:52Z",
   "published": "2021-03-30T15:10:38Z",
   "aliases": [
     "CVE-2021-21409"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "io.netty:netty-codec-http2"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,10 +39,24 @@
         "ecosystem": "Maven",
         "name": "org.jboss.netty:netty"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.0.0"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.netty:netty"
       },
       "ranges": [
         {
@@ -55,13 +64,13 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "3.2.10.Final"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.0.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Prior to netty v4, there was a single artifact `netty` distributed, bother under the `io.netty` and the `org.jboss.netty` namespaces.  This should hopefully ensure that versions of netty prior to v4 are identified as affected.  For some reason setting `<= 3.2.10.Final` in the previous attempt got changed to `< 3.2.10.Final` with a fix of `3.2.10.Final` which I believe is incorrect in this case as there is no fix for the 3.x series.  Also, the 3.x series extended further under the `io.netty` namespace, so here I’ve just used < 4.0.0 to cap these.