### PR TITLE
[GHSA-9vjp-v76f-g363]  SnappyFrameDecoder doesn't restrict chunk length any may buffer skippable chunks in an unnecessary way

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-9vjp-v76f-g363/GHSA-9vjp-v76f-g363.json
+++ b/advisories/github-reviewed/2021/09/GHSA-9vjp-v76f-g363/GHSA-9vjp-v76f-g363.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9vjp-v76f-g363",
-  "modified": "2022-02-08T20:35:49Z",
+  "modified": "2023-08-04T20:06:11Z",
   "published": "2021-09-09T17:11:31Z",
   "aliases": [
     "CVE-2021-37137"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "io.netty:netty-codec"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,10 +39,24 @@
         "ecosystem": "Maven",
         "name": "org.jboss.netty:netty"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.0.0"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.netty:netty"
       },
       "ranges": [
         {
@@ -55,13 +64,13 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "3.2.10.Final"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.0.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Prior to netty v4, there was a single artifact `netty` distributed, bother under the `io.netty` and the `org.jboss.netty` namespaces.  This should hopefully ensure that versions of netty prior to v4 are identified as affected.  For some reason setting `<= 3.2.10.Final` in the previous attempt got changed to `< 3.2.10.Final` with a fix of `3.2.10.Final` which I believe is incorrect in this case as there is no fix for the 3.x series.  Also, the 3.x series extended further under the `io.netty` namespace, so here I’ve just used < 4.0.0 to cap these.