### PR TITLE
[GHSA-wx5j-54mm-rqqq] HTTP request smuggling in io.netty:netty-codec-http

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-wx5j-54mm-rqqq/GHSA-wx5j-54mm-rqqq.json
+++ b/advisories/github-reviewed/2021/12/GHSA-wx5j-54mm-rqqq/GHSA-wx5j-54mm-rqqq.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wx5j-54mm-rqqq",
-  "modified": "2023-08-04T20:07:19Z",
+  "modified": "2023-08-04T20:07:20Z",
   "published": "2021-12-09T19:09:17Z",
   "aliases": [
     "CVE-2021-43797"
   ],
-  "summary": "HTTP request smuggling in netty",
+  "summary": "HTTP request smuggling in io.netty:netty-codec-http",
   "details": "### Impact\n\nNetty currently just skips control chars when these are present at the beginning / end of the header name. We should better fail fast as these are not allowed by the spec and could lead to HTTP request smuggling.\n\nFailing to do the validation might cause netty to \"sanitize\" header names before it forward these to another remote system when used as proxy. This remote system can't see the invalid usage anymore and so not do the validation itself.\n\n",
   "severity": [
     {
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "io.netty:netty-codec-http"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -42,12 +37,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.jboss.netty:netty"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+        "name": "io.netty:netty"
       },
       "ranges": [
         {
@@ -55,13 +45,32 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "3.2.10.Final"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.0.0"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jboss.netty:netty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.0.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Prior to netty v4, there was a single artifact `netty` distributed, bother under the `io.netty` and the `org.jboss.netty` namespaces.  This should hopefully ensure that versions of netty prior to v4 are identified as affected.  For some reason setting `<= 3.2.10.Final` in the previous attempt got changed to `< 3.2.10.Final` with a fix of `3.2.10.Final` which I believe is incorrect in this case as there is no fix for the 3.x series.  Also, the 3.x series extended further under the `io.netty` namespace, so here I’ve just used < 4.0.0 to cap these.