### PR TITLE
[GHSA-77rm-9x9h-xj3g] NULL Pointer Dereference in Protocol Buffers

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-77rm-9x9h-xj3g/GHSA-77rm-9x9h-xj3g.json
+++ b/advisories/github-reviewed/2022/01/GHSA-77rm-9x9h-xj3g/GHSA-77rm-9x9h-xj3g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-77rm-9x9h-xj3g",
-  "modified": "2022-02-03T22:48:51Z",
+  "modified": "2023-04-18T15:01:49Z",
   "published": "2022-01-27T00:01:15Z",
   "aliases": [
     "CVE-2021-22570"
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "com.google.protobuf:protobuf-parent"
+        "name": "com.google.protobuf:protobuf-java"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The protobuf-parent Maven package is a placeholder package to pull in all the needed protobuf packages, This meta package doesn't have to be installed, nor does it contain any code.

You can see that if you look at the Maven repo
https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.1/
vs
https://repo1.maven.org/maven2/com/google/protobuf/protobuf-parent/3.11.1/

The code for this is in the -java package