### PR TITLE
[GHSA-rfj2-q3h3-hm5j] Cargo extracting malicious crates can corrupt arbitrary files

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-rfj2-q3h3-hm5j/GHSA-rfj2-q3h3-hm5j.json
+++ b/advisories/github-reviewed/2022/09/GHSA-rfj2-q3h3-hm5j/GHSA-rfj2-q3h3-hm5j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rfj2-q3h3-hm5j",
-  "modified": "2022-09-21T19:53:20Z",
+  "modified": "2023-06-27T22:31:33Z",
   "published": "2022-09-16T17:12:30Z",
   "aliases": [
     "CVE-2022-36113"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.65.0"
+              "fixed": "0.67.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The vulnerability was patched by commit https://github.com/rust-lang/cargo/commit/97b80919e404b0768ea31ae329c3b4da54bed05a, which was finally introduced in 0.67.0.