### PR TITLE
[GHSA-2hvr-h6gw-qrxp] Cargo extracting malicious crates can fill the file system

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-2hvr-h6gw-qrxp/GHSA-2hvr-h6gw-qrxp.json
+++ b/advisories/github-reviewed/2022/09/GHSA-2hvr-h6gw-qrxp/GHSA-2hvr-h6gw-qrxp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2hvr-h6gw-qrxp",
-  "modified": "2022-09-21T19:54:59Z",
+  "modified": "2023-01-30T05:07:09Z",
   "published": "2022-09-16T17:12:05Z",
   "aliases": [
     "CVE-2022-36114"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.65.0"
+              "fixed": "0.67.0"
             }
           ]
         }

--- a/advisories/github-reviewed/2022/09/GHSA-2hvr-h6gw-qrxp/GHSA-2hvr-h6gw-qrxp.json
+++ b/advisories/github-reviewed/2022/09/GHSA-2hvr-h6gw-qrxp/GHSA-2hvr-h6gw-qrxp.json
@@ -28,6 +28,25 @@
               "introduced": "0"
             },
             {
+              "fixed": "0.65.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "crates.io",
+        "name": "cargo"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
               "fixed": "0.67.0"
             }
           ]


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The patch that fixes this vulnerability is https://github.com/rust-lang/cargo/commit/d1f9553c825f6d7481453be8d58d0e7f117988a7, applied in 0.67.0 for the first time