### PR TITLE
[GHSA-p979-4mfw-53vg] HTTP Request Smuggling in Netty

### DIFF
--- a/advisories/github-reviewed/2019/10/GHSA-p979-4mfw-53vg/GHSA-p979-4mfw-53vg.json
+++ b/advisories/github-reviewed/2019/10/GHSA-p979-4mfw-53vg/GHSA-p979-4mfw-53vg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p979-4mfw-53vg",
-  "modified": "2022-04-01T18:11:58Z",
+  "modified": "2023-08-07T19:23:41Z",
   "published": "2019-10-11T18:41:23Z",
   "aliases": [
     "CVE-2019-16869"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "io.netty:netty-all"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,10 +39,24 @@
         "ecosystem": "Maven",
         "name": "org.jboss.netty:netty"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.0.0"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.netty:netty"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
We also need `netty` under the `io.netty` namespace for versions prior to 4.0.0 to show here.  For some reason that seems to have fallen off of https://github.com/github/advisory-database/pull/2594 