### PR TITLE
[GHSA-gq63-p39p-jrjf] SQL injectionin Yii 2

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-gq63-p39p-jrjf/GHSA-gq63-p39p-jrjf.json
+++ b/advisories/github-reviewed/2023/04/GHSA-gq63-p39p-jrjf/GHSA-gq63-p39p-jrjf.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gq63-p39p-jrjf",
-  "modified": "2023-07-31T17:25:59Z",
+  "modified": "2023-07-31T17:26:00Z",
   "published": "2023-04-04T15:30:27Z",
   "aliases": [
     "CVE-2023-26750"
   ],
-  "summary": "SQL injectionin Yii 2",
-  "details": "SQL injection vulnerability found in Yii Framework Yii 2 Framework before v.2.0.47 allows the a remote attacker to execute arbitrary code via the runAction function.",
+  "summary": "Withdrawn: SQL Injection Yii 2",
+  "details": "# Withdrawn\n\nThis advisory has been withdrawn after the maintainers of Yii2 noted this issue is not a security vulnerability with Yii2 itself, but rather a userland issue.\n\n## Original CVE based description\n\nSQL injection vulnerability found in Yii Framework Yii 2 Framework before v.2.0.47 allows the a remote attacker to execute arbitrary code via the runAction function.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -26,13 +26,13 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "2.0.47"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.0.47"
+      }
     }
   ],
   "references": [
@@ -51,6 +51,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/yiisoft/yii2/issues/19755#issuecomment-1505390813"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/yiisoft/yii2/issues/19755#issuecomment-1506531748"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Summary

**Comments**
It seems this CVE was requested from the original user of the original report, submitting vague issues from their own implementation of Yii2. PHP frameworks can still write insecure code if they work around the protections in place by the framework. With failure to replicate the issue on the framework or provide details - the author resulted to requesting and obtaining an CVE for a non-issue.

https://github.com/yiisoft/yii2/issues/19755#issuecomment-1506531748

This was even misleading that the fix version of v2.0.47 was going to resolve this fake issue - as it never existed to begin with.

I looked at patterns in past how this was handled and it seems they are never deleted, so a withdrawn report seems best. Not sure really how else to proceed when we have a disputed mitre vulnerability.