### PR TITLE
[GHSA-p9xf-74xh-mhw5] fix package name in GHSA-p9xf-74xh-mhw5.json

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-p9xf-74xh-mhw5/GHSA-p9xf-74xh-mhw5.json
+++ b/advisories/github-reviewed/2023/07/GHSA-p9xf-74xh-mhw5/GHSA-p9xf-74xh-mhw5.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "https://github.com/1Panel-dev/1Panel"
+        "name": "github.com/1Panel-dev/1Panel"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- fix package name in advisory

**Comments**
`https://` should not be contained in package names.