### PR TITLE
[GHSA-6r78-m64m-qwcf] Moq v4.20.0 and 4.20.1 share hashed user data

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-6r78-m64m-qwcf/GHSA-6r78-m64m-qwcf.json
+++ b/advisories/github-reviewed/2023/08/GHSA-6r78-m64m-qwcf/GHSA-6r78-m64m-qwcf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6r78-m64m-qwcf",
-  "modified": "2023-08-10T19:25:23Z",
+  "modified": "2023-08-10T19:25:24Z",
   "published": "2023-08-10T19:25:23Z",
   "aliases": [
 
@@ -17,17 +17,12 @@
         "ecosystem": "NuGet",
         "name": "moq"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.20.0"
+              "introduced": "4.20.0-rc"
             },
             {
               "fixed": "4.20.2"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
4.20.0-rc is also affected.