### PR TITLE
[GHSA-5wv5-4vpf-pj6m] Pallets Project Flask is vulnerable to Denial of Service via Unexpected memory usage

### DIFF
--- a/advisories/github-reviewed/2019/07/GHSA-5wv5-4vpf-pj6m/GHSA-5wv5-4vpf-pj6m.json
+++ b/advisories/github-reviewed/2019/07/GHSA-5wv5-4vpf-pj6m/GHSA-5wv5-4vpf-pj6m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5wv5-4vpf-pj6m",
-  "modified": "2023-08-07T15:15:22Z",
+  "modified": "2023-08-07T15:15:23Z",
   "published": "2019-07-19T16:12:46Z",
   "aliases": [
     "CVE-2019-1010083"
@@ -20,11 +20,6 @@
         "ecosystem": "PyPI",
         "name": "flask"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.0.0"
+              "fixed": "1.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Change this version 1.0.0 for 1.0 because, this version 1.0.0 is invalid
Flask: https://pypi.org/project/Flask/1.0/#history
Github Adv Response:
```json
 "advisory": {
              "ghsaId": "GHSA-5wv5-4vpf-pj6m",
              "identifiers": [
                {
                  "type": "GHSA",
                  "value": "GHSA-5wv5-4vpf-pj6m"
                },
                {
                  "type": "CVE",
                  "value": "CVE-2019-1010083"
                }
              ],
              "description": "The Pallets Project Flask before 1.0 is affected by unexpected memory usage. The impact is denial of service. The attack vector is crafted encoded JSON data. The fixed version is 1. NOTE this may overlap CVE-2018-1000656.",
              "references": [
                {
                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010083"
                },
                {
                  "url": "https://www.palletsprojects.com/blog/flask-1-0-released/"
                },
                {
                  "url": "https://github.com/advisories/GHSA-5wv5-4vpf-pj6m"
                }
              ],
              "summary": "Pallets Project Flask is vulnerable to Denial of Service via Unexpected memory usage",
              "origin": "UNSPECIFIED",
              "cvss": {
                "score": 7.5,
                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
              },
              "permalink": "https://github.com/advisories/GHSA-5wv5-4vpf-pj6m",
              "severity": "HIGH",
              "cwes": {
                "edges": [
                  {
                    "node": {
                      "cweId": "CWE-400"
                    }
                  }
                ]
              }
            },
            "firstPatchedVersion": {
              "identifier": "1.0.0"
            },
            "vulnerableVersionRange": "< 1.0.0"
```