### PR TITLE
[GHSA-c2qf-rxjj-qqgw] semver vulnerable to Regular Expression Denial of Service

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-c2qf-rxjj-qqgw/GHSA-c2qf-rxjj-qqgw.json
+++ b/advisories/github-reviewed/2023/06/GHSA-c2qf-rxjj-qqgw/GHSA-c2qf-rxjj-qqgw.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c2qf-rxjj-qqgw",
-  "modified": "2023-07-10T22:57:56Z",
+  "modified": "2023-07-10T22:57:58Z",
   "published": "2023-06-21T06:30:28Z",
   "aliases": [
     "CVE-2022-25883"
   ],
   "summary": "semver vulnerable to Regular Expression Denial of Service",
-  "details": "Versions of the package semver before 7.5.2 on the 7.x branch, before 6.3.1 on the 6.x branch, and all other versions before 5.7.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.",
+  "details": "Versions of the package semver before 7.5.2, patched in 7.5.3, on the 7.x branch, before 6.3.1 on the 6.x branch, and all other versions before 5.7.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+      "score": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:L"
     }
   ],
   "affected": [
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "semver"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "semver.Range"
-        ]
       },
       "ranges": [
         {
@@ -33,21 +28,19 @@
               "introduced": "7.0.0"
             },
             {
-              "fixed": "7.5.2"
+              "fixed": "7.5.4"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 7.5.2"
+      }
     },
     {
       "package": {
         "ecosystem": "npm",
         "name": "semver"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "semver.Range"
-        ]
       },
       "ranges": [
         {
@@ -67,11 +60,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "semver"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "semver.Range"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description

**Comments**
Complexity Issues (CWE-1226)

semver 7.5.4 is readily available and has been noted to work. 
(Waiting on actions to submit reference and proof of viable debug, if security Dependabot becomes actionable patch again, I will take it as the patch did not work on CVE-2022-25883)

Reference: 
https://cwe.mitre.org/data/definitions/1333.html 

Member of:
Comprehensive Categorization: Resource Lifecycle Management (1416) as <body> under <body> for <div id="Memberships">

Reference:
https://cwe.mitre.org/data/definitions/1416.html

under "Relationships" as <body> where <div> is name="oc_1333_Relationships" under <div> further class="reltable" for under <div> name="oc_1333_699_relevant_table"

Fix:
package-lock.json on COMMIT via classicvalues/kill-repo
https://github.com/classicvalues/kill-repo/commit/b7e5a97fcd84426667ead424f2cfdb9d95efacdb
under test via Actions on debug when run second time. Will wait for confirmation to submit to all repos references in:
https://github.com/advisories/GHSA-c2qf-rxjj-qqgw/dependabot
Though, has been submitted to NIST for update via email on softwaresafety.0@gmail.com

Reference is made in https://stackoverflow.com/questions/76538757/how-to-approach-and-fix-npm-security-issues-semver-vulnerable-to-regular-expre to fix being regularly available in 7.5.3 and <div class="container"> under <img src="https://i.stack.imgur.com/BbRJu.png" alt="nodemon's semver dependency"> "package-lock.json" reference file image. 

More API work to be done, work is reference to MITRE, NIST: NVD, CNA:Snyk, @mrgrain, @G-Rath, and StackOverflow contributors by the names of:
https://stackoverflow.com/users/8958122/snehil-shah
https://stackoverflow.com/users/10652129/tost
https://stackoverflow.com/users/18740661/muhammad-usman

ADVISORY:
Under NIST, the statement made is forward that 7.5.2 is enough for a patch. Though, only references to 7.5.3 being patched and viable are made on the internet. Internal admission is needed. Stated as "Up to (excluding)
7.5.2" Though, all other patch information, including their site introduction, make 5.7.2 as patch. I have taken the liberty of moving the needle to 7.5.4 until further notice. Once Action approval and patch reference is made on Dependabot, then I will work on redoing the CVE categorization. Note though, that for now, they work. Will wait for proof of concept and reference to submit Bug Bounty in at all. Only reference to 7.5.3 is on referenced StackOverflow, though I do not have access to sha on any site and have not looking into playing with it on mobile shell I am working on this on, only one on me, would hate to kill it. Though, on cloud I was able to reference and note in COMMIT the usage of 7.5.4 and sha readily available for API usage that Google $ GitHub have been able to reference for me on semantic-release/error and thus my private repository classicvalues/error. Please email me at softwaresafety.0@gmail.com for more access and if there are any questions. NIST would be the authority of concern, last patch was made on 07/11/2023 as referenced in https://nvd.nist.gov/vuln/detail/CVE-2022-25883#VulnChangeHistorySection.
Hope Snyk Action is up in a little. Kudos. 

Especially, 
Laudate Corpus LLC
https://nvd.nist.gov/vuln/detail/CVE-2022-25883#range-9389144





