### PR TITLE
[GHSA-h755-8qp9-cq85] protobufjs Prototype Pollution vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-h755-8qp9-cq85/GHSA-h755-8qp9-cq85.json
+++ b/advisories/github-reviewed/2023/07/GHSA-h755-8qp9-cq85/GHSA-h755-8qp9-cq85.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h755-8qp9-cq85",
-  "modified": "2023-07-07T20:19:02Z",
+  "modified": "2023-07-07T20:19:03Z",
   "published": "2023-07-05T15:30:24Z",
   "aliases": [
     "CVE-2023-36665"
@@ -17,11 +17,6 @@
         "ecosystem": "npm",
         "name": "protobufjs"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "protobufjs.util.setProperty"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -30,11 +25,14 @@
               "introduced": "6.10.0"
             },
             {
-              "fixed": "7.2.4"
+              "fixed": "7.2.4, 6.11.4"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 7.2.4"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The issue https://github.com/protobufjs/protobuf.js/pull/1899 is also claimed to be fixed in 6.11.4, see https://github.com/protobufjs/protobuf.js/commits/release-6.11.4

Can that version also be considered as a patched version?
