### PR TITLE
[GHSA-2f88-5hg8-9x2x] Origin Validation Error in Apache Maven

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-2f88-5hg8-9x2x/GHSA-2f88-5hg8-9x2x.json
+++ b/advisories/github-reviewed/2021/06/GHSA-2f88-5hg8-9x2x/GHSA-2f88-5hg8-9x2x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2f88-5hg8-9x2x",
-  "modified": "2022-07-28T18:02:35Z",
+  "modified": "2023-01-27T05:02:44Z",
   "published": "2021-06-16T17:32:49Z",
   "aliases": [
     "CVE-2021-26291"
@@ -19,6 +19,44 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.apache.maven:maven"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.8.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.maven:maven-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.8.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.maven:maven-compat"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The org.apache.maven:maven package isn't a jar, it's metadata to install the maven jars. Since there's no jar for this, it won't be found when inspecting the post-build images. You can see the metadata here
https://repo1.maven.org/maven2/org/apache/maven/maven/3.8.1/

The actual code fixes for this one can be found in maven-core and maven-compat to allow blocking of http
https://issues.apache.org/jira/browse/MNG-7116
https://github.com/apache/maven/commit/fa79cb22e456cc65522b5bab8c4240fe08c5775f

And the mirror blocking patch and config change in maven-core
https://issues.apache.org/jira/browse/MNG-7117
https://github.com/apache/maven/commit/899465aeec03753ea91e15a79579eab76369c016

This update also adds the maven-core and maven-compat packages so it can be detected when looking at installed jars