### PR TITLE
[GHSA-wfcc-pff6-rgc5] Jetty vulnerable to exposure of sensitive information due to observable discrepancy

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-wfcc-pff6-rgc5/GHSA-wfcc-pff6-rgc5.json
+++ b/advisories/github-reviewed/2018/10/GHSA-wfcc-pff6-rgc5/GHSA-wfcc-pff6-rgc5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wfcc-pff6-rgc5",
-  "modified": "2022-09-14T01:05:21Z",
+  "modified": "2023-01-31T05:03:28Z",
   "published": "2018-10-19T16:15:46Z",
   "aliases": [
     "CVE-2017-9735"
@@ -69,7 +69,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "9.2.0"
+              "introduced": "0"
             },
             {
               "fixed": "9.2.22.v20170606"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Removes the lower bound so that versions prior to 9.2.0 get flagged as vulnerable