### PR TITLE
[GHSA-xqr8-7jwr-rhp7] Removal of e-Tugra root certificate

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-xqr8-7jwr-rhp7/GHSA-xqr8-7jwr-rhp7.json
+++ b/advisories/github-reviewed/2023/07/GHSA-xqr8-7jwr-rhp7/GHSA-xqr8-7jwr-rhp7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xqr8-7jwr-rhp7",
-  "modified": "2023-08-03T19:36:12Z",
+  "modified": "2023-08-14T13:16:17Z",
   "published": "2023-07-25T14:43:53Z",
   "aliases": [
     "CVE-2023-37920"
@@ -20,11 +20,6 @@
         "ecosystem": "PyPI",
         "name": "certifi"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,11 +28,14 @@
               "introduced": "2015.04.28"
             },
             {
-              "fixed": "2023.07.22"
+              "fixed": "2023.7.22"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2023.07.22"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
There is no `0` in the fix version. https://pypi.org/project/certifi/#history

This causes grype to detect the updated package as not being fixed since the version string is different. 
/cc https://github.com/anchore/grype/issues/1430