### PR TITLE
[GHSA-vmch-3w2x-vhgq] .NET Denial of Service Vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-vmch-3w2x-vhgq/GHSA-vmch-3w2x-vhgq.json
+++ b/advisories/github-reviewed/2023/08/GHSA-vmch-3w2x-vhgq/GHSA-vmch-3w2x-vhgq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vmch-3w2x-vhgq",
-  "modified": "2023-08-09T12:56:43Z",
+  "modified": "2023-08-09T12:56:44Z",
   "published": "2023-08-09T12:56:43Z",
   "aliases": [
     "CVE-2023-38180"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "NuGet",
         "name": "Microsoft.AspNetCore.App.Runtime.win-arm64"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -47,11 +42,6 @@
         "ecosystem": "NuGet",
         "name": "Microsoft.AspNetCore.App.Runtime.win-x64"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -74,11 +64,6 @@
         "ecosystem": "NuGet",
         "name": "Microsoft.AspNetCore.App.Runtime.win-x86"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -94,6 +79,138 @@
       ],
       "database_specific": {
         "last_known_affected_version_range": "<= 7.0.9"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.0.21"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 6.0.20"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Microsoft.AspNetCore.App.Runtime.win-arm64"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.0.21"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 6.0.20"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Microsoft.AspNetCore.App.Runtime.win-x64"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.0.21"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 6.0.20"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Microsoft.AspNetCore.App.Runtime.win-x86"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.0.21"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 6.0.20"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.1.40"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.1.39"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.1.40"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.1.39"
       }
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The vulnerability description includes the list of vulnerable and patched packages for .NET 6 and ASP.Net Core 2.1, but those are not represented in the Affected Products section which only listed the .NET 7 packages. I simply added the packages already listed in the description to the Affected Products list.

Other vulnerabilities for .NET do correctly list this information for all the affected/supported .NET versions. See for example this vulnerability, it lists both .NET 7 and .NET 6 affected versions: https://github.com/advisories/GHSA-555c-2p6r-68mm