### PR TITLE
[GHSA-4446-656p-f54g] Deserialization of Untrusted Data in Bouncy castle

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-4446-656p-f54g/GHSA-4446-656p-f54g.json
+++ b/advisories/github-reviewed/2018/10/GHSA-4446-656p-f54g/GHSA-4446-656p-f54g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4446-656p-f54g",
-  "modified": "2022-04-27T17:25:44Z",
+  "modified": "2023-02-01T05:03:23Z",
   "published": "2018-10-17T16:23:12Z",
   "aliases": [
     "CVE-2018-1000613"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.58"
             },
             {
               "fixed": "1.60"
@@ -37,14 +37,14 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.bouncycastle:bcprov-jdk15"
+        "name": "org.bouncycastle:bcprov-jdk15on"
       },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.57"
             },
             {
               "fixed": "1.60"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Vulnerable component was not added to bcprov-jdk14 until version 1.58 and bcprov-jdk15on until version 1.57. This can be observed by searching for `xmss` in the following source archives:

* https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk14/1.57/bcprov-jdk14-1.57-sources.jar
* https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk14/1.58/bcprov-jdk14-1.58-sources.jar
* https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk15on/1.56/bcprov-jdk15on-1.56-sources.jar
* https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk15on/1.57/bcprov-jdk15on-1.57-sources.jar

Additionally, bcmail-jdk15 ends at version 1.46 and the affected versions actually live in bcmail-jdk15on.