### PR TITLE
[GHSA-5mg8-w23w-74h3] Information Disclosure in Guava

### DIFF
--- a/advisories/github-reviewed/2021/03/GHSA-5mg8-w23w-74h3/GHSA-5mg8-w23w-74h3.json
+++ b/advisories/github-reviewed/2021/03/GHSA-5mg8-w23w-74h3/GHSA-5mg8-w23w-74h3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5mg8-w23w-74h3",
-  "modified": "2022-04-26T20:59:20Z",
+  "modified": "2023-06-06T18:42:08Z",
   "published": "2021-03-25T17:04:19Z",
   "aliases": [
     "CVE-2020-8908"
@@ -20,11 +20,6 @@
         "ecosystem": "Maven",
         "name": "com.google.guava:guava"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "com.google.common.io.Files.createTempDir"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "29.0"
+              "fixed": "32.0.0"
             }
           ]
         }
@@ -48,6 +43,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/google/guava/issues/4011"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/google/guava/issues/4011#issuecomment-1573923586"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/google/guava/commit/feb83a1c8fd2e7670b244d5afd23cba5aca43284"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Version 30 didn't actually fix this issue, it just marked the function as deprecated (the functionality still existed). This is explained here
https://github.com/google/guava/issues/4011#issuecomment-1573923586

The actual fix is here
https://github.com/google/guava/commit/feb83a1c8fd2e7670b244d5afd23cba5aca43284
which went into version 32