### PR TITLE
[GHSA-9rgv-h7x4-qw8g] Moderate severity vulnerability that affects org.eclipse.jetty:jetty-server

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-9rgv-h7x4-qw8g/GHSA-9rgv-h7x4-qw8g.json
+++ b/advisories/github-reviewed/2018/10/GHSA-9rgv-h7x4-qw8g/GHSA-9rgv-h7x4-qw8g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9rgv-h7x4-qw8g",
-  "modified": "2021-06-10T23:55:06Z",
+  "modified": "2023-02-01T05:03:45Z",
   "published": "2018-10-19T16:15:56Z",
   "aliases": [
     "CVE-2018-12536"
@@ -47,7 +47,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "9.3.0"
+              "introduced": "9.0.0"
             },
             {
               "fixed": "9.3.24.v20180605"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The upstream bug for this specifies it affects all 9.x versions, but the older versions are deprecated and unfixed
https://bugs.eclipse.org/bugs/show_bug.cgi?id=535670#c0