### PR TITLE
[GHSA-prp9-9gxw-38j8] A deserialization flaw was found in Apache Chainsaw...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-prp9-9gxw-38j8/GHSA-prp9-9gxw-38j8.json
+++ b/advisories/unreviewed/2022/05/GHSA-prp9-9gxw-38j8/GHSA-prp9-9gxw-38j8.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-prp9-9gxw-38j8",
-  "modified": "2022-05-24T19:05:32Z",
+  "modified": "2023-01-29T05:06:34Z",
   "published": "2022-05-24T19:05:32Z",
   "aliases": [
     "CVE-2020-9493"
   ],
+  "summary": "Apache Chainsaw deserialization flaw",
   "details": "A deserialization flaw was found in Apache Chainsaw versions prior to 2.1.0 which could lead to malicious code execution.",
   "severity": [
     {
@@ -14,12 +15,34 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "log4j:apache-chainsaw"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.1.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-9493"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/logging-chainsaw"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
The oss-security email specifies the versions
https://www.openwall.com/lists/oss-security/2021/06/16/1

The groupId and artifactId can be found in the pom file
https://github.com/apache/logging-chainsaw/blob/055e80e069d2c9967c2f6001cbff0ec2ab3e9161/pom.xml#L27C16-L27C16

This mail notes Chainsaw used to be part of log4j
https://www.openwall.com/lists/oss-security/2022/01/18/5

The old artifacts have the same groupId and artifactId, so the one entry will catch them all