### PR TITLE
[GHSA-fhw8-8j55-vwgq] Unsafe deserialization in Apache MINA SSHD

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-fhw8-8j55-vwgq/GHSA-fhw8-8j55-vwgq.json
+++ b/advisories/github-reviewed/2022/11/GHSA-fhw8-8j55-vwgq/GHSA-fhw8-8j55-vwgq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fhw8-8j55-vwgq",
-  "modified": "2022-11-21T23:46:32Z",
+  "modified": "2023-02-01T05:03:57Z",
   "published": "2022-11-16T12:00:18Z",
   "aliases": [
     "CVE-2022-45047"
@@ -33,6 +33,28 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.sshd:sshd-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.9.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.1.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Maven module "sshd-common" was introduced in Apache Mina 2.1.0: https://mina.apache.org/sshd-project/download_2.1.0.html

All versions of Apache Mina are vulnerable - but until version 2.1.0 there was no "sshd-common" module and vulnerable code was in "sshd-core" module:

https://github.com/apache/mina-sshd/commit/10de190e7d3f9189deb76b8d08c72334a1fe2df0#diff-ae34d3a1529f7942e1a47771dd21724c3fef1c7568d3f8455ed9efad96d748ba

So I added "org.apache.sshd:sshd-core" affected package until version 2.1.0.