### PR TITLE
[GHSA-8jjf-w7j6-323c] Samlify vulnerable to Authentication Bypass by allowing tokens to be reused with different usernames

### DIFF
--- a/advisories/github-reviewed/2018/01/GHSA-8jjf-w7j6-323c/GHSA-8jjf-w7j6-323c.json
+++ b/advisories/github-reviewed/2018/01/GHSA-8jjf-w7j6-323c/GHSA-8jjf-w7j6-323c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8jjf-w7j6-323c",
-  "modified": "2022-08-03T16:25:04Z",
+  "modified": "2023-01-11T05:08:24Z",
   "published": "2018-01-04T21:03:33Z",
   "aliases": [
     "CVE-2017-1000452"
@@ -67,6 +67,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
+      "CWE-347",
       "CWE-91"
     ],
     "severity": "HIGH",


### PR DESCRIPTION
**Updates**
- CWEs

**Comments**
Not sure if XML injection is correct here. The attacker adds XML to the token. It's not added by the system. So I would at least propose CWE-347 is added. Btw, I'm also the original finder of this vulnerability (I'm webtonull on hackerone).