### PR TITLE
[GHSA-mjmq-gwgm-5qhm] Apache MINA SSHD information disclosure vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-mjmq-gwgm-5qhm/GHSA-mjmq-gwgm-5qhm.json
+++ b/advisories/github-reviewed/2023/07/GHSA-mjmq-gwgm-5qhm/GHSA-mjmq-gwgm-5qhm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mjmq-gwgm-5qhm",
-  "modified": "2023-07-10T21:53:01Z",
+  "modified": "2023-07-19T20:04:21Z",
   "published": "2023-07-10T18:30:49Z",
   "aliases": [
     "CVE-2023-35887"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.0.0"
+              "introduced": "2.1.0"
             },
             {
               "fixed": "2.10.0"
@@ -52,6 +52,28 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.sshd:sshd-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.0.0"
+            },
+            {
+              "fixed": "2.10.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.1.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Problem with this advisory is similar to advisory https://github.com/advisories/GHSA-fhw8-8j55-vwgq - module "org.apache.sshd:sshd-common" was introduced in version 2.1.0 and functionality of "sshd-common" module was contained in "sshd-core" module until then (https://github.com/apache/mina-sshd/commit/10de190e7d3f9189deb76b8d08c72334a1fe2df0).