### PR TITLE
[GHSA-329j-jfvr-rhr6] Apache Spark vulnerable to Improper Privilege Management

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-329j-jfvr-rhr6/GHSA-329j-jfvr-rhr6.json
+++ b/advisories/github-reviewed/2023/04/GHSA-329j-jfvr-rhr6/GHSA-329j-jfvr-rhr6.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-329j-jfvr-rhr6",
-  "modified": "2023-04-27T15:51:58Z",
+  "modified": "2023-04-27T15:52:00Z",
   "published": "2023-04-17T09:30:23Z",
   "aliases": [
     "CVE-2023-22946"
   ],
   "summary": "Apache Spark vulnerable to Improper Privilege Management",
-  "details": "In Apache Spark versions prior to 3.4.0, applications using spark-submit can specify a `proxy-user` to run as, limiting privileges. The application can execute code with the privileges of the submitting user, however, by providing malicious configuration-related classes on the classpath. This affects architectures relying on proxy-user, for example those using Apache Livy to manage submitted applications.\n\nUpdate to Apache Spark 3.4.0 or later, and ensure that spark.submit.proxyUser.allowCustomClasspathInClusterMode is set to its \ndefault of \"false\", and is not overridden by submitted applications.",
+  "details": "In Apache Spark versions prior to 3.3.3/3.4.0, applications using spark-submit can specify a `proxy-user` to run as, limiting privileges. The application can execute code with the privileges of the submitting user, however, by providing malicious configuration-related classes on the classpath. This affects architectures relying on proxy-user, for example, those using Apache Livy or Apache Kyuubi to manage submitted applications.\n\nUpdate to Apache Spark 3.3.3/3.4.0 or later, and ensure that `spark.submit.proxyUser.allowCustomClasspathInClusterMode` is set to its \ndefault of \"false\", and is not overridden by submitted applications.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "3.4.0"
+              "fixed": "3.3.3,3.4.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.3.2"
+      }
     },
     {
       "package": {
@@ -47,17 +50,24 @@
               "introduced": "0"
             },
             {
-              "fixed": "3.4.0"
+              "fixed": "3.3.3,3.4.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.3.2"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-22946"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/SPARK-41958"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
https://issues.apache.org/jira/browse/SPARK-41958 indicates it was fixed in 3.3.3/3.4.0, not only 3.4.0