### PR TITLE
[GHSA-vcph-37mh-fqrh] HTTP Response Smuggling vulnerability in Apache HTTP...

### DIFF
--- a/advisories/unreviewed/2023/03/GHSA-vcph-37mh-fqrh/GHSA-vcph-37mh-fqrh.json
+++ b/advisories/unreviewed/2023/03/GHSA-vcph-37mh-fqrh/GHSA-vcph-37mh-fqrh.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vcph-37mh-fqrh",
-  "modified": "2023-03-14T18:30:27Z",
+  "modified": "2023-04-25T00:30:41Z",
   "published": "2023-03-07T18:30:39Z",
   "aliases": [
     "CVE-2023-27522"
   ],
+  "summary": "Apache HTTP Server via mod_proxy_uwsgi HTTP response smuggling",
   "details": "HTTP Response Smuggling vulnerability in Apache HTTP Server via mod_proxy_uwsgi. This issue affects Apache HTTP Server: from 2.4.30 through 2.4.55. Special characters in the origin response header can truncate/split the response forwarded to the client.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "uWSGI"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.0.22"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,11 +42,23 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/httpd/commit/d753ea76b5972a85349b68c31b59d04c60014f2d.patch"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/unbit/uwsgi/commit/58ee1df31fa9e9af106aaeabb82374c36b433822"
+    },
+    {
+      "type": "WEB",
       "url": "https://httpd.apache.org/security/vulnerabilities_24.html"
     },
     {
       "type": "WEB",
       "url": "https://lists.debian.org/debian-lts-announce/2023/04/msg00028.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://uwsgi-docs.readthedocs.io/en/latest/Changelog-2.0.22.html"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Summary

**Comments**
The parent issue is for Apache mod_proxy_uwsgi but the code in question is also included in the python uWSGI library. I have included the release notes and patch for uWSGI (I'm unsure if case matters here, the package name is actually capitalized like that)