### PR TITLE
[GHSA-qw3f-w4pf-jh5f] Regular expression denial of service in apache tika

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-qw3f-w4pf-jh5f/GHSA-qw3f-w4pf-jh5f.json
+++ b/advisories/github-reviewed/2022/05/GHSA-qw3f-w4pf-jh5f/GHSA-qw3f-w4pf-jh5f.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-qw3f-w4pf-jh5f",
+  "modified": "2023-01-27T05:04:04Z",
+  "published": "2022-06-01T00:00:36Z",
+  "aliases": [
+    "CVE-2022-30973"
+  ],
+  "summary": "Regular expression denial of service in apache tika",
+  "details": "We failed to apply the fix for CVE-2022-30126 to the 1.x branch in the 1.28.2 release.  In Apache Tika, a regular expression in the StandardsText class, used by the StandardsExtractingContentHandler could lead to a denial of service caused by backtracking on a specially crafted file. This only affects users who are running the StandardsExtractingContentHandler, which is a non-standard handler.  This is fixed in 1.28.3.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tika:tika-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.17"
+            },
+            {
+              "fixed": "1.28.3"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-30973"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tika"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread/gqvb5t4p7tmdpl0y5bdbf72pgxj04h7p"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.netapp.com/advisory/ntap-20220722-0004/"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2022/05/31/2"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2022/06/27/5"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-1333"
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true,
+    "github_reviewed_at": "2022-06-03T22:18:15Z",
+    "nvd_published_at": "2022-05-31T14:15:00Z"
+  }
+}


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
Vulnerable component `org.apache.tika.sax.StandardsText` was added to the 1.x branch in version 1.17 https://github.com/apache/tika/commit/e76302196ebcafb7b51fce37fbe8256e6c0fbc51

As an aside, since this CVE tracks backporting the fix for CVE-2022-30126 to the 1.x branch, would it make sense to exclude the 1.x branch from the 2.x CVE's affected versions?