### PR TITLE
[GHSA-2jjq-x548-rhpv] isolated-vm has vulnerable CachedDataOptions in API

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-2jjq-x548-rhpv/GHSA-2jjq-x548-rhpv.json
+++ b/advisories/github-reviewed/2022/09/GHSA-2jjq-x548-rhpv/GHSA-2jjq-x548-rhpv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2jjq-x548-rhpv",
-  "modified": "2022-09-30T22:59:03Z",
+  "modified": "2023-01-27T05:09:01Z",
   "published": "2022-09-30T22:59:03Z",
   "aliases": [
     "CVE-2022-39266"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "4.3.6"
+              "fixed": "4.3.7"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.3.6"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
as per conversation with target project owner
https://github.com/laverdet/isolated-vm/issues/379

```
laverdet commented last month
Hi the issue was one of documentation. 218e87a is the commit that "fixed" the issue.
```

and commit in question produced was merged in version 4.3.7
https://github.com/laverdet/isolated-vm/commits/v4.3.7

only if cachedData supplied by user this vulnerability coming into picture
it is similar to eval() in base nodejs - when you using it to execute something random coming from user input you will run into security issue
but it doesn't mean nodejs versions providing base eval functionality are all vulnerable
same here - only cachedData produced by isolated-vm methods should be used here by design and maintainer added note about it to his project readme to address possible misuse.

Thank You!