### PR TITLE
[GHSA-3v7m-2jrh-vc93] Froxlor vulnerable to Argument Injection

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-3v7m-2jrh-vc93/GHSA-3v7m-2jrh-vc93.json
+++ b/advisories/github-reviewed/2022/12/GHSA-3v7m-2jrh-vc93/GHSA-3v7m-2jrh-vc93.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3v7m-2jrh-vc93",
-  "modified": "2023-01-10T16:03:04Z",
+  "modified": "2023-02-03T05:01:33Z",
   "published": "2022-12-31T00:30:21Z",
   "aliases": [
     "CVE-2022-4864"
   ],
-  "summary": "Froxlor vulnerable to Argument Injection",
-  "details": "Argument Injection in GitHub repository froxlor/froxlor prior to 2.0.0-beta1.",
+  "summary": "Froxlor vulnerable to Content Spoofing",
+  "details": "Content Spoofing in GitHub repository froxlor/froxlor prior to 2.0.0-beta1.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:N/I:L/A:N"
     }
   ],
   "affected": [
@@ -55,7 +55,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-88"
+      "CWE-451"
     ],
     "severity": "MODERATE",
     "github_reviewed": true,


### PR DESCRIPTION
**Updates**
- CVSS
- CWEs
- Description
- Summary

**Comments**
Looking at the advisory and the Huntr.dev report, this isn't an Argument Injection but rather some Content Spoofing issue. I'm also challenging the CVSS scoring because this is only a phishing vector and it was not proven to impact confidentiality.