### PR TITLE
[GHSA-r58r-74gx-6wx3] Nokogiri gem, via libxml, is affected by DoS vulnerabilities

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-r58r-74gx-6wx3/GHSA-r58r-74gx-6wx3.json
+++ b/advisories/github-reviewed/2022/05/GHSA-r58r-74gx-6wx3/GHSA-r58r-74gx-6wx3.json
@@ -7,7 +7,7 @@
     "CVE-2017-15412"
   ],
   "summary": "Nokogiri gem, via libxml, is affected by DoS vulnerabilities",
-  "details": "Use after free in libxml2 before 2.9.5, as used in Google Chrome prior to 63.0.3239.84 and other products, allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
+  "details": "Affected versions < 2.9.6\nPatched version 2.9.6\n\nThe latest version of nokogiri is 1.15.4. The version mentioned is for libxml2, not nokogiri which Dependabot is referring to.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "RubyGems",
         "name": "nokogiri"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
specify Nokogiri version.