### PR TITLE
[GHSA-r58r-74gx-6wx3] Nokogiri gem, via libxml, is affected by DoS vulnerabilities

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-r58r-74gx-6wx3/GHSA-r58r-74gx-6wx3.json
+++ b/advisories/github-reviewed/2022/05/GHSA-r58r-74gx-6wx3/GHSA-r58r-74gx-6wx3.json
@@ -20,11 +20,6 @@
         "ecosystem": "RubyGems",
         "name": "nokogiri"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.9.6"
+              "fixed": "1.8.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The previously referenced versions of nokogiri were incorrect -- they appear to be libxml versions, not the nokogiri versions.