### PR TITLE
[GHSA-r58r-74gx-6wx3] Nokogiri gem, via libxml, is affected by DoS vulnerabilities

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-r58r-74gx-6wx3/GHSA-r58r-74gx-6wx3.json
+++ b/advisories/github-reviewed/2022/05/GHSA-r58r-74gx-6wx3/GHSA-r58r-74gx-6wx3.json
@@ -20,11 +20,6 @@
         "ecosystem": "RubyGems",
         "name": "nokogiri"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.9.6"
+              "fixed": "1.8.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The bundled version of libxml needs to be 2.9.6 or greater, for nokogiri, this means version 1.8.2, not 2.9.6.