### PR TITLE
[GHSA-r58r-74gx-6wx3] Nokogiri gem, via libxml, is affected by DoS vulnerabilities

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-r58r-74gx-6wx3/GHSA-r58r-74gx-6wx3.json
+++ b/advisories/github-reviewed/2022/05/GHSA-r58r-74gx-6wx3/GHSA-r58r-74gx-6wx3.json
@@ -20,11 +20,6 @@
         "ecosystem": "RubyGems",
         "name": "nokogiri"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.9.6"
+              "fixed": "1.8.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The version numbers in the original report are incorrect. They are the version of the underlying libxml2 library, and not the version of the Nokogiri gem. I am the maintainer of Nokogiri. The correct version that a patched version of libxml2 appears in is Nokogiri 1.8.2.

See:
- https://github.com/sparklemotion/nokogiri/issues/1714
- https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md#182--2018-01-29
- https://github.com/rubysec/ruby-advisory-db/blob/master/gems/nokogiri/CVE-2017-15412.yml

