### PR TITLE
[GHSA-r58r-74gx-6wx3] Nokogiri gem, via libxml, is affected by DoS vulnerabilities

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-r58r-74gx-6wx3/GHSA-r58r-74gx-6wx3.json
+++ b/advisories/github-reviewed/2022/05/GHSA-r58r-74gx-6wx3/GHSA-r58r-74gx-6wx3.json
@@ -18,12 +18,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "nokogiri"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+        "name": "libxml"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
nokogiri is on 1.15 which is a far cry from 2.9.6
However the libxml version is 2.9.6 [Seen Here](https://github.com/rubysec/ruby-advisory-db/blob/master/gems/nokogiri/CVE-2017-15412.yml)
the most up to date version is 4.1.1 [found here](https://rubygems.org/gems/libxml-ruby)