### PR TITLE
[GHSA-r58r-74gx-6wx3] Nokogiri gem, via libxml, is affected by DoS vulnerabilities

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-r58r-74gx-6wx3/GHSA-r58r-74gx-6wx3.json
+++ b/advisories/github-reviewed/2022/05/GHSA-r58r-74gx-6wx3/GHSA-r58r-74gx-6wx3.json
@@ -20,11 +20,6 @@
         "ecosystem": "RubyGems",
         "name": "nokogiri"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.9.6"
+              "fixed": "1.8.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The current version of Nokogiri is 1.15.4  so it's impossible to upgrade to 2.9.6.     Nokogiri addressed this dependency in version 1.8.2.   The stated version number of 2.9.5 applies to libxml, not Nokogiri, so you can't compare them.    I suspect this is a duplicate rule anyway and already covered, but this rule triggered a large number of dependabot false positives.