### PR TITLE
[GHSA-9q9m-c65c-37pq] Reportlab up to v3.6.12 allows attackers to execute...

### DIFF
--- a/advisories/unreviewed/2023/06/GHSA-9q9m-c65c-37pq/GHSA-9q9m-c65c-37pq.json
+++ b/advisories/unreviewed/2023/06/GHSA-9q9m-c65c-37pq/GHSA-9q9m-c65c-37pq.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9q9m-c65c-37pq",
-  "modified": "2023-06-10T00:30:18Z",
+  "modified": "2023-07-05T03:30:24Z",
   "published": "2023-06-05T18:30:27Z",
   "aliases": [
     "CVE-2023-33733"
   ],
+  "summary": "Remote Code Execution vulnerability via supplying a crafted PDF file in Reportlab up to version 3.6.12",
   "details": "Reportlab up to v3.6.12 allows attackers to execute arbitrary code via supplying a crafted PDF file.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "reportlab"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.6.13"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -28,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/c53elyas/CVE-2023-33733"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/mattjmorrison/ReportLab"
     },
     {
       "type": "WEB",
@@ -44,9 +67,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-94"
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- Severity
- Source code location
- Summary

**Comments**
* Source Code Location was added
* Affected Product was added
* CWE was added