### PR TITLE
[GHSA-hr8g-6v94-x4m9] Bouncy Castle For Java LDAP injection vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-hr8g-6v94-x4m9/GHSA-hr8g-6v94-x4m9.json
+++ b/advisories/github-reviewed/2023/07/GHSA-hr8g-6v94-x4m9/GHSA-hr8g-6v94-x4m9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hr8g-6v94-x4m9",
-  "modified": "2023-07-10T19:09:01Z",
+  "modified": "2023-08-24T21:58:02Z",
   "published": "2023-07-05T03:30:23Z",
   "aliases": [
     "CVE-2023-33201"
@@ -181,6 +181,63 @@
             },
             {
               "fixed": "1.74"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.bouncycastle:bcprov-jdk15on"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.70"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.bouncycastle:bcprov-ext-jdk15on"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.70"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.bouncycastle:bcprov-debug-jdk15on"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.70"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
As described at https://www.bouncycastle.org/latest_releases.html:

"BC 1.71 changed the jdk15on jars to jdk18on so the base has now moved to Java 8. For earlier JVMs, or containers/applications that cannot cope with multi-release jars, you should now use the jdk15to18 jars"

This means that jdk15on artifacts (used until version 1.71) are not accounted for with current affected products definition.