### PR TITLE
[GHSA-2474-2566-3qxp] Apache Batik information disclosure vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-2474-2566-3qxp/GHSA-2474-2566-3qxp.json
+++ b/advisories/github-reviewed/2023/08/GHSA-2474-2566-3qxp/GHSA-2474-2566-3qxp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2474-2566-3qxp",
-  "modified": "2023-08-23T17:51:53Z",
+  "modified": "2023-08-23T17:51:55Z",
   "published": "2023-08-22T21:30:26Z",
   "aliases": [
     "CVE-2022-44730"
@@ -16,11 +16,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.apache.xmlgraphics:batik-script"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -41,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-44730"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/xmlgraphics-batik/commit/64658ccda90deaf6bf5f5b4d4a2ec365fe648bfa"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
https://github.com/apache/xmlgraphics-batik/commit/64658ccda90deaf6bf5f5b4d4a2ec365fe648bfa is the more relevant mitigation commit. As discussed in https://www.openwall.com/lists/oss-security/2023/08/22/5, including `java.lang.System` in the allowlist by default was a significant part of the issue, and the chosen mitigation was to use a blank allowlist by default.