### PR TITLE
[GHSA-2h63-qp69-fwvw] Server-side request forgery (SSRF) in Apache Batik

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-2h63-qp69-fwvw/GHSA-2h63-qp69-fwvw.json
+++ b/advisories/github-reviewed/2022/01/GHSA-2h63-qp69-fwvw/GHSA-2h63-qp69-fwvw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2h63-qp69-fwvw",
-  "modified": "2022-02-08T21:33:49Z",
+  "modified": "2023-01-27T05:02:18Z",
   "published": "2022-01-06T20:35:54Z",
   "aliases": [
     "CVE-2020-11987"
@@ -18,45 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.xmlgraphics:batik-util"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.14"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.apache.xmlgraphics:batik-xml"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.14"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.apache.xmlgraphics:batik-ttf2svg"
+        "name": "org.apache.xmlgraphics:batik-svgbrowser"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The reference commit and associated ASF JIRA issue https://issues.apache.org/jira/browse/BATIK-1284 indicate that the vulnerable component is `org.apache.batik.apps.svgbrowser.NodePickerPanel`. I've been unable to find references to `org.apache.batik.apps.svgbrowser` in the packages currently listed on this advisory, and searching the Batik repo at the `batik-1_13` didn't find any references to the svgbrowser module outside of `batik-svgbrowser` or commented-out and test code. Based on https://xmlgraphics.apache.org/batik/using/architecture.html#applicationComponents `batik-svgbrowser` appears to be an application module provided as a demo of how to use Batik that could be used by other applications but is not used by the Batik APIs themselves.