### PR TITLE
[GHSA-58qw-p7qm-5rvh] Eclipse Jetty XmlParser allows arbitrary DOCTYPE declarations

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-58qw-p7qm-5rvh/GHSA-58qw-p7qm-5rvh.json
+++ b/advisories/github-reviewed/2023/07/GHSA-58qw-p7qm-5rvh/GHSA-58qw-p7qm-5rvh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-58qw-p7qm-5rvh",
-  "modified": "2023-07-12T14:43:10Z",
+  "modified": "2023-07-11T22:28:25Z",
   "published": "2023-07-10T21:52:39Z",
   "aliases": [
 
@@ -26,6 +26,25 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "last_affected": "9.4.51.v20230217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.jetty:jetty-xml"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.0.0-alpha0"
             },
             {
               "last_affected": "10.0.15"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The fix for this issue has been backported and released as part of https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.52.v20230823 via https://github.com/eclipse/jetty.project/pull/10299

- Last affected 9.x release is https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.51.v20230217
- Earliest 10.x release taken from https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-xml