### PR TITLE
[GHSA-4993-m7g5-r9hh] etcd has no minimum password length

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-4993-m7g5-r9hh/GHSA-4993-m7g5-r9hh.json
+++ b/advisories/github-reviewed/2022/10/GHSA-4993-m7g5-r9hh/GHSA-4993-m7g5-r9hh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4993-m7g5-r9hh",
-  "modified": "2022-10-06T23:14:23Z",
+  "modified": "2023-01-28T05:00:58Z",
   "published": "2022-10-06T23:14:23Z",
   "aliases": [
     "CVE-2020-15115"
@@ -48,6 +48,25 @@
             },
             {
               "fixed": "3.3.23"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "go.etcd.io/etcd/client/v2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.305.9"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This also affects the v2 library.