### PR TITLE
[GHSA-3j6g-hxx5-3q26] Observable Discrepancy in Apache Kafka

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-3j6g-hxx5-3q26/GHSA-3j6g-hxx5-3q26.json
+++ b/advisories/github-reviewed/2021/09/GHSA-3j6g-hxx5-3q26/GHSA-3j6g-hxx5-3q26.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3j6g-hxx5-3q26",
-  "modified": "2022-02-08T20:43:00Z",
+  "modified": "2023-01-27T05:02:33Z",
   "published": "2021-09-23T23:18:58Z",
   "aliases": [
     "CVE-2021-38153"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.kafka:kafka"
+        "name": "org.apache.kafka:kafka_2.11"
       },
       "ranges": [
         {
@@ -26,6 +26,174 @@
           "events": [
             {
               "introduced": "2.0.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.kafka:kafka_2.12"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0"
+            },
+            {
+              "fixed": "2.6.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.kafka:kafka_2.12"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.kafka:kafka_2.12"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.kafka:kafka_2.13"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0"
+            },
+            {
+              "fixed": "2.6.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.kafka:kafka_2.13"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.kafka:kafka_2.13"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.kafka:kafka-clients"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0"
+            },
+            {
+              "fixed": "2.6.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.kafka:kafka-clients"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.kafka:kafka-clients"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
             },
             {
               "fixed": "2.8.1"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to following sources, Kafka Java Client contained in "kafka-clients" artifact is also affected but Maven coordinates are missing:

https://kafka.apache.org/cve-list ("CVE-2021-38153 Timing Attack Vulnerability for Apache Kafka Connect and Clients")
https://support.confluent.io/hc/en-us/articles/4407632156692-CVE-2021-38153-Confluent-Platform-Vulnerability-Timing-attacks

I also corrected "Affected versions" and "Patched versions" according to sources above.

Another issue is non-existent "org.apache.kafka:kafka" Maven artifact:

https://search.maven.org/search?q=g:org.apache.kafka%20AND%20a:kafka

Kafka server-side artifacts include version of Scala used for build - removal of Scala version suffix is proposed in KIP-897: 

https://cwiki.apache.org/confluence/display/KAFKA/KIP-897%3A+Publish+a+single+kafka+%28aka+core%29+Maven+artifact+in+Apache+Kafka+4.0

There is no fix for Scala 2.11 artifacts, but fixes are available for Scala 2.12 and 2.13:

https://search.maven.org/artifact/org.apache.kafka/kafka_2.11
https://search.maven.org/artifact/org.apache.kafka/kafka_2.12
https://search.maven.org/artifact/org.apache.kafka/kafka_2.13

