### PR TITLE
[GHSA-58qw-p7qm-5rvh] Eclipse Jetty XmlParser allows arbitrary DOCTYPE declarations

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-58qw-p7qm-5rvh/GHSA-58qw-p7qm-5rvh.json
+++ b/advisories/github-reviewed/2023/07/GHSA-58qw-p7qm-5rvh/GHSA-58qw-p7qm-5rvh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-58qw-p7qm-5rvh",
-  "modified": "2023-07-12T14:43:10Z",
+  "modified": "2023-07-11T22:28:25Z",
   "published": "2023-07-10T21:52:39Z",
   "aliases": [
 
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "10.0.15"
+              "fixed": "11.0.16"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 10.0.15"
+      }
     },
     {
       "package": {
@@ -44,14 +47,17 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "11.0.0-alpha0"
+              "introduced": "0"
             },
             {
-              "last_affected": "11.0.15"
+              "fixed": "11.0.16"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 11.0.15"
+      }
     },
     {
       "package": {
@@ -63,14 +69,39 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "12.0.0.beta0"
+              "introduced": "0"
             },
             {
-              "last_affected": "12.0.0.beta3"
+              "fixed": "12.0.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 12.0.0.beta4"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.jetty:jetty-xml"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "9.4.52"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 9.4.51"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Updating affected version ranges (was missing 9.x series), and patched versions (releases that have occurred since this advisory was published).

* https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.52.v20230823
* https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.16
* https://github.com/eclipse/jetty.project/releases/tag/jetty-11.0.16
* https://github.com/eclipse/jetty.project/releases/tag/jetty-12.0.0

