### PR TITLE
[GHSA-wfm5-v35h-vwf4] GitPython untrusted search path on Windows systems leading to arbitrary code execution

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-wfm5-v35h-vwf4/GHSA-wfm5-v35h-vwf4.json
+++ b/advisories/github-reviewed/2023/08/GHSA-wfm5-v35h-vwf4/GHSA-wfm5-v35h-vwf4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wfm5-v35h-vwf4",
-  "modified": "2023-08-29T23:33:53Z",
+  "modified": "2023-08-29T23:33:54Z",
   "published": "2023-08-29T23:33:53Z",
   "aliases": [
     "CVE-2023-40590"
@@ -20,11 +20,6 @@
         "ecosystem": "PyPI",
         "name": "gitpython"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.1.32"
+              "fixed": ">= 3.1.33"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.1.32"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
A new version of GitPython, `v3.1.33`, has been released with a fix:
https://github.com/gitpython-developers/GitPython/releases/tag/3.1.33