### PR TITLE
[GHSA-353f-5xf4-qw67] Vite Server Options (server.fs.deny) can be bypassed using double forward-slash (//)

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-353f-5xf4-qw67/GHSA-353f-5xf4-qw67.json
+++ b/advisories/github-reviewed/2023/06/GHSA-353f-5xf4-qw67/GHSA-353f-5xf4-qw67.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-353f-5xf4-qw67",
-  "modified": "2023-06-06T02:01:39Z",
+  "modified": "2023-06-09T21:10:12Z",
   "published": "2023-06-06T02:01:39Z",
   "aliases": [
     "CVE-2023-34092"
   ],
   "summary": "Vite Server Options (server.fs.deny) can be bypassed using double forward-slash (//)",
-  "details": "### Summary\nVite Server Options (`server.fs.deny`) can be bypassed using double forward-slash (//) allows any unauthenticated user to read file from the Vite root-path of the application including the default [`fs.deny` settings](https://vitejs.dev/config/server-options.html#server-fs-deny) (`['.env', '.env.*', '*.{crt,pem}']`)\n\n### Impact\nOnly users explicitly exposing the Vite dev server to the network (using `--host` or [`server.host` config option](https://vitejs.dev/config/server-options.html#server-host)) are affected, and only files in the immediate Vite project root folder could be exposed.\n\n### Patches\nFixed in vite@4.3.9, vite@4.2.3, vite@4.1.5, vite@4.0.5\nAnd in the latest minors of the previous two majors: vite@3.2.7, vite@2.9.16\n\n### Details\nVite serve the application with under the root-path of the project while running on the dev mode. By default, vite using server options fs.deny to protected the sensitive information of the file. But, with simply double forward-slash, we can bypass this fs restriction. \n\n### PoC\n1. Create a new latest project of vite using any package manager. (here I'm using react and vue templates for tested and pnpm)\n2. Serve the application on dev mode using pnpm run dev.\n3. Directly access the file from url using double forward-slash (`//`) (e.g: `//.env`, `//.env.local`)\n4. Server Options `fs.deny` restrict successfully bypassed.\n\nProof Images:\n![proof-1](https://user-images.githubusercontent.com/30733517/241105344-6ecbc7f6-57b7-45c7-856a-6421a577dda1.png)\n![proof-2](https://user-images.githubusercontent.com/30733517/241105349-ab9561e7-8aff-4f29-97f9-b784e673c122.png)",
+  "details": "\n\n# Vite Server Options Bypass Vulnerability\n\n## Description\n\nThe issue involves a security vulnerability in Vite, where the server options can be bypassed using a double forward slash (`//`). This vulnerability poses a potential security risk as it can allow unauthorized access to sensitive directories and files. This document outlines the steps to address and mitigate this issue.\n\nAdding  Extra References : \nhttps://security.snyk.io/package/npm/vite/3.2.0-beta.4\nhttps://codewave.tistory.com/49\n\n\n## Steps to Fix\n\n1. **Update Vite**:\n\n   Ensure that you are using the latest version of Vite. Security issues like this are often fixed in newer releases.\n\n2. **Secure the Server Configuration**:\n\n   In your `vite.config.js` file, review and update the server configuration options to restrict access to unauthorized requests or directories. For example:\n\n   ```javascript\n   // vite.config.js\n   export default {\n     server: {\n       fs: {\n         deny: ['private-directory'] // Restrict access to specific directories\n       }\n     }\n   }\n\n",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Description

**Comments**
Added Extra references and provided better documentation of the fix.