### PR TITLE
[GHSA-r285-q736-9v95] Filename spoofing in archive

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-r285-q736-9v95/GHSA-r285-q736-9v95.json
+++ b/advisories/github-reviewed/2023/08/GHSA-r285-q736-9v95/GHSA-r285-q736-9v95.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r285-q736-9v95",
-  "modified": "2023-08-31T01:43:38Z",
+  "modified": "2023-08-31T01:43:40Z",
   "published": "2023-08-31T00:30:17Z",
   "aliases": [
     "CVE-2023-39137"
@@ -17,11 +17,6 @@
         "ecosystem": "Pub",
         "name": "archive"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -30,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.3.7"
+              "fixed": "3.3.8"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.3.7"
+      }
     }
   ],
   "references": [
@@ -49,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://blog.ostorlab.co/zip-packages-exploitation.html"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/brendan-duncan/archive"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
Origin GitHub issue has been marked as resolved by package author.

Reference patch commit: 0d17b270a3c33d3bed56cadd9a43da7717ab11f4