### PR TITLE
[GHSA-9v85-q87q-g4vg] Path traversal in Archive

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-9v85-q87q-g4vg/GHSA-9v85-q87q-g4vg.json
+++ b/advisories/github-reviewed/2023/08/GHSA-9v85-q87q-g4vg/GHSA-9v85-q87q-g4vg.json
@@ -17,11 +17,6 @@
         "ecosystem": "Pub",
         "name": "archive"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -30,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.3.7"
+              "fixed": "3.3.8"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.3.7"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The issue appears fixed in 3.3.8, see changelog: https://github.com/brendan-duncan/archive/blob/main/CHANGELOG.md