### PR TITLE
[GHSA-3w37-5p3p-jv92] Apache CXF vulnerable to Exposure of Sensitive Information

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-3w37-5p3p-jv92/GHSA-3w37-5p3p-jv92.json
+++ b/advisories/github-reviewed/2022/12/GHSA-3w37-5p3p-jv92/GHSA-3w37-5p3p-jv92.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3w37-5p3p-jv92",
-  "modified": "2022-12-13T19:26:03Z",
+  "modified": "2023-01-29T05:05:00Z",
   "published": "2022-12-13T15:30:27Z",
   "aliases": [
     "CVE-2022-46363"
@@ -9,7 +9,10 @@
   "summary": "Apache CXF vulnerable to Exposure of Sensitive Information",
   "details": "A vulnerability in Apache CXF before versions 3.5.5 and 3.4.10 allows an attacker to perform a remote directory listing or code exfiltration. The vulnerability only applies when the CXFServlet is configured with both the static-resources-list and redirect-query-check attributes. These attributes are not supposed to be used together, and so the vulnerability can only arise if the CXF service is misconfigured.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+    }
   ],
   "affected": [
     {
@@ -70,7 +73,7 @@
       "CWE-20",
       "CWE-200"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2022-12-13T19:26:03Z",
     "nvd_published_at": "2022-12-13T15:15:00Z"


### PR DESCRIPTION
**Updates**
- CVSS
- Severity

**Comments**
CVSS vector string is available in NIST NVD and it seems accurate. If there is a justification for current "moderate" severity, I haven't found one. 

If "moderate" is used because of last sentence of description ("These attributes are not supposed to be used together, and so the vulnerability can only arise if the CXF service is misconfigured."), CVSS 3.1 specification section 2.1 states that:

"Specific configurations should not impact any attribute contributing to the CVSS Base Score, i.e., if a specific configuration is required for an attack to succeed, the vulnerable component should be scored assuming it is in that configuration."