### PR TITLE
[GHSA-jf2p-4gqj-849g] Temporary File Information Disclosure vulnerability in MPXJ

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-jf2p-4gqj-849g/GHSA-jf2p-4gqj-849g.json
+++ b/advisories/github-reviewed/2022/11/GHSA-jf2p-4gqj-849g/GHSA-jf2p-4gqj-849g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jf2p-4gqj-849g",
-  "modified": "2022-12-01T22:12:03Z",
+  "modified": "2023-07-06T16:02:43Z",
   "published": "2022-11-28T22:09:09Z",
   "aliases": [
     "CVE-2022-41954"
@@ -122,7 +122,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/joniles/mpxj/commit/287ad0234213c52b0638565e14bd9cf3ed44cedd"
+      "url": "https://github.com/joniles/mpxj/commit/ae0af24345d79ad45705265d9927fe55e94a5721"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
https://github.com/joniles/mpxj/commit/287ad0234213c52b0638565e14bd9cf3ed44cedd is a merge commit and has a lot of noise unrelated to the patch. https://github.com/joniles/mpxj/commit/ae0af24345d79ad45705265d9927fe55e94a5721, one of the parents of the merge, is the true patch commit.