### PR TITLE
[GHSA-8qv2-5vq6-g2g7] webpki: CPU denial of service in certificate path building

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-8qv2-5vq6-g2g7/GHSA-8qv2-5vq6-g2g7.json
+++ b/advisories/github-reviewed/2023/08/GHSA-8qv2-5vq6-g2g7/GHSA-8qv2-5vq6-g2g7.json
@@ -20,11 +20,6 @@
         "ecosystem": "crates.io",
         "name": "webpki"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.22.0"
+              "fixed": "0.22.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.22.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
- A patched version was published: https://github.com/briansmith/webpki/issues/69#issuecomment-1699894848
- The RUSTSEC database was already updated: https://rustsec.org/advisories/RUSTSEC-2023-0052.html