### PR TITLE
[GHSA-q3mw-pvr8-9ggc] Apache Tomcat Open Redirect vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-q3mw-pvr8-9ggc/GHSA-q3mw-pvr8-9ggc.json
+++ b/advisories/github-reviewed/2023/08/GHSA-q3mw-pvr8-9ggc/GHSA-q3mw-pvr8-9ggc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q3mw-pvr8-9ggc",
-  "modified": "2023-08-31T18:50:44Z",
+  "modified": "2023-08-31T18:50:45Z",
   "published": "2023-08-25T21:30:48Z",
   "aliases": [
     "CVE-2023-41080"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.apache.tomcat:tomcat"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,11 +39,6 @@
         "ecosystem": "Maven",
         "name": "org.apache.tomcat:tomcat"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -67,11 +57,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.apache.tomcat:tomcat"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -92,10 +77,81 @@
         "ecosystem": "Maven",
         "name": "org.apache.tomcat:tomcat"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.5.0"
+            },
+            {
+              "fixed": "8.5.93"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "11.0.0-M1"
+            },
+            {
+              "fixed": "11.0.0-M11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.1.0-M1"
+            },
+            {
+              "fixed": "10.1.13"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.0-M1"
+            },
+            {
+              "fixed": "9.0.80"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The affected component is also distributed as `org.apache.tomcat.embed:tomcat-embed-core`. 