### PR TITLE
[GHSA-fjq3-5pxw-4wj4] Cross-Site Request Forgery in Webargs

### DIFF
--- a/advisories/github-reviewed/2021/04/GHSA-fjq3-5pxw-4wj4/GHSA-fjq3-5pxw-4wj4.json
+++ b/advisories/github-reviewed/2021/04/GHSA-fjq3-5pxw-4wj4/GHSA-fjq3-5pxw-4wj4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fjq3-5pxw-4wj4",
-  "modified": "2023-08-30T23:02:20Z",
+  "modified": "2023-08-30T23:02:21Z",
   "published": "2021-04-07T21:06:30Z",
   "aliases": [
     "CVE-2020-7965"
@@ -20,11 +20,6 @@
         "ecosystem": "PyPI",
         "name": "webargs"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,11 +28,36 @@
               "introduced": "5.0.0"
             },
             {
+              "fixed": "5.5.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 5.5.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "webargs"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0b1"
+            },
+            {
               "fixed": "6.0.0b4"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 6.0.0b3"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Changelog indicates CVE-2020-7965 was fixed in 5.5.3 https://webargs.readthedocs.io/en/latest/changelog.html#id11. I've added the 6 beta series as a separate affected product, though I doubt anyone would be using that anymore.