### PR TITLE
[GHSA-mrr8-v49w-3333] sweetalert2 v11.6.14 and above contains potentially undesirable behavior

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-mrr8-v49w-3333/GHSA-mrr8-v49w-3333.json
+++ b/advisories/github-reviewed/2023/07/GHSA-mrr8-v49w-3333/GHSA-mrr8-v49w-3333.json
@@ -1,15 +1,18 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mrr8-v49w-3333",
-  "modified": "2023-07-10T19:08:10Z",
+  "modified": "2023-07-10T19:08:11Z",
   "published": "2023-07-10T19:08:10Z",
   "aliases": [
 
   ],
   "summary": "sweetalert2 v11.6.14 and above contains potentially undesirable behavior",
-  "details": "`sweetalert2` versions 11.6.14 and above have potentially undesirable behavior. The package outputs audio and/or video messages that do not pertain to the functionality of the package when run on specific tlds. This functionality is documented on the project's readme",
+  "details": "`sweetalert2` versions 11.6.14 and above have potentially undesirable behavior.\nThe package outputs audio and/or video messages that do not pertain to the functionality of the package when run on specific TLDs, as well as blocking page interaction. This functionality is documented on the project's readme.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
   ],
   "affected": [
     {
@@ -32,7 +35,7 @@
   "references": [
     {
       "type": "WEB",
-      "url": "https://github.com/sweetalert2/sweetalert2#important-notice-about-usage-of-this-software-for-ru-su-by-and-%D1%80%D1%84-domain-zones"
+      "url": "https://github.com/sweetalert2/sweetalert2#important-notice-about-the-usage-of-this-software-for-ru-su-by-and-%D1%80%D1%84-domain-zones"
     },
     {
       "type": "WEB",
@@ -47,7 +50,7 @@
     "cwe_ids": [
       "CWE-440"
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2023-07-10T19:08:10Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- References
- Severity

**Comments**
CVSS is not really well suited to grade this vulnerability. But I think breaking the functionality of the application (blocking website navigation) does not deserve a rating of "Low".