### PR TITLE
[GHSA-xc27-f9q3-4448] Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal') in hyper-bump-it

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-xc27-f9q3-4448/GHSA-xc27-f9q3-4448.json
+++ b/advisories/github-reviewed/2023/09/GHSA-xc27-f9q3-4448/GHSA-xc27-f9q3-4448.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xc27-f9q3-4448",
-  "modified": "2023-09-04T17:02:36Z",
+  "modified": "2023-09-06T19:22:20Z",
   "published": "2023-09-04T17:02:36Z",
   "aliases": [
     "CVE-2023-41057"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:L"
     }
   ],
   "affected": [
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "hyper-bump-it"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -62,7 +57,7 @@
     "cwe_ids": [
       "CWE-22"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2023-09-04T17:02:36Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
[CHANGED] CVSS Assessment
User Interaction changed to None: The danger lies in the fact that the package processes the input without seeking confirmation or validation from the user. A hacker could exploit this flaw to access, modify, or delete files outside of the intended directory.
Confidentiality changed to Low: If an attacker successfully exploits a path traversal vulnerability, they might gain access to sensitive files or data stored on the server on behalf of the service user.
Availability changed to Low: In this vulnerability, the threat actor could potentially cause a DoS by repeatedly requesting particularly large files, or accessing files or directories that the application isn't designed to handle.