### PR TITLE
[GHSA-gv66-v8c8-v69c] The legacy email.utils.parseaddr function in Python...

### DIFF
--- a/advisories/unreviewed/2023/06/GHSA-gv66-v8c8-v69c/GHSA-gv66-v8c8-v69c.json
+++ b/advisories/unreviewed/2023/06/GHSA-gv66-v8c8-v69c/GHSA-gv66-v8c8-v69c.json
@@ -1,22 +1,42 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gv66-v8c8-v69c",
-  "modified": "2023-06-25T18:30:27Z",
+  "modified": "2023-06-27T23:07:53Z",
   "published": "2023-06-25T18:30:27Z",
   "aliases": [
     "CVE-2023-36632"
   ],
+  "summary": "RecursionError in email.utils.parseaddr",
   "details": "The legacy email.utils.parseaddr function in Python through 3.11.4 allows attackers to trigger \"RecursionError: maximum recursion depth exceeded while calling a Python object\" via a crafted argument. This argument is plausibly an untrusted value from an application's input data that was supposed to contain a name and an e-mail address. NOTE: email.utils.parseaddr is categorized as a Legacy API in the documentation of the Python email package. Applications should instead use the email.parser.BytesParser or email.parser.Parser class.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "python"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-36632"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python/cpython/issues/103800"
     },
     {
       "type": "WEB",
@@ -29,6 +49,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/Daybreak2019/PoC_python3.9_Vul/blob/main/RecursionError-email.utils.parseaddr.py"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/python/cpython/blob/1110c5bc828218086f6397ec05a9312fb73ea30a/Lib/email/utils.py#L208"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
See the Python issue listed above (https://github.com/python/cpython/issues/103800). This is most likely not a bug at all, even less a security bug.