### PR TITLE
[GHSA-5q66-v53q-pm35] Keycloak vulnerable to Plaintext Storage of User Password

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-5q66-v53q-pm35/GHSA-5q66-v53q-pm35.json
+++ b/advisories/github-reviewed/2023/09/GHSA-5q66-v53q-pm35/GHSA-5q66-v53q-pm35.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5q66-v53q-pm35",
-  "modified": "2023-09-12T21:10:37Z",
+  "modified": "2023-09-12T21:10:40Z",
   "published": "2023-09-12T21:10:37Z",
   "aliases": [
     "CVE-2023-4918"
@@ -20,17 +20,12 @@
         "ecosystem": "Maven",
         "name": "org.keycloak:keycloak-core"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "22.0.2"
             },
             {
               "fixed": "22.0.3"
@@ -38,9 +33,9 @@
           ]
         }
       ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 22.0.2"
-      }
+      "versions": [
+        "22.0.2"
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Only 22.0.2 is affected