### PR TITLE
[GHSA-3q5p-3558-364f] Fiber unauthorized access vulnerability in `ctx.IsFromLocal()`

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-3q5p-3558-364f/GHSA-3q5p-3558-364f.json
+++ b/advisories/github-reviewed/2023/09/GHSA-3q5p-3558-364f/GHSA-3q5p-3558-364f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3q5p-3558-364f",
-  "modified": "2023-09-11T14:39:57Z",
+  "modified": "2023-09-12T20:16:47Z",
   "published": "2023-09-08T13:27:21Z",
   "aliases": [
     "CVE-2023-41338"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Go",
         "name": "github.com/gofiber/fiber"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,11 +39,6 @@
         "ecosystem": "Go",
         "name": "github.com/gofiber/fiber/v2"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -57,11 +47,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.49.2-0.20230906112033-b8c9ede6efa2"
+              "fixed": "> v2.49.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.49.2-0.20230906112033-b8c9ede6efa2"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
A release has finally been published with the vulnerability patched. Dependabot should probably also publish this.
https://github.com/gofiber/fiber/releases/tag/v2.49.2