### PR TITLE
[GHSA-3gh6-v5v9-6v9j] Jetty vulnerable to errant command quoting in CgiServlet

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-3gh6-v5v9-6v9j/GHSA-3gh6-v5v9-6v9j.json
+++ b/advisories/github-reviewed/2023/09/GHSA-3gh6-v5v9-6v9j/GHSA-3gh6-v5v9-6v9j.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3gh6-v5v9-6v9j",
-  "modified": "2023-09-14T16:16:00Z",
+  "modified": "2023-09-14T16:16:02Z",
   "published": "2023-09-14T16:16:00Z",
   "aliases": [
     "CVE-2023-36479"
   ],
-  "summary": "Jetty vulnerable to errant command quoting in CgiServlet",
+  "summary": "Jetty vulnerable to errant command quoting in CGI Servlet",
   "details": "If a user sends a request to a `org.eclipse.jetty.servlets.CGI` Servlet for a binary with a space in its name, the servlet will escape the command by wrapping it in quotation marks. This wrapped command, plus an optional command prefix, will then be executed through a call to Runtime.exec. If the original binary name provided by the user contains a quotation mark followed by a space, the resulting command line will contain multiple tokens instead of one. For example, if a request references a binary called file” name “here, the escaping algorithm will generate the command line string “file” name “here”, which will invoke the binary named file, not the one that the user requested.\n\n```java\nif (execCmd.length() > 0 && execCmd.charAt(0) != '\"' && execCmd.contains(\" \"))\nexecCmd = \"\\\"\" + execCmd + \"\\\"\";\n```\n\n### Exploit Scenario\nThe cgi-bin directory contains a binary named exec and a subdirectory named exec” commands, which contains a file called bin1. The user sends to the CGI servlet a request for the filename exec” commands/bin1. This request will pass the file existence check on lines 194 through 205. The servlet will add quotation marks around this filename, resulting in the command line string “exec” commands/bin1”. When this string is passed to Runtime.exec, instead of executing the bin1 binary, the server will execute the exec\nbinary with the argument commands/file1”. In addition to being incorrect, this behavior may bypass alias checks, and it may cause other unintended behaviors if a command prefix is configured.\n\nIf the useFullPath configuration setting is off, the command need not pass the existence check. The attack would not rely on a binary and subdirectory having similar names, and the attack will succeed on a much wider variety of directory structures.\n\n### Impact\nUsers of the `org.eclipse.jetty.servlets.CGI` Servlet with a very specific command structure may have the wrong command executed.\n\n### Patches\nNo patch.\nIn Jetty 9.x, 10.x, and 11.x the `org.eclipse.jetty.servlets.CGI` has been deprecated.\nIn Jetty 12 (all environments) the `org.eclipse.jetty.servlets.CGI` has been entirely removed.\n\n### Workarounds\nThe `org.eclipse.jetty.servlets.CGI` Servlet should not be used. Fast CGI support is available instead.\n\n### References\n* https://github.com/eclipse/jetty.project/pull/9516\n* https://github.com/eclipse/jetty.project/pull/9889\n* https://github.com/eclipse/jetty.project/pull/9888",
   "severity": [
     {
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.eclipse.jetty:jetty-servlets"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -47,11 +42,6 @@
         "ecosystem": "Maven",
         "name": "org.eclipse.jetty:jetty-servlets"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -73,11 +63,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.eclipse.jetty:jetty-servlets"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -101,11 +86,6 @@
         "ecosystem": "Maven",
         "name": "org.eclipse.jetty.ee10:jetty-ee10-servlets"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -128,11 +108,6 @@
         "ecosystem": "Maven",
         "name": "org.eclipse.jetty.ee9:jetty-ee9-servlets"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -154,11 +129,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.eclipse.jetty.ee8:jetty-ee8-servlets"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The title incorrectly says "CgiServlet".
There's no such class in Jetty, it's just called "CGI" and it happens to extend from HttpServlet.

See: https://github.com/eclipse/jetty.project/blob/jetty-10.0.x/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CGI.java