### PR TITLE
[GHSA-23c2-gwp5-pxw9] ReDoS based DoS vulnerability in GlobalID

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-23c2-gwp5-pxw9/GHSA-23c2-gwp5-pxw9.json
+++ b/advisories/github-reviewed/2023/01/GHSA-23c2-gwp5-pxw9/GHSA-23c2-gwp5-pxw9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-23c2-gwp5-pxw9",
-  "modified": "2023-02-10T00:20:24Z",
+  "modified": "2023-02-10T00:20:25Z",
   "published": "2023-01-18T18:13:19Z",
   "aliases": [
     "CVE-2023-22799"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-22799"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/globalid/commit/4a75ecbfd73a8e92e32a1723b81a17e3136bd8fc"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for this advisory associated to version 1.0.1: https://github.com/rails/globalid/compare/v1.0.0...v1.0.1 

The CVE is in the commit message:

" Fix ReDoS vulnerability in name parsing

Thanks to ooooooo_q for the patch!

[CVE-2023-22799]"