### PR TITLE
[GHSA-2vx6-fcw6-hpr6] Reference counting error in pyo3

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-2vx6-fcw6-hpr6/GHSA-2vx6-fcw6-hpr6.json
+++ b/advisories/github-reviewed/2021/08/GHSA-2vx6-fcw6-hpr6/GHSA-2vx6-fcw6-hpr6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2vx6-fcw6-hpr6",
-  "modified": "2021-08-19T20:50:20Z",
+  "modified": "2023-01-11T05:05:39Z",
   "published": "2021-08-25T20:49:52Z",
   "aliases": [
     "CVE-2020-35917"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/PyO3/pyo3/pull/1297"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/PyO3/pyo3/commit/8f81f595dd770b586c7ca7195b42004a6c976eb9"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for v0.12.4: https://github.com/PyO3/pyo3/commit/1ee3961a0de6a74a4c5160c97a88696a2164025b

Only two commits exist for v0.12.4: https://github.com/PyO3/pyo3/compare/v0.12.3...v0.12.4

Additionally, the patch link is the same as the original pull 1297 in the advisory: "py: fix reference count bug in From(Py<T>) for PyObject "