### PR TITLE
[GHSA-376m-3rm2-9jm6] Session Fixation in ipsilon

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-376m-3rm2-9jm6/GHSA-376m-3rm2-9jm6.json
+++ b/advisories/github-reviewed/2022/05/GHSA-376m-3rm2-9jm6/GHSA-376m-3rm2-9jm6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-376m-3rm2-9jm6",
-  "modified": "2023-02-14T00:46:20Z",
+  "modified": "2023-02-14T00:46:22Z",
   "published": "2022-05-14T03:55:23Z",
   "aliases": [
     "CVE-2016-8638"
@@ -96,6 +96,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-8638"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ipsilon-project/ipsilon/commit/1c48414877fc110652b6078a29529972c7ec9122"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ipsilon-project/ipsilon/commit/64fc366c054fc6af1d9d2692902db169884b5f78"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ipsilon-project/ipsilon/commit/b4744a92d4fa7f6d7ade0ae2d99a2dc0ea94734d"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v1.0.3: https://github.com/ipsilon-project/ipsilon/commit/64fc366c054fc6af1d9d2692902db169884b5f78
v1.1.2: https://github.com/ipsilon-project/ipsilon/commit/1c48414877fc110652b6078a29529972c7ec9122
v1.2.1: https://github.com/ipsilon-project/ipsilon/commit/b4744a92d4fa7f6d7ade0ae2d99a2dc0ea94734d
v2.0.2: https://github.com/ipsilon-project/ipsilon/commit/a33303b6beb5c316d7c18b23566b7666a4e307a4

The CVE is in the commit message: 
"This resolves an issue where Ipsilon can be requested to initiate logout sessions for all currently open sessions, regardless of currently logged in user.
Fixes: CVE-2016-8638"

It's best to have a patch link for each fixed version due to minor changes from the backports. 