### PR TITLE
[GHSA-43w2-9j62-hq99] Buffer overflow in SmallVec::insert_many

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-43w2-9j62-hq99/GHSA-43w2-9j62-hq99.json
+++ b/advisories/github-reviewed/2022/05/GHSA-43w2-9j62-hq99/GHSA-43w2-9j62-hq99.json
@@ -20,11 +20,6 @@
         "ecosystem": "crates.io",
         "name": "smallvec"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "smallvec::SmallVec::insert_many"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -43,11 +38,6 @@
       "package": {
         "ecosystem": "crates.io",
         "name": "smallvec"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "smallvec::SmallVec::insert_many"
-        ]
       },
       "ranges": [
         {
@@ -72,6 +62,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/servo/rust-smallvec/issues/252"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/servo/rust-smallvec/commit/5757ac500d4e544485d796b542e4e589749c291b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/servo/rust-smallvec/commit/9998ba0694a6b51aa6604748b00b6a98f0a0039e"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding the patch link for:
v0.6.14: https://github.com/servo/rust-smallvec/commit/5757ac500d4e544485d796b542e4e589749c291b
v1.6.1: https://github.com/servo/rust-smallvec/commit/9998ba0694a6b51aa6604748b00b6a98f0a0039e

The commit message mentions fixing the original issue (252): 
"Fix potential buffer overflow in insert_many. Fixes 252." 