### PR TITLE
[GHSA-c9j3-wqph-5xx9] Command Injection in egg-scripts

### DIFF
--- a/advisories/github-reviewed/2018/09/GHSA-c9j3-wqph-5xx9/GHSA-c9j3-wqph-5xx9.json
+++ b/advisories/github-reviewed/2018/09/GHSA-c9j3-wqph-5xx9/GHSA-c9j3-wqph-5xx9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c9j3-wqph-5xx9",
-  "modified": "2023-02-03T20:45:07Z",
+  "modified": "2023-02-03T20:45:08Z",
   "published": "2018-09-17T20:43:34Z",
   "aliases": [
     "CVE-2018-3786"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/eggjs/egg-scripts/pull/26"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/eggjs/egg-scripts/commit/b98fd03d1e3aaed68004b881f0b3d42fe47341dd"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v2.8.1: https://github.com/eggjs/egg-scripts/commit/b98fd03d1e3aaed68004b881f0b3d42fe47341dd

The commit message mentions fixing the original issue (26): 
"fix: use execFile instead of exec for security reason (26)"