### PR TITLE
[GHSA-h423-w6qv-2wj3] parse-server crashes when receiving file download request with invalid byte range

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-h423-w6qv-2wj3/GHSA-h423-w6qv-2wj3.json
+++ b/advisories/github-reviewed/2022/10/GHSA-h423-w6qv-2wj3/GHSA-h423-w6qv-2wj3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h423-w6qv-2wj3",
-  "modified": "2022-10-18T16:08:49Z",
+  "modified": "2023-07-14T21:55:54Z",
   "published": "2022-10-18T16:08:49Z",
   "aliases": [
     "CVE-2022-39313"
@@ -62,6 +62,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-39313"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/parse-community/parse-server/commit/066f29673ab4030b6b5b90c0c0326f7d3fe7612a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/parse-community/parse-server/commit/3d7a61ecd5231638f01ff1a965b6313043c594a7"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v4.10.17: https://github.com/parse-community/parse-server/commit/3d7a61ecd5231638f01ff1a965b6313043c594a7
v5.2.8: https://github.com/parse-community/parse-server/commit/066f29673ab4030b6b5b90c0c0326f7d3fe7612a

The commit message mentions fixing the GHSA-ID (GHSA-h423-w6qv-2wj3): 
"fix: server crashes when receiving file download request with invalid byte range; this fixes a security vulnerability that allows an attacker to impact the availability of the server instance; the fix improves parsing of the range parameter to properly handle invalid range requests GHSA-h423-w6qv-2wj3 (8235)"