### PR TITLE
[GHSA-h45v-vgvp-3h5v] Out-of-bounds write in stack

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-h45v-vgvp-3h5v/GHSA-h45v-vgvp-3h5v.json
+++ b/advisories/github-reviewed/2021/08/GHSA-h45v-vgvp-3h5v/GHSA-h45v-vgvp-3h5v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h45v-vgvp-3h5v",
-  "modified": "2023-06-13T20:54:35Z",
+  "modified": "2023-06-13T20:54:36Z",
   "published": "2021-08-25T20:49:13Z",
   "aliases": [
     "CVE-2020-35895"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/arcnmx/stack-rs/issues/4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/arcnmx/stack-rs/commit/369e55736f9bd29c37b1712afc2923f4028148c6"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v0.3.1: https://github.com/arcnmx/stack-rs/commit/369e55736f9bd29c37b1712afc2923f4028148c6

The commit message mentions fixing the original issue (4) from the security advisory: 
"Add bounds check to Vector::insert. Fixes 4"