### PR TITLE
[GHSA-m4mm-pg93-fv78] Undertow denial of service vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-m4mm-pg93-fv78/GHSA-m4mm-pg93-fv78.json
+++ b/advisories/github-reviewed/2023/09/GHSA-m4mm-pg93-fv78/GHSA-m4mm-pg93-fv78.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m4mm-pg93-fv78",
-  "modified": "2023-09-15T13:37:03Z",
+  "modified": "2023-09-15T13:37:04Z",
   "published": "2023-09-14T15:31:23Z",
   "aliases": [
     "CVE-2023-1108"
@@ -20,10 +20,24 @@
         "ecosystem": "Maven",
         "name": "io.undertow:undertow-core"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.3.0.Final"
+            },
+            {
+              "fixed": "2.3.5.Final"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.undertow:undertow-core"
       },
       "ranges": [
         {
@@ -33,7 +47,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.3.5.Final"
+              "fixed": "2.2.24.Final"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
From what I've seen, this issue already had backport bug fixes in pull request [#1457](https://github.com/undertow-io/undertow/pull/1457) and was released in version 2.2.24.Final. However, this vulnerability CVE-2023-1108 is still listed as unresolved in versions < 2.3.5.Final, as reported four days ago.