### PR TITLE
[GHSA-2mhh-w6q8-5hxw] Remote Memory Disclosure in ws

### DIFF
--- a/advisories/github-reviewed/2019/02/GHSA-2mhh-w6q8-5hxw/GHSA-2mhh-w6q8-5hxw.json
+++ b/advisories/github-reviewed/2019/02/GHSA-2mhh-w6q8-5hxw/GHSA-2mhh-w6q8-5hxw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2mhh-w6q8-5hxw",
-  "modified": "2020-08-31T18:09:55Z",
+  "modified": "2023-01-09T05:02:30Z",
   "published": "2019-02-18T23:56:42Z",
   "aliases": [
     "CVE-2016-10518"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-10518"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/websockets/ws/commit/29293ed11b679e0366fa0f6bb9310b330dafd795"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v1.0.1: https://github.com/websockets/ws/commit/29293ed11b679e0366fa0f6bb9310b330dafd795

Found from the original reference link (https://gist.github.com/c0nrad/e92005446c480707a74a): 
"Even though the advisory is wrong, the fix is still correct. https://github.com/websockets/ws/commit/29293ed11b679e0366fa0f6bb9310b330dafd795"

Commit message: "[fix] Prevent allocation of memory through ping frames"