### PR TITLE
[GHSA-xxfx-w2rw-gh63] csaf-poc/csaf_distribution Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-xxfx-w2rw-gh63/GHSA-xxfx-w2rw-gh63.json
+++ b/advisories/github-reviewed/2022/12/GHSA-xxfx-w2rw-gh63/GHSA-xxfx-w2rw-gh63.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xxfx-w2rw-gh63",
-  "modified": "2022-12-14T14:06:08Z",
+  "modified": "2023-01-30T05:05:37Z",
   "published": "2022-12-14T00:30:23Z",
   "aliases": [
     "CVE-2022-43996"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43996"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/csaf-poc/csaf_distribution/commit/17f22855ee8d4270dd17ff748c30ed7304846fdc"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v0.8.2: https://github.com/csaf-poc/csaf_distribution/commit/17f22855ee8d4270dd17ff748c30ed7304846fdc

The fix is highly related to the advisory description to ignore non-conforming files. Additionally, this was the only commit for version 0.8.2: https://github.com/csaf-poc/csaf_distribution/compare/v0.8.1...v0.8.2 

Commit message: "Add filename conformity check
* Add util function to check a filename for confirming to csaf-v2.0-csd02.
* Add code to reject bad filenames in provider, checker, aggregator and uploader."