### PR TITLE
[GHSA-82hx-w2r5-c2wq] Kubernetes API Server DoS Via API Requests

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-82hx-w2r5-c2wq/GHSA-82hx-w2r5-c2wq.json
+++ b/advisories/github-reviewed/2022/02/GHSA-82hx-w2r5-c2wq/GHSA-82hx-w2r5-c2wq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-82hx-w2r5-c2wq",
-  "modified": "2023-09-18T20:33:04Z",
+  "modified": "2023-09-18T20:33:05Z",
   "published": "2022-02-15T01:57:18Z",
   "aliases": [
     "CVE-2020-8552"
@@ -20,11 +20,6 @@
         "ecosystem": "Go",
         "name": "k8s.io/apiserver"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.15.10"
+              "fixed": "0.15.10"
             }
           ]
         }
@@ -44,20 +39,15 @@
         "ecosystem": "Go",
         "name": "k8s.io/apiserver"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.16.0"
+              "introduced": "0.16.0"
             },
             {
-              "fixed": "1.16.7"
+              "fixed": "0.16.7"
             }
           ]
         }
@@ -68,20 +58,15 @@
         "ecosystem": "Go",
         "name": "k8s.io/apiserver"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.17.0"
+              "introduced": "0.17.0"
             },
             {
-              "fixed": "1.17.3"
+              "fixed": "0.17.3"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Go versions of k8s.io artifacts start with 0, see for example https://pkg.go.dev/k8s.io/apiserver?tab=versions. The version corresponding to Kubernetes 1.17.3 is 0.17.3.