### PR TITLE
[GHSA-82hx-w2r5-c2wq] Kubernetes API Server DoS Via API Requests

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-82hx-w2r5-c2wq/GHSA-82hx-w2r5-c2wq.json
+++ b/advisories/github-reviewed/2022/02/GHSA-82hx-w2r5-c2wq/GHSA-82hx-w2r5-c2wq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-82hx-w2r5-c2wq",
-  "modified": "2023-09-18T20:33:04Z",
+  "modified": "2023-09-18T20:33:05Z",
   "published": "2022-02-15T01:57:18Z",
   "aliases": [
     "CVE-2020-8552"
@@ -18,12 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "k8s.io/apiserver"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+        "name": "k8s.io/kubernetes"
       },
       "ranges": [
         {
@@ -42,12 +37,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "k8s.io/apiserver"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+        "name": "k8s.io/kubernetes"
       },
       "ranges": [
         {
@@ -66,12 +56,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "k8s.io/apiserver"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+        "name": "k8s.io/kubernetes"
       },
       "ranges": [
         {
@@ -82,6 +67,63 @@
             },
             {
               "fixed": "1.17.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "k8s.io/apiserver"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.15.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "k8s.io/apiserver"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.16.0"
+            },
+            {
+              "fixed": "0.16.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "k8s.io/apiserver"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.17.0"
+            },
+            {
+              "fixed": "0.17.3"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The kubernetes components that are split/cloned into separate repositories (from github.com/kubernetes/kubernetes/staging) follow a different version tagging scheme than the kubernetes main package. Kubernetes v1.x.y becomes v0.x.y in the split repos:
https://github.com/kubernetes/kubernetes/blob/master/staging/README.md

https://nvd.nist.gov/vuln/detail/CVE-2020-8552