### PR TITLE
[GHSA-m4mm-pg93-fv78] Undertow denial of service vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-m4mm-pg93-fv78/GHSA-m4mm-pg93-fv78.json
+++ b/advisories/github-reviewed/2023/09/GHSA-m4mm-pg93-fv78/GHSA-m4mm-pg93-fv78.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m4mm-pg93-fv78",
-  "modified": "2023-09-15T13:37:03Z",
+  "modified": "2023-09-19T20:54:29Z",
   "published": "2023-09-14T15:31:23Z",
   "aliases": [
     "CVE-2023-1108"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "io.undertow:undertow-core"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,11 +39,6 @@
         "ecosystem": "Maven",
         "name": "io.undertow:undertow-core"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -57,7 +47,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.2.25.Final"
+              "fixed": "2.2.24.Final"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Starting from undertow 2.2.24.Final (not 2.2.25.Final) CVE-2023-1108 is already fixed and has been tracked through:

https://issues.redhat.com/browse/UNDERTOW-2239

This can be verified through the following GitHub blame link on the 2.2.24.Final tagged codebase:

https://github.com/undertow-io/undertow/blame/2.2.24.Final/core/src/main/java/io/undertow/protocols/ssl/SslConduit.java#L1002-L1003

More details available by the following links:

- https://bugzilla.redhat.com/show_bug.cgi?id=2174246#c0
- https://github.com/undertow-io/undertow/pull/1457
- https://github.com/jeremylong/DependencyCheck/issues/5713#issuecomment-1542337243