### PR TITLE
[GHSA-j7hp-h8jx-5ppr] libwebp: OOB write in BuildHuffmanTable

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-j7hp-h8jx-5ppr/GHSA-j7hp-h8jx-5ppr.json
+++ b/advisories/github-reviewed/2023/09/GHSA-j7hp-h8jx-5ppr/GHSA-j7hp-h8jx-5ppr.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j7hp-h8jx-5ppr",
-  "modified": "2023-09-18T18:40:09Z",
+  "modified": "2023-09-18T18:40:11Z",
   "published": "2023-09-12T15:30:20Z",
   "aliases": [
     "CVE-2023-4863"
   ],
   "summary": "libwebp: OOB write in BuildHuffmanTable",
-  "details": "Heap buffer overflow in WebP allow a remote attacker to perform an out of bounds memory write via a crafted HTML page. ",
+  "details": "Heap buffer overflow in libwebp allow a remote attacker to perform an out of bounds memory write via a crafted HTML page. ",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "crates.io",
         "name": "libwebp-sys2"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,11 +39,6 @@
         "ecosystem": "crates.io",
         "name": "libwebp-sys"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -67,11 +57,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "electron"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -92,11 +77,6 @@
         "ecosystem": "npm",
         "name": "electron"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -115,11 +95,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "electron"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -140,11 +115,6 @@
         "ecosystem": "npm",
         "name": "electron"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -164,11 +134,6 @@
         "ecosystem": "npm",
         "name": "electron"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -178,6 +143,60 @@
             },
             {
               "fixed": "27.0.0-beta.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "SkiaSharp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.0.0"
+            },
+            {
+              "fixed": "3.0.0-alpha.1.27"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "SkiaSharp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0"
+            },
+            {
+              "fixed": "2.88.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/chai2010/webp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.0.0"
             }
           ]
         }
@@ -243,7 +262,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/qnighy/libwebp-sys2-rs"
+      "url": "https://github.com/webmproject/libwebp"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location

**Comments**
Update based on prior discussion in https://github.com/github/advisory-database/pull/2727:

- Add SkiaSharp now that a patched version is available
- Add github.com/chai2010/webp with no patched version available since the package is unmaintained
- Fix the main source code location to point to libwebp, not its Rust binding

cc @darakian