### PR TITLE
[GHSA-8727-m6gj-mc37] Possible Strong Parameters Bypass in ActionPack

### DIFF
--- a/advisories/github-reviewed/2020/05/GHSA-8727-m6gj-mc37/GHSA-8727-m6gj-mc37.json
+++ b/advisories/github-reviewed/2020/05/GHSA-8727-m6gj-mc37/GHSA-8727-m6gj-mc37.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8727-m6gj-mc37",
-  "modified": "2023-08-08T15:10:35Z",
+  "modified": "2023-08-17T05:01:38Z",
   "published": "2020-05-26T15:09:16Z",
   "aliases": [
     "CVE-2020-8164"
   ],
   "summary": "Possible Strong Parameters Bypass in ActionPack",
-  "details": "There is a strong parameters bypass vector in ActionPack.\n\nVersions Affected:  rails <= 6.0.3\nNot affected:       rails < 4.0.0\nFixed Versions:     rails >= 5.2.4.3, rails >= 6.0.3.1\n\nImpact\n------\nIn some cases user supplied information can be inadvertently leaked from\nStrong Parameters.  Specifically the return value of `each`, or `each_value`,\nor `each_pair` will return the underlying \"untrusted\" hash of data that was\nread from the parameters.  Applications that use this return value may be\ninadvertently use untrusted user input.\n\nImpacted code will look something like this:\n\n```\ndef update\n  # Attacker has included the parameter: `{ is_admin: true }`\n  User.update(clean_up_params)\nend\n\ndef clean_up_params\n   params.each { |k, v|  SomeModel.check(v) if k == :name }\nend\n```\n\nNote the mistaken use of `each` in the `clean_up_params` method in the above\nexample.\n\nWorkarounds\n-----------\nDo not use the return values of `each`, `each_value`, or `each_pair` in your\napplication.",
+  "details": "There is a strong parameters bypass vector in ActionPack.\n\nVersions Affected:  rails <= 6.0.3\nNot affected:       rails < 5.0.0\nFixed Versions:     rails >= 5.2.4.3, rails >= 6.0.3.1\n\nImpact\n------\nIn some cases user supplied information can be inadvertently leaked from\nStrong Parameters.  Specifically the return value of `each`, or `each_value`,\nor `each_pair` will return the underlying \"untrusted\" hash of data that was\nread from the parameters.  Applications that use this return value may be\ninadvertently use untrusted user input.\n\nImpacted code will look something like this:\n\n```\ndef update\n  # Attacker has included the parameter: `{ is_admin: true }`\n  User.update(clean_up_params)\nend\n\ndef clean_up_params\n   params.each { |k, v|  SomeModel.check(v) if k == :name }\nend\n```\n\nNote the mistaken use of `each` in the `clean_up_params` method in the above\nexample.\n\nWorkarounds\n-----------\nDo not use the return values of `each`, `each_value`, or `each_pair` in your\napplication.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "RubyGems",
         "name": "actionpack"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -46,11 +41,6 @@
       "package": {
         "ecosystem": "RubyGems",
         "name": "actionpack"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Affected versions are clearly mentioned. But in the description it says not affected version rails < v4.0.0 and affected version rails < v6.0.3. Which implies, that affected versions are between 4.0.0 and 6.0.3 (>= 4.0.0, < 6.0.3) which is not the case.

The `each_pair` method returned `super` until v4.2.11.3. Which means whatever logic was written did not matter because it did not modify the class state but rather returned the instance of super class.

But later in v5.0.0.beta1 `each_pair` implementation returned the params itself. This caused the users to get the return values from the function which should not happen. Later it was fixed by returning an instance of its class.

This issue is mitigated either by bumping rails version or actionpack.