### PR TITLE
[GHSA-cwvm-v4w8-q58c] Blind local file inclusion

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-cwvm-v4w8-q58c/GHSA-cwvm-v4w8-q58c.json
+++ b/advisories/github-reviewed/2023/08/GHSA-cwvm-v4w8-q58c/GHSA-cwvm-v4w8-q58c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cwvm-v4w8-q58c",
-  "modified": "2023-09-06T17:28:06Z",
+  "modified": "2023-09-07T21:32:03Z",
   "published": "2023-08-30T20:09:36Z",
   "aliases": [
     "CVE-2023-41040"
@@ -28,13 +28,13 @@
               "introduced": "0"
             },
             {
-              "fixed": "3.1.35"
+              "fixed": "3.1.37"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 3.1.34"
+        "last_known_affected_version_range": "<= 3.1.36"
       }
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The fix in GitPython 3.1.35 was incomplete, as discussed in https://github.com/gitpython-developers/GitPython/pull/1672. A new release, https://github.com/gitpython-developers/GitPython/releases/tag/3.1.37, includes a proper fix. The maintainer has updated the advisory associated with the repository, https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-cwvm-v4w8-q58c, to indicate that the fully patched version is 3.1.37 instead of any earlier version.

This change proposes the corresponding change in the GitHub Advisory Database, which would make both advisories convey the same, up-to-date information. The maintainer of GitPython, @Byron, has requested that this be done (https://github.com/gitpython-developers/GitPython/pull/1672#issuecomment-1731007627, https://github.com/gitpython-developers/GitPython/pull/1672#issuecomment-1732511789).

This is based on a preference, in this case, to update the existing advisory and not to create a new one (as noted in the linked comments above). However, if this change to the advisory would not be sufficient to raise Dependabot alerts, that may be relevant.