### PR TITLE
[GHSA-2m34-jcjv-45xf] XSS in Django

### DIFF
--- a/advisories/github-reviewed/2020/06/GHSA-2m34-jcjv-45xf/GHSA-2m34-jcjv-45xf.json
+++ b/advisories/github-reviewed/2020/06/GHSA-2m34-jcjv-45xf/GHSA-2m34-jcjv-45xf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2m34-jcjv-45xf",
-  "modified": "2022-09-08T14:02:49Z",
+  "modified": "2023-01-29T05:02:05Z",
   "published": "2020-06-05T16:24:28Z",
   "aliases": [
     "CVE-2020-13596"
@@ -58,6 +58,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-13596"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/1f2dd37f6fcefdd10ed44cb233b2e62b520afb38"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/6d61860b22875f358fac83d903dc629897934815"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v2.2.13: https://github.com/django/django/commit/6d61860b22875f358fac83d903dc629897934815
v3.0.7: https://github.com/django/django/commit/1f2dd37f6fcefdd10ed44cb233b2e62b520afb38

Adding the fix for each patch version. The CVE is in the commit message: "Fixed CVE-2020-13596 -- Fixed potential XSS in admin ForeignKeyRawIdWidget."