### PR TITLE
[GHSA-9jfq-54vc-9rr2] Foreman Transpilation Enables OS Command Injection

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
+++ b/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9jfq-54vc-9rr2",
-  "modified": "2023-09-27T00:34:08Z",
+  "modified": "2023-09-27T00:34:09Z",
   "published": "2023-09-22T15:30:15Z",
   "aliases": [
     "CVE-2022-3874"
@@ -18,12 +18,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "foreman"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+        "name": ""
       },
       "ranges": [
         {
@@ -31,9 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "3.8.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This is incorrectly marking the foreman rubygem 0.87.2 (which has nothing to do with theforeman.org or the vulnerability listed here)