### PR TITLE
[GHSA-9jfq-54vc-9rr2] Foreman Transpilation Enables OS Command Injection

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
+++ b/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9jfq-54vc-9rr2",
-  "modified": "2023-09-27T00:34:08Z",
+  "modified": "2023-09-27T00:34:09Z",
   "published": "2023-09-22T15:30:15Z",
   "aliases": [
     "CVE-2022-3874"
   ],
   "summary": "Foreman Transpilation Enables OS Command Injection",
-  "details": "A command injection flaw was found in foreman. This flaw allows an authenticated user with admin privileges on the foreman instance to transpile commands through CoreOS and Fedora CoreOS configurations in templates, possibly resulting in arbitrary command execution on the underlying operating system.",
+  "details": "A command injection flaw was found in foreman. This flaw allows an authenticated user with admin privileges on the foreman instance to transpile commands through CoreOS and Fedora CoreOS configurations in templates, possibly resulting in arbitrary command execution on the underlying operating system.\n\nNOTE: There is a similarly named project on Github called [foreman](https://github.com/ddollar/foreman) (a CLI tool to run the process), but that one is not relevant.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "RubyGems",
         "name": "foreman"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Added additional information about the tool of the same name. Both tools are implemented in ruby and are likely to be misidentified.