### PR TITLE
[GHSA-9jfq-54vc-9rr2] Foreman Transpilation Enables OS Command Injection

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
+++ b/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "foreman"
+        "name": ""
       },
       "ranges": [
         {
@@ -26,9 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "3.8.0"
             }
           ]
         }

--- a/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
+++ b/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9jfq-54vc-9rr2",
-  "modified": "2023-09-27T00:34:08Z",
+  "modified": "2023-09-27T00:34:09Z",
   "published": "2023-09-22T15:30:15Z",
   "aliases": [
     "CVE-2022-3874"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "RubyGems",
         "name": "foreman"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
https://github.com/theforeman/foreman is probably not related to rubygem https://rubygems.org/gems/foreman .

That rubygem is related to https://github.com/ddollar/foreman, but I don't think it's related to this vulnerability.