### PR TITLE
[GHSA-9jfq-54vc-9rr2] Foreman Transpilation Enables OS Command Injection

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
+++ b/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9jfq-54vc-9rr2",
-  "modified": "2023-09-27T00:34:08Z",
+  "modified": "2023-09-27T00:34:09Z",
   "published": "2023-09-22T15:30:15Z",
   "aliases": [
     "CVE-2022-3874"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "RubyGems",
         "name": "foreman"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
A Gemfile containing foreman (https://github.com/ddollar/foreman) will be marked a vulnerable because of this advisory.

I don't know on which ecosystem I'd put this project though, but it's not a RubyGem.