### PR TITLE
[GHSA-xx36-6rv4-gj8r] ecdsa-elixir fails to check signatures, vulnerable to message forging

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-xx36-6rv4-gj8r/GHSA-xx36-6rv4-gj8r.json
+++ b/advisories/github-reviewed/2022/05/GHSA-xx36-6rv4-gj8r/GHSA-xx36-6rv4-gj8r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xx36-6rv4-gj8r",
-  "modified": "2022-07-01T17:15:25Z",
+  "modified": "2023-01-27T05:03:35Z",
   "published": "2022-05-24T19:20:12Z",
   "aliases": [
     "CVE-2021-43568"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Hex",
-        "name": "ecdsa-elixir"
+        "name": "starkbank_ecdsa"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It appears that the actual package name from the hex registry is [starkbank_ecdsa](https://hex.pm/packages/starkbank_ecdsa).  I'm unsure if it makes sense to keep the originally identified `ecdsa-elixir` name around.  I couldn't find anything corresponding to that name in any package registries though.