### PR TITLE
[GHSA-4q53-fqhc-cr46] ember-source Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2018/08/GHSA-4q53-fqhc-cr46/GHSA-4q53-fqhc-cr46.json
+++ b/advisories/github-reviewed/2018/08/GHSA-4q53-fqhc-cr46/GHSA-4q53-fqhc-cr46.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4q53-fqhc-cr46",
-  "modified": "2023-08-29T10:51:34Z",
+  "modified": "2023-08-29T10:51:35Z",
   "published": "2018-08-28T22:33:42Z",
   "aliases": [
     "CVE-2014-0046"
@@ -16,11 +16,6 @@
       "package": {
         "ecosystem": "RubyGems",
         "name": "ember-source"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -41,11 +36,6 @@
         "ecosystem": "RubyGems",
         "name": "ember-source"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -64,11 +54,6 @@
       "package": {
         "ecosystem": "RubyGems",
         "name": "ember-source"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -89,6 +74,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0046"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/emberjs/ember.js/commit/45ee8df2a0efc0afe233d6b9b17045782a2e6b2d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/emberjs/ember.js/commit/94b28b8773acf894c4d7d7fccf4411a706292436"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/emberjs/ember.js/commit/ab3199e68e1d0fc3c8f7f453cd38c51fe02af90b"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding the patch link for:
 v1.2.2: https://github.com/emberjs/ember.js/commit/ab3199e68e1d0fc3c8f7f453cd38c51fe02af90b
 v1.3.2: https://github.com/emberjs/ember.js/commit/94b28b8773acf894c4d7d7fccf4411a706292436
v1.4.0-beta.6: https://github.com/emberjs/ember.js/commit/45ee8df2a0efc0afe233d6b9b17045782a2e6b2d

The commit message mentions fixing the CVE:
 "[SECURITY CVE-2014-0046] Ensure link-to non-block escapes title."