### PR TITLE
[GHSA-9jfq-54vc-9rr2] Foreman Transpilation Enables OS Command Injection

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
+++ b/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9jfq-54vc-9rr2",
-  "modified": "2023-09-27T00:34:08Z",
+  "modified": "2023-09-27T00:34:09Z",
   "published": "2023-09-22T15:30:15Z",
   "aliases": [
     "CVE-2022-3874"
@@ -18,12 +18,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "foreman"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+        "name": "theforeman/foreman-IS-NO-A-GEM"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This CVE is being falsely attributed to the Ruby Gem `foreman` and not to the [theforeman/foreman](https://github.com/theforeman/foreman) hosted on Github

I'm not sure how to update the form above to indicate this.

The gem `foreman` found https://rubygems.org/gems/foreman which is hosted on Github at:
- https://github.com/ddollar/foreman

The theforeman/foreman to which this CVE applies _specifically_ mentions ddollar/foreman as a "[Similarly Named Project](https://github.com/theforeman/foreman#similarly-named-project)"

- thanks