### PR TITLE
[GHSA-65hj-9ppw-77xc] ff4j is vulnerable to Remote Code Execution (RCE)

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-65hj-9ppw-77xc/GHSA-65hj-9ppw-77xc.json
+++ b/advisories/github-reviewed/2022/12/GHSA-65hj-9ppw-77xc/GHSA-65hj-9ppw-77xc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-65hj-9ppw-77xc",
-  "modified": "2022-12-21T18:16:26Z",
+  "modified": "2023-01-30T05:01:00Z",
   "published": "2022-12-01T06:30:26Z",
   "aliases": [
     "CVE-2022-44262"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/ff4j/ff4j/issues/624"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ff4j/ff4j/commit/62d03140f3bfbd380d0f4b4e5a94dcb8baa9d9c6"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
 v1.9: https://github.com/ff4j/ff4j/commit/62d03140f3bfbd380d0f4b4e5a94dcb8baa9d9c6

This commit is the complete merge of pull 625, which resolved the original issue 624 mentioned in the advisory. Additionally, the CVE is mentioned in the commit message: "fix: CVE-2022-44262 (624)"