### PR TITLE
[GHSA-7r7m-5h27-29hp] Potential infinite loop in Pillow

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-7r7m-5h27-29hp/GHSA-7r7m-5h27-29hp.json
+++ b/advisories/github-reviewed/2021/06/GHSA-7r7m-5h27-29hp/GHSA-7r7m-5h27-29hp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7r7m-5h27-29hp",
-  "modified": "2021-09-15T18:25:52Z",
+  "modified": "2023-02-01T05:06:07Z",
   "published": "2021-06-08T18:48:53Z",
   "aliases": [
     "CVE-2021-28676"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/python-pillow/Pillow/pull/5377"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/commit/bb6c11fb889e6c11b0ee122b828132ee763b5856"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v8.2.0: https://github.com/python-pillow/Pillow/commit/bb6c11fb889e6c11b0ee122b828132ee763b5856

The CVE is mentioned in the commit message: 
"Fix FLI DOS -- CVE-2021-28676
* FliDecode did not properly check that the block advance was
  non-zero, potentally leading to an infinite loop on load.
* This dates to the PIL Fork
* Found with oss-fuzz"