### PR TITLE
[GHSA-jmm9-2p29-vh2w] activerecord vulnerable to SQL Injection

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-jmm9-2p29-vh2w/GHSA-jmm9-2p29-vh2w.json
+++ b/advisories/github-reviewed/2017/10/GHSA-jmm9-2p29-vh2w/GHSA-jmm9-2p29-vh2w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jmm9-2p29-vh2w",
-  "modified": "2023-05-12T17:17:16Z",
+  "modified": "2023-05-12T17:17:17Z",
   "published": "2017-10-24T18:33:38Z",
   "aliases": [
     "CVE-2011-0448"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2011-0448"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/rails/commit/354da43ab0a10b3b7b3f9cb0619aa562c3be8474"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v3.0.4: https://github.com/rails/rails/commit/354da43ab0a10b3b7b3f9cb0619aa562c3be8474

The CVE is mentioned in the commit message: 
"limit() should sanitize limit values. This fixes CVE-2011-0448"