### PR TITLE
[GHSA-p99v-5w3c-jqq9] Django Access Control Bypass possibly leading to SSRF, RFI, and LFI attacks 

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-p99v-5w3c-jqq9/GHSA-p99v-5w3c-jqq9.json
+++ b/advisories/github-reviewed/2021/06/GHSA-p99v-5w3c-jqq9/GHSA-p99v-5w3c-jqq9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p99v-5w3c-jqq9",
-  "modified": "2023-09-05T13:14:51Z",
+  "modified": "2023-09-05T13:14:52Z",
   "published": "2021-06-10T17:21:12Z",
   "aliases": [
     "CVE-2021-33571"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "django"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,11 +39,6 @@
         "ecosystem": "PyPI",
         "name": "django"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -67,11 +57,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "django"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -92,6 +77,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-33571"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/203d4ab9ebcd72fc4d6eb7398e66ed9e474e118e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/9f75e2e562fa0c0482f3dde6fc7399a9070b4a3d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/f27c38ab5d90f68c9dd60cabef248a570c0be8fc"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding the patch link for:
v2.2.24: https://github.com/django/django/commit/f27c38ab5d90f68c9dd60cabef248a570c0be8fc
v3.1.12: https://github.com/django/django/commit/203d4ab9ebcd72fc4d6eb7398e66ed9e474e118e
v3.2.4: https://github.com/django/django/commit/9f75e2e562fa0c0482f3dde6fc7399a9070b4a3d

The CVE is mentioned in the commit message: 
"Fixed CVE-2021-33571 -- Prevented leading zeros in IPv4 addresses.

validate_ipv4_address() was affected only on Python < 3.9.5, see [1].
URLValidator() uses a regular expressions and it was affected on all
Python versions."