### PR TITLE
[GHSA-pg8v-g4xq-hww9] Rails::Html::Sanitizer vulnerable to Cross-site Scripting

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-pg8v-g4xq-hww9/GHSA-pg8v-g4xq-hww9.json
+++ b/advisories/github-reviewed/2022/06/GHSA-pg8v-g4xq-hww9/GHSA-pg8v-g4xq-hww9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pg8v-g4xq-hww9",
-  "modified": "2022-07-07T17:13:54Z",
+  "modified": "2023-02-01T05:03:22Z",
   "published": "2022-06-25T00:00:54Z",
   "aliases": [
     "CVE-2022-32209"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-32209"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/rails-html-sanitizer/commit/45a5c10fed3d9aa141594c80afa06d748fa0967d"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v1.4.3: https://github.com/rails/rails-html-sanitizer/commit/45a5c10fed3d9aa141594c80afa06d748fa0967d

The CVE is mentioned in the commit message: 
"fix: modify safelist option if it contains both select and style. Addresses CVE-2022-32209"