### PR TITLE
[GHSA-q4xr-rc97-m4xx] OS Command Injection in celery

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-q4xr-rc97-m4xx/GHSA-q4xr-rc97-m4xx.json
+++ b/advisories/github-reviewed/2022/01/GHSA-q4xr-rc97-m4xx/GHSA-q4xr-rc97-m4xx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q4xr-rc97-m4xx",
-  "modified": "2022-01-06T19:17:52Z",
+  "modified": "2023-02-03T05:03:53Z",
   "published": "2022-01-06T22:22:02Z",
   "aliases": [
     "CVE-2021-23727"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-23727"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/celery/celery/commit/1f7ad7e6df1e02039b6ab9eec617d283598cad6b"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v5.2.2: https://github.com/celery/celery/commit/1f7ad7e6df1e02039b6ab9eec617d283598cad6b

The CVE is mentioned in the commit message: 
"Fix CVE-2021-23727 (Stored Command Injection securtiy vulnerability)."