### PR TITLE
[GHSA-r28v-mw67-m5p9] Django Denial-of-service possibility in urlize and urlizetrunc template filters

### DIFF
--- a/advisories/github-reviewed/2019/01/GHSA-r28v-mw67-m5p9/GHSA-r28v-mw67-m5p9.json
+++ b/advisories/github-reviewed/2019/01/GHSA-r28v-mw67-m5p9/GHSA-r28v-mw67-m5p9.json
@@ -20,11 +20,6 @@
         "ecosystem": "PyPI",
         "name": "django"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -43,11 +38,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "django"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -68,11 +58,6 @@
         "ecosystem": "PyPI",
         "name": "django"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -92,6 +77,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-7536"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/1ca63a66ef3163149ad822701273e8a1844192c2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/abf89d729f210c692a50e0ad3f75fb6bec6fae16"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/e157315da3ae7005fa0683ffc9751dbeca7306c8"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding the patch link for:
v1.8.19: https://github.com/django/django/commit/1ca63a66ef3163149ad822701273e8a1844192c2
v1.11.11: https://github.com/django/django/commit/abf89d729f210c692a50e0ad3f75fb6bec6fae16
v2.0.3: https://github.com/django/django/commit/e157315da3ae7005fa0683ffc9751dbeca7306c8

The CVE is mentioned in the commit message: 
"Fixed CVE-2018-7536 -- Fixed catastrophic backtracking in urlize and urlizetrunc template filters."