### PR TITLE
[GHSA-rxjp-mfm9-w4wr] Path Traversal in Django

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-rxjp-mfm9-w4wr/GHSA-rxjp-mfm9-w4wr.json
+++ b/advisories/github-reviewed/2021/06/GHSA-rxjp-mfm9-w4wr/GHSA-rxjp-mfm9-w4wr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rxjp-mfm9-w4wr",
-  "modified": "2022-06-29T20:40:42Z",
+  "modified": "2023-01-27T05:00:54Z",
   "published": "2021-06-04T21:15:56Z",
   "aliases": [
     "CVE-2021-31542"
@@ -77,6 +77,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-31542"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/04ac1624bdc2fa737188401757cf95ced122d26d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/25d84d64122c15050a0ee739e859f22ddab5ac48"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/c98f446c188596d4ba6de71d1b77b4a6c5c2a007"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v2.2.21: https://github.com/django/django/commit/04ac1624bdc2fa737188401757cf95ced122d26d
v3.1.9: https://github.com/django/django/commit/25d84d64122c15050a0ee739e859f22ddab5ac48
v3.2.1: https://github.com/django/django/commit/c98f446c188596d4ba6de71d1b77b4a6c5c2a007

The CVE is mentioned in the commit message: 
"Fixed CVE-2021-31542 -- Tightened path & file name sanitation in file uploads."