### PR TITLE
[GHSA-x7m3-jprg-wc5g] Gevent allows remote attacker to escalate privileges

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-x7m3-jprg-wc5g/GHSA-x7m3-jprg-wc5g.json
+++ b/advisories/github-reviewed/2023/09/GHSA-x7m3-jprg-wc5g/GHSA-x7m3-jprg-wc5g.json
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "23.9.1"
+              "fixed": "23.9.0"
             }
           ]
         }
@@ -55,6 +55,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/pypa/advisory-database/tree/main/vulns/gevent/PYSEC-2023-177.yaml"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.gevent.org/changelog.html"
     }
   ],
   "database_specific": {

--- a/advisories/github-reviewed/2023/09/GHSA-x7m3-jprg-wc5g/GHSA-x7m3-jprg-wc5g.json
+++ b/advisories/github-reviewed/2023/09/GHSA-x7m3-jprg-wc5g/GHSA-x7m3-jprg-wc5g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x7m3-jprg-wc5g",
-  "modified": "2023-09-26T13:58:44Z",
+  "modified": "2023-09-26T13:58:45Z",
   "published": "2023-09-25T12:30:44Z",
   "aliases": [
     "CVE-2023-41419"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "gevent"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Version suggestion is incorrect, see http://www.gevent.org/changelog.html - vulnerability was fixed in 23.9.0, not 23.9.1