### PR TITLE
[GHSA-4p8f-2fwv-6xcw] Missing permission check in Jenkins RocketChat Notifier Plugin

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-4p8f-2fwv-6xcw/GHSA-4p8f-2fwv-6xcw.json
+++ b/advisories/github-reviewed/2022/03/GHSA-4p8f-2fwv-6xcw/GHSA-4p8f-2fwv-6xcw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4p8f-2fwv-6xcw",
-  "modified": "2022-11-29T22:23:53Z",
+  "modified": "2023-02-01T05:07:17Z",
   "published": "2022-03-30T00:00:25Z",
   "aliases": [
     "CVE-2022-28139"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-28139"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/rocketchatnotifier-plugin/commit/1a0023be9f2e143434d028d5292ef9dc3195d051"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v1.5.0: https://github.com/jenkinsci/rocketchatnotifier-plugin/commit/1a0023be9f2e143434d028d5292ef9dc3195d051

This patch performs the exact updates described in the description by starting to check permission within the RocketChatNotifier: Jenkins.get().checkPermission(Jenkins.ADMINISTER);. 
Additionally, the commit message is relatively intuitive to be related to the fix: "feat(Security): Improve credential handling"