### PR TITLE
[GHSA-qwph-4952-7xr6] jsonwebtoken vulnerable to signature validation bypass due to insecure default algorithm in jwt.verify()

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-qwph-4952-7xr6/GHSA-qwph-4952-7xr6.json
+++ b/advisories/github-reviewed/2022/12/GHSA-qwph-4952-7xr6/GHSA-qwph-4952-7xr6.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qwph-4952-7xr6",
-  "modified": "2023-07-14T22:03:13Z",
+  "modified": "2023-07-14T22:03:14Z",
   "published": "2022-12-22T03:32:59Z",
   "aliases": [
     "CVE-2022-23540"
   ],
-  "summary": "jsonwebtoken vulnerable to signature validation bypass due to insecure default algorithm in jwt.verify()",
+  "summary": "Improper Authentication and Use of a Broken or Risky Cryptographic Algorithm and Improper Verification of Cryptographic Signature in jsonwebtoken",
   "details": "# Overview\n\nIn versions <=8.5.1 of jsonwebtoken library, lack of algorithm definition and a falsy secret or key in the `jwt.verify()` function can lead to signature validation bypass due to defaulting to the `none` algorithm for signature verification.\n\n# Am I affected?\nYou will be affected if all the following are true in the `jwt.verify()` function:\n- a token with no signature is received\n- no algorithms are specified \n- a falsy (e.g. null, false, undefined) secret or key is passed \n\n# How do I fix it?\n \nUpdate to version 9.0.0 which removes the default support for the none algorithm in the `jwt.verify()` method. \n\n# Will the fix impact my users?\n\nThere will be no impact, if you update to version 9.0.0 and you don’t need to allow for the `none` algorithm. If you need 'none' algorithm, you have to explicitly specify that in `jwt.verify()` options.\n",
   "severity": [
     {


### PR DESCRIPTION
**Updates**
- Summary

**Comments**
By selecting these links, you will be leaving NIST webspace. We have provided these links to other web sites because they may have information that would be of interest to you. No inferences should be drawn on account of other sites being referenced, or not, from this page. There may be other web sites that are more appropriate for your purpose. NIST does not necessarily endorse the views expressed, or concur with the facts presented on these sites. Further, NIST does not endorse any commercial products that may be mentioned on these sites. Please address comments about this page to nvd@nist.gov.