### PR TITLE
[GHSA-5m2v-hc64-56h6] Rubyzip denial of service 

### DIFF
--- a/advisories/github-reviewed/2019/09/GHSA-5m2v-hc64-56h6/GHSA-5m2v-hc64-56h6.json
+++ b/advisories/github-reviewed/2019/09/GHSA-5m2v-hc64-56h6/GHSA-5m2v-hc64-56h6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5m2v-hc64-56h6",
-  "modified": "2023-08-29T15:33:31Z",
+  "modified": "2023-08-29T15:33:32Z",
   "published": "2019-09-30T16:05:32Z",
   "aliases": [
     "CVE-2019-16892"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "RubyGems",
         "name": "rubyzip"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -48,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/rubyzip/rubyzip/pull/403"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rubyzip/rubyzip/commit/d65fe7bd283ec94f9d6dc7605f61a6b0dd00f55e"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding the patch link for:
v1.3.0: https://github.com/rubyzip/rubyzip/commit/d65fe7bd283ec94f9d6dc7605f61a6b0dd00f55e

This is the complete merge of the original pull 403 from the advisory: "Validate entry sizes when extracting." This adds `validate_entry_sizes` option so that callers can trust an entry's reported size when using `extract.`