### PR TITLE
[GHSA-5rrv-m36h-qwf8] Use-after-free in chttp

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-5rrv-m36h-qwf8/GHSA-5rrv-m36h-qwf8.json
+++ b/advisories/github-reviewed/2021/08/GHSA-5rrv-m36h-qwf8/GHSA-5rrv-m36h-qwf8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5rrv-m36h-qwf8",
-  "modified": "2023-06-13T16:55:57Z",
+  "modified": "2023-06-22T05:03:03Z",
   "published": "2021-08-25T20:44:40Z",
   "aliases": [
     "CVE-2019-16140"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/sagebind/isahc/issues/2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/sagebind/isahc/commit/9e9f1fb44114078c000c78c72e691eeb9e7ac260"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v0.1.3: https://github.com/sagebind/isahc/commit/9e9f1fb44114078c000c78c72e691eeb9e7ac260

This is the patch link that was marked as closing the original issue (2) mentioned in the advisory: "fix 2"