### PR TITLE
[GHSA-j7hp-h8jx-5ppr] libwebp: OOB write in BuildHuffmanTable

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-j7hp-h8jx-5ppr/GHSA-j7hp-h8jx-5ppr.json
+++ b/advisories/github-reviewed/2023/09/GHSA-j7hp-h8jx-5ppr/GHSA-j7hp-h8jx-5ppr.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j7hp-h8jx-5ppr",
-  "modified": "2023-09-21T17:24:00Z",
+  "modified": "2023-09-28T19:26:40Z",
   "published": "2023-09-12T15:30:20Z",
   "aliases": [
     "CVE-2023-4863"
   ],
   "summary": "libwebp: OOB write in BuildHuffmanTable",
-  "details": "Heap buffer overflow in libwebp allow a remote attacker to perform an out of bounds memory write via a crafted HTML page. ",
+  "details": "Heap buffer overflow in libwebp allow a remote attacker to perform an out of bounds memory write via a crafted HTML page. \n\nHello -> this repo is popular and frequently used.   I believe that it includes a static version of libwebp before the fix for this cve.\n\nhttps://github.com/bytedeco/javacpp/issues/711#issuecomment-1740132687\n\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "crates.io",
         "name": "libwebp-sys2"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,11 +39,6 @@
         "ecosystem": "crates.io",
         "name": "libwebp-sys"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -67,11 +57,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "electron"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -92,11 +77,6 @@
         "ecosystem": "npm",
         "name": "electron"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -115,11 +95,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "electron"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -140,11 +115,6 @@
         "ecosystem": "npm",
         "name": "electron"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -163,11 +133,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "electron"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -188,11 +153,6 @@
         "ecosystem": "NuGet",
         "name": "SkiaSharp"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -211,11 +171,6 @@
       "package": {
         "ecosystem": "Go",
         "name": "github.com/chai2010/webp"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
some third party software includes libwebp.a vs libwebp.so and may be vulnerable unless built on a version that includes the CVE fix. 