### PR TITLE
[GHSA-2777-2vq8-c4v4] SQL Injection in sequelize

### DIFF
--- a/advisories/github-reviewed/2019/04/GHSA-2777-2vq8-c4v4/GHSA-2777-2vq8-c4v4.json
+++ b/advisories/github-reviewed/2019/04/GHSA-2777-2vq8-c4v4/GHSA-2777-2vq8-c4v4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2777-2vq8-c4v4",
-  "modified": "2021-08-30T16:08:57Z",
+  "modified": "2023-01-09T05:02:29Z",
   "published": "2019-04-11T16:33:17Z",
   "aliases": [
     "CVE-2019-11069"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/sequelize/sequelize/pull/10746/files"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/sequelize/sequelize/commit/850c7fd04669e0fef9238b6dc4f8d6ee93ed71e9"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v5.3.0: https://github.com/sequelize/sequelize/commit/850c7fd04669e0fef9238b6dc4f8d6ee93ed71e9

This is the complete merge of pull 10746 mentioned in the original advisory: "feat(postgres): enable standard conforming strings when required (10746)"