### PR TITLE
[GHSA-2ggq-vfcp-gwhj] Cross-Site Scripting in @hapi/boom

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-2ggq-vfcp-gwhj/GHSA-2ggq-vfcp-gwhj.json
+++ b/advisories/github-reviewed/2020/09/GHSA-2ggq-vfcp-gwhj/GHSA-2ggq-vfcp-gwhj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2ggq-vfcp-gwhj",
-  "modified": "2021-10-04T20:48:50Z",
+  "modified": "2023-01-09T05:04:26Z",
   "published": "2020-09-04T17:33:53Z",
   "aliases": [
 
@@ -36,6 +36,10 @@
     }
   ],
   "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/hapijs/boom/commit/0f8640bdba65aec6e6799bfc16ff5753150bfcaf"
+    },
     {
       "type": "PACKAGE",
       "url": "https://github.com/hapijs/boom"


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v0.3.8: https://github.com/hapijs/boom/commit/0f8640bdba65aec6e6799bfc16ff5753150bfcaf

The patch link was mentioned in the external reference of Snyk: https://snyk.io/vuln/SNYK-JS-HAPIBOOM-541183. Additionally, the commit message is related: "Adding extra XSS protection"