### PR TITLE
[GHSA-33c7-2mpw-hg34] Log injection in uvicorn

### DIFF
--- a/advisories/github-reviewed/2020/07/GHSA-33c7-2mpw-hg34/GHSA-33c7-2mpw-hg34.json
+++ b/advisories/github-reviewed/2020/07/GHSA-33c7-2mpw-hg34/GHSA-33c7-2mpw-hg34.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-33c7-2mpw-hg34",
-  "modified": "2021-07-29T21:17:18Z",
+  "modified": "2023-02-01T05:04:22Z",
   "published": "2020-07-29T18:07:16Z",
   "aliases": [
     "CVE-2020-7694"
@@ -42,6 +42,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/encode/uvicorn/issues/723"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/encode/uvicorn/commit/895807f94ea9a8e588605c12076b7d7517cda503"
+    },
+    {
+      "type": "PACKAGE",
       "url": "https://github.com/encode/uvicorn"
     },
     {


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Adding the patch link for:
v0.11.7: https://github.com/encode/uvicorn/commit/895807f94ea9a8e588605c12076b7d7517cda503

Also, adding the original issue (Mentions CVE-2020-7694): https://github.com/encode/uvicorn/issues/723

The patch link was used in pull (724) to close the original issue (723): "Quote path component before logging (724)"