### PR TITLE
[GHSA-34wj-p5jm-2p96] Improper Restriction of XML External Entity Reference in python-docx

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-34wj-p5jm-2p96/GHSA-34wj-p5jm-2p96.json
+++ b/advisories/github-reviewed/2022/05/GHSA-34wj-p5jm-2p96/GHSA-34wj-p5jm-2p96.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-34wj-p5jm-2p96",
-  "modified": "2022-07-06T19:44:36Z",
+  "modified": "2023-01-29T05:01:53Z",
   "published": "2022-05-13T01:06:10Z",
   "aliases": [
     "CVE-2016-5851"
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-5851"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python-openxml/python-docx/commit/61b40b161b64173ab8e362aec1fd197948431beb"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v0.8.6: https://github.com/python-openxml/python-docx/commit/61b40b161b64173ab8e362aec1fd197948431beb

From the commit message: "Resolving entities in the XML is not required by the Open XML standard and represents a security vulnerability. Turn off entity resolution in both the opc (package) parser and the part parser."

The developer also set "resolve_entities=False", which means that the parser will not resolve any entity references (like &amp; or &lt;) to their corresponding characters (like & or <). 