### PR TITLE
[GHSA-35rx-7pc8-6963] API keys stored in plain text by Jenkins Katalon Plugin

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-35rx-7pc8-6963/GHSA-35rx-7pc8-6963.json
+++ b/advisories/github-reviewed/2022/10/GHSA-35rx-7pc8-6963/GHSA-35rx-7pc8-6963.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-35rx-7pc8-6963",
-  "modified": "2022-12-16T19:45:04Z",
+  "modified": "2023-02-01T05:06:41Z",
   "published": "2022-10-19T19:00:18Z",
   "aliases": [
     "CVE-2022-43419"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-43419"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/katalon-plugin/pull/28"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/katalon-plugin/commit/64f819387f3f14d54f3a1542578a5c7aa9feb85c"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v1.0.33: https://github.com/jenkinsci/katalon-plugin/commit/64f819387f3f14d54f3a1542578a5c7aa9feb85c

Adding the PR: https://github.com/jenkinsci/katalon-plugin/pull/28

The PR mentions the same reference in the advisory: "Resolve issue from https://issues.jenkins.io/browse/SECURITY-2846"

The commit is from the PR: "Stop storing credentials in plain text"