### PR TITLE
[GHSA-3f5c-4qxj-vmpf] Next.js Directory Traversal Vulnerability

### DIFF
--- a/advisories/github-reviewed/2017/12/GHSA-3f5c-4qxj-vmpf/GHSA-3f5c-4qxj-vmpf.json
+++ b/advisories/github-reviewed/2017/12/GHSA-3f5c-4qxj-vmpf/GHSA-3f5c-4qxj-vmpf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3f5c-4qxj-vmpf",
-  "modified": "2023-09-05T22:34:28Z",
+  "modified": "2023-09-05T22:34:30Z",
   "published": "2017-12-05T02:04:14Z",
   "aliases": [
     "CVE-2017-16877"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "next"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-16877"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vercel/next.js/commit/02fe7cf63f6265d73bdaf8bc50a4f2fb539dcd00"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding the patch link for:
v2.4.1: https://github.com/vercel/next.js/commit/02fe7cf63f6265d73bdaf8bc50a4f2fb539dcd00

The patch adds a new function, isServableURL, which is used to determine whether a given path is within the allowed directories to be served and prevents the serving of files outside those directories. Additionally, the branch merge was named "fix-dir-traversal-error," which is what the advisory is for.  

Also, github.com/zeit/next.js redirects to github.com/vercel/next.js ...which is why the patch is under vercel/next.js.