### PR TITLE
[GHSA-3fgr-xjr6-xqm8] code injection in phpxmlrpc/phpxmlrpc

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-3fgr-xjr6-xqm8/GHSA-3fgr-xjr6-xqm8.json
+++ b/advisories/github-reviewed/2022/11/GHSA-3fgr-xjr6-xqm8/GHSA-3fgr-xjr6-xqm8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3fgr-xjr6-xqm8",
-  "modified": "2022-11-28T22:07:33Z",
+  "modified": "2023-01-08T05:05:56Z",
   "published": "2022-11-28T22:07:33Z",
   "aliases": [
 
@@ -36,6 +36,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/gggeek/phpxmlrpc/issues/80"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/gggeek/phpxmlrpc/commit/cf6e605e09d001ce520bfa8e7b168cfa514e663b"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:

v4.9.0: https://github.com/gggeek/phpxmlrpc/commit/cf6e605e09d001ce520bfa8e7b168cfa514e663b

The commit message mentions the original issue (80): "fix security issues 80 and 81; comments; whitespace; docs; tag for release"