### PR TITLE
[GHSA-3fr8-mwpp-8h9p] Cross-site scripting in TileServer GL

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-3fr8-mwpp-8h9p/GHSA-3fr8-mwpp-8h9p.json
+++ b/advisories/github-reviewed/2021/05/GHSA-3fr8-mwpp-8h9p/GHSA-3fr8-mwpp-8h9p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3fr8-mwpp-8h9p",
-  "modified": "2021-05-11T19:36:26Z",
+  "modified": "2023-02-01T05:05:31Z",
   "published": "2021-05-17T21:01:15Z",
   "aliases": [
     "CVE-2020-15500"
@@ -46,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/maptiler/tileserver-gl/issues/461"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/maptiler/tileserver-gl/commit/10431d70d0f0d7b7950ae2c02aea0850c7566621"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:

v3.1.0: https://github.com/maptiler/tileserver-gl/commit/10431d70d0f0d7b7950ae2c02aea0850c7566621

The commit message mentions the original issue (461): "Fix reflected XSS in 'key' parameter. Fixes 461"