### PR TITLE
[GHSA-4cww-f7w5-x525] Stack consumption in trust-dns-server

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-4cww-f7w5-x525/GHSA-4cww-f7w5-x525.json
+++ b/advisories/github-reviewed/2021/08/GHSA-4cww-f7w5-x525/GHSA-4cww-f7w5-x525.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4cww-f7w5-x525",
-  "modified": "2023-06-13T22:25:56Z",
+  "modified": "2023-06-13T22:25:57Z",
   "published": "2021-08-25T20:46:13Z",
   "aliases": [
     "CVE-2020-35857"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/bluejekyll/trust-dns/issues/980"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/bluejekyll/trust-dns/commit/8b9eab05795fdc098976262853b2498055c7a8f3"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:

v0.18.1: https://github.com/bluejekyll/trust-dns/commit/8b9eab05795fdc098976262853b2498055c7a8f3

This commit was mentioned in the original issue (980) as closing the issue: "reproduce error stack overflow from . as MX target stop additional lookup on Root name"