### PR TITLE
[GHSA-4jv9-3563-23j3] Knex.js has a limited SQL injection vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-4jv9-3563-23j3/GHSA-4jv9-3563-23j3.json
+++ b/advisories/github-reviewed/2022/12/GHSA-4jv9-3563-23j3/GHSA-4jv9-3563-23j3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4jv9-3563-23j3",
-  "modified": "2023-01-08T15:23:32Z",
+  "modified": "2023-02-03T05:01:32Z",
   "published": "2022-12-19T09:30:23Z",
   "aliases": [
     "CVE-2016-20018"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/knex/knex/issues/1227"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/knex/knex/commit/e145322da92749be7749f9ade5b5f5a66d6586a4"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:

v2.4.0: https://github.com/knex/knex/commit/e145322da92749be7749f9ade5b5f5a66d6586a4

This commit was mentioned in the original issue (1227) as closing the issue: "1227: add assertion for basic where clause values (5417)"