### PR TITLE
[GHSA-qqvq-6xgj-jw8g] Heap buffer overflow in vp8 encoding in libvpx in Google...

### DIFF
--- a/advisories/unreviewed/2023/09/GHSA-qqvq-6xgj-jw8g/GHSA-qqvq-6xgj-jw8g.json
+++ b/advisories/unreviewed/2023/09/GHSA-qqvq-6xgj-jw8g/GHSA-qqvq-6xgj-jw8g.json
@@ -6,7 +6,7 @@
   "aliases": [
     "CVE-2023-5217"
   ],
-  "summary": "Add electron 22.3.25 to patched versions",
+  "summary": "Add electron `24.8.5`, `25.8.4`, `26.2.4` and `27.0.0-beta8` to patched versions",
   "details": "Heap buffer overflow in vp8 encoding in libvpx in Google Chrome prior to 117.0.5938.132 and libvpx 1.13.1 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page. (Chromium security severity: High)",
   "severity": [
 
@@ -25,7 +25,64 @@
               "introduced": "0"
             },
             {
-              "fixed": "22.3.25"
+              "fixed": "24.8.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "electron"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "25.8.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "electron"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "26.2.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "electron"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "27.0.0-beta.8"
             }
           ]
         }
@@ -36,6 +93,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-5217"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/electron/electron/pull/40023"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/electron/electron/pull/40024"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/electron/electron/pull/40025"
     },
     {
       "type": "WEB",

--- a/advisories/unreviewed/2023/09/GHSA-qqvq-6xgj-jw8g/GHSA-qqvq-6xgj-jw8g.json
+++ b/advisories/unreviewed/2023/09/GHSA-qqvq-6xgj-jw8g/GHSA-qqvq-6xgj-jw8g.json
@@ -1,22 +1,45 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qqvq-6xgj-jw8g",
-  "modified": "2023-09-28T18:30:45Z",
+  "modified": "2023-09-29T15:30:27Z",
   "published": "2023-09-28T18:30:45Z",
   "aliases": [
     "CVE-2023-5217"
   ],
+  "summary": "Add electron 22.3.25 to patched versions",
   "details": "Heap buffer overflow in vp8 encoding in libvpx in Google Chrome prior to 117.0.5938.132 and libvpx 1.13.1 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page. (Chromium security severity: High)",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "electron"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "22.3.25"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-5217"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/electron/electron/pull/40026"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Summary

**Comments**
Patched in Electron v22.3.25, see https://releases.electronjs.org/release/v22.3.25