### PR TITLE
[GHSA-c27h-mcmw-48hv] Deserialization of Untrusted Data in org.codehaus.jackson:jackson-mapper-asl

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-c27h-mcmw-48hv/GHSA-c27h-mcmw-48hv.json
+++ b/advisories/github-reviewed/2022/05/GHSA-c27h-mcmw-48hv/GHSA-c27h-mcmw-48hv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c27h-mcmw-48hv",
-  "modified": "2023-02-14T00:56:25Z",
+  "modified": "2023-02-21T05:06:38Z",
   "published": "2022-05-24T16:57:28Z",
   "aliases": [
     "CVE-2019-10202"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.codehaus.jackson:jackson-mapper-asl"
+        "name": ""
       },
       "ranges": [
         {
@@ -26,9 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "1.9.13"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to the CVE CPEs (https://nvd.nist.gov/vuln/detail/CVE-2019-10202), this is affect Codehaus 1.9.x implemented in EAP 7, not the base jackson packages