### PR TITLE
[GHSA-4xf9-pgvv-xx67] Regular Expression Denial of Service in simple-markdown

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-4xf9-pgvv-xx67/GHSA-4xf9-pgvv-xx67.json
+++ b/advisories/github-reviewed/2020/09/GHSA-4xf9-pgvv-xx67/GHSA-4xf9-pgvv-xx67.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4xf9-pgvv-xx67",
-  "modified": "2021-09-29T18:16:33Z",
+  "modified": "2023-01-09T05:04:00Z",
   "published": "2020-09-03T20:27:46Z",
   "aliases": [
 
@@ -39,6 +39,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/Khan/simple-markdown/issues/71"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ariabuckles/simple-markdown/commit/89797fef9abb4cab2fb76a335968266a92588816"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:

v0.5.2: https://github.com/ariabuckles/simple-markdown/commit/89797fef9abb4cab2fb76a335968266a92588816

This commit was mentioned in the original issue (71) as the fix: "inlineCode: Fix ReDoS & improve escape semantics". 

Also, the repo owner changed from Khan to ariabuckles, which is why the patch link differs. 