### PR TITLE
[GHSA-55m5-whcv-c49c] Use of Uninitialized Resource in smallvec

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-55m5-whcv-c49c/GHSA-55m5-whcv-c49c.json
+++ b/advisories/github-reviewed/2022/01/GHSA-55m5-whcv-c49c/GHSA-55m5-whcv-c49c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-55m5-whcv-c49c",
-  "modified": "2023-06-13T20:53:48Z",
+  "modified": "2023-06-13T20:53:49Z",
   "published": "2022-01-06T22:20:28Z",
   "aliases": [
     "CVE-2018-25023"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/servo/rust-smallvec/issues/126"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/servo/rust-smallvec/commit/e64afc8c473d43e375ab42bd33db2d0d4ac4e41b"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:

v0.6.13: https://github.com/servo/rust-smallvec/commit/e64afc8c473d43e375ab42bd33db2d0d4ac4e41b

This commit was used to backport the fix to 0.6.13, it was mentioned in the original issue (126) as part of the fix from pull (162): " Use MaybeUninit for storage of inline items. This is a backport of 162 to the smallvec 0.6 branch."