### PR TITLE
[GHSA-5c2c-cvg6-ghjm] Password stored in plain text by Jenkins Nomad Plugin

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-5c2c-cvg6-ghjm/GHSA-5c2c-cvg6-ghjm.json
+++ b/advisories/github-reviewed/2022/05/GHSA-5c2c-cvg6-ghjm/GHSA-5c2c-cvg6-ghjm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5c2c-cvg6-ghjm",
-  "modified": "2022-12-16T15:47:12Z",
+  "modified": "2023-02-01T05:06:55Z",
   "published": "2022-05-24T19:12:36Z",
   "aliases": [
     "CVE-2021-21681"
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21681"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/nomad-plugin/commit/d45123487d57c0e2a8a6869866b05362f690f511"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:

v0.7.5: https://github.com/jenkinsci/nomad-plugin/commit/d45123487d57c0e2a8a6869866b05362f690f511

The commit message mentions the Jenkins security advisory number (SECURITY-2396) referenced in the advisory : "SECURITY-2396"