### PR TITLE
[GHSA-5x4f-7xgq-r42x] Object state limitation has no effect

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-5x4f-7xgq-r42x/GHSA-5x4f-7xgq-r42x.json
+++ b/advisories/github-reviewed/2022/04/GHSA-5x4f-7xgq-r42x/GHSA-5x4f-7xgq-r42x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5x4f-7xgq-r42x",
-  "modified": "2022-04-29T15:39:18Z",
+  "modified": "2023-01-07T05:03:47Z",
   "published": "2022-04-29T15:39:18Z",
   "aliases": [
 
@@ -36,6 +36,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/ezsystems/ezpublish-kernel/security/advisories/GHSA-5x4f-7xgq-r42x"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ezsystems/ezpublish-kernel/commit/133c33cbcaa330953d6283865153f3dfdc7a2e45"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:

v7.5.28: https://github.com/ezsystems/ezpublish-kernel/commit/133c33cbcaa330953d6283865153f3dfdc7a2e45

The commit message mentions the GHSA-ID: " Merge pull request from GHSA-5x4f-7xgq-r42x

* IBX-2786: Fixed evaluating Root Location in ObjectStateLimitationType

* IBX-2786: [Tests] Added test coverage for Non-Root Location"