### PR TITLE
[GHSA-96mh-7xpr-qcgw] October CMS XSS

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-96mh-7xpr-qcgw/GHSA-96mh-7xpr-qcgw.json
+++ b/advisories/github-reviewed/2022/05/GHSA-96mh-7xpr-qcgw/GHSA-96mh-7xpr-qcgw.json
@@ -1,24 +1,21 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-96mh-7xpr-qcgw",
-  "modified": "2023-07-21T20:43:17Z",
+  "modified": "2023-07-21T20:43:18Z",
   "published": "2022-05-13T01:24:44Z",
   "aliases": [
     "CVE-2018-7198"
   ],
-  "summary": "October CMS XSS",
-  "details": "October CMS through 1.0.431 allows XSS by entering HTML on the Add Posts page.",
+  "summary": "October CMS - RainLab Blog Plugin XSS",
+  "details": "The RainLab Blog Plugin used in October CMS through 1.0.431 allows XSS by entering HTML on the Add Posts page if the correct permissions are not established on an untrusted user.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
-    }
+
   ],
   "affected": [
     {
       "package": {
         "ecosystem": "Packagist",
-        "name": "october/october"
+        "name": "rainlab/blog-plugin"
       },
       "ranges": [
         {
@@ -26,9 +23,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "1.0.431"
             }
           ]
         }
@@ -57,7 +51,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2023-07-21T20:43:17Z",
     "nvd_published_at": "2018-02-18T03:29:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Summary

**Comments**
Wrong package. Not a vulnerability since user is trusted. Behavior is controlled by a permission (`backend.allow_unsafe_markdown`).