### PR TITLE
[GHSA-f73w-4m7g-ch9x] Langchain vulnerable to arbitrary code execution via the evaluate function in the numexpr library

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-f73w-4m7g-ch9x/GHSA-f73w-4m7g-ch9x.json
+++ b/advisories/github-reviewed/2023/09/GHSA-f73w-4m7g-ch9x/GHSA-f73w-4m7g-ch9x.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f73w-4m7g-ch9x",
-  "modified": "2023-09-06T21:21:55Z",
+  "modified": "2023-09-06T21:21:56Z",
   "published": "2023-09-01T18:30:41Z",
   "aliases": [
     "CVE-2023-39631"
   ],
   "summary": "Langchain vulnerable to arbitrary code execution via the evaluate function in the numexpr library",
-  "details": "An issue in LanChain-ai Langchain v.0.0.245 allows a remote attacker to execute arbitrary code via the evaluate function in the numexpr library.",
+  "details": "An issue in LanChain-ai Langchain v.0.0.245 allows a remote attacker to execute arbitrary code via the evaluate function in the numexpr library.\n\nPatches\n\nReleased in v.0.0.308. numexpr dependency is optional for langchain\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -20,11 +20,6 @@
         "ecosystem": "PyPI",
         "name": "langchain"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.0.245"
+              "fixed": "0.0.308"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.0.245"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Patched release in Langchain version 0.0.308. The dependency is now optional and will not be installed by default.