### PR TITLE
[GHSA-3qc2-v3hp-6cv8] sidekiq Denial of Service vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-3qc2-v3hp-6cv8/GHSA-3qc2-v3hp-6cv8.json
+++ b/advisories/github-reviewed/2023/09/GHSA-3qc2-v3hp-6cv8/GHSA-3qc2-v3hp-6cv8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3qc2-v3hp-6cv8",
-  "modified": "2023-09-26T18:09:12Z",
+  "modified": "2023-09-26T18:09:13Z",
   "published": "2023-09-14T06:30:19Z",
   "aliases": [
     "CVE-2023-26141"
@@ -20,11 +20,6 @@
         "ecosystem": "RubyGems",
         "name": "sidekiq"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -34,6 +29,25 @@
             },
             {
               "fixed": "7.1.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "sidekiq"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "6.5.10"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The sidekiq gem version 6.5.10 that was released a few days ago fixes this issue, see https://github.com/sidekiq/sidekiq/blob/6-x/Changes.md#6510
This is also reflected in https://github.com/rubysec/ruby-advisory-db/blob/master/gems/sidekiq/CVE-2023-26141.yml.

So I think the version 6.5.10 should be added as a "patched version".