### PR TITLE
[GHSA-9324-jv53-9cc8] dio vulnerable to CRLF injection with HTTP method string

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-9324-jv53-9cc8/GHSA-9324-jv53-9cc8.json
+++ b/advisories/github-reviewed/2023/03/GHSA-9324-jv53-9cc8/GHSA-9324-jv53-9cc8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9324-jv53-9cc8",
-  "modified": "2023-03-21T22:41:11Z",
+  "modified": "2023-03-22T01:39:28Z",
   "published": "2023-03-21T22:41:11Z",
   "aliases": [
     "CVE-2021-31402"
@@ -67,8 +67,6 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-74",
-      "CWE-88",
       "CWE-93"
     ],
     "severity": "HIGH",


### PR DESCRIPTION
**Updates**
- CWEs

**Comments**
[NVD remapped this CVE from CWE-88 to CWE-74](https://nvd.nist.gov/vuln/detail/CVE-2021-31402#VulnChangeHistorySection). We can be even more accurate and categorize it as CWE-93, based on the description of the issue and other reviews (i.e., [Snyk](https://security.snyk.io/vuln/SNYK-PUB-DIO-5891148)'s).