### PR TITLE
[GHSA-7fh5-64p2-3v2j] PostCSS line return parsing error

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-7fh5-64p2-3v2j/GHSA-7fh5-64p2-3v2j.json
+++ b/advisories/github-reviewed/2023/09/GHSA-7fh5-64p2-3v2j/GHSA-7fh5-64p2-3v2j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7fh5-64p2-3v2j",
-  "modified": "2023-10-03T15:04:58Z",
+  "modified": "2023-10-03T15:04:59Z",
   "published": "2023-09-30T00:31:10Z",
   "aliases": [
     "CVE-2023-44270"
@@ -16,11 +16,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "postcss"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
Would you consider please retracting this advisory or can we apply better quality standards? There is absolutely no word on any kind of security impact, which makes the advisory useless as it doesn't advise the readers what the impact of this bug is in any way.

I would like to improve this advisory, but there is no documentation on this at all other than the poorly written advisory text and a single line code change that doesn't allow anyone to distinguish between a security bug or a simple logic handling bug.