### PR TITLE
Improve GHSA-53x6-4x5p-rrvv

### DIFF
--- a/advisories/github-reviewed/2019/10/GHSA-53x6-4x5p-rrvv/GHSA-53x6-4x5p-rrvv.json
+++ b/advisories/github-reviewed/2019/10/GHSA-53x6-4x5p-rrvv/GHSA-53x6-4x5p-rrvv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-53x6-4x5p-rrvv",
-  "modified": "2021-06-15T17:21:48Z",
+  "modified": "2023-10-06T06:22:19Z",
   "published": "2019-10-11T18:41:08Z",
   "aliases": [
     "CVE-2019-12402"
@@ -32,6 +32,15 @@
             }
           ]
         }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.github.1tchy.java9modular.org.apache.commons:commons-compress"
+      },
+      "versions": [
+        "1.18.1"
       ]
     }
   ],
@@ -159,6 +168,10 @@
     {
       "type": "WEB",
       "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jensdietrich/xshady-release/tree/main/CVE-2019-12402"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Several other components are also affected as a result of cloning (copying source code) or shading (copying source code and renaming packages). Proof-of-Vulnerability projects with tests to verify the presence of the CVE can be found here: https://github.com/jensdietrich/xshady-release/.

See https://github.com/github/advisory-database/pull/2258, especially https://github.com/github/advisory-database/pull/2258#issuecomment-1569073245, for more details.