### PR TITLE
[GHSA-8whr-v3gm-w8h9] Command Injection in node-rules

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-8whr-v3gm-w8h9/GHSA-8whr-v3gm-w8h9.json
+++ b/advisories/github-reviewed/2020/09/GHSA-8whr-v3gm-w8h9/GHSA-8whr-v3gm-w8h9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8whr-v3gm-w8h9",
-  "modified": "2021-10-04T21:08:30Z",
+  "modified": "2023-01-09T05:04:12Z",
   "published": "2020-09-03T15:51:04Z",
   "aliases": [
 
@@ -39,6 +39,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/mithunsatheesh/node-rules/issues/84"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mithunsatheesh/node-rules/commit/100862223904bb6478fcc33b701c7dee11f7b832"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v5.0.0: https://github.com/mithunsatheesh/node-rules/commit/100862223904bb6478fcc33b701c7dee11f7b832

In the original issue (84), a developer mentioned the fix as: "We should get rid of fromJSON and toJSON APIs in V5.0 release."

The patch link does that: "Remove fromJSON and toJSON from exposed APIs"

Snyk also has the same referenced patch link. 