### PR TITLE
[GHSA-65rp-cv85-263x] etcd denial of service vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-65rp-cv85-263x/GHSA-65rp-cv85-263x.json
+++ b/advisories/github-reviewed/2023/08/GHSA-65rp-cv85-263x/GHSA-65rp-cv85-263x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-65rp-cv85-263x",
-  "modified": "2023-08-31T16:54:03Z",
+  "modified": "2023-08-31T16:54:04Z",
   "published": "2023-08-22T21:30:26Z",
   "aliases": [
     "CVE-2022-34038"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Go",
         "name": "go.etcd.io/etcd/v3"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -66,7 +61,7 @@
     "cwe_ids": [
       "CWE-787"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2023-08-23T13:25:22Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
Please see https://github.com/golang/vulndb/issues/2016#issuecomment-1698677762. The vendor does not consider this a valid vulnerability (CVE-2022-34038 has been marked as DISPUTED). As such, this should be invalidated.