### PR TITLE
Improve GHSA-xwf4-88xr-hx2j

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-xwf4-88xr-hx2j/GHSA-xwf4-88xr-hx2j.json
+++ b/advisories/github-reviewed/2022/05/GHSA-xwf4-88xr-hx2j/GHSA-xwf4-88xr-hx2j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xwf4-88xr-hx2j",
-  "modified": "2023-10-06T22:38:28Z",
+  "modified": "2023-10-10T05:19:57Z",
   "published": "2022-05-13T01:25:29Z",
   "aliases": [
     "CVE-2016-5394"
@@ -39,6 +39,19 @@
         "ecosystem": "Maven",
         "name": "org.apache.sling:org.apache.sling.xss.compat"
       },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.1.0"
+            }
+          ]
+        }
+      ],
       "versions": [
         "1.0.0"
       ]

--- a/advisories/github-reviewed/2022/05/GHSA-xwf4-88xr-hx2j/GHSA-xwf4-88xr-hx2j.json
+++ b/advisories/github-reviewed/2022/05/GHSA-xwf4-88xr-hx2j/GHSA-xwf4-88xr-hx2j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xwf4-88xr-hx2j",
-  "modified": "2022-11-03T19:12:07Z",
+  "modified": "2023-10-06T22:38:28Z",
   "published": "2022-05-13T01:25:29Z",
   "aliases": [
     "CVE-2016-5394"
@@ -33,6 +33,15 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.sling:org.apache.sling.xss.compat"
+      },
+      "versions": [
+        "1.0.0"
+      ]
     }
   ],
   "references": [
@@ -47,6 +56,10 @@
     {
       "type": "WEB",
       "url": "http://www.securityfocus.com/bid/99870"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jensdietrich/xshady-release/tree/main/CVE-2016-5394"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Several other components are also affected as a result of cloning (copying source code) or shading (copying source code and renaming packages). Proof-of-Vulnerability projects with tests to verify the presence of the CVE can be found here: https://github.com/jensdietrich/xshady-release/.

See https://github.com/github/advisory-database/pull/2258, especially https://github.com/github/advisory-database/pull/2258#issuecomment-1569073245, for more details.