### PR TITLE
Improve GHSA-7g54-vgp6-jj5w

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-7g54-vgp6-jj5w/GHSA-7g54-vgp6-jj5w.json
+++ b/advisories/github-reviewed/2022/05/GHSA-7g54-vgp6-jj5w/GHSA-7g54-vgp6-jj5w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7g54-vgp6-jj5w",
-  "modified": "2022-11-03T20:48:21Z",
+  "modified": "2023-10-07T03:39:01Z",
   "published": "2022-05-17T02:26:22Z",
   "aliases": [
     "CVE-2016-6798"
@@ -33,6 +33,15 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.sling:org.apache.sling.xss.compat"
+      },
+      "versions": [
+        "1.0.0"
+      ]
     }
   ],
   "references": [
@@ -47,6 +56,10 @@
     {
       "type": "WEB",
       "url": "http://www.securityfocus.com/bid/99873"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jensdietrich/xshady-release/tree/main/CVE-2016-6798"
     }
   ],
   "database_specific": {

--- a/advisories/github-reviewed/2022/05/GHSA-7g54-vgp6-jj5w/GHSA-7g54-vgp6-jj5w.json
+++ b/advisories/github-reviewed/2022/05/GHSA-7g54-vgp6-jj5w/GHSA-7g54-vgp6-jj5w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7g54-vgp6-jj5w",
-  "modified": "2023-10-07T03:39:01Z",
+  "modified": "2023-10-10T21:05:51Z",
   "published": "2022-05-17T02:26:22Z",
   "aliases": [
     "CVE-2016-6798"
@@ -39,6 +39,19 @@
         "ecosystem": "Maven",
         "name": "org.apache.sling:org.apache.sling.xss.compat"
       },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.1.0"
+            }
+          ]
+        }
+      ],
       "versions": [
         "1.0.0"
       ]


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Several other components are also affected as a result of cloning (copying source code) or shading (copying source code and renaming packages). Proof-of-Vulnerability projects with tests to verify the presence of the CVE can be found here: https://github.com/jensdietrich/xshady-release/.

See https://github.com/github/advisory-database/pull/2258, especially https://github.com/github/advisory-database/pull/2258#issuecomment-1569073245, for more details.