### PR TITLE
[GHSA-9jfq-54vc-9rr2] Foreman Transpilation Enables OS Command Injection

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
+++ b/advisories/github-reviewed/2023/09/GHSA-9jfq-54vc-9rr2/GHSA-9jfq-54vc-9rr2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9jfq-54vc-9rr2",
-  "modified": "2023-09-27T22:57:13Z",
+  "modified": "2023-09-27T22:57:17Z",
   "published": "2023-09-22T15:30:15Z",
   "withdrawn": "2023-09-27T22:57:13Z",
   "aliases": [
@@ -19,12 +19,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "foreman"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
+        "name": "theforeman"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The package name is incorrect as 'foreman' relates to this unrelated rubygem (https://rubygems.org/gems/foreman), see https://github.com/ddollar/foreman/issues/716

There is in fact no gemspec for 'theforeman' https://github.com/theforeman/foreman