### PR TITLE
[GHSA-mmjr-5q74-p3m4] Exposure of Resource to Wrong Sphere in Drupal Core

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-mmjr-5q74-p3m4/GHSA-mmjr-5q74-p3m4.json
+++ b/advisories/github-reviewed/2022/02/GHSA-mmjr-5q74-p3m4/GHSA-mmjr-5q74-p3m4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mmjr-5q74-p3m4",
-  "modified": "2022-02-25T15:35:08Z",
+  "modified": "2023-02-03T05:06:01Z",
   "published": "2022-02-12T00:00:47Z",
   "aliases": [
     "CVE-2020-13670"
@@ -15,25 +15,6 @@
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "Packagist",
-        "name": "drupal/core"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "8.0.0"
-            },
-            {
-              "fixed": "8.8.10"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "Packagist",
@@ -71,12 +52,35 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "drupal/core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.0.0"
+            },
+            {
+              "fixed": "8.8.10"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-13670"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/drupal/core/commit/f93a37b713b59f8d24e826bc74378099853eef3d"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v9.0.6: https://github.com/drupal/core/commit/f93a37b713b59f8d24e826bc74378099853eef3d

The commit message mentions the same Drupal issue (SA-Core-2020-011):  "SA-CORE-2020-011"