### PR TITLE
[GHSA-mp6f-p9gp-vpj9] Array size is not checked in sized-chunks

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-mp6f-p9gp-vpj9/GHSA-mp6f-p9gp-vpj9.json
+++ b/advisories/github-reviewed/2021/08/GHSA-mp6f-p9gp-vpj9/GHSA-mp6f-p9gp-vpj9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mp6f-p9gp-vpj9",
-  "modified": "2022-06-14T20:54:51Z",
+  "modified": "2023-01-11T05:05:48Z",
   "published": "2021-08-25T20:46:06Z",
   "aliases": [
     "CVE-2020-25792"
@@ -43,6 +43,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/bodil/sized-chunks/issues/11"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/bodil/sized-chunks/commit/3ae48bd463c1af41c24b96b84079946f51f51e3c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/bodil/sized-chunks/commit/99e593c3037438db478256a1f3101371a69cbd3f"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch links for:
v0.6.3: https://github.com/bodil/sized-chunks/commit/99e593c3037438db478256a1f3101371a69cbd3f

&

https://github.com/bodil/sized-chunks/commit/3ae48bd463c1af41c24b96b84079946f51f51e3c

The original issue (11) required two PRs to fix the advisory. The first is PR 13: "Fix soundness issues in sized chunks and ringbuffer. This fixes (hopefully) part of 11, + something I've seen on the way."

The second is PR 14: "Fix alignment issues of InlineArray. This is case 4 of 11."