### PR TITLE
[GHSA-mrx7-8hxf-f853] Cross-Site Scripting in swagger-ui

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-mrx7-8hxf-f853/GHSA-mrx7-8hxf-f853.json
+++ b/advisories/github-reviewed/2020/09/GHSA-mrx7-8hxf-f853/GHSA-mrx7-8hxf-f853.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mrx7-8hxf-f853",
-  "modified": "2021-09-23T21:33:20Z",
+  "modified": "2023-01-09T05:04:01Z",
   "published": "2020-09-01T15:36:27Z",
   "aliases": [
     "CVE-2016-1000233"
@@ -40,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/swagger-api/swagger-ui/issues/1863"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/swagger-api/swagger-ui/commit/331d2be070d89162aa3174a8773ae4a0093f78bc"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch links for:
v2.2.1: https://github.com/swagger-api/swagger-ui/commit/331d2be070d89162aa3174a8773ae4a0093f78bc

This is from the PR (1869) that closed the original issue (1863): "Escape curl command to fix XSS vulnerability."