### PR TITLE
[GHSA-mwwc-3jv2-62j3] AdGuardHome vulnerable to Cross-Site Request Forgery

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-mwwc-3jv2-62j3/GHSA-mwwc-3jv2-62j3.json
+++ b/advisories/github-reviewed/2022/10/GHSA-mwwc-3jv2-62j3/GHSA-mwwc-3jv2-62j3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mwwc-3jv2-62j3",
-  "modified": "2022-10-13T18:05:31Z",
+  "modified": "2023-01-27T05:05:05Z",
   "published": "2022-10-11T19:00:29Z",
   "aliases": [
     "CVE-2022-32175"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-32175"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/AdguardTeam/AdGuardHome/commit/756b14a61de138889130c239406dae43f1f115cb"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v0.108.0-b.16: https://github.com/AdguardTeam/AdGuardHome/commit/756b14a61de138889130c239406dae43f1f115cb

This is the only commit to fix a cross-site request forgery for v0.108.0-b.16 (https://github.com/AdguardTeam/AdGuardHome/compare/v0.108.0-b.15...v0.108.0-b.16): "Pull request: HOFTIX-csrf."