### PR TITLE
[GHSA-p28m-34f6-967q] PyOpenSSL Use-After-Free vulnerability

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-p28m-34f6-967q/GHSA-p28m-34f6-967q.json
+++ b/advisories/github-reviewed/2018/10/GHSA-p28m-34f6-967q/GHSA-p28m-34f6-967q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p28m-34f6-967q",
-  "modified": "2023-08-30T23:17:41Z",
+  "modified": "2023-08-30T23:17:43Z",
   "published": "2018-10-10T16:10:38Z",
   "aliases": [
     "CVE-2018-1000807"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "pyopenssl"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -48,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/pyca/pyopenssl/pull/723"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pyca/pyopenssl/commit/e73818600065821d588af475b024f4eb518c3509"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding the patch link for:
v17.5.0: https://github.com/pyca/pyopenssl/commit/e73818600065821d588af475b024f4eb518c3509

This is the squashed merge from pull 723: "fix a memory leak and a potential UAF and also 722 (723)"