### PR TITLE
[GHSA-pchc-949f-53m5] Improper Input Validation in multi_xml

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-pchc-949f-53m5/GHSA-pchc-949f-53m5.json
+++ b/advisories/github-reviewed/2017/10/GHSA-pchc-949f-53m5/GHSA-pchc-949f-53m5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pchc-949f-53m5",
-  "modified": "2023-02-13T17:01:58Z",
+  "modified": "2023-02-13T17:01:59Z",
   "published": "2017-10-24T18:33:37Z",
   "aliases": [
     "CVE-2013-0175"
@@ -40,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/sferik/multi_xml/pull/34"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/sferik/multi_xml/commit/c94b136d06822514fc2e99dc851e6c4eeb4c8bdf"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v0.5.2: https://github.com/sferik/multi_xml/commit/c94b136d06822514fc2e99dc851e6c4eeb4c8bdf

This is the squashed merge of the original pull (34): "remove-ability-to-parse-symbols-and-yaml

Remove ability to parse symbols and yaml"