### PR TITLE
[GHSA-qfcv-5whw-7pcw] Exposure of Sensitive Information to an Unauthorized Actor in AEgir

### DIFF
--- a/advisories/github-reviewed/2020/05/GHSA-qfcv-5whw-7pcw/GHSA-qfcv-5whw-7pcw.json
+++ b/advisories/github-reviewed/2020/05/GHSA-qfcv-5whw-7pcw/GHSA-qfcv-5whw-7pcw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qfcv-5whw-7pcw",
-  "modified": "2021-10-08T19:56:28Z",
+  "modified": "2023-02-01T05:03:02Z",
   "published": "2020-05-27T21:09:15Z",
   "aliases": [
     "CVE-2020-11059"
@@ -43,6 +43,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-11059"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ipfs/aegir/commit/e36e1def57b2dc1e4b7a5beba964c5924e87f8d8"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v21.10.1: https://github.com/ipfs/aegir/commit/e36e1def57b2dc1e4b7a5beba964c5924e87f8d8


The commit no longer passes all environment variables to the bundled code, which could have leaked keys: "fix: whitelist process env keys (557)
PSA: previous versions included process.env in the bundles so tokens, keys etc might be compromised please reset those to be safe!!"