### PR TITLE
[GHSA-qvjc-g5vr-mfgr] Regular Expression Denial of Service in papaparse

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-qvjc-g5vr-mfgr/GHSA-qvjc-g5vr-mfgr.json
+++ b/advisories/github-reviewed/2020/09/GHSA-qvjc-g5vr-mfgr/GHSA-qvjc-g5vr-mfgr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qvjc-g5vr-mfgr",
-  "modified": "2021-10-04T21:11:37Z",
+  "modified": "2023-01-09T05:04:05Z",
   "published": "2020-09-04T18:03:04Z",
   "aliases": [
 
@@ -39,6 +39,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/mholt/PapaParse/issues/777"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mholt/PapaParse/commit/235a12758cd77266d2e98fd715f53536b34ad621"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Adding the patch link for:
v5.2.0: https://github.com/mholt/PapaParse/commit/235a12758cd77266d2e98fd715f53536b34ad621

The commit message mentions the original issue (777): "Avoid ReDOS on float dynamic typing (779) Fixes 777"