### PR TITLE
[GHSA-2qrg-x229-3v8q] Deserialization of Untrusted Data in Log4j

### DIFF
--- a/advisories/github-reviewed/2020/01/GHSA-2qrg-x229-3v8q/GHSA-2qrg-x229-3v8q.json
+++ b/advisories/github-reviewed/2020/01/GHSA-2qrg-x229-3v8q/GHSA-2qrg-x229-3v8q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2qrg-x229-3v8q",
-  "modified": "2023-05-24T20:58:14Z",
+  "modified": "2023-05-24T20:58:15Z",
   "published": "2020-01-06T18:43:49Z",
   "aliases": [
     "CVE-2019-17571"
@@ -29,6 +29,22 @@
             },
             {
               "last_affected": "1.2.17"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.zenframework.z8.dependencies.commons:log4j-1.2.17"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
org.zenframework.z8.dependencies.commons:log4j-1.2.17 (https://mvnrepository.com/artifact/org.zenframework.z8.dependencies.commons/log4j-1.2.17) is a "forked" version of log4j-1.2.17. Their digest are the same:
 - log4j-1.2.17-2.0.jar.sha1: 5af35056b4d257e4b64b9e8069c0746e8b08629f (https://repo1.maven.org/maven2/org/zenframework/z8/dependencies/commons/log4j-1.2.17/2.0/log4j-1.2.17-2.0.jar.sha1)
 - log4j-1.2.17.jar.sha1: 5af35056b4d257e4b64b9e8069c0746e8b08629f (https://repo1.maven.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17.jar.sha1)

This suggests that these two packages are identical, and therefore this vulnerability would apply to this package as well. The sources of this package are not easily found, but for the sake of checking, I have decompiled the jar file (https://repo1.maven.org/maven2/org/zenframework/z8/dependencies/commons/log4j-1.2.17/2.0/log4j-1.2.17-2.0.jar). The vulnerable SocketServer class has not been modified (as expected) and therefore this vulnerability should apply to this package as well.

The description does not need to be modified as the mitigation ("Users are advised to migrate to `org.apache.logging.log4j:log4j-core`.") also applies in this case.

Furthermore, Snyk also reports this package as vulnerable.