### PR TITLE
[GHSA-rq8g-5pc5-wrhr] Insufficient Entropy in cryptiles

### DIFF
--- a/advisories/github-reviewed/2018/09/GHSA-rq8g-5pc5-wrhr/GHSA-rq8g-5pc5-wrhr.json
+++ b/advisories/github-reviewed/2018/09/GHSA-rq8g-5pc5-wrhr/GHSA-rq8g-5pc5-wrhr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rq8g-5pc5-wrhr",
-  "modified": "2023-03-29T19:11:42Z",
+  "modified": "2023-03-31T21:46:12Z",
   "published": "2018-09-11T18:22:50Z",
   "aliases": [
     "CVE-2018-1000620"
@@ -20,18 +20,12 @@
         "ecosystem": "npm",
         "name": "cryptiles"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "cryptiles.randomDigits",
-          "cryptiles.randomBits"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.1.0"
             },
             {
               "fixed": "4.1.2"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Vulnerable function `randomDigits()` is introduced in https://github.com/hapijs/cryptiles/commit/6bdcd0f6ee8ade96e7b30350bad39ee0c2ef0f9b, which is part of the 3.1.0 release and is not found in 3.0.2 (https://github.com/hapijs/cryptiles/blob/v3.0.2/lib/index.js) or below.