### PR TITLE
[GHSA-gchv-364h-r896] XML External Entity Reference in apache jena

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-gchv-364h-r896/GHSA-gchv-364h-r896.json
+++ b/advisories/github-reviewed/2022/05/GHSA-gchv-364h-r896/GHSA-gchv-364h-r896.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gchv-364h-r896",
-  "modified": "2022-05-24T20:52:33Z",
+  "modified": "2023-02-01T05:02:07Z",
   "published": "2022-05-06T00:00:53Z",
   "aliases": [
     "CVE-2022-28890"
   ],
   "summary": "XML External Entity Reference in apache jena",
-  "details": "A vulnerability in the RDF/XML parser of Apache Jena allows an attacker to cause an external DTD to be retrieved. This issue affects Apache Jena version 4.4.0 and prior versions. Apache Jena 4.2.x and 4.3.x do not allow external entities.",
+  "details": "A vulnerability in the RDF/XML parser of Apache Jena allows an attacker to cause an external DTD to be retrieved. This issue affects Apache Jena version 4.4.0 only.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -33,28 +33,6 @@
           ]
         }
       ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.apache.jena:jena"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.5.0"
-            }
-          ]
-        }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 4.2.0"
-      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Link: https://jena.apache.org/about_jena/security-advisories.html#cve-2022-28890---processing-external-dtds
It says here under CVE-2022-28890 - Processing External DTDs that only version 4.4.0 is affected. We had a false positive with version 3.1.1.

Thanks!