### PR TITLE
[GHSA-rmqp-9w4c-gc7w] ** UNSUPPPORTED WHEN ASSIGNED ** ** UNSUPPORTED WHEN...

### DIFF
--- a/advisories/unreviewed/2023/09/GHSA-rmqp-9w4c-gc7w/GHSA-rmqp-9w4c-gc7w.json
+++ b/advisories/unreviewed/2023/09/GHSA-rmqp-9w4c-gc7w/GHSA-rmqp-9w4c-gc7w.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rmqp-9w4c-gc7w",
-  "modified": "2023-09-11T18:31:29Z",
+  "modified": "2023-09-20T05:03:35Z",
   "published": "2023-09-05T15:30:25Z",
   "aliases": [
     "CVE-2023-40743"
   ],
+  "summary": "Apache Axis 1.x (EOL) may allow RCE when untrusted input is passed to getService",
   "details": "** UNSUPPPORTED WHEN ASSIGNED ** ** UNSUPPORTED WHEN ASSIGNED ** When integrating Apache Axis 1.x in an application, it may not have been obvious that looking up a service through \"ServiceFactory.getService\" allows potentially dangerous lookup mechanisms such as LDAP. When passing untrusted input to this API method, this could expose the application to DoS, SSRF and even attacks leading to RCE.\n\nAs Axis 1 has been EOL we recommend you migrate to a different SOAP engine, such as Apache Axis 2/Java. As a workaround, you may review your code to verify no untrusted or unsanitized input is passed to \"ServiceFactory.getService\", or by applying the patch from  https://github.com/apache/axis-axis1-java/commit/7e66753427466590d6def0125e448d2791723210 . The Apache Axis project does not expect to create an Axis 1.x release fixing this problem, though contributors that would like to work towards this are welcome.\n\n",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.axis:axis"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -26,6 +45,10 @@
       "url": "https://github.com/apache/axis-axis1-java/commit/7e66753427466590d6def0125e448d2791723210"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/axis-axis1-java"
+    },
+    {
       "type": "WEB",
       "url": "https://lists.apache.org/thread/gs0qgk2mgss7zfhzdd6ftfjvm4kp7v82"
     }
@@ -34,7 +57,7 @@
     "cwe_ids": [
       "CWE-20"
     ],
-    "severity": null,
+    "severity": "CRITICAL",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Source code location
- Summary

**Comments**
Advisory title from https://lists.apache.org/thread/gs0qgk2mgss7zfhzdd6ftfjvm4kp7v82.

Apache's announcement says versions through 1.3 are applicable, with 1.3 being the newest tag on https://github.com/apache/axis-axis1-java. However, a 1.4 release was announced on https://axis.apache.org/axis/ in 2006 and also contains the vulnerable function ServiceFactory.getService in org/apache/axis/client/ServiceFactory.java (see https://repo1.maven.org/maven2/org/apache/axis/axis/1.4/axis-1.4-sources.jar).