### PR TITLE
[GHSA-w9p3-5cr8-m3jj] Deserialization of Untrusted Data in Log4j 1.x

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-w9p3-5cr8-m3jj/GHSA-w9p3-5cr8-m3jj.json
+++ b/advisories/github-reviewed/2022/01/GHSA-w9p3-5cr8-m3jj/GHSA-w9p3-5cr8-m3jj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w9p3-5cr8-m3jj",
-  "modified": "2022-02-23T22:07:51Z",
+  "modified": "2023-01-27T05:02:33Z",
   "published": "2022-01-21T23:27:14Z",
   "aliases": [
     "CVE-2022-23302"
@@ -29,6 +29,25 @@
             },
             {
               "last_affected": "1.2.17"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.zenframework.z8.dependencies.commons:log4j-1.2.17"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This is similar to https://github.com/github/advisory-database/pull/2844 that was already merged.

org.zenframework.z8.dependencies.commons:log4j-1.2.17 (https://mvnrepository.com/artifact/org.zenframework.z8.dependencies.commons/log4j-1.2.17) is a "forked" version of log4j-1.2.17. Their digest are the same:

- log4j-1.2.17-2.0.jar.sha1: 5af35056b4d257e4b64b9e8069c0746e8b08629f (https://repo1.maven.org/maven2/org/zenframework/z8/dependencies/commons/log4j-1.2.17/2.0/log4j-1.2.17-2.0.jar.sha1)
- log4j-1.2.17.jar.sha1: 5af35056b4d257e4b64b9e8069c0746e8b08629f (https://repo1.maven.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17.jar.sha1)

This suggests that these two packages are identical, and therefore this vulnerability would apply to this package as well. The sources of this package are not easily found, but for the sake of checking, I have decompiled the jar file (https://repo1.maven.org/maven2/org/zenframework/z8/dependencies/commons/log4j-1.2.17/2.0/log4j-1.2.17-2.0.jar). The vulnerable JMSSink class has not been modified (as expected) and therefore this vulnerability should apply to this package as well.

The description does not need to be modified as the mitigation ("Users should upgrade to Log4j 2 as it addresses numerous other issues from the previous versions.") also applies in this case.