### PR TITLE
Improve GHSA-h436-432x-8fvx

### DIFF
--- a/advisories/github-reviewed/2019/03/GHSA-h436-432x-8fvx/GHSA-h436-432x-8fvx.json
+++ b/advisories/github-reviewed/2019/03/GHSA-h436-432x-8fvx/GHSA-h436-432x-8fvx.json
@@ -121,6 +121,10 @@
       "url": "https://github.com/jensdietrich/xshady-release/tree/main/CVE-2018-1324"
     },
     {
+      "type": "WEB",
+      "url": "https://arxiv.org/pdf/2306.05534.pdf"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/liferay/liferay-portal"
     }

--- a/advisories/github-reviewed/2019/03/GHSA-h436-432x-8fvx/GHSA-h436-432x-8fvx.json
+++ b/advisories/github-reviewed/2019/03/GHSA-h436-432x-8fvx/GHSA-h436-432x-8fvx.json
@@ -64,6 +64,16 @@
         "ecosystem": "Maven",
         "name": "io.takari:commons-compress"
       },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.12"
+            }
+          ]
+        }
+      ],
       "versions": [
         "1.12"
       ]

--- a/advisories/github-reviewed/2019/03/GHSA-h436-432x-8fvx/GHSA-h436-432x-8fvx.json
+++ b/advisories/github-reviewed/2019/03/GHSA-h436-432x-8fvx/GHSA-h436-432x-8fvx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h436-432x-8fvx",
-  "modified": "2023-10-09T21:17:53Z",
+  "modified": "2023-10-15T22:29:51Z",
   "published": "2019-03-14T15:41:12Z",
   "aliases": [
     "CVE-2018-1324"
@@ -42,6 +42,19 @@
         "ecosystem": "Maven",
         "name": "com.liferay:com.liferay.portal.tools.bundle.support"
       },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.2.7"
+            },
+            {
+              "fixed": "3.7.4"
+            }
+          ]
+        }
+      ],
       "versions": [
         "3.2.7"
       ]
@@ -94,8 +107,12 @@
       "url": "http://www.securitytracker.com/id/1040549"
     },
     {
-      "type": "WEB",
+      "type": "EVIDENCE",
       "url": "https://github.com/jensdietrich/xshady-release/tree/main/CVE-2018-1324"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/liferay/liferay-portal"
     }
   ],
   "database_specific": {

--- a/advisories/github-reviewed/2019/03/GHSA-h436-432x-8fvx/GHSA-h436-432x-8fvx.json
+++ b/advisories/github-reviewed/2019/03/GHSA-h436-432x-8fvx/GHSA-h436-432x-8fvx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h436-432x-8fvx",
-  "modified": "2022-05-26T19:37:39Z",
+  "modified": "2023-10-09T21:17:53Z",
   "published": "2019-03-14T15:41:12Z",
   "aliases": [
     "CVE-2018-1324"
@@ -36,6 +36,24 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 1.15"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.liferay:com.liferay.portal.tools.bundle.support"
+      },
+      "versions": [
+        "3.2.7"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.takari:commons-compress"
+      },
+      "versions": [
+        "1.12"
+      ]
     }
   ],
   "references": [
@@ -74,6 +92,10 @@
     {
       "type": "WEB",
       "url": "http://www.securitytracker.com/id/1040549"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jensdietrich/xshady-release/tree/main/CVE-2018-1324"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Several other components are also affected as a result of cloning (copying source code) or shading (copying source code and renaming packages). Proof-of-Vulnerability projects with tests to verify the presence of the CVE can be found here: https://github.com/jensdietrich/xshady-release/.

See https://github.com/github/advisory-database/pull/2258, especially https://github.com/github/advisory-database/pull/2258#issuecomment-1569073245, for more details.