### PR TITLE
[GHSA-29mw-wpgm-hmr9] Regular Expression Denial of Service (ReDoS) in lodash

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-29mw-wpgm-hmr9/GHSA-29mw-wpgm-hmr9.json
+++ b/advisories/github-reviewed/2022/01/GHSA-29mw-wpgm-hmr9/GHSA-29mw-wpgm-hmr9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-29mw-wpgm-hmr9",
-  "modified": "2023-09-05T22:58:25Z",
+  "modified": "2023-09-05T22:58:26Z",
   "published": "2022-01-06T20:30:46Z",
   "aliases": [
     "CVE-2020-28500"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "lodash"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -44,11 +39,6 @@
         "ecosystem": "npm",
         "name": "lodash-es"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -68,48 +58,38 @@
         "ecosystem": "npm",
         "name": "lodash.trimend"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "4.17.21"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.5.1"
+      }
     },
     {
       "package": {
         "ecosystem": "npm",
         "name": "lodash.trim"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "4.17.21"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.5.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Hello!
If i understand correctly, `lodash` team has moved `lodash.trim` and `lodash.trimend` packages inside `lodash` package:
https://github.com/lodash/lodash/tree/npm-packages/lodash.trim =>  https://github.com/lodash/lodash/blob/npm/trim.js
They have stopped updating of these packages:
https://www.npmjs.com/package/lodash.trim
https://www.npmjs.com/package/lodash.trimend

I checked code and looks like there is no fix for this CVE for these packages:
e.g.:
`lodash.trimend` still uses `string.replace(reTrimEnd, '')`(with `/\s+$/` value) -  https://github.com/lodash/lodash/blob/aaa111912cb05e6f0f9f23d1eb8a41ccfcf9c2c2/lodash.trimend/index.js#L356 (fix of this - https://github.com/lodash/lodash/pull/5065/files#diff-36b7ba0ba252cc39fa5921d9484b7674c8bc7af119636ba7f46194ee871047b6R15046).

I could be wrong. Can you take a look and correct me/update this advisory.

Thank you in advance! 
Best Regards, Dmitriy