### PR TITLE
[GHSA-f7jc-p66f-75xp] Buffer overflow in PJSUA API when calling pjsua_call_dump...

### DIFF
--- a/advisories/unreviewed/2022/02/GHSA-f7jc-p66f-75xp/GHSA-f7jc-p66f-75xp.json
+++ b/advisories/unreviewed/2022/02/GHSA-f7jc-p66f-75xp/GHSA-f7jc-p66f-75xp.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f7jc-p66f-75xp",
-  "modified": "2022-03-29T00:01:49Z",
+  "modified": "2023-08-30T03:30:13Z",
   "published": "2022-02-17T00:00:26Z",
   "aliases": [
     "CVE-2021-43303"
   ],
-  "details": "Buffer overflow in PJSUA API when calling pjsua_call_dump. An attacker-controlled 'buffer' argument may cause a buffer overflow, since supplying an output buffer smaller than 128 characters may overflow the output buffer, regardless of the 'maxlen' argument supplied",
+  "summary": "Buffer overflow in PJSUA API when calling pjsua_call_dump",
+  "details": "An attacker-controlled 'buffer' argument may cause a buffer overflow, since supplying an output buffer smaller than 128 characters may overflow the output buffer, regardless of the 'maxlen' argument supplied.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "GitHub Actions",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">= 2.12"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.11.1"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Summary

**Comments**
Propose to update the title because it is empty. Also update the affected versions and patched versions so they match to https://github.com/pjsip/pjproject/security/advisories/GHSA-qcvw-h34v-c7r9