### PR TITLE
[GHSA-wgh7-54f2-x98r] HTTP/2 HPACK integer overflow and buffer allocation

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-wgh7-54f2-x98r/GHSA-wgh7-54f2-x98r.json
+++ b/advisories/github-reviewed/2023/10/GHSA-wgh7-54f2-x98r/GHSA-wgh7-54f2-x98r.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wgh7-54f2-x98r",
-  "modified": "2023-10-10T21:16:23Z",
+  "modified": "2023-10-10T21:16:26Z",
   "published": "2023-10-10T21:16:23Z",
   "aliases": [
     "CVE-2023-36478"
   ],
-  "summary": "HTTP/2 HPACK integer overflow and buffer allocation",
+  "summary": "HTTP/2 HPACK and HTTP/3 QPACK integer overflow and buffer allocation",
   "details": "An integer overflow in `MetaDataBuilder.checkSize` allows for HTTP/2 HPACK header values to\nexceed their size limit. \n\nIn `MetaDataBuilder.java`, the following code determines if a header name or value\nexceeds the size limit, and throws an exception if the limit is exceeded:\n\n```java\n291 public void checkSize(int length, boolean huffman) throws SessionException\n292 {\n293 // Apply a huffman fudge factor\n294 if (huffman)\n295 length = (length * 4) / 3;\n296 if ((_size + length) > _maxSize)\n297 throw new HpackException.SessionException(\"Header too large %d > %d\",\n_size + length, _maxSize);\n298 }\n```\n\nHowever, when length is very large and huffman is true, the multiplication by 4 in line 295\nwill overflow, and length will become negative. (_size+length) will now be negative, and\nthe check on line 296 will not be triggered.\n\nFurthermore, `MetaDataBuilder.checkSize` allows for user-entered HPACK header value sizes to be\nnegative, potentially leading to a very large buffer allocation later on when the\nuser-entered size is multiplied by 2.\n\nIn `MetaDataBuilder.java`, the following code determines if a header name or value\nexceeds the size limit, and throws an exception if the limit is exceeded:\n\n```java\npublic void checkSize(int length, boolean huffman) throws SessionException\n{\n// Apply a huffman fudge factor\nif (huffman)\nlength = (length * 4) / 3;\nif ((_size + length) > _maxSize)\nthrow new HpackException.SessionException(\"Header too large %d > %d\", _size\n+ length, _maxSize);\n}\n```\n\nHowever, no exception is thrown in the case of a negative size.\nLater, in `Huffman.decode`, the user-entered length is multiplied by 2 before allocating a buffer:\n\n```java\npublic static String decode(ByteBuffer buffer, int length) throws\nHpackException.CompressionException\n{\nUtf8StringBuilder utf8 = new Utf8StringBuilder(length * 2);\n// ...\n```\n\nThis means that if a user provides a negative length value (or, more precisely, a length\nvalue which, when multiplied by the 4/3 fudge factor, is negative), and this length value is a\nvery large positive number when multiplied by 2, then the user can cause a very large\nbuffer to be allocated on the server.\n\n\n### Exploit Scenario 1\nAn attacker repeatedly sends HTTP messages with the HPACK header 0x00ffffffffff02.\nEach time this header is decoded:\n+ `HpackDecode.decode` will determine that a Huffman-coded value of length\n805306494 needs to be decoded.\n+ `MetaDataBuilder.checkSize` will approve this length.\n+ Huffman.decode will allocate a 1.6 GB string array.\n+ Huffman.decode will have a buffer overflow error, and the array will be deallocated\nthe next time garbage collection happens. (Note: this can be delayed by appending\nvalid huffman-coded characters to the end of the header.)\n\nDepending on the timing of garbage collection, the number of threads, and the amount of\nmemory available on the server, this may cause the server to run out of memory.\n\n\n### Exploit Scenario 2\nAn attacker repeatedly sends HTTP messages with the HPACK header 0x00ff8080ffff0b. Each\ntime this header is decoded:\n + HpackDecode.decode will determine that a Huffman-coded value of length\n-1073758081 needs to be decoded\n +  MetaDataBuilder.checkSize will approve this length\n + The number will be multiplied by 2 to get 2147451134, and Huffman.decode will\nallocate a 2.1 GB string array\n + Huffman.decode will have a buffer overflow error, and the array will be deallocated\nthe next time garbage collection happens (Note that this deallocation can be\ndelayed by adding valid Huffman-coded characters to the end of the header)\n\nDepending on the timing of garbage collection, the number of threads, and the amount of\nmemory available on the server, this may cause the server to run out of memory.\n\n### Impact\nUsers of HTTP/2 can be impacted by a remote denial of service attack.\n\n### Patches\nFixed in Jetty 10.0.16 and Jetty 11.0.16\nFixed in Jetty 9.4.53\nJetty 12.x is unaffected.\n\n### Workarounds\nNo workarounds possible, only patched versions of Jetty.\n\n### References\n* https://github.com/eclipse/jetty.project/pull/9634",
   "severity": [
     {
@@ -20,11 +20,6 @@
         "ecosystem": "Maven",
         "name": "org.eclipse.jetty.http2:http2-hpack"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -46,65 +41,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.eclipse.jetty.http2:http2-hpack"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "11.0.0"
-            },
-            {
-              "fixed": "11.0.16"
-            }
-          ]
-        }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 11.0.15"
-      }
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.jetty:jetty-http"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "10.0.0"
-            },
-            {
-              "fixed": "10.0.16"
-            }
-          ]
-        }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 10.0.15"
-      }
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.jetty:jetty-http"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -128,11 +64,6 @@
         "ecosystem": "Maven",
         "name": "org.eclipse.jetty.http3:http3-qpack"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -155,11 +86,6 @@
         "ecosystem": "Maven",
         "name": "org.eclipse.jetty.http3:http3-qpack"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -181,38 +107,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.eclipse.jetty.http2:http2-hpack"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "9.3.0"
-            },
-            {
-              "fixed": "9.4.53"
-            }
-          ]
-        }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 9.4.52"
-      }
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.jetty:jetty-http"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Fixing title to include references to HTTP/3 and QPACK too.
Also removing `jetty-http` from impacted packages list, as those are where the fixes went, but have no release where those packages are vulnerable.