### PR TITLE
[GHSA-qppj-fm5r-hxr3] swift-nio-http2 vulnerable to HTTP/2 Stream Cancellation Attack

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-qppj-fm5r-hxr3/GHSA-qppj-fm5r-hxr3.json
+++ b/advisories/github-reviewed/2023/10/GHSA-qppj-fm5r-hxr3/GHSA-qppj-fm5r-hxr3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qppj-fm5r-hxr3",
-  "modified": "2023-10-10T21:28:24Z",
+  "modified": "2023-10-16T21:44:16Z",
   "published": "2023-10-10T21:28:24Z",
   "aliases": [
     "CVE-2023-44487"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
     }
   ],
   "affected": [
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "purl-type:swift",
         "name": "https://github.com/apple/swift-nio-http2"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -509,7 +504,7 @@
     "cwe_ids": [
       "CWE-400"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2023-10-10T21:28:24Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
This advisory is co-opting the public CVE-2023-44487 found referenced everywhere on github now.
Those references should point to something like https://nvd.nist.gov/vuln/detail/CVE-2023-44487, not this Advisory.

Also, the CVSS score for the public CVE https://nvd.nist.gov/vuln/detail/CVE-2023-44487 is 7.5 High - CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H  (not the low number on this advisory)

To make the rest of the github sane, please remove the CVE id from this advisory, or make this advisory have it's own unique CVE id.