### PR TITLE
[GHSA-75qf-wgfj-v652] github.com/u-root/u-root/pkg/tarutil Arbitrary File Write via Archive Extraction (Zip Slip)

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-75qf-wgfj-v652/GHSA-75qf-wgfj-v652.json
+++ b/advisories/github-reviewed/2021/05/GHSA-75qf-wgfj-v652/GHSA-75qf-wgfj-v652.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-75qf-wgfj-v652",
-  "modified": "2023-09-14T19:21:08Z",
+  "modified": "2023-10-02T12:22:35Z",
   "published": "2021-05-18T18:28:03Z",
   "aliases": [
     "CVE-2020-7669"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Go",
         "name": "github.com/u-root/u-root"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Versions seem off and should be 0.7.0
This vuln was fixed in 0.9.0
https://github.com/u-root/u-root/issues/2449