### PR TITLE
[GHSA-rmqp-9w4c-gc7w] Apache Axis 1.x (EOL) may allow RCE when untrusted input is passed to getService

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-rmqp-9w4c-gc7w/GHSA-rmqp-9w4c-gc7w.json
+++ b/advisories/github-reviewed/2023/09/GHSA-rmqp-9w4c-gc7w/GHSA-rmqp-9w4c-gc7w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rmqp-9w4c-gc7w",
-  "modified": "2023-10-18T22:22:36Z",
+  "modified": "2023-10-18T22:22:37Z",
   "published": "2023-09-05T15:30:25Z",
   "aliases": [
     "CVE-2023-40743"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.apache.axis:axis"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Hi there.
We have this artifact being used https://mvnrepository.com/artifact/org.apache.axis/com.springsource.org.apache.axis/1.4.0, Are you able to confirm if it is also affected by the vulnerability? Thank you in advance.