### PR TITLE
[GHSA-cr45-98w9-gwqx] Empty `severity[].score`

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-cr45-98w9-gwqx/GHSA-cr45-98w9-gwqx.json
+++ b/advisories/github-reviewed/2023/10/GHSA-cr45-98w9-gwqx/GHSA-cr45-98w9-gwqx.json
@@ -1,19 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cr45-98w9-gwqx",
-  "modified": "2023-10-19T19:32:39Z",
+  "modified": "2023-10-20T15:01:52Z",
   "published": "2023-10-19T16:13:50Z",
   "aliases": [
     "CVE-2023-45815"
   ],
   "summary": "Viewing wget extractor output while logged in as an admin allows archived JS to execute in the admins context",
   "details": "### Impact\n\nAny users who are using the `wget` extractor and view the content it outputs. \n\nThe impact is potentially severe if you are logged in to the ArchiveBox admin site in the same browser session and view an archived malicious page designed to target your ArchiveBox instance. Malicious JS could potentially act using your logged-in admin credentials and add/remove/modify snapshots, add/remove/modify ArchiveBox users, and generally do anything an admin user could do. \n\nThe impact is less severe for non-logged-in users, as malicious JS cannot *modify* any archives, but it can still *read* all the other archived content by fetching the snapshot index and iterating through it.\n\nBecause all of ArchiveBox's archived content is served from the same host and port as the admin panel, when archived pages are viewed the JS executes in the same context as all the other archived pages (and the admin panel), defeating most of the browser's usual CORS/CSRF security protections and leading to this issue.\n\n### Patches\n\nFollow here for progress on mitigating this issue: https://github.com/ArchiveBox/ArchiveBox/issues/239\n\n### Workarounds\n\nDisable the wget extractor by setting [`archivebox config --set SAVE_WGET=False`](https://github.com/ArchiveBox/ArchiveBox/wiki/Configuration#save_wget), ensure you are always logged out, or serve only a [static HTML version](https://github.com/ArchiveBox/ArchiveBox/wiki/Publishing-Your-Archive#2-export-and-host-it-as-static-html) of your archive.\n\n### References\n\n- https://en.wikipedia.org/wiki/Cross-site_request_forgery\n- https://github.com/ArchiveBox/ArchiveBox#caveats\n- https://github.com/ArchiveBox/ArchiveBox/wiki/Security-Overview\n- https://github.com/ArchiveBox/ArchiveBox/wiki/Publishing-Your-Archive#security-concerns",
-  "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": ""
-    }
-  ],
   "affected": [
     {
       "package": {


### PR DESCRIPTION
Removed invalid severity (empty string)