### PR TITLE
[GHSA-qppj-fm5r-hxr3] swift-nio-http2 vulnerable to HTTP/2 Stream Cancellation Attack

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-qppj-fm5r-hxr3/GHSA-qppj-fm5r-hxr3.json
+++ b/advisories/github-reviewed/2023/10/GHSA-qppj-fm5r-hxr3/GHSA-qppj-fm5r-hxr3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qppj-fm5r-hxr3",
-  "modified": "2023-10-10T21:28:24Z",
+  "modified": "2023-10-16T21:44:16Z",
   "published": "2023-10-10T21:28:24Z",
   "aliases": [
     "CVE-2023-44487"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "purl-type:swift",
         "name": "https://github.com/apple/swift-nio-http2"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {
@@ -53,6 +48,63 @@
             },
             {
               "fixed": "0.17.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "google.golang.org/grpc"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.58.0"
+            },
+            {
+              "fixed": "1.58.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "google.golang.org/grpc"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.57.0"
+            },
+            {
+              "fixed": "1.57.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "google.golang.org/grpc"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.56.3"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Grpc-go is also affected: https://github.com/grpc/grpc-go/pull/6703.
Release notes at https://github.com/grpc/grpc-go/releases for a reference to the patched versions.