### PR TITLE
[GHSA-mrr8-v49w-3333] sweetalert2 v11.6.14 and above contains potentially undesirable behavior

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-mrr8-v49w-3333/GHSA-mrr8-v49w-3333.json
+++ b/advisories/github-reviewed/2023/07/GHSA-mrr8-v49w-3333/GHSA-mrr8-v49w-3333.json
@@ -1,15 +1,18 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mrr8-v49w-3333",
-  "modified": "2023-07-10T19:08:10Z",
+  "modified": "2023-07-10T19:08:11Z",
   "published": "2023-07-10T19:08:10Z",
   "aliases": [
 
   ],
   "summary": "sweetalert2 v11.6.14 and above contains potentially undesirable behavior",
-  "details": "`sweetalert2` versions 11.6.14 and above have potentially undesirable behavior. The package outputs audio and/or video messages that do not pertain to the functionality of the package when run on specific tlds. This functionality is documented on the project's readme",
+  "details": "Versions `11.6.14` and above of the sweetalert2 library contain a critical vulnerability that manifests in targeted disruption of user experience. Contrary to the intended functionality of this UI library, the package automatically plays loud political music and blocks user interaction on websites when certain conditions related to top-level domains (TLDs) and language settings are met.\n\nThis behavior is not only inconsistent with the library's documented purpose but also represents a form of client-side Denial of Service (DoS) and unauthorized media playback. The code essentially renders affected websites unusable by disabling DOM root `pointer-events` and forcibly plays audio without user consent. The issue is particularly severe as it discriminatively targets users based on their geographical location and language settings, affecting a large number of domains.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:H"
+    }
   ],
   "affected": [
     {
@@ -35,6 +38,10 @@
       "url": "https://github.com/sweetalert2/sweetalert2#important-notice-about-usage-of-this-software-for-ru-su-by-and-%D1%80%D1%84-domain-zones"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/sweetalert2/sweetalert2/blob/f157867a16611944316da4eb8e8f6bf0d766d881/src/SweetAlert.js#L261"
+    },
+    {
       "type": "WEB",
       "url": "https://github.com/sweetalert2/sweetalert2/releases/tag/v11.4.9"
     },
@@ -45,9 +52,11 @@
   ],
   "database_specific": {
     "cwe_ids": [
+      "CWE-1021",
+      "CWE-400",
       "CWE-440"
     ],
-    "severity": "LOW",
+    "severity": "CRITICAL",
     "github_reviewed": true,
     "github_reviewed_at": "2023-07-10T19:08:10Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- References
- Severity
- Source code location

**Comments**
Reason for Change

I propose to reclassify the severity level of this vulnerability from 'Low' to 'Critical'. This vulnerability disrupts user interface by blocking DOM root pointer-events, rendering the website unusable. It also forcibly plays loud political music without user consent, targeting a specific group of users based on their language settings and geographic locations.

Impact Scope

The vulnerability specifically affects websites with domain extensions: .ru, .su, .by, .рф. Over 6 million websites could be adversely impacted by this issue.

User Harassment and Unauthorized Audio Playback

This code disrupts the user experience and constitutes harassment by forcibly playing political music. This can be considered a form of hate speech or political propaganda, and also violates user consent policies regarding automatic media playback.

Denial of Service (DoS)

By blocking DOM root pointer-events, the code essentially performs a client-side Denial of Service (DoS), making websites unusable. This aligns with vulnerability classification CWE-400 (Uncontrolled Resource Consumption).

Unauthorized UI Manipulation

The unauthorized playing of political music without user consent can be classified under CWE-1021 (Improper Restriction of Rendered UI Layers or Frames).

Community Trust and Legal Implications

Trust in open-source libraries is paramount. This vulnerability not only violates that trust but also poses potential legal risks due to its discriminatory and harassing nature.

Recommended Actions

I strongly recommend that users be cautioned against using this library until the vulnerability is patched, and that this issue be escalated for immediate remediation.