### PR TITLE
[GHSA-m88m-crr9-jvqq] OpenRefine vulnerable to zip slip in project import

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-m88m-crr9-jvqq/GHSA-m88m-crr9-jvqq.json
+++ b/advisories/github-reviewed/2023/07/GHSA-m88m-crr9-jvqq/GHSA-m88m-crr9-jvqq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m88m-crr9-jvqq",
-  "modified": "2023-07-18T18:47:27Z",
+  "modified": "2023-07-18T18:47:30Z",
   "published": "2023-07-18T18:47:27Z",
   "aliases": [
     "CVE-2023-37476"
@@ -55,6 +55,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/OpenRefine/OpenRefine/releases/tag/3.7.4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.sonarsource.com/blog/openrefine-zip-slip/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Added reference to blog post, which details the vulnerability.