### PR TITLE
[GHSA-frqg-7g38-6gcf] Improper escaping of command arguments on Windows leading to command injection

### DIFF
--- a/advisories/github-reviewed/2021/10/GHSA-frqg-7g38-6gcf/GHSA-frqg-7g38-6gcf.json
+++ b/advisories/github-reviewed/2021/10/GHSA-frqg-7g38-6gcf/GHSA-frqg-7g38-6gcf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-frqg-7g38-6gcf",
-  "modified": "2021-10-11T18:39:06Z",
+  "modified": "2023-02-01T05:06:27Z",
   "published": "2021-10-05T20:23:18Z",
   "aliases": [
     "CVE-2021-41116"
@@ -70,6 +70,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/composer/composer"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.sonarsource.com/blog/securing-developer-tools-package-managers/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
A blog post was released with details about the vulnerability: https://www.sonarsource.com/blog/securing-developer-tools-package-managers/

**Please also sync this change to the CVE entry.**