### PR TITLE
[GHSA-fj7f-vq84-fh43] Local Code Execution through Argument Injection via dash leading git url parameter in Gemfile.

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-fj7f-vq84-fh43/GHSA-fj7f-vq84-fh43.json
+++ b/advisories/github-reviewed/2021/12/GHSA-fj7f-vq84-fh43/GHSA-fj7f-vq84-fh43.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fj7f-vq84-fh43",
-  "modified": "2021-12-14T15:31:09Z",
+  "modified": "2023-05-04T19:32:53Z",
   "published": "2021-12-08T19:51:36Z",
   "aliases": [
     "CVE-2021-43809"
@@ -63,6 +63,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/bundler/CVE-2021-43809.yml"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.sonarsource.com/blog/securing-developer-tools-package-managers/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References

**Comments**
A blog post was released with details about the vulnerability: https://www.sonarsource.com/blog/securing-developer-tools-package-managers/

**Please also sync this change to the CVE entry.**