### PR TITLE
[GHSA-m5q5-8mfw-p2hr] CasaOS contains weak JWT secrets

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-m5q5-8mfw-p2hr/GHSA-m5q5-8mfw-p2hr.json
+++ b/advisories/github-reviewed/2023/07/GHSA-m5q5-8mfw-p2hr/GHSA-m5q5-8mfw-p2hr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m5q5-8mfw-p2hr",
-  "modified": "2023-07-17T14:40:16Z",
+  "modified": "2023-07-19T19:23:48Z",
   "published": "2023-07-17T14:40:16Z",
   "aliases": [
     "CVE-2023-37266"
@@ -51,6 +51,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/IceWhaleTech/CasaOS"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.sonarsource.com/blog/security-vulnerabilities-in-casaos/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Updates references with a public technical advisory.