### PR TITLE
[GHSA-vjh7-5r6x-xh6g] CasaOS Gateway vulnerable to incorrect identification of source IP addresses

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-vjh7-5r6x-xh6g/GHSA-vjh7-5r6x-xh6g.json
+++ b/advisories/github-reviewed/2023/07/GHSA-vjh7-5r6x-xh6g/GHSA-vjh7-5r6x-xh6g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vjh7-5r6x-xh6g",
-  "modified": "2023-07-17T14:36:09Z",
+  "modified": "2023-07-19T19:23:17Z",
   "published": "2023-07-17T14:36:09Z",
   "aliases": [
     "CVE-2023-37265"
@@ -51,6 +51,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/IceWhaleTech/CasaOS-Gateway"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.sonarsource.com/blog/security-vulnerabilities-in-casaos/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Update references with a public technical advisory.