### PR TITLE
[GHSA-57m8-f3v5-hm5m] Netty-handler does not validate host names by default

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-57m8-f3v5-hm5m/GHSA-57m8-f3v5-hm5m.json
+++ b/advisories/github-reviewed/2023/10/GHSA-57m8-f3v5-hm5m/GHSA-57m8-f3v5-hm5m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-57m8-f3v5-hm5m",
-  "modified": "2023-10-04T20:27:04Z",
+  "modified": "2023-10-10T21:32:44Z",
   "published": "2023-10-04T12:30:14Z",
   "aliases": [
     "CVE-2023-4586"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "Maven",
         "name": "io.netty:netty-handler"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          ""
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This security advisory should be removed all together as it's a "false-positive". Netty's `SslHandler` can be used with any protocol and so the user is responsible to configure it the right way. This is the same as when the user just use `SSLEngine` which is part of the JDK. 