### PR TITLE
[GHSA-rv63-gqm8-9w8q] Loop with Unreachable Exit Condition in Netty

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-rv63-gqm8-9w8q/GHSA-rv63-gqm8-9w8q.json
+++ b/advisories/github-reviewed/2022/05/GHSA-rv63-gqm8-9w8q/GHSA-rv63-gqm8-9w8q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rv63-gqm8-9w8q",
-  "modified": "2022-07-06T19:54:08Z",
+  "modified": "2023-01-27T05:02:18Z",
   "published": "2022-05-13T01:11:43Z",
   "aliases": [
     "CVE-2016-4970"
@@ -18,29 +18,29 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "io.netty:netty-all"
+        "name": "io.netty:netty-handler"
       },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.0.0"
+              "introduced": "4.0.0.Alpha1"
             },
             {
-              "fixed": "4.0.37"
+              "fixed": "4.0.37.Final"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 4.0.36"
+        "last_known_affected_version_range": "<= 4.0.36.Final"
       }
     },
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "io.netty:netty-all"
+        "name": "io.netty:netty-handler"
       },
       "ranges": [
         {
@@ -50,7 +50,7 @@
               "introduced": "4.1.0.Beta1"
             },
             {
-              "fixed": "4.1.1"
+              "fixed": "4.1.1.Final"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Wrong fixed version (missing Final release) and wrong artifact (the vulnerability is only on netty-handler artifact, as can be inferred from path of the affected files)