### PR TITLE
[GHSA-5mwm-wccq-xqcp] The e-mail module of Python 0 - 2.7.18, 3.x - 3.11...

### DIFF
--- a/advisories/unreviewed/2023/04/GHSA-5mwm-wccq-xqcp/GHSA-5mwm-wccq-xqcp.json
+++ b/advisories/unreviewed/2023/04/GHSA-5mwm-wccq-xqcp/GHSA-5mwm-wccq-xqcp.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5mwm-wccq-xqcp",
-  "modified": "2023-04-27T21:30:25Z",
+  "modified": "2023-06-10T05:01:21Z",
   "published": "2023-04-19T00:30:16Z",
   "aliases": [
     "CVE-2023-27043"
   ],
-  "details": "The e-mail module of Python 0 - 2.7.18, 3.x - 3.11 incorrectly parses e-mail addresses which contain a special character. This vulnerability allows attackers to send messages from e-ail addresses that would otherwise be rejected.",
+  "summary": "Python stdlib email address parsing",
+  "details": "The e-mail module of Python 0 - 2.7.18, 3.0 - 3.12 incorrectly parses e-mail addresses which contain a special character. This vulnerability allows attackers to send messages from e-mail addresses that would otherwise be rejected.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,7 +15,22 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -31,22 +47,18 @@
     },
     {
       "type": "WEB",
+      "url": "https://python.org"
+    },
+    {
+      "type": "WEB",
       "url": "https://security.netapp.com/advisory/ntap-20230601-0003/"
-    },
-    {
-      "type": "WEB",
-      "url": "http://python.com"
-    },
-    {
-      "type": "WEB",
-      "url": "http://python.org"
     }
   ],
   "database_specific": {
     "cwe_ids": [
       "CWE-20"
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Severity
- Summary

**Comments**
Correct/improve versions.  Correct spelling (e-ail).  Remove bogus link (python.com has nothing to do with the language).  Update correct link (to https).