### PR TITLE
Update GHSA-c59h-r6p8-q9wc.json

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-c59h-r6p8-q9wc/GHSA-c59h-r6p8-q9wc.json
+++ b/advisories/github-reviewed/2023/10/GHSA-c59h-r6p8-q9wc/GHSA-c59h-r6p8-q9wc.json
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.9.9"
             },
             {
               "fixed": "13.4.20-canary.13"


### PR DESCRIPTION
Fix issue where security vulnerability is incorrectly applied to the v0.4 version of `next` which is a totally different product than one started at v0.9.9. 

Issue is that security is reported for packages that still depend on `next@0.4`, which doesn't make sense. It was already discussed here, see https://github.com/github/advisory-database/pull/179 for context

_Note: I wasn't able to introduce this change via suggest form as it exposes just "Affected versions" field, which logically would have to be  `>=0.9.9  <13.4.20-canary.13`  and that's not accepted_