### PR TITLE
[GHSA-jq66-xh47-j9f3] Type confusion if __private_get_type_id__ is overriden

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-jq66-xh47-j9f3/GHSA-jq66-xh47-j9f3.json
+++ b/advisories/github-reviewed/2022/06/GHSA-jq66-xh47-j9f3/GHSA-jq66-xh47-j9f3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jq66-xh47-j9f3",
-  "modified": "2023-08-25T00:12:18Z",
+  "modified": "2023-08-25T00:12:19Z",
   "published": "2022-06-16T23:06:58Z",
   "aliases": [
     "CVE-2020-25575"
@@ -18,31 +18,7 @@
     {
       "package": {
         "ecosystem": "crates.io",
-        "name": "streebog"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "0.8.0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "crates.io",
         "name": "failure"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "failure::Fail::__private_get_type_id__"
-        ]
       },
       "ranges": [
         {
@@ -79,10 +55,6 @@
     {
       "type": "WEB",
       "url": "https://github.com/RustSec/advisory-db/blob/main/crates/failure/RUSTSEC-2019-0036.md"
-    },
-    {
-      "type": "WEB",
-      "url": "https://rustsec.org/advisories/RUSTSEC-2019-0030.html"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
This doesn't seem related to the streebog package.

CC: https://github.com/rustsec/advisory-db/pull/1815