### PR TITLE
[GHSA-xpw8-rcwv-8f8p] io.netty:netty-codec-http2 vulnerable to HTTP/2 Rapid Reset Attack

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-xpw8-rcwv-8f8p/GHSA-xpw8-rcwv-8f8p.json
+++ b/advisories/github-reviewed/2023/10/GHSA-xpw8-rcwv-8f8p/GHSA-xpw8-rcwv-8f8p.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
     }
   ],
   "affected": [
@@ -47,13 +47,17 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/netty/netty"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2023-44487"
     }
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-400"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2023-10-10T22:22:54Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- References
- Severity

**Comments**
The severity score is 7.5 because Availability is High
Source: https://nvd.nist.gov/vuln/detail/CVE-2023-44487

I also don't see this CVE is linked in CVE ID and I can't add it myself. 