### PR TITLE
[GHSA-m3v5-gjj9-rg24] Craft CMS vulnerable to HTML injection

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-m3v5-gjj9-rg24/GHSA-m3v5-gjj9-rg24.json
+++ b/advisories/github-reviewed/2023/06/GHSA-m3v5-gjj9-rg24/GHSA-m3v5-gjj9-rg24.json
@@ -25,14 +25,17 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.0.0"
             },
             {
-              "last_affected": "4.4.9"
+              "fixed": "4.4.15"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.4.9"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
https://github.com/craftcms/cms/releases/tag/4.4.15

Version 3 is not affected, but reported as such.