### PR TITLE
[GHSA-c9rf-qf73-r46f] A heap buffer overflow vulnerability in Wibu CodeMeter...

### DIFF
--- a/advisories/unreviewed/2023/09/GHSA-c9rf-qf73-r46f/GHSA-c9rf-qf73-r46f.json
+++ b/advisories/unreviewed/2023/09/GHSA-c9rf-qf73-r46f/GHSA-c9rf-qf73-r46f.json
@@ -1,20 +1,42 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c9rf-qf73-r46f",
-  "modified": "2023-09-13T15:31:14Z",
+  "modified": "2023-09-19T09:30:15Z",
   "published": "2023-09-13T15:31:14Z",
   "aliases": [
     "CVE-2023-3935"
   ],
-  "details": "A heap buffer overflow vulnerability in Wibu CodeMeter Runtime network service up to version 7.60b allows an unauthenticated, remote attacker to achieve RCE and gain full access of the host system.",
+  "summary": "Heap Buffer Overflow Vulnerability in CodeMeter Runtime",
+  "details": "A heap buffer overflow vulnerability in Wibu CodeMeter Runtime network service up to version 7.60b allows an unauthenticated, remote attacker to achieve RCE and gain full access of the host system. The issue was fixed in version >=7.60c and in version 7.21g.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "GitHub Actions",
+        "name": "CodeMeterRuntime"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": ">=7.60c and 7.21g"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 7.60c"
+      }
+    }
   ],
   "references": [
     {
@@ -23,7 +45,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://cdn.wibu.com/fileadmin/wibu_downloads/security_advisories/AdvisoryWIBU-230704-01-v3.0.pdf"
+      "url": "https://cdn.wibu.com/fileadmin/wibu_downloads/security_advisories/AdvisoryWIBU-230704-01.pdf"
     },
     {
       "type": "WEB",
@@ -36,9 +58,10 @@
   ],
   "database_specific": {
     "cwe_ids": [
+      "CWE-122",
       "CWE-787"
     ],
-    "severity": null,
+    "severity": "CRITICAL",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- References
- Severity
- Summary

**Comments**
Evidence: the current security advisory contains all modifications and additions I suggested: https://cdn.wibu.com/fileadmin/wibu_downloads/security_advisories/AdvisoryWIBU-230704-01.pdf