### PR TITLE
[GHSA-qppj-fm5r-hxr3] swift-nio-http2 vulnerable to HTTP/2 Stream Cancellation Attack

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-qppj-fm5r-hxr3/GHSA-qppj-fm5r-hxr3.json
+++ b/advisories/github-reviewed/2023/10/GHSA-qppj-fm5r-hxr3/GHSA-qppj-fm5r-hxr3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qppj-fm5r-hxr3",
-  "modified": "2023-10-10T21:28:24Z",
+  "modified": "2023-11-06T16:24:56Z",
   "published": "2023-10-10T21:28:24Z",
   "aliases": [
     "CVE-2023-44487"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
     }
   ],
   "affected": [
@@ -105,6 +105,25 @@
             },
             {
               "fixed": "1.56.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.netty:netty-codec-http2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.1.100.Final"
             }
           ]
         }
@@ -681,7 +700,7 @@
     "cwe_ids": [
       "CWE-400"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2023-10-10T21:28:24Z",
     "nvd_published_at": "2023-10-10T14:15:10Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
Add netty package since [GHSA-xpw8-rcwv-8f8p](https://github.com/advisories/GHSA-xpw8-rcwv-8f8p) can not link to CVE-2023-44487
[NVD](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) shows availability high, making this CVE a score of 7.5