### PR TITLE
[GHSA-w9cp-3x79-2p8p] transmute-core unsafe YAML deserialization vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-w9cp-3x79-2p8p/GHSA-w9cp-3x79-2p8p.json
+++ b/advisories/github-reviewed/2023/11/GHSA-w9cp-3x79-2p8p/GHSA-w9cp-3x79-2p8p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w9cp-3x79-2p8p",
-  "modified": "2023-11-02T21:01:55Z",
+  "modified": "2023-11-02T21:01:56Z",
   "published": "2023-11-02T06:30:25Z",
   "aliases": [
     "CVE-2023-47204"
@@ -9,7 +9,10 @@
   "summary": "transmute-core unsafe YAML deserialization vulnerability",
   "details": "Unsafe YAML deserialization in yaml.Loader in transmute-core before 1.13.5 allows attackers to execute arbitrary Python code.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+    }
   ],
   "affected": [
     {
@@ -60,9 +63,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-502"
     ],
-    "severity": "MODERATE",
+    "severity": "CRITICAL",
     "github_reviewed": true,
     "github_reviewed_at": "2023-11-02T21:01:55Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity

**Comments**
I am the author of the CVE, this vulnerability was discovered during a penetration test, where this API framework was used by a client. If this framework is also used for authentication (login endpoint), or if there is an endpoint accesible without authentication, this results in pre-auth RCE. 