### PR TITLE
[GHSA-mxq6-vrrr-ppmg] tree-kill vulnerable to remote code execution

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-mxq6-vrrr-ppmg/GHSA-mxq6-vrrr-ppmg.json
+++ b/advisories/github-reviewed/2022/05/GHSA-mxq6-vrrr-ppmg/GHSA-mxq6-vrrr-ppmg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mxq6-vrrr-ppmg",
-  "modified": "2023-10-19T18:39:48Z",
+  "modified": "2023-10-19T18:39:49Z",
   "published": "2022-05-24T17:04:00Z",
   "aliases": [
     "CVE-2019-15599"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.2.1"
+              "fixed": "1.2.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.2.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Please review the referenced commit with tag 1.2.2 addressing the command injection flaw in tree-kill by implementing pid sanitization. Although a formal GitHub release has not been created post-commit, it directly targets the vulnerability described in CVE-2019-15599, which involves a code injection vulnerability on Windows.

Reference:
https://github.com/pkrumins/node-tree-kill/commit/deee138a8cbc918463d8af5ce8c2bec33c3fd164
https://github.com/pkrumins/node-tree-kill/releases/tag/v1.2.2