### PR TITLE
[GHSA-cpmr-mw4j-99r7] Nginx alias path traversal allows unauthenticated attackers to read all files on /label_studio/core/

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-cpmr-mw4j-99r7/GHSA-cpmr-mw4j-99r7.json
+++ b/advisories/github-reviewed/2023/03/GHSA-cpmr-mw4j-99r7/GHSA-cpmr-mw4j-99r7.json
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.7.1"
+              "fixed": "1.7.2" 
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.7.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**

* Fixed version

**Comments** 
We are issuing an update to the previously published GHSA-cpmr-mw4j-99r7. In our initial advisory, the specific version in which the vulnerability was addressed was not mentioned. This was an oversight due to our unfamiliarity with the public advisory process, as it was our first time issuing such an announcement.

The vulnerability was originally resolved in version `1.7.2`. This fix was implemented in `heartexlabs/label-studio` and can be traced to [commit](https://github.com/HumanSignal/label-studio/commit/60a3ef57a22c50d7230a56c11d85e14454c99a28). The patch was derived from a private advisory fork before being merged into the main project.

I apologize for any inconvenience and are taking steps to ensure that future advisories are more comprehensive. Thank you for your understanding.

