### PR TITLE
[GHSA-67hx-6x53-jw92] Babel vulnerable to arbitrary code execution when compiling specifically crafted malicious code

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-67hx-6x53-jw92/GHSA-67hx-6x53-jw92.json
+++ b/advisories/github-reviewed/2023/10/GHSA-67hx-6x53-jw92/GHSA-67hx-6x53-jw92.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-67hx-6x53-jw92",
-  "modified": "2023-10-16T13:55:36Z",
+  "modified": "2023-10-24T18:32:24Z",
   "published": "2023-10-16T13:55:36Z",
   "aliases": [
     "CVE-2023-45133"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -101,7 +101,7 @@
       "CWE-184",
       "CWE-697"
     ],
-    "severity": "CRITICAL",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2023-10-16T13:55:36Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
Using Babel to compile code that was specifically crafted by an attacker can lead to arbitrary code execution during compilation, when using plugins that rely on the path.evaluate()or path.evaluateTruthy() internal Babel methods.

Known affected plugins are:

@babel/plugin-transform-runtime
@babel/preset-env when using its useBuiltIns option
Any "polyfill provider" plugin that depends on @babel/helper-define-polyfill-provider, such as babel-plugin-polyfill-corejs3, babel-plugin-polyfill-corejs2, babel-plugin-polyfill-es-shims, babel-plugin-polyfill-regenerator
No other plugins under the @babel/ namespace are impacted, but third-party plugins might be.

Users that only compile trusted code are not impacted.

Patches
The vulnerability has been fixed in @babel/traverse@7.23.2.

Babel 6 does not receive security fixes anymore (see Babel's security policy), hence there is no patch planned for babel-traverse@6.

Workarounds
Upgrade @babel/traverse to v7.23.2 or higher. You can do this by deleting it from your package manager's lockfile and re-installing the dependencies. @babel/core >=7.23.2 will automatically pull in a non-vulnerable version.
If you cannot upgrade @babel/traverse and are using one of the affected packages mentioned above, upgrade them to their latest version to avoid triggering the vulnerable code path in affected @babel/traverse versions:
@babel/plugin-transform-runtime v7.23.2
@babel/preset-env v7.23.2
@babel/helper-define-polyfill-provider v0.4.3
babel-plugin-polyfill-corejs2 v0.4.6
babel-plugin-polyfill-corejs3 v0.8.5
babel-plugin-polyfill-es-shims v0.10.0
babel-plugin-polyfill-regenerator v0.5.3