### PR TITLE
[GHSA-r3rr-wph6-9638] Password stored in plain text by Jenkins Publish Over SSH Plugin

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-r3rr-wph6-9638/GHSA-r3rr-wph6-9638.json
+++ b/advisories/github-reviewed/2022/01/GHSA-r3rr-wph6-9638/GHSA-r3rr-wph6-9638.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r3rr-wph6-9638",
-  "modified": "2022-11-29T21:26:23Z",
+  "modified": "2023-02-01T05:07:16Z",
   "published": "2022-01-13T00:00:53Z",
   "aliases": [
     "CVE-2022-23114"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23114"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/publish-over-ssh-plugin/commit/2b4b9b2dfab5c001669f9a74c0e6078b0a27b928"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/publish-over-ssh-plugin/commit/70b7689bf6fc894f4dc6c0ff34dd72808840760e"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch commit links for v1.23: https://github.com/jenkinsci/publish-over-ssh-plugin/commit/70b7689bf6fc894f4dc6c0ff34dd72808840760e
https://github.com/jenkinsci/publish-over-ssh-plugin/commit/2b4b9b2dfab5c001669f9a74c0e6078b0a27b928

The commit messages have explicitly shown their aim for fixing this CVE: "[SECURITY-2291] Unprotected Storage of Credentials".