### PR TITLE
[GHSA-wf5p-g6vw-rhxx] Axios Cross-Site Request Forgery Vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-wf5p-g6vw-rhxx/GHSA-wf5p-g6vw-rhxx.json
+++ b/advisories/github-reviewed/2023/11/GHSA-wf5p-g6vw-rhxx/GHSA-wf5p-g6vw-rhxx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wf5p-g6vw-rhxx",
-  "modified": "2023-11-10T00:35:37Z",
+  "modified": "2023-11-10T00:35:38Z",
   "published": "2023-11-08T21:30:37Z",
   "aliases": [
     "CVE-2023-45857"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Hi, I do not know how to propose changes to this alert, so forgive me if I took the wrong route.

From info at https://github.com/axios/axios/releases/tag/v1.6.1 it looks like form data is broken in 1.6.0, and was fixed in 1.6.1 just after this security advisory was issued. I think it would be better that Dependabot pushes 1.6.1 as the update version, instead of 1.6.0 to lower the risk of regressions.