### PR TITLE
[GHSA-vc4f-2g7f-pmqr] A Cross-Site Scripting (XSS) vulnerability in the comment...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-vc4f-2g7f-pmqr/GHSA-vc4f-2g7f-pmqr.json
+++ b/advisories/unreviewed/2022/05/GHSA-vc4f-2g7f-pmqr/GHSA-vc4f-2g7f-pmqr.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vc4f-2g7f-pmqr",
-  "modified": "2022-05-24T17:24:15Z",
+  "modified": "2023-01-29T05:03:36Z",
   "published": "2022-05-24T17:24:15Z",
   "aliases": [
     "CVE-2020-15885"
   ],
+  "summary": "XSS Filter Bypass On Comments",
   "details": "A Cross-Site Scripting (XSS) vulnerability in the comment module before 4.0 for MunkiReport allows remote attackers to inject arbitrary web script or HTML by posting a new comment.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "MunkiReport"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.6.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 5.6.2"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-15885"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/munkireport/managedinstalls/commit/708f6a2abc4b80a3751bcc9cf896f80d84250c55"
     },
     {
       "type": "WEB",
@@ -37,9 +66,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2020-07-23T14:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- References
- Severity
- Summary

**Comments**
Primarily add the patch link for v4.1: https://github.com/munkireport/managedinstalls/commit/708f6a2abc4b80a3751bcc9cf896f80d84250c55.

The changes made in the commit directly address the core issue highlighted in CVE-2020-15885. By enhancing the HTML filtering process, the commit mitigates the risk of malicious scripts being injected through comments, which is the primary concern in the CVE. This approach is a standard remediation technique for XSS vulnerabilities, focusing on better sanitization of user-provided data.

Other info update according to the info from NVD and the disclose of the repo owner: https://github.com/munkireport/munkireport-php/wiki/20200722--XSS-Filter-Bypass-On-Comments#vulnerable-versions-of-munkireport-from-253-to-562-are-vulnerable, especially for the version affected.