### PR TITLE
[GHSA-79xr-v794-wq35] A Cross-Site Scripting (XSS) vulnerability in the...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-79xr-v794-wq35/GHSA-79xr-v794-wq35.json
+++ b/advisories/unreviewed/2022/05/GHSA-79xr-v794-wq35/GHSA-79xr-v794-wq35.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-79xr-v794-wq35",
-  "modified": "2022-05-24T17:24:15Z",
+  "modified": "2023-01-29T05:03:24Z",
   "published": "2022-05-24T17:24:15Z",
   "aliases": [
     "CVE-2020-15883"
   ],
+  "summary": "Reflected XSS In Managedinstalls Module",
   "details": "A Cross-Site Scripting (XSS) vulnerability in the managedinstalls module before 2.6 for MunkiReport allows remote attackers to inject arbitrary web script or HTML via the last two URL parameters (through which installed packages names and versions are reported).",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "managedinstalls"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.6 6.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.6"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-15883"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/munkireport/managedinstalls/commit/708f6a2abc4b80a3751bcc9cf896f80d84250c55"
     },
     {
       "type": "WEB",
@@ -37,7 +66,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-79"
     ],
     "severity": "MODERATE",
     "github_reviewed": false,


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- References
- Summary

**Comments**
Primarily add the patch link for v6.0: https://github.com/munkireport/managedinstalls/commit/708f6a2abc4b80a3751bcc9cf896f80d84250c55.

The commit message explicitly showed the purpose: "Fix xss in controller".

Other info update according to the info from NVD and the refrence report: https://github.com/munkireport/munkireport-php/wiki/20200722-Reflected-XSS-In-Managedinstalls-Module.