### PR TITLE
[GHSA-p9wv-phc4-8hqf] The WordPress Popular Posts WordPress plugin is...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-p9wv-phc4-8hqf/GHSA-p9wv-phc4-8hqf.json
+++ b/advisories/unreviewed/2022/05/GHSA-p9wv-phc4-8hqf/GHSA-p9wv-phc4-8hqf.json
@@ -1,22 +1,51 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p9wv-phc4-8hqf",
-  "modified": "2022-05-24T19:20:40Z",
+  "modified": "2023-01-30T05:03:54Z",
   "published": "2022-05-24T19:20:40Z",
   "aliases": [
     "CVE-2021-42362"
   ],
+  "summary": "Insufficient input file type validation",
   "details": "The WordPress Popular Posts WordPress plugin is vulnerable to arbitrary file uploads due to insufficient input file type validation found in the ~/src/Image.php file which makes it possible for attackers with contributor level access and above to upload malicious files that can be used to obtain remote code execution, in versions up to and including 5.3.2.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "WordPress-Popular-Posts"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.3.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 5.3.2"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-42362"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cabrerahector/wordpress-popular-posts/commit/d9b274cf6812eb446e4103cb18f69897ec6fe601"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- References
- Summary

**Comments**
Add the patch commit for v6.3.4: https://github.com/cabrerahector/wordpress-popular-posts/commit/d9b274cf6812eb446e4103cb18f69897ec6fe601

The commit msg also mentioned it aims to input file type validation: "Image: verifies that URLs are images", the code diff shows the same file that CVE desc mentioned as well.