### PR TITLE
[GHSA-q84x-3476-8ff2] Apache James MIME4J vulnerable to information disclosure to local users

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-q84x-3476-8ff2/GHSA-q84x-3476-8ff2.json
+++ b/advisories/github-reviewed/2023/01/GHSA-q84x-3476-8ff2/GHSA-q84x-3476-8ff2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q84x-3476-8ff2",
-  "modified": "2023-01-12T16:49:59Z",
+  "modified": "2023-01-28T05:03:47Z",
   "published": "2023-01-06T12:31:34Z",
   "aliases": [
     "CVE-2022-45787"
@@ -33,12 +33,35 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.james:apache-mime4j-storage"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.8.9"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-45787"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/james-mime4j/commit/021eb79ba312fe5a7f99fa867ee5350aa5533069"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The issue in question also affects the -storage component.

If you look at the patch
https://github.com/apache/james-mime4j/commit/021eb79ba312fe5a7f99fa867ee5350aa5533069

The patch is in the storage componet. The storage component is included in the apache-mime4j, keeping them both in affected makes sense