### PR TITLE
[GHSA-pvc3-wvxr-7cmf] It was found that the smallrye health metrics UI...

### DIFF
--- a/advisories/unreviewed/2022/08/GHSA-pvc3-wvxr-7cmf/GHSA-pvc3-wvxr-7cmf.json
+++ b/advisories/unreviewed/2022/08/GHSA-pvc3-wvxr-7cmf/GHSA-pvc3-wvxr-7cmf.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pvc3-wvxr-7cmf",
-  "modified": "2022-09-03T00:00:24Z",
+  "modified": "2023-01-31T05:02:38Z",
   "published": "2022-08-26T00:03:29Z",
   "aliases": [
     "CVE-2021-3914"
   ],
+  "summary": "SmallRye Health: UI cross site scripting",
   "details": "It was found that the smallrye health metrics UI component did not properly sanitize some user inputs. An attacker could use this flaw to conduct cross-site scripting attacks.",
   "severity": [
     {
@@ -14,7 +15,44 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.smallrye.smallrye-health-ui"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.2.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.smallrye.smallrye-health-ui"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.3.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,11 +61,23 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/smallrye/smallrye-health/pull/333"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/smallrye/smallrye-health/commit/01b25a038824887363cd413d8cd14052f5fc3541"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/security/cve/CVE-2021-3914"
     },
     {
       "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2018015"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/smallrye/smallrye-health"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
There's not a ton of data on this one. I'm mostly working from the patch I tracked down and added to the references

We can see the fixed versions, looks like 3.2.1 and 3.3.1 picked this up

➜  smallrye-health git:(main) git branch --contains 01b25a038824887363cd413d8cd14052f5fc3541 | cat
  dependabot/maven/io.smallrye.config-smallrye-config-3.4.4
  jakarta
* main
  release-3.2.1
  release-3.3.1
  release-4.0.0
  release-4.0.0-RC1
  release-4.0.0-RC2
  release-4.0.1
  release-4.0.2
  release-4.0.3
  release-4.0.4