### PR TITLE
[GHSA-w33c-445m-f8w7] Okio Signed to Unsigned Conversion Error vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-w33c-445m-f8w7/GHSA-w33c-445m-f8w7.json
+++ b/advisories/github-reviewed/2023/07/GHSA-w33c-445m-f8w7/GHSA-w33c-445m-f8w7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w33c-445m-f8w7",
-  "modified": "2023-07-13T17:01:48Z",
+  "modified": "2023-11-05T05:03:00Z",
   "published": "2023-07-12T21:30:50Z",
   "aliases": [
     "CVE-2023-3635"
@@ -25,10 +25,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0.0"
             },
             {
               "fixed": "3.4.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.squareup.okio:okio"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.17.6"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to the okio change log, the vulnerability also has been fixed in version 1.17.6, see https://github.com/square/okio/blob/master/CHANGELOG.md#version-1176