### PR TITLE
[GHSA-7g45-4rm6-3mm3] Guava vulnerable to insecure use of temporary directory

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-7g45-4rm6-3mm3/GHSA-7g45-4rm6-3mm3.json
+++ b/advisories/github-reviewed/2023/06/GHSA-7g45-4rm6-3mm3/GHSA-7g45-4rm6-3mm3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7g45-4rm6-3mm3",
-  "modified": "2023-06-14T21:01:07Z",
+  "modified": "2023-11-09T18:41:54Z",
   "published": "2023-06-14T18:30:38Z",
   "aliases": [
     "CVE-2023-2976"
@@ -29,6 +29,25 @@
             },
             {
               "fixed": "32.0.0-android"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.google.guava:guava"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.0"
+            },
+            {
+              "fixed": "32.0.0-jre"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The issue seems not to be restricted to the `-android` variant of guava.