### PR TITLE
[GHSA-gx6w-fqg7-mc3p] An issue was discovered jackson-databind thru 2.15.2...

### DIFF
--- a/advisories/unreviewed/2023/06/GHSA-gx6w-fqg7-mc3p/GHSA-gx6w-fqg7-mc3p.json
+++ b/advisories/unreviewed/2023/06/GHSA-gx6w-fqg7-mc3p/GHSA-gx6w-fqg7-mc3p.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gx6w-fqg7-mc3p",
-  "modified": "2023-06-26T18:30:26Z",
+  "modified": "2023-11-05T05:03:06Z",
   "published": "2023-06-14T15:30:39Z",
   "aliases": [
     "CVE-2023-35116"
   ],
+  "summary": "Possible stack overflow when user code serialized recursive data structures ",
   "details": "An issue was discovered jackson-databind thru 2.15.2 allows attackers to cause a denial of service or other unspecified impacts via crafted object that uses cyclic dependencies.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.fasterxml.java.core:jackson-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.16.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -24,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/FasterXML/jackson-databind/issues/3972"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-core/pull/1055"
     }
   ],
   "database_specific": {
@@ -31,7 +54,7 @@
       "CWE-502",
       "CWE-770"
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-06-14T14:15:10Z"


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Severity
- Summary

**Comments**
Fix is in jackson-core 2.16.0 release out today. Stack overflow is protected against. We still contend that this issue is not CVE worthy. You can only get it by writing your own bad code.