### PR TITLE
[GHSA-54xq-cgqr-rpm3] sharp vulnerability in libwebp dependency CVE-2023-4863

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-54xq-cgqr-rpm3/GHSA-54xq-cgqr-rpm3.json
+++ b/advisories/github-reviewed/2023/11/GHSA-54xq-cgqr-rpm3/GHSA-54xq-cgqr-rpm3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-54xq-cgqr-rpm3",
-  "modified": "2023-11-16T17:14:15Z",
+  "modified": "2023-11-16T17:14:17Z",
   "published": "2023-11-16T17:14:15Z",
   "aliases": [
 


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
improve 