### PR TITLE
[GHSA-hrfw-7pg5-g3x6] The Admin Columns Free WordPress plugin before 4.3 and...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-hrfw-7pg5-g3x6/GHSA-hrfw-7pg5-g3x6.json
+++ b/advisories/unreviewed/2022/05/GHSA-hrfw-7pg5-g3x6/GHSA-hrfw-7pg5-g3x6.json
@@ -1,22 +1,67 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hrfw-7pg5-g3x6",
-  "modified": "2022-05-24T19:05:48Z",
+  "modified": "2023-01-29T05:08:04Z",
   "published": "2022-05-24T19:05:48Z",
   "aliases": [
     "CVE-2021-24366"
   ],
+  "summary": "Stored Cross-Site Scripting attacks can be performed.",
   "details": "The Admin Columns Free WordPress plugin before 4.3 and Admin Columns Pro WordPress plugin before 5.5.1, rendered input on the posted pages with improper input validation on the value passed into the field 'Label' parameter, by taking this as an advantage an authenticated attacker can supply a crafted arbitrary script and execute it.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "Admin-Columns"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "Admin-Columns-Pro"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.5.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-24366"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/codepress/admin-columns/commit/b45571ed21d574d13687213a5002e0c68e4442c7"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- References
- Summary

**Comments**
Add the patch commit link for v4.3-v4.6.9: https://github.com/codepress/admin-columns/commit/b45571ed21d574d13687213a5002e0c68e4442c7

Mend Vulnerability Database also mentioned it at https://www.mend.io/vulnerability-database/CVE-2021-24366. 
Meanwhile, this patch link has been confirmed by CNA (WPScan) and updated on CVE and NVD official website.