### PR TITLE
[GHSA-hxwp-5hw8-g4xg] Vulnerability in OpenGrok (component: Web App). Versions...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-hxwp-5hw8-g4xg/GHSA-hxwp-5hw8-g4xg.json
+++ b/advisories/unreviewed/2022/05/GHSA-hxwp-5hw8-g4xg/GHSA-hxwp-5hw8-g4xg.json
@@ -1,22 +1,63 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hxwp-5hw8-g4xg",
-  "modified": "2022-05-24T19:06:04Z",
+  "modified": "2023-01-29T05:07:06Z",
   "published": "2022-05-24T19:06:04Z",
   "aliases": [
     "CVE-2021-2322"
   ],
+  "summary": "Allow low privileged attacker with network access via HTTPS to compromise OpenGrok.",
   "details": "Vulnerability in OpenGrok (component: Web App). Versions that are affected are 1.6.7 and prior. Easily exploitable vulnerability allows low privileged attacker with network access via HTTPS to compromise OpenGrok. Successful attacks of this vulnerability can result in takeover of OpenGrok. CVSS 3.1 Base Score 8.8 (Confidentiality, Integrity and Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H).",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "opengrok"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.6.8"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.6.7"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-2322"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/oracle/opengrok/pull/3528"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/oracle/opengrok/pull/3528/commits/601c283179d97542df011f92509fdc204a90b04b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/oracle/opengrok/pull/3528/commits/e0f6c20ca12f4a1f5a80095a4cb7fa7b85d1602c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/oracle/opengrok/pull/3528/commits/ff2b8efab6a844933bd963f4121997afd4009545"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- References
- Summary

**Comments**
Add three patch commit links: https://github.com/oracle/opengrok/pull/3528/commits/ff2b8efab6a844933bd963f4121997afd4009545
https://github.com/oracle/opengrok/pull/3528/commits/e0f6c20ca12f4a1f5a80095a4cb7fa7b85d1602c
https://github.com/oracle/opengrok/pull/3528/commits/601c283179d97542df011f92509fdc204a90b04b
And the corresponding pr: https://github.com/oracle/opengrok/pull/3528

The rationale is that RedHat has mentioned it in the reference link: https://www.oracle.com/security-alerts/oracle-open-source-cves-outside-other-oracle-public-documents.html.