### PR TITLE
[GHSA-hm9r-7f84-25c9] Apache Airflow allows authenticated and DAG-view authorized users to modify some DAG run detail values when submitting notes

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-hm9r-7f84-25c9/GHSA-hm9r-7f84-25c9.json
+++ b/advisories/github-reviewed/2023/11/GHSA-hm9r-7f84-25c9/GHSA-hm9r-7f84-25c9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hm9r-7f84-25c9",
-  "modified": "2023-11-13T20:43:20Z",
+  "modified": "2023-11-13T20:43:21Z",
   "published": "2023-11-12T15:30:20Z",
   "aliases": [
     "CVE-2023-47037"
@@ -40,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/pull/33413"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/b7a46c970d638028a4a7643ad000dcee951fb9ef"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
added fix commit .