### PR TITLE
[GHSA-83w4-x5w9-hf4h] XXL-JOB vulnerable to Server-Side Request Forgery (SSRF)

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-83w4-x5w9-hf4h/GHSA-83w4-x5w9-hf4h.json
+++ b/advisories/github-reviewed/2022/11/GHSA-83w4-x5w9-hf4h/GHSA-83w4-x5w9-hf4h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-83w4-x5w9-hf4h",
-  "modified": "2022-11-21T22:33:41Z",
+  "modified": "2023-02-01T05:04:04Z",
   "published": "2022-11-17T21:30:49Z",
   "aliases": [
     "CVE-2022-43183"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/xuxueli/xxl-job/issues/3002"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/xuxueli/xxl-job/commit/9293c61ca0a8d54afdfb27cc568885ae639a14dc"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add the patch commit for v2.4.0: https://github.com/xuxueli/xxl-job/commit/9293c61ca0a8d54afdfb27cc568885ae639a14dc

The commit message has explicitly claimed it: `"CVE-2022-43183" SSRF漏洞修复。`