### PR TITLE
[GHSA-7qq9-9g2w-56f9] Improper Privilege Management in com.xuxueli:xxl-job

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-7qq9-9g2w-56f9/GHSA-7qq9-9g2w-56f9.json
+++ b/advisories/github-reviewed/2022/08/GHSA-7qq9-9g2w-56f9/GHSA-7qq9-9g2w-56f9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7qq9-9g2w-56f9",
-  "modified": "2022-08-30T20:42:16Z",
+  "modified": "2023-01-28T05:01:25Z",
   "published": "2022-08-20T00:00:30Z",
   "aliases": [
     "CVE-2022-36157"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.3.1"
+              "fixed": "2.4.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.3.1"
+      }
     }
   ],
   "references": [
@@ -43,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/Richard-Muzi/vulnerability/issues/1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/xuxueli/xxl-job/commit/730c1066b80e8ab44503ed34ced19ef8e0471fec"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add the patch commit link for v2.4.0: https://github.com/xuxueli/xxl-job/commit/730c1066b80e8ab44503ed34ced19ef8e0471fec

The commit message has claimed it:""CVE-2022-36157"授权漏洞修复。"
