### PR TITLE
[GHSA-rwhx-6hx7-pqc8] SQL injection in jeecgboot

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-rwhx-6hx7-pqc8/GHSA-rwhx-6hx7-pqc8.json
+++ b/advisories/github-reviewed/2023/09/GHSA-rwhx-6hx7-pqc8/GHSA-rwhx-6hx7-pqc8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rwhx-6hx7-pqc8",
-  "modified": "2023-09-25T17:21:03Z",
+  "modified": "2023-11-07T05:05:16Z",
   "published": "2023-09-22T21:30:23Z",
   "aliases": [
     "CVE-2023-40989"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.5.3"
+              "fixed": "3.6.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.5.3"
+      }
     }
   ],
   "references": [
@@ -42,7 +45,27 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/jeecgboot/jeecg-boot/commit/44952c79c244a998e3904e44cea47baab0ee681b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jeecgboot/jeecg-boot/commit/473875a9d261780a3400cf6f8260ca441b768ed1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jeecgboot/jeecg-boot/commit/56e81fbf7bce11d2762b691f5d965b2265be608e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jeecgboot/jeecg-boot/commit/87677df925e55e51233bf740433b30a751fc7705"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/Zone1-Z/CVE-2023-40989/blob/main/CVE-2023-40989"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jeecgboot/jeecg-boot"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add the patch commit links for v3.6.0:  https://github.com/jeecgboot/jeecg-boot/commit/44952c79c244a998e3904e44cea47baab0ee681b, 
https://github.com/jeecgboot/jeecg-boot/commit/56e81fbf7bce11d2762b691f5d965b2265be608e
https://github.com/jeecgboot/jeecg-boot/commit/87677df925e55e51233bf740433b30a751fc7705.

And
https://github.com/jeecgboot/jeecg-boot/commit/473875a9d261780a3400cf6f8260ca441b768ed1 aims to deeply fix the bug induced by the bug fix for this CVE: "深度解决SQL注入漏洞问题(修复导致的bug修复)".

These commit messages have claimed their purpose: "解决严重SQL漏洞", which means solving the SQL injection in Chinese.
