### PR TITLE
[GHSA-4qq5-mxxx-m6gg] MLflow authentication requirement bypass can allow a user to arbitrarily create an account

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-4qq5-mxxx-m6gg/GHSA-4qq5-mxxx-m6gg.json
+++ b/advisories/github-reviewed/2023/11/GHSA-4qq5-mxxx-m6gg/GHSA-4qq5-mxxx-m6gg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4qq5-mxxx-m6gg",
-  "modified": "2023-11-17T22:49:27Z",
+  "modified": "2023-11-17T22:49:28Z",
   "published": "2023-11-16T21:30:46Z",
   "aliases": [
     "CVE-2023-6014"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6014"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mlflow/mlflow/issues/9669"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add the patch links at: https://github.com/mlflow/mlflow/pull/9700/commits/9b3032a98c8f6a34ea515cde87f0d9d21bc5ccd3, and https://github.com/mlflow/mlflow/pull/9700/commits/52dd2b375ec75fbb0facc10b3a1ab25e693743c0.
The fix PR containing these two patches is: https://github.com/mlflow/mlflow/pull/9700. They all mentioned that they changed the vulnable lines to "only admin create users".

The issue can prove it is at: https://github.com/mlflow/mlflow/issues/9669, which also matches the info in the original bug report: https://huntr.com/bounties/3e64df69-ddc2-463e-9809-d07c24dc1de4.