### PR TITLE
[GHSA-c5hg-mr8r-f6jp] Hazelcast connection caching

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-c5hg-mr8r-f6jp/GHSA-c5hg-mr8r-f6jp.json
+++ b/advisories/github-reviewed/2022/12/GHSA-c5hg-mr8r-f6jp/GHSA-c5hg-mr8r-f6jp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c5hg-mr8r-f6jp",
-  "modified": "2023-03-20T15:45:32Z",
+  "modified": "2023-03-20T15:45:34Z",
   "published": "2022-12-27T14:40:39Z",
   "aliases": [
     "CVE-2022-36437"
@@ -50,11 +50,14 @@
               "introduced": "4.0"
             },
             {
-              "last_affected": "4.0.6"
+              "fixed": "4.0.7"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.0.6"
+      }
     },
     {
       "package": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
I'll suggest to add a fix version here for the range >= 4.0, <= 4.0.6 and the package com.hazelcast:hazelcast since we know the vulnerability has a patch version and without a fix version but only a "last affected" it would be misleading towards the version of the package greater than 4.0.6 but lesser than the upper range. Thanks!