### PR TITLE
[GHSA-c59h-r6p8-q9wc] Next.js missing cache-control header may lead to CDN caching empty reply

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-c59h-r6p8-q9wc/GHSA-c59h-r6p8-q9wc.json
+++ b/advisories/github-reviewed/2023/10/GHSA-c59h-r6p8-q9wc/GHSA-c59h-r6p8-q9wc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c59h-r6p8-q9wc",
-  "modified": "2023-10-24T19:18:58Z",
+  "modified": "2023-11-09T05:04:04Z",
   "published": "2023-10-22T03:30:23Z",
   "aliases": [
     "CVE-2023-46298"
@@ -9,7 +9,10 @@
   "summary": "Next.js missing cache-control header may lead to CDN caching empty reply",
   "details": "Next.js before 13.4.20-canary.13 lacks a cache-control header and thus empty prefetch responses may sometimes be cached by a CDN, causing a denial of service to all users requesting the same URL via that CDN. Cloudflare considers these requests cacheable assets.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
   ],
   "affected": [
     {
@@ -62,7 +65,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2023-10-24T19:18:58Z",
     "nvd_published_at": "2023-10-22T03:15:07Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
The severity is currently set to Low but the base CVSS 3.1 base score is 7.5 High. -> https://nvd.nist.gov/vuln/detail/CVE-2023-46298