### PR TITLE
[GHSA-p4jj-gwpg-9jwh] ConcreteCMS Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-p4jj-gwpg-9jwh/GHSA-p4jj-gwpg-9jwh.json
+++ b/advisories/github-reviewed/2023/10/GHSA-p4jj-gwpg-9jwh/GHSA-p4jj-gwpg-9jwh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p4jj-gwpg-9jwh",
-  "modified": "2023-10-06T23:36:20Z",
+  "modified": "2023-11-10T05:01:46Z",
   "published": "2023-10-06T15:30:19Z",
   "aliases": [
     "CVE-2023-44761"
@@ -28,17 +28,24 @@
               "introduced": "0"
             },
             {
-              "last_affected": "9.2.1"
+              "fixed": "9.2.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 9.2.1"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-44761"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/commit/4990e68e8a4be2ee66e2d2bfcbfca38712614f76"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch commit for v9.2.2: https://github.com/concretecms/concretecms/commit/4990e68e8a4be2ee66e2d2bfcbfca38712614f76,
which has been mentioned in v9.2.2 release note https://github.com/concretecms/concretecms/releases: "Fixed CVE-2023-44761 Admin can add XSS via Data Objects with this commit"