### PR TITLE
[GHSA-6xx7-r8x4-fpjp] ConcreteCMS Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-6xx7-r8x4-fpjp/GHSA-6xx7-r8x4-fpjp.json
+++ b/advisories/github-reviewed/2023/10/GHSA-6xx7-r8x4-fpjp/GHSA-6xx7-r8x4-fpjp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6xx7-r8x4-fpjp",
-  "modified": "2023-10-06T22:40:45Z",
+  "modified": "2023-11-10T05:01:52Z",
   "published": "2023-10-06T15:30:19Z",
   "aliases": [
     "CVE-2023-44765"
@@ -39,6 +39,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-44765"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/pull/11746"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/pull/11746/commits/0f0564232e0a49719d0bdff6223539b624f116ee"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/pull/11746/commits/92bcc208078571f4beda38cb0952f8e99887737a"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch commit for v9.2.2: 
https://github.com/concretecms/concretecms/pull/11746/commits/92bcc208078571f4beda38cb0952f8e99887737a
and 
https://github.com/concretecms/concretecms/pull/11746/commits/0f0564232e0a49719d0bdff6223539b624f116ee

The commits belong to this PR: https://github.com/concretecms/concretecms/pull/11746, which has been mentioned in v9.2.2 release note https://github.com/concretecms/concretecms/releases: "Fixed CVE-2023-44765 Stored XSS Associations (via data objects) with commit 11746"