### PR TITLE
[GHSA-xfmj-r86m-j2hr] Stored cross site scripting on API integration

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-xfmj-r86m-j2hr/GHSA-xfmj-r86m-j2hr.json
+++ b/advisories/github-reviewed/2023/04/GHSA-xfmj-r86m-j2hr/GHSA-xfmj-r86m-j2hr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xfmj-r86m-j2hr",
-  "modified": "2023-05-01T13:53:49Z",
+  "modified": "2023-11-07T05:05:46Z",
   "published": "2023-04-28T15:30:19Z",
   "aliases": [
     "CVE-2023-28477"
@@ -42,7 +42,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/commit/546cef6ec29208d5c079113635cd6e6b250e9f7c"
+    },
+    {
+      "type": "WEB",
       "url": "https://concretecms.com"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/concretecms/concretecms"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add patch commit for v8.5.13:
https://github.com/concretecms/concretecms/commit/546cef6ec29208d5c079113635cd6e6b250e9f7c, 

which has been mentioned in the release note https://github.com/concretecms/concretecms/releases/tag/8.5.13: "Fixed CVE-2023-28477 stored XSS on API Integrations via the name parameter in the 8.5 version".