### PR TITLE
[GHSA-vcpr-hm2m-gjjj] Reflected cross site scripting

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-vcpr-hm2m-gjjj/GHSA-vcpr-hm2m-gjjj.json
+++ b/advisories/github-reviewed/2023/04/GHSA-vcpr-hm2m-gjjj/GHSA-vcpr-hm2m-gjjj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vcpr-hm2m-gjjj",
-  "modified": "2023-05-05T20:34:28Z",
+  "modified": "2023-11-12T05:02:56Z",
   "published": "2023-04-28T15:30:18Z",
   "aliases": [
     "CVE-2023-28475"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28475"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/commit/861ba66d248165c9ee9d6d11a0457908b97d68f0"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch commit for v8.5.13:
https://github.com/concretecms/concretecms/commit/861ba66d248165c9ee9d6d11a0457908b97d68f0

which has been mentioned in the release note https://github.com/concretecms/concretecms/releases/tag/8.5.13: "Fixed CVE-2023-28475 Concrete was vulnerable to reflected XSS".

