### PR TITLE
[GHSA-f55r-8rcv-mqcf] Missing secure cookie parameters

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-f55r-8rcv-mqcf/GHSA-f55r-8rcv-mqcf.json
+++ b/advisories/github-reviewed/2023/04/GHSA-f55r-8rcv-mqcf/GHSA-f55r-8rcv-mqcf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f55r-8rcv-mqcf",
-  "modified": "2023-05-05T20:33:58Z",
+  "modified": "2023-11-12T05:02:56Z",
   "published": "2023-04-28T15:30:18Z",
   "aliases": [
     "CVE-2023-28472"
@@ -42,7 +42,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/pull/11749"
+    },
+    {
+      "type": "WEB",
       "url": "https://concretecms.com"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/releases/tag/8.5.13"
     },
     {
       "type": "WEB",
@@ -51,7 +59,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-614"
     ],
     "severity": "MODERATE",
     "github_reviewed": true,


### PR DESCRIPTION
**Updates**
- CWEs
- References

**Comments**
Add patch commit for v8.5.13:
https://github.com/concretecms/concretecms/pull/11749

which has been mentioned in the release note https://github.com/concretecms/concretecms/releases/tag/8.5.13: "Fixed CVE-2023-28472 in version 8.5 by updating the Survey Block Controller.".