### PR TITLE
[GHSA-pj76-75cm-3552] Authenication bypass

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-pj76-75cm-3552/GHSA-pj76-75cm-3552.json
+++ b/advisories/github-reviewed/2023/04/GHSA-pj76-75cm-3552/GHSA-pj76-75cm-3552.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pj76-75cm-3552",
-  "modified": "2023-05-05T20:34:09Z",
+  "modified": "2023-11-12T05:02:23Z",
   "published": "2023-04-28T15:30:18Z",
   "aliases": [
     "CVE-2023-28473"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "9.2.0"
+              "fixed": "8.5.13, 9.2.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 9.2.0"
+      }
     }
   ],
   "references": [
@@ -42,7 +45,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/pull/11749"
+    },
+    {
+      "type": "WEB",
       "url": "https://concretecms.com"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/concretecms/concretecms/releases/tag/8.5.13"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch commit for v8.5.13:
https://github.com/concretecms/concretecms/pull/11749,

which has been mentioned in the release note https://github.com/concretecms/concretecms/releases/tag/8.5.13: "Fixed CVE-2023-28473 possible Auth bypass in the jobs section in version 8.5.“