### PR TITLE
[GHSA-4g88-4hgm-m99x] NASA Open MCT Cross Site Request Forgery (CSRF) vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-4g88-4hgm-m99x/GHSA-4g88-4hgm-m99x.json
+++ b/advisories/github-reviewed/2023/11/GHSA-4g88-4hgm-m99x/GHSA-4g88-4hgm-m99x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4g88-4hgm-m99x",
-  "modified": "2023-11-15T17:28:47Z",
+  "modified": "2023-11-15T17:28:48Z",
   "published": "2023-11-09T18:34:55Z",
   "aliases": [
     "CVE-2023-45884"
@@ -28,17 +28,28 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.1.0"
+              "fixed": "3.1.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.1.0"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-45884"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nasa/openmct/pull/7148"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nasa/openmct/pull/7148/commits/4e95e12559c9c5364269ff366a59768573baacb4"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch commit for v3.1.1: https://github.com/nasa/openmct/pull/7148/commits/4e95e12559c9c5364269ff366a59768573baacb4
which belongs to this PR: https://github.com/nasa/openmct/pull/7148
And they were mentioned in the release notes for v3.1.1: https://github.com/nasa/openmct/releases/tag/v3.1.1: "cherry-pick(#7144): fix(#7143): add eslint-plugin-no-unsanitized and fix errors by @ozyx in #7148
Fixes CVE-2023-45884, CVE-2023-45885" .