### PR TITLE
[GHSA-v8fc-qxvj-f3mg] NASA Open MCT Cross Site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-v8fc-qxvj-f3mg/GHSA-v8fc-qxvj-f3mg.json
+++ b/advisories/github-reviewed/2023/11/GHSA-v8fc-qxvj-f3mg/GHSA-v8fc-qxvj-f3mg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v8fc-qxvj-f3mg",
-  "modified": "2023-11-16T20:16:26Z",
+  "modified": "2023-11-16T20:16:27Z",
   "published": "2023-11-09T18:34:55Z",
   "aliases": [
     "CVE-2023-45885"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-45885"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nasa/openmct/pull/7148"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nasa/openmct/pull/7148/commits/4e95e12559c9c5364269ff366a59768573baacb4"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch commit for v3.1.1: https://github.com/nasa/openmct/pull/7148/commits/4e95e12559c9c5364269ff366a59768573baacb4
which belongs to this PR: https://github.com/nasa/openmct/pull/7148
And they were mentioned in the release notes for v3.1.1: https://github.com/nasa/openmct/releases/tag/v3.1.1: "cherry-pick(#7144): fix(#7143): add eslint-plugin-no-unsanitized and fix errors by @ozyx in #7148
Fixes CVE-2023-45884, CVE-2023-45885" .