### PR TITLE
[GHSA-w496-f5qq-m58j] Mattermost vulnerable to excessive memory consumption

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-w496-f5qq-m58j/GHSA-w496-f5qq-m58j.json
+++ b/advisories/github-reviewed/2023/11/GHSA-w496-f5qq-m58j/GHSA-w496-f5qq-m58j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w496-f5qq-m58j",
-  "modified": "2023-11-08T15:00:48Z",
+  "modified": "2023-11-08T15:00:50Z",
   "published": "2023-11-06T18:30:19Z",
   "aliases": [
     "CVE-2023-5969"
@@ -99,6 +99,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-5969"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mattermost/mattermost/pull/24429"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mattermost/mattermost/commit/77f094c7ee8c7a00be01c2df72f948a62c690b66"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch commit for v9.0.1: https://github.com/mattermost/mattermost/commit/77f094c7ee8c7a00be01c2df72f948a62c690b66,
the pointed pr is: https://github.com/mattermost/mattermost/pull/24429

The message within the commit and pr mentioned this fix:
`MM-54219 - Fix: Improve limits on redirectLocationDataCache`.