### PR TITLE
[GHSA-r67m-mf7v-qp7j] Mattermost password hash disclosure vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-r67m-mf7v-qp7j/GHSA-r67m-mf7v-qp7j.json
+++ b/advisories/github-reviewed/2023/11/GHSA-r67m-mf7v-qp7j/GHSA-r67m-mf7v-qp7j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r67m-mf7v-qp7j",
-  "modified": "2023-11-14T18:40:44Z",
+  "modified": "2023-11-14T18:41:35Z",
   "published": "2023-11-06T18:30:19Z",
   "aliases": [
     "CVE-2023-5968"
@@ -99,6 +99,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-5968"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mattermost/mattermost/pull/24362"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mattermost/mattermost/pull/24566"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mattermost/mattermost/commit/698f4a97da564e2c1f2bf1fbd01755cefa3b7881"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add the patch commit for v9.0.1:https://github.com/mattermost/mattermost/commit/698f4a97da564e2c1f2bf1fbd01755cefa3b7881, 
pointing to these two prs: https://github.com/mattermost/mattermost/pull/24362 and https://github.com/mattermost/mattermost/pull/24566,
which mentioned the purpose: "Sanitize user in update user response (#24362) (#24566)".