### PR TITLE
[GHSA-5h3x-9wvq-w4m2] OpenZeppelin Contracts's governor proposal creation may be blocked by frontrunning

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-5h3x-9wvq-w4m2/GHSA-5h3x-9wvq-w4m2.json
+++ b/advisories/github-reviewed/2023/06/GHSA-5h3x-9wvq-w4m2/GHSA-5h3x-9wvq-w4m2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5h3x-9wvq-w4m2",
-  "modified": "2023-06-08T18:03:11Z",
+  "modified": "2023-11-05T05:03:53Z",
   "published": "2023-06-08T18:03:11Z",
   "aliases": [
     "CVE-2023-34234"
@@ -62,6 +62,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-34234"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/commit/66f390fa516b550838e2c2f65132b5bc2afe1ced"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch commit for **openzeppelin-contracts-upgradeable** v4.9.1:https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/commit/66f390fa516b550838e2c2f65132b5bc2afe1ced,
which is the fix for openzeppelin-contracts-upgradeable, the code changes are same with the existng patch (https://github.com/OpenZeppelin/openzeppelin-contracts/commit/d9474327a492f9f310f31bc53f38dbea56ed9a57) for openzeppelin-contracts.