### PR TITLE
[GHSA-97cp-mr4m-9mcf] n8n Privilege Escalation vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-97cp-mr4m-9mcf/GHSA-97cp-mr4m-9mcf.json
+++ b/advisories/github-reviewed/2023/05/GHSA-97cp-mr4m-9mcf/GHSA-97cp-mr4m-9mcf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-97cp-mr4m-9mcf",
-  "modified": "2023-05-17T21:33:20Z",
+  "modified": "2023-11-11T05:05:39Z",
   "published": "2023-05-10T15:30:22Z",
   "aliases": [
     "CVE-2023-27563"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27563"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/n8n-io/n8n/pull/5526"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/n8n-io/n8n/pull/5526/commits/1414bfa7906ea089b9dc55853405e774a5384ce2"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch commit for 0.216.1: https://github.com/n8n-io/n8n/pull/5526/commits/1414bfa7906ea089b9dc55853405e774a5384ce2
The corresponding pr is https://github.com/n8n-io/n8n/pull/5526
their msg mentioned that "fix(core): User update endpoint should only allow updating email, firstName, and lastName #5526", also mentioned in the release note for this version.