### PR TITLE
[GHSA-p58x-7733-vp9m] n8n Directory Traversal vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-p58x-7733-vp9m/GHSA-p58x-7733-vp9m.json
+++ b/advisories/github-reviewed/2023/05/GHSA-p58x-7733-vp9m/GHSA-p58x-7733-vp9m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p58x-7733-vp9m",
-  "modified": "2023-05-17T21:32:37Z",
+  "modified": "2023-11-11T05:05:35Z",
   "published": "2023-05-10T15:30:22Z",
   "aliases": [
     "CVE-2023-27562"
@@ -39,6 +39,22 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27562"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/n8n-io/n8n/pull/5522"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/n8n-io/n8n/pull/5523"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/n8n-io/n8n/commit/40b97846483fe7c58229c156acb66f43a5a79dc3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/n8n-io/n8n/commit/fb07d77106bb4933758c63bbfb87f591bf4a27dd"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch commit for v0.216.1: https://github.com/n8n-io/n8n/commit/40b97846483fe7c58229c156acb66f43a5a79dc3 and https://github.com/n8n-io/n8n/commit/fb07d77106bb4933758c63bbfb87f591bf4a27dd.

The prs are https://github.com/n8n-io/n8n/pull/5523 and https://github.com/n8n-io/n8n/pull/5522.

As release note for v0.216.1 https://github.com/n8n-io/n8n/releases/tag/n8n%400.216.1 mentioned: "core: Do not allow arbitrary path traversal in BinaryDataManager (#5523) (40b9784)
core: Do not allow arbitrary path traversal in the credential-translation endpoint (#5522) (fb07d77)".