### PR TITLE
[GHSA-r9xw-p7wj-w792] n8n Information Disclosure vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-r9xw-p7wj-w792/GHSA-r9xw-p7wj-w792.json
+++ b/advisories/github-reviewed/2023/05/GHSA-r9xw-p7wj-w792/GHSA-r9xw-p7wj-w792.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r9xw-p7wj-w792",
-  "modified": "2023-05-17T21:33:32Z",
+  "modified": "2023-11-11T05:05:39Z",
   "published": "2023-05-10T15:30:22Z",
   "aliases": [
     "CVE-2023-27564"
   ],
   "summary": "n8n Information Disclosure vulnerability",
-  "details": "The n8n package prior to 0.216.1 for Node.js allows Information Disclosure.",
+  "details": "The n8n package prior to 0.216.1 for Node.js allows Information Disclosure.\n\nAn authentication bypass, which can be associated to one of the\nprevious path traversals to create a pre-authenticated file read. On a server using SQLite, this\nwould allow downloading the database in order to:\n◦ Attempt to crack users passwords.\n◦ Generate a valid invitation link for an invited user.\n◦ Generate a valid link in order to reset password for an account.\n◦ Extract secrets by exploiting the vulnerability twice in order to extract the encryption key.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27564"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/n8n-io/n8n/pull/5525"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/n8n-io/n8n/commit/27adea70459329fc0dddabee69e10c9d1453835f"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Description
- References

**Comments**
Add the patch commit at: https://github.com/n8n-io/n8n/commit/27adea70459329fc0dddabee69e10c9d1453835f
the pr is: https://github.com/n8n-io/n8n/pull/5525.

the release note mentioned it: "core: Do not explicitly bypass auth on urls containing .svg (#5525) (27adea7)", is consistent with the content in the exising reference: https://www.synacktiv.com/sites/default/files/2023-05/Synacktiv-N8N-Multiple-Vulnerabilities_0.pdf--"An authentication bypass, which can be associated to one of the
previous path traversals to create a pre-authenticated file read." Meanwhile, the desc was also updated according to this existing refrence.