### PR TITLE
[GHSA-mx2q-35m2-x2rh] OpenZeppelin Contracts TransparentUpgradeableProxy clashing selector calls may not be delegated

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-mx2q-35m2-x2rh/GHSA-mx2q-35m2-x2rh.json
+++ b/advisories/github-reviewed/2023/04/GHSA-mx2q-35m2-x2rh/GHSA-mx2q-35m2-x2rh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mx2q-35m2-x2rh",
-  "modified": "2023-04-18T16:14:52Z",
+  "modified": "2023-11-11T05:02:01Z",
   "published": "2023-04-17T16:45:21Z",
   "aliases": [
     "CVE-2023-30541"
@@ -66,6 +66,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4154"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/commit/58fa0f81c4036f1a3b616fdffad2fd27e5d5ce21"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add anther patch commit, which is for @openzeppelin/contracts-upgradeable v4.8.3: https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/commit/58fa0f81c4036f1a3b616fdffad2fd27e5d5ce21.
The code change is same with the exising patch for @openzeppelin/contracts.