### PR TITLE
[GHSA-vvwv-h69m-wg6f] XXE in PHPSpreadsheet due to incomplete fix for previous encoding issue

### DIFF
--- a/advisories/github-reviewed/2019/11/GHSA-vvwv-h69m-wg6f/GHSA-vvwv-h69m-wg6f.json
+++ b/advisories/github-reviewed/2019/11/GHSA-vvwv-h69m-wg6f/GHSA-vvwv-h69m-wg6f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vvwv-h69m-wg6f",
-  "modified": "2023-09-11T13:38:04Z",
+  "modified": "2023-09-11T13:38:05Z",
   "published": "2019-11-20T01:39:57Z",
   "aliases": [
     "CVE-2019-12331"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-12331"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/PHPOffice/PhpSpreadsheet/pull/1041"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/PHPOffice/PhpSpreadsheet/commit/0e6238c69e863b58aeece61e48ea032696c6dccd"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add patch commit for v1.8.0: https://github.com/PHPOffice/PhpSpreadsheet/commit/0e6238c69e863b58aeece61e48ea032696c6dccd,
belonging to pr: https://github.com/PHPOffice/PhpSpreadsheet/pull/1041.
The commit message has claimed to fix this cve, and was also mentioned in the release note on version 1.8.0: "Security Fix (CVE-2019-12331)"