### PR TITLE
[GHSA-xcrg-29h7-h4cj] XXE in PHPSpreadsheet due to encoding issue

### DIFF
--- a/advisories/github-reviewed/2019/11/GHSA-xcrg-29h7-h4cj/GHSA-xcrg-29h7-h4cj.json
+++ b/advisories/github-reviewed/2019/11/GHSA-xcrg-29h7-h4cj/GHSA-xcrg-29h7-h4cj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xcrg-29h7-h4cj",
-  "modified": "2022-04-19T20:14:24Z",
+  "modified": "2023-02-01T05:02:43Z",
   "published": "2019-11-20T01:38:52Z",
   "aliases": [
     "CVE-2018-19277"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.5.0"
+              "fixed": "1.5.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.5.0"
+      }
     }
   ],
   "references": [
@@ -47,6 +50,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/PHPOffice/PhpSpreadsheet/issues/771"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/PHPOffice/PhpSpreadsheet/pull/780"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/PHPOffice/PhpSpreadsheet/commit/0f8f071e24ee8b114d894ac172f77dc250e5bfa4"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
patched verison is 1.5.1, was mentioned in the existing reference link: https://github.com/PHPOffice/PhpSpreadsheet/issues/771.
Also mentioned in the release note at v1.5.1: https://github.com/PHPOffice/PhpSpreadsheet/releases/tag/1.5.1.

Add the patch commit at https://github.com/PHPOffice/PhpSpreadsheet/commit/0f8f071e24ee8b114d894ac172f77dc250e5bfa4, the pr is: https://github.com/PHPOffice/PhpSpreadsheet/pull/780.