### PR TITLE
[GHSA-7r88-wjhj-jr8m] RaspAP Command Injection vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-7r88-wjhj-jr8m/GHSA-7r88-wjhj-jr8m.json
+++ b/advisories/github-reviewed/2023/08/GHSA-7r88-wjhj-jr8m/GHSA-7r88-wjhj-jr8m.json
@@ -28,7 +28,7 @@
               "introduced": "2.8.0"
             },
             {
-              "fixed": "2.8.8"
+              "fixed": "2.9.5"
             }
           ]
         }
@@ -45,11 +45,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/RaspAP/raspap-webgui/pull/1303"
+      "url": "https://github.com/RaspAP/raspap-webgui/pull/1395"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/RaspAP/raspap-webgui/pull/1303/commits/1fabc481690e008279113e18d0642c5279e3b56e"
+      "url": "https://github.com/RaspAP/raspap-webgui/commit/e87e7d1d3a61617430851f2a040379de1ff3dd9d"
     },
     {
       "type": "PACKAGE",

--- a/advisories/github-reviewed/2023/08/GHSA-7r88-wjhj-jr8m/GHSA-7r88-wjhj-jr8m.json
+++ b/advisories/github-reviewed/2023/08/GHSA-7r88-wjhj-jr8m/GHSA-7r88-wjhj-jr8m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7r88-wjhj-jr8m",
-  "modified": "2023-08-04T13:31:59Z",
+  "modified": "2023-11-06T05:01:10Z",
   "published": "2023-08-01T15:30:30Z",
   "aliases": [
     "CVE-2022-39987"
@@ -28,17 +28,28 @@
               "introduced": "2.8.0"
             },
             {
-              "last_affected": "2.9.2"
+              "fixed": "2.8.8"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.9.2"
+      }
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-39987"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/RaspAP/raspap-webgui/pull/1303"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/RaspAP/raspap-webgui/pull/1303/commits/1fabc481690e008279113e18d0642c5279e3b56e"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch commit for v2.8.8: https://github.com/RaspAP/raspap-webgui/pull/1303/commits/1fabc481690e008279113e18d0642c5279e3b56e,
belongs to pr: https://github.com/RaspAP/raspap-webgui/pull/1303

they are mentioned in release note v2.8.8: "Security: Sanitize post data w/ escapeshellcmd() by @billz in #1303 thanks @buglloc"