### PR TITLE
[GHSA-w33c-445m-f8w7] Okio Signed to Unsigned Conversion Error vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-w33c-445m-f8w7/GHSA-w33c-445m-f8w7.json
+++ b/advisories/github-reviewed/2023/07/GHSA-w33c-445m-f8w7/GHSA-w33c-445m-f8w7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w33c-445m-f8w7",
-  "modified": "2023-07-13T17:01:48Z",
+  "modified": "2023-11-16T15:23:03Z",
   "published": "2023-07-12T21:30:50Z",
   "aliases": [
     "CVE-2023-3635"
@@ -48,6 +48,25 @@
             },
             {
               "fixed": "1.17.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.squareup.okio:okio-jvm"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0-RC1"
+            },
+            {
+              "fixed": "3.4.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The `okio-jvm` is a packaging of okio specific for JVM (There is also a specific for multiplatform). The vulnerability concerns specifically the JVM so we need to alert people about `okio-jvm` as well.