### PR TITLE
[GHSA-7r88-wjhj-jr8m] RaspAP Command Injection vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-7r88-wjhj-jr8m/GHSA-7r88-wjhj-jr8m.json
+++ b/advisories/github-reviewed/2023/08/GHSA-7r88-wjhj-jr8m/GHSA-7r88-wjhj-jr8m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7r88-wjhj-jr8m",
-  "modified": "2023-08-04T13:31:59Z",
+  "modified": "2023-11-06T05:01:10Z",
   "published": "2023-08-01T15:30:30Z",
   "aliases": [
     "CVE-2022-39987"
@@ -28,11 +28,14 @@
               "introduced": "2.8.0"
             },
             {
-              "last_affected": "2.9.2"
+              "fixed": "2.9.5"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.9.2"
+      }
     }
   ],
   "references": [
@@ -41,12 +44,24 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-39987"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/RaspAP/raspap-webgui/pull/1395"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/RaspAP/raspap-webgui/commit/e87e7d1d3a61617430851f2a040379de1ff3dd9d"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/RaspAP/raspap-webgui"
     },
     {
       "type": "WEB",
       "url": "https://github.com/RaspAP/raspap-webgui/blob/master/ajax/networking/get_wgkey.php"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/RaspAP/raspap-webgui/releases/tag/2.9.5"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add the patch commit for v2.9.5: https://github.com/RaspAP/raspap-webgui/commit/e87e7d1d3a61617430851f2a040379de1ff3dd9d
- PR: https://github.com/RaspAP/raspap-webgui/pull/1395

mentioned in release note v2.9.5: "Sanitize post with escapeshellcmd() in #1395"