### PR TITLE
[GHSA-6hr3-44gx-g6wh] XSS vulnerability in drag-and-drop upload of phpMyAdmin

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-6hr3-44gx-g6wh/GHSA-6hr3-44gx-g6wh.json
+++ b/advisories/github-reviewed/2023/02/GHSA-6hr3-44gx-g6wh/GHSA-6hr3-44gx-g6wh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6hr3-44gx-g6wh",
-  "modified": "2023-02-23T21:32:13Z",
+  "modified": "2023-02-23T21:32:14Z",
   "published": "2023-02-13T06:30:59Z",
   "aliases": [
     "CVE-2023-25727"
@@ -58,6 +58,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25727"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/phpmyadmin/phpmyadmin/commit/53f70fd7f3b388639922e6cc1ca51fbe890c91cc"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/phpmyadmin/phpmyadmin/commit/efa2406695551667f726497750d3db91fb6f662e"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patches:
-  on the 4.9 branch to fix this issue: https://github.com/phpmyadmin/phpmyadmin/commit/53f70fd7f3b388639922e6cc1ca51fbe890c91cc

- 5.2 branch to fix this issue: https://github.com/phpmyadmin/phpmyadmin/commit/efa2406695551667f726497750d3db91fb6f662e

they are also mentioned in the reference link: https://www.phpmyadmin.net/security/PMASA-2023-1/
