### PR TITLE
[GHSA-85p4-q357-72h9] Apache Storm Local Information Disclosure Vulnerability in Storm-core on Unix-Like systems due temporary files 

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-85p4-q357-72h9/GHSA-85p4-q357-72h9.json
+++ b/advisories/github-reviewed/2023/11/GHSA-85p4-q357-72h9/GHSA-85p4-q357-72h9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-85p4-q357-72h9",
-  "modified": "2023-11-24T16:53:46Z",
+  "modified": "2023-11-24T16:53:48Z",
   "published": "2023-11-23T12:30:23Z",
   "aliases": [
     "CVE-2023-43123"
@@ -36,6 +36,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-43123"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/storm/pull/3582"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/storm/commit/b778125a17ce7497d80aea1e339f3a282aeeb65a"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/storm"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add patch commit for v2.6.0: https://github.com/apache/storm/commit/b778125a17ce7497d80aea1e339f3a282aeeb65a,
- PR: https://github.com/apache/storm/pull/3582

The commit msg shows the change matches the vuln fix: "Replace File.createTempFile with java.nio.file.Files.createTempFile".