### PR TITLE
[GHSA-946c-f9w6-2c25] Download route allows filename change in eZpublish kernel

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-946c-f9w6-2c25/GHSA-946c-f9w6-2c25.json
+++ b/advisories/github-reviewed/2023/11/GHSA-946c-f9w6-2c25/GHSA-946c-f9w6-2c25.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-946c-f9w6-2c25",
-  "modified": "2023-11-03T18:45:11Z",
+  "modified": "2023-11-03T18:45:12Z",
   "published": "2023-11-03T18:45:11Z",
   "aliases": [
 
@@ -50,7 +50,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2023-11-03T18:45:11Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- Severity

**Comments**
The severity is marked as High here -> https://developers.ibexa.co/security-advisories/ibexa-sa-2023-005-vulnerabilities-in-solr-search-and-file-downloads