### PR TITLE
[GHSA-gwp4-hfv6-p7hw] Deserialization of untrusted data in FasterXML jackson-databind

### DIFF
--- a/advisories/github-reviewed/2019/08/GHSA-gwp4-hfv6-p7hw/GHSA-gwp4-hfv6-p7hw.json
+++ b/advisories/github-reviewed/2019/08/GHSA-gwp4-hfv6-p7hw/GHSA-gwp4-hfv6-p7hw.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gwp4-hfv6-p7hw",
-  "modified": "2023-09-13T17:26:54Z",
+  "modified": "2023-09-13T17:26:55Z",
   "published": "2019-08-01T19:18:06Z",
   "aliases": [
     "CVE-2019-14439"
   ],
   "summary": "Deserialization of untrusted data in FasterXML jackson-databind",
-  "details": "A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9.2, 2.8.11.14, 2.7.9.6, and 2.6.7.3. This occurs when Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the logback jar in the classpath.",
+  "details": "A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9.2, 2.8.11.4, 2.7.9.6, and 2.6.7.3. This occurs when Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the logback jar in the classpath.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -47,11 +47,14 @@
               "introduced": "2.8.0"
             },
             {
-              "fixed": "2.8.11.14"
+              "fixed": "2.8.11.4"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.8.11.14"
+      }
     },
     {
       "package": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
The actual 2.8.11.x fix version is 2.8.11.4, not the 2.8.11.14 which does not exist.
As per the updated source: https://nvd.nist.gov/vuln/detail/CVE-2019-14439
https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/