### PR TITLE
[GHSA-g3wg-6mcf-8jj6] Local Temp Directory Hijacking Vulnerability

### DIFF
--- a/advisories/github-reviewed/2020/11/GHSA-g3wg-6mcf-8jj6/GHSA-g3wg-6mcf-8jj6.json
+++ b/advisories/github-reviewed/2020/11/GHSA-g3wg-6mcf-8jj6/GHSA-g3wg-6mcf-8jj6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g3wg-6mcf-8jj6",
-  "modified": "2022-02-08T22:03:47Z",
+  "modified": "2023-02-01T05:05:08Z",
   "published": "2020-11-04T17:50:24Z",
   "aliases": [
     "CVE-2020-27216"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "9.4.33"
+              "fixed": "9.4.33.v20201020"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 9.4.33"
+      }
     },
     {
       "package": {
@@ -47,11 +50,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "9.4.33"
+              "fixed": "9.4.33.v20201020"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 9.4.33"
+      }
     },
     {
       "package": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Actual version of fix is `9.4.33.v20201020`, not the shorthand `9.4.33`, which can not be found and fixed automatically.