### PR TITLE
[GHSA-4hh5-2678-83fx] Cross-Site Request Forgery vulnerability in Prefect

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-4hh5-2678-83fx/GHSA-4hh5-2678-83fx.json
+++ b/advisories/github-reviewed/2023/11/GHSA-4hh5-2678-83fx/GHSA-4hh5-2678-83fx.json
@@ -9,10 +9,7 @@
   "summary": "Cross-Site Request Forgery vulnerability in Prefect",
   "details": "An attacker is able to steal secrets and potentially gain remote code execution via CSRF using the Prefect API.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
-    }
+
   ],
   "affected": [
     {
@@ -26,9 +23,6 @@
           "events": [
             {
               "introduced": "2.0.0"
-            },
-            {
-              "fixed": "2.14.3"
             }
           ]
         }
@@ -53,7 +47,7 @@
     "cwe_ids": [
       "CWE-352"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2023-11-27T23:21:29Z",
     "nvd_published_at": "2023-11-16T17:15:09Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
Prefect's open source package does not ship with authentication, CORS, or protection against CSRF. If users want to run prefect in an open source environment, they need to secure the application themselves.

It does not seem fair to mark this as a vulnerability with the prefect package.