### PR TITLE
[GHSA-5p3h-7fwh-92rc] An attacker can overwrite any file on the server hosting...

### DIFF
--- a/advisories/unreviewed/2023/11/GHSA-5p3h-7fwh-92rc/GHSA-5p3h-7fwh-92rc.json
+++ b/advisories/unreviewed/2023/11/GHSA-5p3h-7fwh-92rc/GHSA-5p3h-7fwh-92rc.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5p3h-7fwh-92rc",
-  "modified": "2023-11-16T18:30:31Z",
+  "modified": "2023-11-16T18:30:37Z",
   "published": "2023-11-16T18:30:31Z",
   "aliases": [
     "CVE-2023-6018"
   ],
+  "summary": "Added affected package and version",
   "details": "An attacker can overwrite any file on the server hosting MLflow without any authentication.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "mlflow"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.6.0"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
As mentioned here https://huntr.com/bounties/7cf918b5-43f4-48c0-a371-4d963ce69b30 (also provided in the existing report), the actual package and version are indicated and should be added here as well. I think that this vulnerability is not yet fixed and hence, the affected version may also be 2.8.1 (though the report under https://huntr.com/bounties/7cf918b5-43f4-48c0-a371-4d963ce69b30 only tests it for 2.6.0 but all future releases don't seem to address it).