### PR TITLE
[GHSA-jpr7-q523-hx25] phpseclib vulnerable to denial of service

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-jpr7-q523-hx25/GHSA-jpr7-q523-hx25.json
+++ b/advisories/github-reviewed/2023/11/GHSA-jpr7-q523-hx25/GHSA-jpr7-q523-hx25.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jpr7-q523-hx25",
-  "modified": "2023-11-28T17:43:31Z",
+  "modified": "2023-11-28T17:43:32Z",
   "published": "2023-11-27T18:31:14Z",
   "aliases": [
     "CVE-2023-49316"
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.0.0"
             },
             {
               "fixed": "3.0.34"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
In v2 of `phpseclib` `Math/BinaryField` does not exist, see https://github.com/phpseclib/phpseclib/issues/1964