### PR TITLE
[GHSA-jv74-f9pj-xp3f] Apache Camel's Mail is vulnerable to path traversal

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-jv74-f9pj-xp3f/GHSA-jv74-f9pj-xp3f.json
+++ b/advisories/github-reviewed/2018/10/GHSA-jv74-f9pj-xp3f/GHSA-jv74-f9pj-xp3f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jv74-f9pj-xp3f",
-  "modified": "2022-11-17T19:14:08Z",
+  "modified": "2023-01-12T05:06:48Z",
   "published": "2018-10-16T23:07:57Z",
   "aliases": [
     "CVE-2018-8041"
@@ -80,6 +80,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-8041"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/4580e4d6c65cfd544c1791c824b5819477c583cc"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
found the patch for 
- v4.2.0: https://github.com/apache/camel/commit/4580e4d6c65cfd544c1791c824b5819477c583cc

The commit msg also pointed the issue: CAMEL-12630