### PR TITLE
[GHSA-f554-x222-wgf7] Command Injection in Xstream

### DIFF
--- a/advisories/github-reviewed/2019/05/GHSA-f554-x222-wgf7/GHSA-f554-x222-wgf7.json
+++ b/advisories/github-reviewed/2019/05/GHSA-f554-x222-wgf7/GHSA-f554-x222-wgf7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f554-x222-wgf7",
-  "modified": "2021-08-04T15:07:00Z",
+  "modified": "2023-02-01T05:02:00Z",
   "published": "2019-05-29T18:05:03Z",
   "aliases": [
     "CVE-2013-7285"
@@ -28,10 +28,32 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.4.6"
+              "fixed": "1.4.7"
             }
           ]
         }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.thoughtworks.xstream:xstream"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.4.10"
+            },
+            {
+              "fixed": "1.4.11"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.4.10"
       ]
     }
   ],
@@ -39,6 +61,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-7285"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/x-stream/xstream/commit/6344867dce6767af7d0fe34fb393271a6456672d#diff-e36235a498f4191f29c4b0194d0da5d2945adf7265d3b469f4ad53a220bdf0c0"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The affected version is not correctly recorded in GHSA based on the patch commit and the CVE description. 
Affected versions have been updated and the link to the patch commit has been added to the references.