### PR TITLE
[GHSA-m9xq-6h2j-65r2] Markdown vulnerable to Out-of-bounds Read while parsing citations

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-m9xq-6h2j-65r2/GHSA-m9xq-6h2j-65r2.json
+++ b/advisories/github-reviewed/2023/09/GHSA-m9xq-6h2j-65r2/GHSA-m9xq-6h2j-65r2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m9xq-6h2j-65r2",
-  "modified": "2023-09-27T13:55:11Z",
+  "modified": "2023-11-09T05:05:20Z",
   "published": "2023-09-22T19:59:49Z",
   "aliases": [
     "CVE-2023-42821"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.0.0-20230922105210-14b16010c2ee"
+              "fixed": ">= 0.0.0-20230922105210-14b16010c2ee"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 0.0.0-20230922105210-14b16010c2ee"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
As can be seen here, https://github.com/gomarkdown/markdown/commits/master, the fix was made in https://github.com/gomarkdown/markdown/commit/14b16010c2ee7ff33a940a541d993bd043a88940 and subsequent commits should also be considered as "patched versions".