### PR TITLE
[GHSA-jpr7-q523-hx25] phpseclib vulnerable to denial of service

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-jpr7-q523-hx25/GHSA-jpr7-q523-hx25.json
+++ b/advisories/github-reviewed/2023/11/GHSA-jpr7-q523-hx25/GHSA-jpr7-q523-hx25.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jpr7-q523-hx25",
-  "modified": "2023-11-28T17:43:31Z",
+  "modified": "2023-11-28T17:43:32Z",
   "published": "2023-11-27T18:31:14Z",
   "aliases": [
     "CVE-2023-49316"
   ],
   "summary": "phpseclib vulnerable to denial of service",
-  "details": "In Math/BinaryField.php in phpseclib before 3.0.34, excessively large degrees in binary fields can lead to a denial of service.",
+  "details": "In Math/BinaryField.php in phpseclib version 3, before 3.0.34, excessively large degrees in binary fields can lead to a denial of service.",
   "severity": [
 
   ],
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3"
             },
             {
               "fixed": "3.0.34"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-49316"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/phpseclib/phpseclib/issues/1964"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
Version 2 is not affected from this CVE