### PR TITLE
[GHSA-vmq6-5m68-f53m] logback serialization vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-vmq6-5m68-f53m/GHSA-vmq6-5m68-f53m.json
+++ b/advisories/github-reviewed/2023/11/GHSA-vmq6-5m68-f53m/GHSA-vmq6-5m68-f53m.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vmq6-5m68-f53m",
-  "modified": "2023-11-29T21:33:01Z",
+  "modified": "2023-11-29T21:33:04Z",
   "published": "2023-11-29T12:30:16Z",
   "aliases": [
     "CVE-2023-6378"
   ],
   "summary": "logback serialization vulnerability",
-  "details": "A serialization vulnerability in logback receiver component part of logback version 1.4.11 allows an attacker to mount a Denial-Of-Service attack by sending poisoned data.\n\n",
+  "details": "A serialization vulnerability in logback receiver component part of logback version 1.4.11 allows an attacker to mount a Denial-Of-Service attack by sending poisoned data.\n\nThis is only exploitable if logback receiver component is deployed. See https://logback.qos.ch/manual/receivers.html",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -108,6 +108,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/qos-ch/logback"
+    },
+    {
+      "type": "WEB",
+      "url": "https://logback.qos.ch/manual/receivers.html"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
Adding a clarification that it's only vulnerable if using receivers, and documentation for receivers so it's clear how to find if you're using them.