### PR TITLE
[GHSA-jfhm-5ghh-2f97] cryptography vulnerable to NULL-dereference when loading PKCS7 certificates

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-jfhm-5ghh-2f97/GHSA-jfhm-5ghh-2f97.json
+++ b/advisories/github-reviewed/2023/11/GHSA-jfhm-5ghh-2f97/GHSA-jfhm-5ghh-2f97.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jfhm-5ghh-2f97",
-  "modified": "2023-11-29T21:50:16Z",
+  "modified": "2023-11-29T21:50:17Z",
   "published": "2023-11-28T20:46:46Z",
   "aliases": [
     "CVE-2023-49083"
@@ -9,10 +9,7 @@
   "summary": "cryptography vulnerable to NULL-dereference when loading PKCS7 certificates",
   "details": "### Summary\n\nCalling `load_pem_pkcs7_certificates` or `load_der_pkcs7_certificates` could lead to a NULL-pointer dereference and segfault.\n\n### PoC\nHere is a Python code that triggers the issue:\n```python\nfrom cryptography.hazmat.primitives.serialization.pkcs7 import load_der_pkcs7_certificates, load_pem_pkcs7_certificates\n\npem_p7 = b\"\"\"\n-----BEGIN PKCS7-----\nMAsGCSqGSIb3DQEHAg==\n-----END PKCS7-----\n\"\"\"\n\nder_p7 = b\"\\x30\\x0B\\x06\\x09\\x2A\\x86\\x48\\x86\\xF7\\x0D\\x01\\x07\\x02\"\n\nload_pem_pkcs7_certificates(pem_p7)\nload_der_pkcs7_certificates(der_p7)\n```\n\n### Impact\nExploitation of this vulnerability poses a serious risk of Denial of Service (DoS) for any application attempting to deserialize a PKCS7 blob/certificate. The consequences extend to potential disruptions in system availability and stability.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H"
-    }
+
   ],
   "affected": [
     {
@@ -65,7 +62,7 @@
     "cwe_ids": [
       "CWE-476"
     ],
-    "severity": "CRITICAL",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2023-11-28T20:46:46Z",
     "nvd_published_at": "2023-11-29T19:15:07Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
The project published this advisory with a moderate severity score https://github.com/pyca/cryptography/security/advisories/GHSA-jfhm-5ghh-2f97

The GHSA entry shows up as critical with "integrity: high". There simply cannot be a complete loss of integrity from a NULL pointer deferefence.