### PR TITLE
[GHSA-hx93-gc73-5rpr] Exposure of Sensitive Information in Elastic APM .NET Agent

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-hx93-gc73-5rpr/GHSA-hx93-gc73-5rpr.json
+++ b/advisories/github-reviewed/2023/11/GHSA-hx93-gc73-5rpr/GHSA-hx93-gc73-5rpr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hx93-gc73-5rpr",
-  "modified": "2023-11-22T20:56:15Z",
+  "modified": "2023-11-30T21:44:23Z",
   "published": "2023-11-22T03:30:19Z",
   "aliases": [
     "CVE-2021-22143"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-22143"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/elastic/apm-agent-dotnet/pull/1286"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/elastic/apm-agent-dotnet/commit/c2b519aaa0fe5e5044b736cfec695342f124bf30"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch commit for v1.10.0: https://github.com/elastic/apm-agent-dotnet/commit/c2b519aaa0fe5e5044b736cfec695342f124bf30

PR is: https://github.com/elastic/apm-agent-dotnet/pull/1286

the commit msg also mentioned: "Sanitize HTTP headers when the agent reads them"