### PR TITLE
[GHSA-vmq6-5m68-f53m] logback serialization vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-vmq6-5m68-f53m/GHSA-vmq6-5m68-f53m.json
+++ b/advisories/github-reviewed/2023/11/GHSA-vmq6-5m68-f53m/GHSA-vmq6-5m68-f53m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vmq6-5m68-f53m",
-  "modified": "2023-12-02T00:40:41Z",
+  "modified": "2023-12-02T00:40:42Z",
   "published": "2023-11-29T12:30:16Z",
   "aliases": [
     "CVE-2023-6378"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.3.0"
             },
             {
               "fixed": "1.3.12"
@@ -63,7 +63,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.3.0"
             },
             {
               "fixed": "1.3.12"
@@ -86,6 +86,44 @@
             },
             {
               "fixed": "1.4.12"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "ch.qos.logback:logback-classic"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.2.13"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "ch.qos.logback:logback-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.2.13"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Based on https://logback.qos.ch/news.html#1.2.13, fixed for the 1.2 branch as well. Upgrade from 1.2.x to 1.3.x can be prevented by breaking changes.