### PR TITLE
[GHSA-vmq6-5m68-f53m] logback serialization vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-vmq6-5m68-f53m/GHSA-vmq6-5m68-f53m.json
+++ b/advisories/github-reviewed/2023/11/GHSA-vmq6-5m68-f53m/GHSA-vmq6-5m68-f53m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vmq6-5m68-f53m",
-  "modified": "2023-12-02T00:40:41Z",
+  "modified": "2023-12-02T00:40:42Z",
   "published": "2023-11-29T12:30:16Z",
   "aliases": [
     "CVE-2023-6378"
@@ -90,6 +90,28 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "ch.qos.logback:logback-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.2.13"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.2.12"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Logback documentation has been updated to include:

"Note that logback versions 1.3.14/1.4.14 provide more complete fixes for this vulnerability, i.e. CVE-2023-6378. Moreover, logback version 1.2.13 also fixes CVE-2023-6378 as well as CVE-2023-6481."