### PR TITLE
[GHSA-4grx-2x9w-596c] Marvin Attack: potential key recovery through timing sidechannels

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-4grx-2x9w-596c/GHSA-4grx-2x9w-596c.json
+++ b/advisories/github-reviewed/2023/11/GHSA-4grx-2x9w-596c/GHSA-4grx-2x9w-596c.json
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.9.5"
+              "last_affected": "0.9.6"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
rsa v0.9.6 has been released on 2023-12-01 and is still vulnerable to CVE-2023-49092. Currently, there is not solution available.

https://github.com/RustCrypto/RSA
https://github.com/RustCrypto/RSA/blob/master/CHANGELOG.md