### PR TITLE
[GHSA-c38w-74pg-36hr] Marvin Attack: potential key recovery through timing sidechannels

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-c38w-74pg-36hr/GHSA-c38w-74pg-36hr.json
+++ b/advisories/github-reviewed/2023/11/GHSA-c38w-74pg-36hr/GHSA-c38w-74pg-36hr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c38w-74pg-36hr",
-  "modified": "2023-11-28T23:28:27Z",
+  "modified": "2023-11-28T23:28:28Z",
   "published": "2023-11-28T23:28:27Z",
   "aliases": [
     "CVE-2023-49092"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.9.5"
+              "last_affected": "0.9.6"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
rsa v0.9.6 has been released on 2023-12-01 and is still vulnerable to CVE-2023-49092. Currently, there is not solution available.

https://github.com/RustCrypto/RSA
https://github.com/RustCrypto/RSA/blob/master/CHANGELOG.md