### PR TITLE
[GHSA-5m2h-7rf2-rpx6] UniSharp Laravel Filemanager directory traversal vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-5m2h-7rf2-rpx6/GHSA-5m2h-7rf2-rpx6.json
+++ b/advisories/github-reviewed/2022/09/GHSA-5m2h-7rf2-rpx6/GHSA-5m2h-7rf2-rpx6.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5m2h-7rf2-rpx6",
-  "modified": "2022-09-19T20:25:06Z",
+  "modified": "2023-01-28T05:02:52Z",
   "published": "2022-09-15T00:00:14Z",
   "aliases": [
     "CVE-2022-40734"
   ],
   "summary": "UniSharp Laravel Filemanager directory traversal vulnerability",
-  "details": "UniSharp laravel-filemanager (aka Laravel Filemanager) through 2.5.1 allows download?working_dir=%2F.. directory traversal to read arbitrary files, as exploited in the wild in June 2022.",
+  "details": "UniSharp laravel-filemanager (aka Laravel Filemanager) with `league/flysystem` version `< 2.0.0` allows download?working_dir=%2F.. directory traversal to read arbitrary files, as exploited in the wild in June 2022.\n\nSince `v2.6.4`, UniSharp laravel-filemanager (aka Laravel Filemanager) requires users to install `league/flysystem` version `>= 2.0.0`.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.5.1"
+              "fixed": "2.6.4"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.6.3"
+      }
     }
   ],
   "references": [
@@ -43,6 +46,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/UniSharp/laravel-filemanager/issues/1150"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/UniSharp/laravel-filemanager/issues/1150#issuecomment-1320186966"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/UniSharp/laravel-filemanager/issues/1150#issuecomment-1825310417"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
I am the maintainer of unisharp/laravel-filemanager. `v2.6.4` has been released to fix this issue.