### PR TITLE
[GHSA-4grx-2x9w-596c] Marvin Attack: potential key recovery through timing sidechannels

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-4grx-2x9w-596c/GHSA-4grx-2x9w-596c.json
+++ b/advisories/github-reviewed/2023/11/GHSA-4grx-2x9w-596c/GHSA-4grx-2x9w-596c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4grx-2x9w-596c",
-  "modified": "2023-11-28T23:28:25Z",
+  "modified": "2023-12-06T18:50:52Z",
   "published": "2023-11-28T23:28:25Z",
   "aliases": [
 
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
     }
   ],
   "affected": [
@@ -57,7 +57,7 @@
     "cwe_ids": [
       "CWE-385"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2023-11-28T23:28:25Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
There shouldn't be any integrity impact since the vulnerability allows attackers to only reveal the private key. The CVSS scoring shouldn't consider any further actions being taken. This would correspond to the latest scoring of NVD/MITRE: https://nvd.nist.gov/vuln/detail/CVE-2023-49092