### PR TITLE
[GHSA-c38w-74pg-36hr] Marvin Attack: potential key recovery through timing sidechannels

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-c38w-74pg-36hr/GHSA-c38w-74pg-36hr.json
+++ b/advisories/github-reviewed/2023/11/GHSA-c38w-74pg-36hr/GHSA-c38w-74pg-36hr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c38w-74pg-36hr",
-  "modified": "2023-11-28T23:28:27Z",
+  "modified": "2023-12-06T18:50:49Z",
   "published": "2023-11-28T23:28:27Z",
   "aliases": [
     "CVE-2023-49092"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
     }
   ],
   "affected": [
@@ -57,7 +57,7 @@
     "cwe_ids": [
       "CWE-385"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2023-11-28T23:28:27Z",
     "nvd_published_at": "2023-11-28T21:15:08Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
There shouldn't be any integrity impact since the vulnerability allows attackers to only reveal the private key. The CVSS scoring shouldn't consider any further actions being taken. This would correspond to the latest scoring of NVD/MITRE: https://nvd.nist.gov/vuln/detail/CVE-2023-49092