### PR TITLE
[GHSA-mjmq-gwgm-5qhm] Apache MINA SSHD information disclosure vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-mjmq-gwgm-5qhm/GHSA-mjmq-gwgm-5qhm.json
+++ b/advisories/github-reviewed/2023/07/GHSA-mjmq-gwgm-5qhm/GHSA-mjmq-gwgm-5qhm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mjmq-gwgm-5qhm",
-  "modified": "2023-08-21T13:55:24Z",
+  "modified": "2023-11-06T05:03:36Z",
   "published": "2023-07-10T18:30:49Z",
   "aliases": [
     "CVE-2023-35887"
@@ -18,25 +18,6 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.sshd:sshd-common"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.1.0"
-            },
-            {
-              "fixed": "2.10.0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
         "name": "org.apache.sshd:sshd-sftp"
       },
       "ranges": [
@@ -47,7 +28,26 @@
               "introduced": "1.0.0"
             },
             {
-              "fixed": "2.10.0"
+              "fixed": "2.9.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.sshd:sshd-common"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.1.0"
+            },
+            {
+              "fixed": "2.9.3"
             }
           ]
         }
@@ -66,14 +66,11 @@
               "introduced": "1.0.0"
             },
             {
-              "fixed": "2.10.0"
+              "fixed": "2.9.3"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 2.1.0"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
NVD database updated to reflect 2.9.3 release on November 21st.