### PR TITLE
[GHSA-7cwq-p8cr-h9qg] Buttercup v2.20.3 allows attackers to obtain the hash of...

### DIFF
--- a/advisories/unreviewed/2023/09/GHSA-7cwq-p8cr-h9qg/GHSA-7cwq-p8cr-h9qg.json
+++ b/advisories/unreviewed/2023/09/GHSA-7cwq-p8cr-h9qg/GHSA-7cwq-p8cr-h9qg.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7cwq-p8cr-h9qg",
-  "modified": "2023-09-12T21:30:15Z",
+  "modified": "2023-11-11T05:04:40Z",
   "published": "2023-09-08T00:31:02Z",
   "aliases": [
     "CVE-2023-41646"
   ],
+  "summary": "Buttercup desktop/core stores encrypted master password for vaults in local config file (vaults.json)",
   "details": "Buttercup v2.20.3 allows attackers to obtain the hash of the master password for the password manager via accessing the file /vaults.json/",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "buttercup"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -26,6 +45,10 @@
       "url": "https://buttercup.pw/"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/buttercup/buttercup-core"
+    },
+    {
       "type": "WEB",
       "url": "https://github.com/tristao-marinho/CVE-2023-41646/"
     }
@@ -34,7 +57,7 @@
     "cwe_ids": [
       "CWE-916"
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-09-07T22:15:07Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Source code location
- Summary

**Comments**
Links to source code, affected npm package/versions, title