### PR TITLE
[GHSA-vfp6-jrw2-99g9] Cosign vulnerable to possible endless data attack from attacker-controlled registry

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-vfp6-jrw2-99g9/GHSA-vfp6-jrw2-99g9.json
+++ b/advisories/github-reviewed/2023/11/GHSA-vfp6-jrw2-99g9/GHSA-vfp6-jrw2-99g9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vfp6-jrw2-99g9",
-  "modified": "2023-11-08T15:02:51Z",
+  "modified": "2023-11-14T21:38:50Z",
   "published": "2023-11-08T15:02:51Z",
   "aliases": [
     "CVE-2023-46737"
@@ -15,25 +15,6 @@
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "Go",
-        "name": "github.com/sigstore/cosign"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "last_affected": "1.13.1"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "Go",
@@ -52,6 +33,28 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/sigstore/cosign"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "v1.13.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.13.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The fix for this vulnerability has been ported back to v1.x.x

- https://github.com/sigstore/cosign/releases/tag/v1.13.2
- https://github.com/sigstore/cosign/pull/3364

