### PR TITLE
[GHSA-2j39-qcjm-428w] Apache Struts vulnerable to path traversal

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-2j39-qcjm-428w/GHSA-2j39-qcjm-428w.json
+++ b/advisories/github-reviewed/2023/12/GHSA-2j39-qcjm-428w/GHSA-2j39-qcjm-428w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2j39-qcjm-428w",
-  "modified": "2023-12-09T04:21:30Z",
+  "modified": "2023-12-09T04:21:32Z",
   "published": "2023-12-07T09:30:45Z",
   "aliases": [
     "CVE-2023-50164"
@@ -65,6 +65,10 @@
       "url": "https://github.com/apache/struts/commit/d8c69691ef1d15e76a5f4fcf33039316da2340b6"
     },
     {
+      "type": "WEB",
+      "url": "https://cwiki.apache.org/confluence/display/WW/S2-066"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/apache/struts"
     },
@@ -85,7 +89,7 @@
     "cwe_ids": [
       "CWE-552"
     ],
-    "severity": "MODERATE",
+    "severity": "CRITICAL",
     "github_reviewed": true,
     "github_reviewed_at": "2023-12-07T21:34:55Z",
     "nvd_published_at": "2023-12-07T09:15:07Z"


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Severity

**Comments**
CVE-2023-50164(S2-066) is considered Critical by the official wiki.
https://cwiki.apache.org/confluence/display/WW/S2-066