### PR TITLE
[GHSA-rp65-9cf3-cjxr] Inefficient Regular Expression Complexity in nth-check

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-rp65-9cf3-cjxr/GHSA-rp65-9cf3-cjxr.json
+++ b/advisories/github-reviewed/2021/09/GHSA-rp65-9cf3-cjxr/GHSA-rp65-9cf3-cjxr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rp65-9cf3-cjxr",
-  "modified": "2023-09-13T21:49:54Z",
+  "modified": "2023-11-29T22:11:25Z",
   "published": "2021-09-20T20:47:31Z",
   "aliases": [
     "CVE-2021-3803"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "nth-check"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(nth-check).parse"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
There is a Regular Expression Denial of Service (ReDoS) vulnerability in nth-check that causes a denial of service when parsing crafted invalid CSS nth-checks.
