### PR TITLE
[GHSA-vf4q-8mr7-5c5c] Camel-castor component in Apache Camel is vulnerable to Java object de-serialisation

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-vf4q-8mr7-5c5c/GHSA-vf4q-8mr7-5c5c.json
+++ b/advisories/github-reviewed/2018/10/GHSA-vf4q-8mr7-5c5c/GHSA-vf4q-8mr7-5c5c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vf4q-8mr7-5c5c",
-  "modified": "2022-04-26T19:18:08Z",
+  "modified": "2023-01-09T05:03:26Z",
   "published": "2018-10-16T23:05:58Z",
   "aliases": [
     "CVE-2017-12634"
@@ -64,11 +64,39 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/2ae645e90edff3bcc1b958cb53ddc5e60a7f49fd"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/573ebd3de810cc7e239f175e1d2d6993f1f2ad08"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/ad3c1ce9d8300c339cfa7d0f4a4dea691a947988"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/adc06a78f04c8d798709a5818104abe5a8ae4b38"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/bdff8f3f3583e4f14cdaf24f2037e0fbef252630"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/c613905e95a3dab87158d9526aea9439f2de9621"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2018:0319"
     },
     {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-vf4q-8mr7-5c5c"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/camel/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
add some patch links related to CVE-2017-12634