### PR TITLE
[GHSA-jv74-f9pj-xp3f] Apache Camel's Mail is vulnerable to path traversal

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-jv74-f9pj-xp3f/GHSA-jv74-f9pj-xp3f.json
+++ b/advisories/github-reviewed/2018/10/GHSA-jv74-f9pj-xp3f/GHSA-jv74-f9pj-xp3f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jv74-f9pj-xp3f",
-  "modified": "2022-11-17T19:14:08Z",
+  "modified": "2023-12-02T00:36:09Z",
   "published": "2018-10-16T23:07:57Z",
   "aliases": [
     "CVE-2018-8041"
@@ -84,6 +84,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/camel/commit/4580e4d6c65cfd544c1791c824b5819477c583cc"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/4f401c09d22c45c94fa97746dc31905e06b19e3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/63c7c080de4d18f9ceb25843508710df2c2c6d4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/a0d25d9582c6ee85e9567fa39413df0b4f02ef7"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add some patch links which related to CVE-2018-8041(fixed in multi-branch)