### PR TITLE
[GHSA-8vfm-4388-6rpc] Apache is vulnerable to XXE in XSD validation processor

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-8vfm-4388-6rpc/GHSA-8vfm-4388-6rpc.json
+++ b/advisories/github-reviewed/2018/10/GHSA-8vfm-4388-6rpc/GHSA-8vfm-4388-6rpc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8vfm-4388-6rpc",
-  "modified": "2022-11-17T18:47:38Z",
+  "modified": "2023-12-12T18:36:25Z",
   "published": "2018-10-16T23:06:25Z",
   "aliases": [
     "CVE-2018-8027"
@@ -141,6 +141,10 @@
     {
       "type": "WEB",
       "url": "http://camel.apache.org/security-advisories.data/CVE-2018-8027.txt.asc"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.securityfocus.com/bid/104933"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add some patch links related to CVE-2018-8027（fixed in multi-branch）.