### PR TITLE
[GHSA-vq9j-jh62-5hmp] Apache Camel using an outdated vulnerable JSON-lib library

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-vq9j-jh62-5hmp/GHSA-vq9j-jh62-5hmp.json
+++ b/advisories/github-reviewed/2018/10/GHSA-vq9j-jh62-5hmp/GHSA-vq9j-jh62-5hmp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vq9j-jh62-5hmp",
-  "modified": "2022-04-26T21:36:33Z",
+  "modified": "2023-01-09T05:03:23Z",
   "published": "2018-10-16T23:13:11Z",
   "aliases": [
     "CVE-2017-5643"
@@ -61,11 +61,55 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/22c355bb4ffb500405499d189db30932ca5aac92"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/2c6964ae94d8f9a9c9a32e5ae5a0b794e8b8d3be"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/2e8f21dec883b083ddcdddd802847b4c378a61a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/87c92b7b38890c217bc76f2c55036e6a5cca9a07"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/8afc5d1757795fde715902067360af5d90f046da"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/99cbcd78b7e64083fae1d9552ead7425a90994b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/9c6a8f61de40c20f28240fbb2af4cb425793d41e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/9f7376abbff7434794f2c7c2909e02bac232fb5b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/ec3d0db81ba061b27e934d5ff56e9baca0049ebf"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2017:1832"
     },
     {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-vq9j-jh62-5hmp"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/camel/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/CAMEL-10894"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source location link and patch links related to CVE-2017-5643 which fixed in multi-branch.