### PR TITLE
[GHSA-hvpr-9cr6-q5v7] Apache Camel's camel-snakeyaml component is vulnerable to Java object de-serialization

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-hvpr-9cr6-q5v7/GHSA-hvpr-9cr6-q5v7.json
+++ b/advisories/github-reviewed/2018/10/GHSA-hvpr-9cr6-q5v7/GHSA-hvpr-9cr6-q5v7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hvpr-9cr6-q5v7",
-  "modified": "2022-11-17T18:54:40Z",
+  "modified": "2023-01-12T05:05:39Z",
   "published": "2018-10-16T17:21:42Z",
   "aliases": [
     "CVE-2017-3159"
@@ -61,6 +61,34 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/20e26226107f3133c87d0f5c845e02f824823f69"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/21c04b635cacd57bf4d438fc2308533ca1babde9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/2f19ce59cc4d89f21455f47604915fab6a22233b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/6b979d07fd4be6ac913368f2abeae690d3325d37"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/bea972e99b5c75dc0edeb93ecbba9ff70c36bb43"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/c98e48a7421b813bd47d5ae2717aea35a98d187"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/dcb5a74a3987d2264ad195c7844bbb6c8121661"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2017:0868"
     },
     {
@@ -70,6 +98,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/apache/camel"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/CAMEL-10575"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add issue link and some patch links related to CVE-2017-3159 which fixed in multi-branch.