### PR TITLE
[GHSA-vvjc-q5vr-52q6] Apache Camel's Jackson and JacksonXML unmarshalling operation are vulnerable to Remote Code Execution attacks

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-vvjc-q5vr-52q6/GHSA-vvjc-q5vr-52q6.json
+++ b/advisories/github-reviewed/2018/10/GHSA-vvjc-q5vr-52q6/GHSA-vvjc-q5vr-52q6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vvjc-q5vr-52q6",
-  "modified": "2022-04-26T19:23:57Z",
+  "modified": "2023-01-09T05:03:26Z",
   "published": "2018-10-16T23:13:00Z",
   "aliases": [
     "CVE-2016-8749"
@@ -79,12 +79,100 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-8749"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/camel/commit/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/02270ab9c90ac0d59b85dbd59fb9c1007eb44a1b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/10f552643d7e4565104d142bbc160db5a30f9f7e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/235036d2396ae45b6809b72a1983dee33b5ba326"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/2b0e96117d6f01eba0c18e2ff8df6a438e819721"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/342b09e8e376b7b09290152f4f30097794049581"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/57d01e2fc8923263df896e9810329ee5b7f9b69e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/5ae9c0dcc4843347cd01ffb58ce5dd0687755a14"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/6c2db21d128cde8e3cdb8617b2b81c9f07baa11"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/7567488f844f01d72840f7ab6ca18114a11f20d8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/83fef7108456eeac1506853d194cd1360851c4fe"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/881e5099f94316d4a66ffbff0a3e6915829d49d7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/8c862aa11e31d0f804c4a4516a0715e05e3eebcf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/97e3928de57c45235cade4b185e4cf2d59f87c28"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/abb45b2c2ada2bbb34138230540b37d259c1e98d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/af3f54de35a90a5a49a4af4622e8bd1011bf5ecc"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/b093ebdb97d8d5cb05887b8ebf7bcecbbfe41f81"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/c93a87c36aa4d14ad6f7ee1df9507fa2ca1fd91a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/ccf149c76bf37adc5977dc626e141a14e60b5aee"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/d4102512147eca2af21c3b6ed63a67d852f4e66a"
+    },
+    {
       "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2017:1832"
     },
     {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-vvjc-q5vr-52q6"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/CAMEL-10567"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/CAMEL-10604"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add issue links, source code location link and some patch links related to CVE-2016-8749 which fixed in multi-branch.