### PR TITLE
[GHSA-26v6-w6fw-rh94] Apache Camel can allow remote attackers to execute arbitrary commands

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-26v6-w6fw-rh94/GHSA-26v6-w6fw-rh94.json
+++ b/advisories/github-reviewed/2018/10/GHSA-26v6-w6fw-rh94/GHSA-26v6-w6fw-rh94.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-26v6-w6fw-rh94",
-  "modified": "2022-04-26T19:23:27Z",
+  "modified": "2023-01-09T05:02:29Z",
   "published": "2018-10-16T23:12:20Z",
   "aliases": [
     "CVE-2015-5348"
@@ -104,8 +104,112 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5348"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/0afcf721ff209eb10a24c5e4b48ca9d6727ea99a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/13e43c1412ad72d99030b4eb4cb72c84fa57d5ff"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/190d7c81b7e3ce767514e319630b1bbaf27e6817"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/1b1ccbcd94860f6f1d8caf98fb59e6ab7b3940b4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/23655fe0c15189ca41a6e99c31a3c38001a7cdb0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/32eacdaff16f8709da55e27b83fa21a16d739f63"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/349109b0834764560f0be69eb74f43a16bd220b0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/44e6a3036e5a11d90b60c142cf51ed74b792de31"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/4f065fe07c1dcd7b451e6005a6dc8e96d77da43e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/515c822148d52de9e7cdf4f6b01f7b793f2f273f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/5ea0a6f6c6a54f1cddf9691a99b0c237afc95348"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/735ee02c693964b5f700af13a2adfeae56b848a4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/7e28d0af471ea992eb74807a4abd1626b88d678a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/92081b203523c5ed502ed41df43cbd8655caf9b9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/94330f99acb6f28155793b253de9956c3798f3bb"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/9cbd5867fe73ef07ecba6f16d64689632e3f2a16"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/a68434c258cdcd30587ae7adc5dabbac43eadbbf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/c349d13ab98ac61daba8140f41690a4306880340"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/c47cffcadabca0c588753555a386942184a33627"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/c558f30a6d3820faa3d8c4ad5e54448914ec60d0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/c703479f5880a099c38f2fd5e63c7d9f0567e5ff"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/d853853469292cd54fd9662c3605030ab5a9566b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/e7fd5f049c2fd51a528f8062da91a1c75e33b0e8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/ec4a48d38e7335b40efcb14979fad8144eb00acf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/f7f0b18f6924fe0b01f32a25ed1e38e29b1bf8e5"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-26v6-w6fw-rh94"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/camel/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source location link and some patch links related to CVE-2015-5348 which fixed in multi-branch.