### PR TITLE
[GHSA-gv5f-cjw9-5vxg] Camel-xstream component in Apache Camel can allow remote attackers to execute arbitrary commands 

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-gv5f-cjw9-5vxg/GHSA-gv5f-cjw9-5vxg.json
+++ b/advisories/github-reviewed/2018/10/GHSA-gv5f-cjw9-5vxg/GHSA-gv5f-cjw9-5vxg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gv5f-cjw9-5vxg",
-  "modified": "2022-04-26T19:21:32Z",
+  "modified": "2023-01-09T05:02:54Z",
   "published": "2018-10-16T23:10:23Z",
   "aliases": [
     "CVE-2015-5344"
@@ -63,8 +63,44 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5344"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/157c0b4a3c8017de432f1c99f83e374e97dc4d36"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/369d0a6d605055cb843e7962b101e3bbcd113fec"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/4491c080cb6c8659fc05441e49307b7d4349aa56"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/4cdc6b177ee7391eedc9f0b695c05d56f84b0812"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/8386d8f7260143802553bc6dbae2880d6c0bafda"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/b7afb3769a38b8e526f8046414d4a71430d77df0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/f07a33c467adb3d37aa8192698caadfee43a17dc"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-gv5f-cjw9-5vxg"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/camel/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/CAMEL-9297"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source location link, issue link and patch related to CVE-2015-5344 which fixed in multi-branch.