### PR TITLE
[GHSA-mhx2-r3jx-g94c] Apache Camel allows remote actor to read arbitrary files via external entity in invalid XML string or GenericFile object

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-mhx2-r3jx-g94c/GHSA-mhx2-r3jx-g94c.json
+++ b/advisories/github-reviewed/2018/10/GHSA-mhx2-r3jx-g94c/GHSA-mhx2-r3jx-g94c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mhx2-r3jx-g94c",
-  "modified": "2022-11-17T19:39:36Z",
+  "modified": "2023-01-12T05:05:40Z",
   "published": "2018-10-16T23:09:15Z",
   "aliases": [
     "CVE-2015-0264"
@@ -55,6 +55,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-0264"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/7360aada5154434c68774aa30e0f21ddc5f27b9f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/b47b51a195b38e7ab7c099d19910af70a16638f6"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add some patch links related to CVE-2015-1264.