### PR TITLE
[GHSA-3hrc-f439-727g] Apache Camel XML External Entity vulnerability

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-3hrc-f439-727g/GHSA-3hrc-f439-727g.json
+++ b/advisories/github-reviewed/2018/10/GHSA-3hrc-f439-727g/GHSA-3hrc-f439-727g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3hrc-f439-727g",
-  "modified": "2022-11-17T18:38:58Z",
+  "modified": "2023-01-12T05:06:47Z",
   "published": "2018-10-16T23:08:43Z",
   "aliases": [
     "CVE-2015-0263"
@@ -55,6 +55,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-0263"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/06db9e0744f2bb9f6e3bf16c0dfe7099a3481558"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/7d19340bcdb42f7aae584d9c5003ac4f7ddaee36"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add two patch links related to CVE-2015-0263.