### PR TITLE
[GHSA-h6rp-8v4j-hwph] Apache Camel's XSLT component allows remote attackers to execute arbitrary Java methods

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-h6rp-8v4j-hwph/GHSA-h6rp-8v4j-hwph.json
+++ b/advisories/github-reviewed/2018/10/GHSA-h6rp-8v4j-hwph/GHSA-h6rp-8v4j-hwph.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h6rp-8v4j-hwph",
-  "modified": "2023-02-15T22:19:51Z",
+  "modified": "2023-02-15T22:19:52Z",
   "published": "2018-10-16T23:13:49Z",
   "aliases": [
     "CVE-2014-0003"
@@ -55,6 +55,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0003"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/483b445dc77487e2d0f3d8c8bf1a7bbab04464c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/c6de749e9b3c7b61861c5480e91550290585224"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/e922f89290f236f3107039de61af0375826bd96d"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add three patch links related to CVE-2014-0003.