### PR TITLE
[GHSA-2fw5-rvf2-jq56] Apache Camel's XSLT component allows remote attackers to read arbitrary files

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-2fw5-rvf2-jq56/GHSA-2fw5-rvf2-jq56.json
+++ b/advisories/github-reviewed/2018/10/GHSA-2fw5-rvf2-jq56/GHSA-2fw5-rvf2-jq56.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2fw5-rvf2-jq56",
-  "modified": "2023-02-15T22:19:10Z",
+  "modified": "2023-02-15T22:19:12Z",
   "published": "2018-10-16T23:13:26Z",
   "aliases": [
     "CVE-2014-0002"
@@ -55,6 +55,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0002"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/2ec54fa0c13ae65bdcccff764af081a79fcc05f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/341d4e6cca71c53c90962d1c3d45fc9e05cc50c6"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/camel/commit/54b65c1d30848835f26bd138c0ba407bc1e560d"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add three patch links related to CVE-2014-0002.