### PR TITLE
[GHSA-4px2-gqhv-mrc7] OpenDaylight Karaf 0.6.1-Carbon fails to clear the cache...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-4px2-gqhv-mrc7/GHSA-4px2-gqhv-mrc7.json
+++ b/advisories/unreviewed/2022/05/GHSA-4px2-gqhv-mrc7/GHSA-4px2-gqhv-mrc7.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4px2-gqhv-mrc7",
-  "modified": "2022-05-17T00:12:25Z",
+  "modified": "2023-02-03T05:01:11Z",
   "published": "2022-05-17T00:12:25Z",
   "aliases": [
     "CVE-2017-1000406"
   ],
+  "summary": "CVE-2017-1000406",
   "details": "OpenDaylight Karaf 0.6.1-Carbon fails to clear the cache after a password change, allowing the old password to be used until the Karaf cache is manually cleared (e.g. via restart).",
   "severity": [
     {
@@ -14,7 +15,15 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.opendaylight.integration:distribution-karaf"
+      },
+      "versions": [
+        "0.6.4-Carbon"
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
https://nvd.nist.gov/vuln/detail/CVE-2017-1000406#match-4089415
https://jira.opendaylight.org/browse/AAA-151