### PR TITLE
[GHSA-3m87-5598-2v4f] Prometheus XSS Vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-3m87-5598-2v4f/GHSA-3m87-5598-2v4f.json
+++ b/advisories/github-reviewed/2023/12/GHSA-3m87-5598-2v4f/GHSA-3m87-5598-2v4f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3m87-5598-2v4f",
-  "modified": "2023-12-13T21:26:54Z",
+  "modified": "2023-12-13T21:26:55Z",
   "published": "2023-12-13T21:26:54Z",
   "aliases": [
     "CVE-2019-3826"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0.0"
             },
             {
               "fixed": "2.7.1"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This vulnerability was fixed in release [2.7.1](https://github.com/prometheus/prometheus/releases/tag/v2.7.1). However, starting with release v2.35.0 the prometheus team changed the go versioning scheme to respect Go rules, and the Go library version became [v0.35.0](https://github.com/prometheus/prometheus/releases/tag/v0.35.0). 

In essence, all `v0.x.x` versions are not vulnerable since they're all after v2.7.1.