### PR TITLE
[GHSA-h3qr-39j9-4r5v] Data written to GitHub Actions Cache may expose secrets

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-h3qr-39j9-4r5v/GHSA-h3qr-39j9-4r5v.json
+++ b/advisories/github-reviewed/2023/05/GHSA-h3qr-39j9-4r5v/GHSA-h3qr-39j9-4r5v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h3qr-39j9-4r5v",
-  "modified": "2023-05-01T13:42:44Z",
+  "modified": "2023-11-07T05:05:20Z",
   "published": "2023-05-01T13:42:44Z",
   "aliases": [
     "CVE-2023-30853"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.4.2"
+              "fixed": "2.4.2, 2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.4.2"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The advisory on the affected repository was updated to include v2 already: https://github.com/gradle/gradle-build-action/security/advisories/GHSA-h3qr-39j9-4r5v