### PR TITLE
[GHSA-2j39-qcjm-428w] Apache Struts vulnerable to path traversal

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-2j39-qcjm-428w/GHSA-2j39-qcjm-428w.json
+++ b/advisories/github-reviewed/2023/12/GHSA-2j39-qcjm-428w/GHSA-2j39-qcjm-428w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2j39-qcjm-428w",
-  "modified": "2023-12-14T12:31:43Z",
+  "modified": "2023-12-13T19:12:22Z",
   "published": "2023-12-07T09:30:45Z",
   "aliases": [
     "CVE-2023-50164"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.5-BETA1"
+              "introduced": "2.0.0"
             },
             {
               "fixed": "2.5.33"
@@ -74,10 +74,6 @@
     {
       "type": "WEB",
       "url": "https://lists.apache.org/thread/yh09b3fkf6vz5d6jdgrlvmg60lfwtqhj"
-    },
-    {
-      "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20231214-0010/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The [official advisory](https://cwiki.apache.org/confluence/display/WW/S2-066) mentions that 2.0.0 - 2.3.37 are also affected.

I tested version 2.3.1 from 2011 and can confirm that the vulnerability is present in this release.