### PR TITLE
[GHSA-3m87-5598-2v4f] Prometheus XSS Vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-3m87-5598-2v4f/GHSA-3m87-5598-2v4f.json
+++ b/advisories/github-reviewed/2023/12/GHSA-3m87-5598-2v4f/GHSA-3m87-5598-2v4f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3m87-5598-2v4f",
-  "modified": "2023-12-13T21:26:54Z",
+  "modified": "2023-12-13T21:26:55Z",
   "published": "2023-12-13T21:26:54Z",
   "aliases": [
     "CVE-2019-3826"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
As reported in various other places, this vulnerability does not apply to go packages that use the library. See https://gitlab.com/gitlab-org/security-products/gemnasium-db/-/merge_requests/26608 and https://github.com/aquasecurity/trivy/issues/2992