### PR TITLE
[GHSA-rjhf-4mh8-9xjq] Zerocopy: Some Ref methods are unsound with some type parameters

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-rjhf-4mh8-9xjq/GHSA-rjhf-4mh8-9xjq.json
+++ b/advisories/github-reviewed/2023/12/GHSA-rjhf-4mh8-9xjq/GHSA-rjhf-4mh8-9xjq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rjhf-4mh8-9xjq",
-  "modified": "2023-12-18T19:18:46Z",
+  "modified": "2023-12-18T19:18:49Z",
   "published": "2023-12-18T19:18:46Z",
   "aliases": [
 


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This GHSA is a duplicate of https://github.com/advisories/GHSA-3mv5-343c-w2qg and should be revoked as soon as that feature is available.