### PR TITLE
[GHSA-45x7-px36-x8w8] Russh vulnerable to Prefix Truncation Attack against ChaCha20-Poly1305 and Encrypt-then-MAC

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-45x7-px36-x8w8/GHSA-45x7-px36-x8w8.json
+++ b/advisories/github-reviewed/2023/12/GHSA-45x7-px36-x8w8/GHSA-45x7-px36-x8w8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-45x7-px36-x8w8",
-  "modified": "2023-12-18T19:22:09Z",
+  "modified": "2023-12-18T21:38:00Z",
   "published": "2023-12-18T19:22:09Z",
   "aliases": [
     "CVE-2023-48795"
@@ -48,6 +48,25 @@
             },
             {
               "fixed": "0.17.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "paramiko"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.4.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
https://github.com/paramiko/paramiko/issues/2337 which is already in references. This advisory probably should be rewritten to not be Russh specific (CVE-2023-48795 is an issue affecting a lot of libraries, and in fact GitHub already acknowledges it affects golang.org/x/crypto).

See also: https://github.com/github/advisory-database/issues/2869.