### PR TITLE
[GHSA-4532-pmx7-9ww7] Cross-site Scripting in cesium

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-4532-pmx7-9ww7/GHSA-4532-pmx7-9ww7.json
+++ b/advisories/github-reviewed/2023/11/GHSA-4532-pmx7-9ww7/GHSA-4532-pmx7-9ww7.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4532-pmx7-9ww7",
-  "modified": "2023-12-07T22:40:42Z",
+  "modified": "2023-12-07T22:40:45Z",
   "published": "2023-11-14T18:30:27Z",
   "aliases": [
     "CVE-2023-48094"
   ],
   "summary": "Cross-site Scripting in cesium",
-  "details": "A cross-site scripting (XSS) vulnerability in CesiumJS v1.111 allows attackers to execute arbitrary code in the context of the victim's browser via sending a crafted payload to /container_files/public_html/doc/index.html. NOTE: the vendor’s position is that Apps/Sandcastle/standalone.html is part of the CesiumGS/cesium GitHub repository, but is demo code that is not part of the CesiumJS JavaScript library product.'",
+  "details": "A cross-site scripting (XSS) vulnerability in CesiumJS v1.111 allows attackers to execute arbitrary code in the context of the victim's browser via sending a crafted payload to /container_files/public_html/doc/index.html.\n\nNOTE: the vendor’s position is that Apps/Sandcastle/standalone.html is part of the CesiumGS/cesium GitHub repository, but is demo code that is not part of the CesiumJS JavaScript library product.'",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "npm",
-        "name": "cesium"
+        "name": ""
       },
       "ranges": [
         {
@@ -26,9 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "1.111.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Removed the cesium npm package from the list of affected products. There doesn't seem to be a way to completely remove the advisory from the "Improve security advisory" form -- it may be a legit advisory, but the npm package itself is not affected.

The vulnerability exists in demo code within the Cesium Github repository, but is NOT included in the npm package or actual Cesium library that gets distributed. It should therefore not appear as an advisory in other applications that are using the Cesium library.