### PR TITLE
[GHSA-mfhr-3xmc-r2gg] Improper Neutralization of Input During Web Page Generation in Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-mfhr-3xmc-r2gg/GHSA-mfhr-3xmc-r2gg.json
+++ b/advisories/github-reviewed/2022/05/GHSA-mfhr-3xmc-r2gg/GHSA-mfhr-3xmc-r2gg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mfhr-3xmc-r2gg",
-  "modified": "2022-07-08T19:05:34Z",
+  "modified": "2023-01-27T05:02:30Z",
   "published": "2022-05-17T01:36:25Z",
   "aliases": [
     "CVE-2013-1879"
@@ -39,7 +39,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/148ca81dcd8f14cfe2ff37012fd1aa42518f02dc"
+    },
+    {
+      "type": "WEB",
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/85586"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source code location link and patch link related to CVE-2013-1879.