### PR TITLE
[GHSA-c9gx-27hq-wcvj] Apache ActiveMQ Cross-site scripting (XSS) vulnerability in the Portfolio publisher servlet 

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-c9gx-27hq-wcvj/GHSA-c9gx-27hq-wcvj.json
+++ b/advisories/github-reviewed/2022/05/GHSA-c9gx-27hq-wcvj/GHSA-c9gx-27hq-wcvj.json
@@ -39,7 +39,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/fafd12dfd4f71336f8e32c090d40ed1445959b40"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=924447"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add source code link and patch link related to CVE-2013-1880