### PR TITLE
[GHSA-3wfj-vh84-732p] Improper Neutralization of Special Elements used in an OS Command in Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-3wfj-vh84-732p/GHSA-3wfj-vh84-732p.json
+++ b/advisories/github-reviewed/2022/05/GHSA-3wfj-vh84-732p/GHSA-3wfj-vh84-732p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3wfj-vh84-732p",
-  "modified": "2022-07-07T22:40:47Z",
+  "modified": "2023-01-27T05:02:36Z",
   "published": "2022-05-14T01:14:52Z",
   "aliases": [
     "CVE-2014-3576"
@@ -43,6 +43,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/activemq/commit/00921f2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/f07e6a53216f9388185ac2b39f366f3bfd6a8a55"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source code link and one patch link related to CVE-2014-3576.