### PR TITLE
[GHSA-4vhf-2hv7-8mrx] Improper Restriction of XML External Entity Reference in Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4vhf-2hv7-8mrx/GHSA-4vhf-2hv7-8mrx.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4vhf-2hv7-8mrx/GHSA-4vhf-2hv7-8mrx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4vhf-2hv7-8mrx",
-  "modified": "2022-07-07T22:38:48Z",
+  "modified": "2023-01-27T05:02:36Z",
   "published": "2022-05-14T01:14:52Z",
   "aliases": [
     "CVE-2014-3600"
@@ -42,7 +42,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/3e5ac6326db59f524a0e71f6b717428607d7b67d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/b9696ac80bb496b52d05c3884f81b0746d9af9e2"
+    },
+    {
+      "type": "WEB",
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/100722"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source code link and patch link related to CVE-2014-3600.