### PR TITLE
[GHSA-3v63-f83x-37x4] Improper Limitation of a Pathname to a Restricted Directory in Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-3v63-f83x-37x4/GHSA-3v63-f83x-37x4.json
+++ b/advisories/github-reviewed/2022/05/GHSA-3v63-f83x-37x4/GHSA-3v63-f83x-37x4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3v63-f83x-37x4",
-  "modified": "2022-07-06T20:23:30Z",
+  "modified": "2023-02-13T20:24:01Z",
   "published": "2022-05-14T01:14:51Z",
   "aliases": [
     "CVE-2015-1830"
@@ -39,6 +39,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-1830"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/729c4731574ffffaf58ebefdbaeb3bd19ed1c7b7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/9fd5cb7dfe0fcc431f99d5e14206e0090e72f36b"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source location and patch links related to CVE-2015-1830.