### PR TITLE
[GHSA-jvpp-hxjj-5ccc] Improper Input Validation and Missing Authentication for Critical Function in Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2019/08/GHSA-jvpp-hxjj-5ccc/GHSA-jvpp-hxjj-5ccc.json
+++ b/advisories/github-reviewed/2019/08/GHSA-jvpp-hxjj-5ccc/GHSA-jvpp-hxjj-5ccc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jvpp-hxjj-5ccc",
-  "modified": "2021-08-17T20:27:34Z",
+  "modified": "2023-02-01T05:02:22Z",
   "published": "2019-08-01T19:17:45Z",
   "aliases": [
     "CVE-2015-7559"
@@ -42,7 +42,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/338a74dfa42a7b19d39adecacfa5f626a050e807"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/b8fc78ec6c367cbe2a40a674eaec64ac3d7d1ec"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2015-7559"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add location link and patch links related to CVE-2015-7559.