### PR TITLE
[GHSA-rxqh-fc23-gxp2] Improper Input Validation in Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-rxqh-fc23-gxp2/GHSA-rxqh-fc23-gxp2.json
+++ b/advisories/github-reviewed/2022/05/GHSA-rxqh-fc23-gxp2/GHSA-rxqh-fc23-gxp2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rxqh-fc23-gxp2",
-  "modified": "2022-07-06T19:56:52Z",
+  "modified": "2023-01-27T05:02:20Z",
   "published": "2022-05-14T01:14:51Z",
   "aliases": [
     "CVE-2016-3088"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-3088"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/3dd86d04e8b90ba309819317d19e7260d414d9e7"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add location link and patch link related to CVE-2016-3088.