### PR TITLE
[GHSA-7qm4-p377-fr2r] ActiveMQ's OpenWire protocol exposes certain system details as plain text

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-7qm4-p377-fr2r/GHSA-7qm4-p377-fr2r.json
+++ b/advisories/github-reviewed/2022/05/GHSA-7qm4-p377-fr2r/GHSA-7qm4-p377-fr2r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7qm4-p377-fr2r",
-  "modified": "2022-11-22T19:42:50Z",
+  "modified": "2023-02-02T05:01:17Z",
   "published": "2022-05-13T01:11:29Z",
   "aliases": [
     "CVE-2017-15709"
@@ -58,6 +58,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-15709"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/5fa0bbd5156f29d97dcf48fd9fdb6a0488a8df1a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/8ff18c5e254bf43395f2e0d7e3a1092b33ec646"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/d2e49be3a8f21d862726c1f6bc9e1caa6ee8b58"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add source code link and patch links related to CVE-2017-15709.