### PR TITLE
[GHSA-r6j3-px5g-cq3x] Apache Tomcat Improper Input Validation vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-r6j3-px5g-cq3x/GHSA-r6j3-px5g-cq3x.json
+++ b/advisories/github-reviewed/2023/10/GHSA-r6j3-px5g-cq3x/GHSA-r6j3-px5g-cq3x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r6j3-px5g-cq3x",
-  "modified": "2023-11-04T06:34:05Z",
+  "modified": "2023-11-04T06:34:06Z",
   "published": "2023-10-10T21:31:12Z",
   "aliases": [
     "CVE-2023-45648"
@@ -76,6 +76,82 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.apache.tomcat:tomcat"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.5.0"
+            },
+            {
+              "fixed": "8.5.94"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "11.0.0-M1"
+            },
+            {
+              "fixed": "11.0.0-M12"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.1.0-M1"
+            },
+            {
+              "fixed": "10.1.14"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.0-M1"
+            },
+            {
+              "fixed": "9.0.81"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Improve visibility for org.apache.tomcat.embed:tomcat-embed-core

Reasoning -> fixed components are also part of tomcat-embed-core package:
(11.0.x) https://github.com/apache/tomcat/commit/eb5c094e5560764cda436362254997511a3ca1f6
(10.1.x) https://github.com/apache/tomcat/commit/8ecff306507be8e4fd3adee1ae5de1ea6661a8f4
(9.0.x) https://github.com/apache/tomcat/commit/59583245639d8c42ae0009f4a4a70464d3ea70a0
(8.5.x) https://github.com/apache/tomcat/commit/59583245639d8c42ae0009f4a4a70464d3ea70a0

