### PR TITLE
[GHSA-g8pj-r55q-5c2v] Apache Tomcat Incomplete Cleanup vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-g8pj-r55q-5c2v/GHSA-g8pj-r55q-5c2v.json
+++ b/advisories/github-reviewed/2023/10/GHSA-g8pj-r55q-5c2v/GHSA-g8pj-r55q-5c2v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g8pj-r55q-5c2v",
-  "modified": "2023-10-16T22:21:44Z",
+  "modified": "2023-11-13T05:04:39Z",
   "published": "2023-10-10T18:31:35Z",
   "aliases": [
     "CVE-2023-42795"
@@ -76,6 +76,82 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.apache.tomcat:tomcat"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.5.0"
+            },
+            {
+              "fixed": "8.5.94"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "11.0.0-M1"
+            },
+            {
+              "fixed": "11.0.0-M12"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.1.0-M1"
+            },
+            {
+              "fixed": "10.1.14"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.0-M1"
+            },
+            {
+              "fixed": "9.0.81"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Improve visibility for org.apache.tomcat.embed:tomcat-embed-core

Reasoning -> fixed components are also part of tomcat-embed-core package:
(11.0.x) https://github.com/apache/tomcat/commit/d6db22e411307c97ddf78315c15d5889356eca38
(10.1.x) https://github.com/apache/tomcat/commit/9375d67106f8df9eb9d7b360b2bef052fe67d3d4
(9.0.x) https://github.com/apache/tomcat/commit/44d05d75d696ca10ce251e4e370511e38f20ae75
(8.5.x) https://github.com/apache/tomcat/commit/30f8063d7a9b4c43ae4722f5e382a76af1d7a6bf