### PR TITLE
[GHSA-2g99-c67p-56hm] XML Signature/Encryption Not Validated in Apache CXF

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-2g99-c67p-56hm/GHSA-2g99-c67p-56hm.json
+++ b/advisories/github-reviewed/2022/05/GHSA-2g99-c67p-56hm/GHSA-2g99-c67p-56hm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2g99-c67p-56hm",
-  "modified": "2022-07-13T21:20:48Z",
+  "modified": "2023-02-13T17:12:45Z",
   "published": "2022-05-13T01:09:22Z",
   "aliases": [
     "CVE-2012-2379"
@@ -74,6 +74,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2012-2379"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/440528d928be1e2030e7227b958c9c072847d9b2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/4500bf901cb2a7312291b6663045f28a95d2a0c4"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch links related to CVE-2012-2379