### PR TITLE
[GHSA-3336-h95j-hvvf] Improper Access Control in Apache CXF

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-3336-h95j-hvvf/GHSA-3336-h95j-hvvf.json
+++ b/advisories/github-reviewed/2022/05/GHSA-3336-h95j-hvvf/GHSA-3336-h95j-hvvf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3336-h95j-hvvf",
-  "modified": "2022-07-06T20:13:40Z",
+  "modified": "2023-11-21T11:58:17Z",
   "published": "2022-05-13T01:09:20Z",
   "aliases": [
     "CVE-2015-5253"
@@ -86,11 +86,27 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/02245c656941f28b6b2be5e461e6db04a70d2436"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/1c2a53080004d6ce275f2e70f46a0098d4140787"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/cxf/commit/845eccb6484b43ba02875c71e824db23ae4f20c0#diff-921f09f2f42d9dee79e60428679f11cd4788a33854bb957f18ded6c939f585fd"
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/f318ee614c8cdc6f2c485d42ff2d670d67e6455a"
+    },
+    {
+      "type": "WEB",
       "url": "https://git-wip-us.apache.org/repos/asf?p=cxf.git;a=commitdiff;h=845eccb6484b43ba02875c71e824db23ae4f20c0"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/cxf/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add source code link and patch links related to CVE-2015-5253.