### PR TITLE
[GHSA-x7xf-253v-x3w8] Improper Restriction of XML External Entity Reference in Apache CXF JAX-RS

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-x7xf-253v-x3w8/GHSA-x7xf-253v-x3w8.json
+++ b/advisories/github-reviewed/2022/05/GHSA-x7xf-253v-x3w8/GHSA-x7xf-253v-x3w8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x7xf-253v-x3w8",
-  "modified": "2022-07-06T19:47:38Z",
+  "modified": "2023-01-27T05:02:13Z",
   "published": "2022-05-13T01:09:20Z",
   "aliases": [
     "CVE-2016-8739"
@@ -67,7 +67,59 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/34359c952209dd5b66ede5255f83bcdd729b53de"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/3c874549a1c9653482f83f874003b1442d7379ae"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/5f5be21a69c01848d9772ea6a477ee3e6079fe39"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/6afd8f9e25f7685e296fade372308b9d312342af"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/70591bf2091e0406346f8afecb2f10f0e9168566"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/8c898d665163ed6710067893ce999ecbe2416249"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/8e4970d9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/9deb2d17"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/9f7c1181c46fa345e7394d8761661c96d5fbf494"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/c322ba957e09c58ccef0fe25b382497b031fdc06"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/d9e2a6e7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/e1d0a78fa8ce50aa5c88a9d12bed01509936af94"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2017:0868"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/cxf/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source code link and patch links related to CVE-2016-8739