### PR TITLE
[GHSA-jc7r-v6fg-2gpf] High severity vulnerability that affects org.apache.cxf:apache-cxf, org.apache.cxf:apache-cxf , and org.apache.cxf:cxf

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-jc7r-v6fg-2gpf/GHSA-jc7r-v6fg-2gpf.json
+++ b/advisories/github-reviewed/2018/10/GHSA-jc7r-v6fg-2gpf/GHSA-jc7r-v6fg-2gpf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jc7r-v6fg-2gpf",
-  "modified": "2021-12-03T14:29:04Z",
+  "modified": "2023-02-01T05:03:44Z",
   "published": "2018-10-19T16:40:01Z",
   "aliases": [
     "CVE-2018-8039"
@@ -96,6 +96,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-8039"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf/commit/8ed6208f987ff72e4c4d2cf8a6b1ec9b27575d4"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add one patch link related to CVE-2018-8039