### PR TITLE
[GHSA-qhxw-54m9-6wwc] Jenkins Maven Plugin 2.17 and earlier bundled a version...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-qhxw-54m9-6wwc/GHSA-qhxw-54m9-6wwc.json
+++ b/advisories/unreviewed/2022/05/GHSA-qhxw-54m9-6wwc/GHSA-qhxw-54m9-6wwc.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qhxw-54m9-6wwc",
-  "modified": "2022-05-14T03:45:43Z",
+  "modified": "2023-02-03T05:00:32Z",
   "published": "2022-05-14T03:45:43Z",
   "aliases": [
     "CVE-2017-1000397"
   ],
+  "summary": "CVE-2017-1000397",
   "details": "Jenkins Maven Plugin 2.17 and earlier bundled a version of the commons-httpclient library with the vulnerability CVE-2012-6153 that incorrectly verified SSL certificates, making it susceptible to man-in-the-middle attacks. Maven Plugin 3.0 no longer has a dependency on commons-httpclient.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:maven-plugin"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.17"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
At the top of the vulnerability report link:
https://www.jenkins.io/security/advisory/2017-10-11/

the hyperlink of 'maven plugin' points to:
https://github.com/jenkinsci/maven-plugin

Then  in its `pom.xml`, includes the library name:
~~~
  <groupId>org.jenkins-ci.main</groupId><!-- for historical reason, this plugin has a different groupId -->
  <artifactId>maven-plugin</artifactId><!-- for the same reason, artifactId is against the convention -->
  <version>${revision}${changelist}</version>
  <packaging>hpi</packaging>
~~~

The affected versions are easy to find in vulnerability description