### PR TITLE
[GHSA-c3hf-8vgx-72rh] Microsoft Security Advisory CVE-2023-36049: .NET Elevation of Privilege Vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-c3hf-8vgx-72rh/GHSA-c3hf-8vgx-72rh.json
+++ b/advisories/github-reviewed/2023/11/GHSA-c3hf-8vgx-72rh/GHSA-c3hf-8vgx-72rh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c3hf-8vgx-72rh",
-  "modified": "2023-11-14T21:37:37Z",
+  "modified": "2023-11-14T21:37:40Z",
   "published": "2023-11-14T20:39:33Z",
   "aliases": [
     "CVE-2023-36049"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "System.Net.Requests"
+        "name": "Microsoft.NETCore.App.Ref"
       },
       "ranges": [
         {
@@ -40,7 +40,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "System.Net.Requests"
+        "name": "Microsoft.NETCore.App.Ref"
       },
       "ranges": [
         {
@@ -62,7 +62,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "System.Net.Requests"
+        "name": "Microsoft.NETCore.App.Ref"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The System.Net.Requests nuget is not a valid package for this alert.  There may not be an appropriate package to use in this alert, though I've selected Microsoft.NETCore.App.Ref (https://www.nuget.org/packages/Microsoft.NETCore.App.Ref) in order to submit the form and provide a better reference to the issue.

Background: System.Net.Requests.dll is a file assembly that's is included in the Microsoft .NET (Core) API runtime, which is installed on the host or in the container. Referencing the NuGet package for System.Net.Requests with the listed versioning is causing downstream SCA scanning tools to report the _assembly_ DLL needs to get patched to version 6.0.25, 7.0.14, or 8.0.0, which cannot be done. System.Net.Requests has to get updated by updating the .NET  runtime or SDK.  Also, System.Net.Requests's package listing at https://www.nuget.org/packages/System.Net.Requests is old - you cannot update it via nuget - and should have never been used.

Referencing a package manager for this GHSA may itself be incorrect, as Microsoft stopped releasing nuget packages for the .NET runtime and SDKs, and instead distribute these as their own (installed) software.  

Not sure the *best* way to modify this alert, so I hope this is a start for the team's review!