### PR TITLE
[GHSA-h755-h99p-9ffv] An issue was discovered in weixin-java-tools v3.3.0....

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-h755-h99p-9ffv/GHSA-h755-h99p-9ffv.json
+++ b/advisories/unreviewed/2022/05/GHSA-h755-h99p-9ffv/GHSA-h755-h99p-9ffv.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h755-h99p-9ffv",
-  "modified": "2022-05-14T01:40:24Z",
+  "modified": "2023-02-02T05:04:19Z",
   "published": "2022-05-14T01:40:24Z",
   "aliases": [
     "CVE-2019-5312"
   ],
+  "summary": "CVE-2019-5312",
   "details": "An issue was discovered in weixin-java-tools v3.3.0. There is an XXE vulnerability in the getXmlDoc method of the BaseWxPayResult.java file. NOTE: this issue exists because of an incomplete fix for CVE-2018-20318.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.github.binarywang:weixin-java-common"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.3.2.B"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
In the given reference:
https://github.com/Wechat-Group/WxJava/issues/903

It provides the vulnerability patch link in the version `3.3.2.B`:
https://github.com/Wechat-Group/WxJava/commit/8ec61d1328f50e23cd14285a950ca57a088b32b2

This link indicates that the affected package is `com.github.binarywang:weixin-java-common`.