### PR TITLE
[GHSA-j88v-q3vw-p9vr] The Java implementation of AMF3 deserializers used in...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-j88v-q3vw-p9vr/GHSA-j88v-q3vw-p9vr.json
+++ b/advisories/unreviewed/2022/05/GHSA-j88v-q3vw-p9vr/GHSA-j88v-q3vw-p9vr.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j88v-q3vw-p9vr",
-  "modified": "2022-05-13T01:36:43Z",
+  "modified": "2023-02-01T05:09:02Z",
   "published": "2022-05-13T01:36:43Z",
   "aliases": [
     "CVE-2017-3202"
   ],
+  "summary": "CVE-2017-3202",
   "details": "The Java implementation of AMF3 deserializers used in Flamingo amf-serializer by Exadel, version 2.2.0, may allow instantiation of arbitrary classes via their public parameter-less constructor and subsequently call arbitrary Java Beans setter methods. The ability to exploit this vulnerability depends on the availability of classes in the class path that make use of deserialization. A remote attacker with the ability to spoof or control information may be able to send serialized Java objects with pre-set properties that result in arbitrary code execution when deserialized.",
   "severity": [
     {
@@ -14,7 +15,15 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.exadel.flamingo.flex:amf-serializer"
+      },
+      "versions": [
+        "2.2.0"
+      ]
+    }
   ],
   "references": [
     {
@@ -40,7 +49,8 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-502"
+      "CWE-502",
+      "CWE-913"
     ],
     "severity": "CRITICAL",
     "github_reviewed": false,


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- Summary

**Comments**
The vulnerability description in:
https://www.kb.cert.org/vuls/id/307983

mentions that the affected library is `Flamingo amf-serializer by Exadel`, which matches `com.exadel.flamingo.flex:amf-serializer` in Maven.
and this library description in Maven is `Library for AMF0/AMF3 messages serialization/deserialization` :
https://mvnrepository.com/artifact/com.exadel.flamingo.flex/amf-serializer
