### PR TITLE
[GHSA-339j-hqgx-qrrx] Prototype Pollution in nedb

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-339j-hqgx-qrrx/GHSA-339j-hqgx-qrrx.json
+++ b/advisories/github-reviewed/2021/06/GHSA-339j-hqgx-qrrx/GHSA-339j-hqgx-qrrx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-339j-hqgx-qrrx",
-  "modified": "2023-08-08T19:57:23Z",
+  "modified": "2023-08-17T05:02:30Z",
   "published": "2021-06-21T17:13:06Z",
   "aliases": [
     "CVE-2021-23395"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
nedb  *
Severity: critical
Prototype Pollution in nedb - https://github.com/advisories/GHSA-339j-hqgx-qrrx
Depends on vulnerable versions of binary-search-tree
Depends on vulnerable versions of underscore
No fix available
node_modules/nedb