### PR TITLE
[GHSA-jq35-85cj-fj4p] /sys/devices/virtual/powercap accessible by default to containers

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-jq35-85cj-fj4p/GHSA-jq35-85cj-fj4p.json
+++ b/advisories/github-reviewed/2023/10/GHSA-jq35-85cj-fj4p/GHSA-jq35-85cj-fj4p.json
@@ -30,6 +30,28 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/docker/docker"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "23.0.8"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 23.0.7"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to the Moby project, this vulnerability was fixed in v23.0.8 as well, see https://github.com/moby/moby/releases/tag/v23.0.8