### PR TITLE
[GHSA-2ppp-xj34-vvf7] The CookieInterceptor component in Apache Struts before 2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-2ppp-xj34-vvf7/GHSA-2ppp-xj34-vvf7.json
+++ b/advisories/unreviewed/2022/05/GHSA-2ppp-xj34-vvf7/GHSA-2ppp-xj34-vvf7.json
@@ -1,22 +1,46 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2ppp-xj34-vvf7",
-  "modified": "2022-05-04T00:29:43Z",
+  "modified": "2023-02-01T05:01:40Z",
   "published": "2022-05-04T00:29:43Z",
   "aliases": [
     "CVE-2012-0392"
   ],
+  "summary": "The CookieInterceptor component in Apache Struts before 2.3.1.1 does not use the parameter-name whitelist",
   "details": "The CookieInterceptor component in Apache Struts before 2.3.1.1 does not use the parameter-name whitelist, which allows remote attackers to execute arbitrary commands via a crafted HTTP Cookie header that triggers Java code execution through a static method.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.struts»struts2-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2012-0392"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/struts/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Add source code link and patch links and affected package name related to CVE-2012-0392