### PR TITLE
[GHSA-whmq-v94q-34p9] Improper Control of Generation of Code in Apache Struts

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-whmq-v94q-34p9/GHSA-whmq-v94q-34p9.json
+++ b/advisories/github-reviewed/2022/05/GHSA-whmq-v94q-34p9/GHSA-whmq-v94q-34p9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-whmq-v94q-34p9",
-  "modified": "2022-07-08T19:05:59Z",
+  "modified": "2023-01-27T05:02:22Z",
   "published": "2022-05-14T00:54:15Z",
   "aliases": [
     "CVE-2013-1965"
@@ -42,7 +42,31 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/7e6f641ebb142663cbd1653dc49bed725edf7f56"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/d7804297e319c7a12245e1b536e565fcea6d6503"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/d934c6e7430b7b98e43a0a085a2304bd31a75c3d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/ea96d18d0f75c390d2595648efa3563785c272c6"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/fed4f8e8a4ec69b5e7612b92d8ce3e476680474b"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=967655"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/struts/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add some patch links and source code link related to CVE-2013-1965.