### PR TITLE
[GHSA-q5q8-jghf-3pm3] Apache Struts2 Broken Access Control Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-q5q8-jghf-3pm3/GHSA-q5q8-jghf-3pm3.json
+++ b/advisories/github-reviewed/2022/05/GHSA-q5q8-jghf-3pm3/GHSA-q5q8-jghf-3pm3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q5q8-jghf-3pm3",
-  "modified": "2023-08-15T19:02:21Z",
+  "modified": "2023-08-15T19:02:22Z",
   "published": "2022-05-17T04:44:52Z",
   "aliases": [
     "CVE-2013-4310"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-4310"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/0c8366cb792227d484b9ca13e537037dd0cb57dc"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add one patch link related to CVE-2013-4310.