### PR TITLE
[GHSA-38xm-xhvj-q2qf] Jenkins Credentials Binding Plugin 1.14 and earlier masks...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-38xm-xhvj-q2qf/GHSA-38xm-xhvj-q2qf.json
+++ b/advisories/unreviewed/2022/05/GHSA-38xm-xhvj-q2qf/GHSA-38xm-xhvj-q2qf.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-38xm-xhvj-q2qf",
-  "modified": "2022-05-13T01:48:30Z",
+  "modified": "2023-02-02T05:01:38Z",
   "published": "2022-05-13T01:48:30Z",
   "aliases": [
     "CVE-2018-1000057"
   ],
+  "summary": "CVE-2018-1000057",
   "details": "Jenkins Credentials Binding Plugin 1.14 and earlier masks passwords it provides to build processes in their build logs. Jenkins however transforms provided password values, e.g. replacing environment variable references, which could result in values different from but similar to configured passwords being provided to the build. Those values are not subject to masking, and could allow unauthorized users to recover the original password.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:credentials-binding"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.15"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.14"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Only one library in maven corresponds to `Jenkins Credentials Binding Plugin`
https://jenkins.io/security/advisory/2018-02-05/