### PR TITLE
[GHSA-mmj6-cjj4-hpr5] Apache Struts 2.3.19 to 2.3.20.2, 2.3.21 to 2.3.24.1, and...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-mmj6-cjj4-hpr5/GHSA-mmj6-cjj4-hpr5.json
+++ b/advisories/unreviewed/2022/05/GHSA-mmj6-cjj4-hpr5/GHSA-mmj6-cjj4-hpr5.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mmj6-cjj4-hpr5",
-  "modified": "2022-05-14T00:54:14Z",
+  "modified": "2023-02-02T05:02:47Z",
   "published": "2022-05-14T00:54:14Z",
   "aliases": [
     "CVE-2016-3087"
   ],
+  "summary": "An vulnerability in Apache Struts 2.3.19 to 2.3.20.2, 2.3.21 to 2.3.24.1, and 2.3.25 to 2.3.28",
   "details": "Apache Struts 2.3.19 to 2.3.20.2, 2.3.21 to 2.3.24.1, and 2.3.25 to 2.3.28, when Dynamic Method Invocation is enabled, allow remote attackers to execute arbitrary code via vectors related to an ! (exclamation mark) operator to the REST Plugin.",
   "severity": [
     {
@@ -14,12 +15,39 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.struts:struts2-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-3087"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/6bd694b7980494c12d49ca1bf39f12aec3e03e2f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/98d2692e434fe7f4d445ade24fe2c9860de1c13f"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/struts/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Add some patch links and affected prodect related to CVE-2016-3087.