### PR TITLE
[GHSA-38qw-j787-v8c2] Apache Struts CSRF Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-38qw-j787-v8c2/GHSA-38qw-j787-v8c2.json
+++ b/advisories/github-reviewed/2022/05/GHSA-38qw-j787-v8c2/GHSA-38qw-j787-v8c2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-38qw-j787-v8c2",
-  "modified": "2023-11-02T20:26:49Z",
+  "modified": "2023-11-02T20:26:50Z",
   "published": "2022-05-17T00:29:27Z",
   "aliases": [
     "CVE-2016-4430"
@@ -45,6 +45,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/struts/commit/eccc31ebce5430f9e91b9684c63eaaf885e603f9"
     },
     {
@@ -53,7 +57,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/apache/struts-master"
+      "url": "https://github.com/apache/struts"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add some patch links related to CVE-2016-4430.