### PR TITLE
[GHSA-xm92-v2mq-842q] Apache Struts 2 before 2.3.29 and 2.5.x before 2.5.1...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-xm92-v2mq-842q/GHSA-xm92-v2mq-842q.json
+++ b/advisories/unreviewed/2022/05/GHSA-xm92-v2mq-842q/GHSA-xm92-v2mq-842q.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xm92-v2mq-842q",
-  "modified": "2022-05-17T02:16:00Z",
+  "modified": "2023-01-27T05:04:28Z",
   "published": "2022-05-17T02:16:00Z",
   "aliases": [
     "CVE-2016-4436"
   ],
+  "summary": "Apache Struts 2 before 2.3.29 and 2.5.x before 2.5.1 allow attackers to have unspecified impact via vectors related to improper action name clean up",
   "details": "Apache Struts 2 before 2.3.29 and 2.5.x before 2.5.1 allow attackers to have unspecified impact via vectors related to improper action name clean up.",
   "severity": [
     {
@@ -14,12 +15,39 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.struts:struts2-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-4436"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/237432512df0e27013f7c7b9ab59fdce44ca34a5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/27ca165ddbf81c84bafbd083b99a18d89cc49ca7"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/struts/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Add affectted product and patch links related to CVE-2016-4436.