### PR TITLE
[GHSA-8fx9-5hx8-crhm] Apache Struts 2.0.1 uses an unintentional expression in a Freemarker tag instead of string literal

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-8fx9-5hx8-crhm/GHSA-8fx9-5hx8-crhm.json
+++ b/advisories/github-reviewed/2018/10/GHSA-8fx9-5hx8-crhm/GHSA-8fx9-5hx8-crhm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8fx9-5hx8-crhm",
-  "modified": "2022-04-26T18:59:36Z",
+  "modified": "2023-01-09T05:02:49Z",
   "published": "2018-10-16T19:35:40Z",
   "aliases": [
     "CVE-2017-12611"
@@ -66,8 +66,20 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-12611"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/2306f5f7fad7f0157f216f34331238feb0539fa"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/637ad1c3707266c33daabb18d7754e795e6681f"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-8fx9-5hx8-crhm"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/struts/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source code link and patch links related to CVE-2017-12611.