### PR TITLE
[GHSA-j77q-2qqg-6989] Apache Struts vulnerable to remote arbitrary command execution due to improper input validation

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-j77q-2qqg-6989/GHSA-j77q-2qqg-6989.json
+++ b/advisories/github-reviewed/2018/10/GHSA-j77q-2qqg-6989/GHSA-j77q-2qqg-6989.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j77q-2qqg-6989",
-  "modified": "2022-09-14T01:02:56Z",
+  "modified": "2023-01-31T05:03:28Z",
   "published": "2018-10-18T19:24:26Z",
   "aliases": [
     "CVE-2017-5638"
@@ -71,6 +71,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/b06dd50af2a3319dd896bf5c2f4972d2b772cf2b"
+    },
+    {
+      "type": "WEB",
       "url": "https://arstechnica.com/security/2017/03/critical-vulnerability-under-massive-attack-imperils-high-impact-sites/"
     },
     {
@@ -96,6 +100,10 @@
     {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-j77q-2qqg-6989"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/struts/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source code link and patch links related to CVE-2017-5638.