### PR TITLE
[GHSA-9gp7-jvm2-r4mx] Moderate severity vulnerability that affects org.apache.struts:struts2-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-9gp7-jvm2-r4mx/GHSA-9gp7-jvm2-r4mx.json
+++ b/advisories/github-reviewed/2018/10/GHSA-9gp7-jvm2-r4mx/GHSA-9gp7-jvm2-r4mx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9gp7-jvm2-r4mx",
-  "modified": "2021-09-07T21:35:59Z",
+  "modified": "2023-01-09T05:02:50Z",
   "published": "2018-10-16T19:36:43Z",
   "aliases": [
     "CVE-2017-7672"
@@ -41,8 +41,44 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-7672"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/13828056b47a25e7ddee80a042a6a8d3b670ff32"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/3fddfb6eb562d597c935084e9e81d43ed6bcd02c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/418a20c0594f23764fe29ced400c1219239899a8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/744c1f409d983641af3e8e3b573c2f2d2c2c6d9c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/8a04e80f01350c90f053d71366d5e0c2186fded5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/8df5a897f61f3ef45c36fdd9275e66669ae4516c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/9d47af6ffa355977b5acc713e6d1f25fac260a28"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/a05259ed69a5a48379aa91650e4cd1cb4bd6e5ad"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-9gp7-jvm2-r4mx"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/struts/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source code link and patch links related to CVE-2017-7672.