### PR TITLE
[GHSA-8mr5-h28g-36qx] Spring AOP functionality (Struts) vulnerable to DoS attack

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-8mr5-h28g-36qx/GHSA-8mr5-h28g-36qx.json
+++ b/advisories/github-reviewed/2018/10/GHSA-8mr5-h28g-36qx/GHSA-8mr5-h28g-36qx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8mr5-h28g-36qx",
-  "modified": "2022-04-26T19:00:20Z",
+  "modified": "2023-01-09T05:02:49Z",
   "published": "2018-10-16T19:37:07Z",
   "aliases": [
     "CVE-2017-9787"
@@ -60,8 +60,20 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-9787"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/086b63735527d4bb0c1dd0d86a7c0374b825ff2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/0d6442bab5b44d93c4c2e63c5335f0a331333b9"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-8mr5-h28g-36qx"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/struts/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add some patch links and source code link related to CVE-2017-9787 which fixed in multi-branch.