### PR TITLE
[GHSA-x5x7-3v85-wpc4] Apache Struts allows entering a custom URL in a form field if built-in URLValidator is used

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-x5x7-3v85-wpc4/GHSA-x5x7-3v85-wpc4.json
+++ b/advisories/github-reviewed/2018/10/GHSA-x5x7-3v85-wpc4/GHSA-x5x7-3v85-wpc4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x5x7-3v85-wpc4",
-  "modified": "2023-06-12T22:33:41Z",
+  "modified": "2023-06-12T22:33:44Z",
   "published": "2018-10-16T19:37:33Z",
   "aliases": [
     "CVE-2017-9804"
@@ -66,8 +66,36 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-9804"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/3fddfb6eb562d597c935084e9e81d43ed6bcd02"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/418a20c0594f23764fe29ced400c1219239899a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/744c1f409d983641af3e8e3b573c2f2d2c2c6d9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/8a04e80f01350c90f053d71366d5e0c2186fded"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/9d47af6ffa355977b5acc713e6d1f25fac260a2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/a05259ed69a5a48379aa91650e4cd1cb4bd6e5a"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-x5x7-3v85-wpc4"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/struts/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source code link and patch links related to CVE-2017-9804 which fixed in multi-branch.