### PR TITLE
[GHSA-gg9m-fj3v-r58c] REST Plugin in Apache Struts uses an XStreamHandler with an instance of XStream for deserialization without any type filtering

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-gg9m-fj3v-r58c/GHSA-gg9m-fj3v-r58c.json
+++ b/advisories/github-reviewed/2018/10/GHSA-gg9m-fj3v-r58c/GHSA-gg9m-fj3v-r58c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gg9m-fj3v-r58c",
-  "modified": "2022-04-26T19:03:19Z",
+  "modified": "2023-01-09T05:03:17Z",
   "published": "2018-10-16T19:37:56Z",
   "aliases": [
     "CVE-2017-9805"
@@ -61,6 +61,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/19494718865f2fb7da5ea363de3822f87fbda26"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/6dd6e5cfb7b5e020abffe7e8091bd63fe97c10a"
+    },
+    {
+      "type": "WEB",
       "url": "https://blogs.apache.org/foundation/entry/apache-struts-statement-on-equifax"
     },
     {
@@ -74,6 +82,10 @@
     {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-gg9m-fj3v-r58c"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/struts/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source code link and some patch links related to CVE-2017-9805.