### PR TITLE
[GHSA-cr6j-3jp9-rw65] Apache Struts vulnerable to remote command execution (RCE) due to improper input validation

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-cr6j-3jp9-rw65/GHSA-cr6j-3jp9-rw65.json
+++ b/advisories/github-reviewed/2018/10/GHSA-cr6j-3jp9-rw65/GHSA-cr6j-3jp9-rw65.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cr6j-3jp9-rw65",
-  "modified": "2022-10-04T21:52:32Z",
+  "modified": "2023-11-04T05:05:10Z",
   "published": "2018-10-18T19:24:38Z",
   "aliases": [
     "CVE-2018-11776"
@@ -64,6 +64,26 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-11776"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/4a3917176de2df7f33a85511d067f31e50dcc1b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/6e87474f9ad0549f07dd2c37d50a9ccd0977c6e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/6efaf900d4ffb7be8a74065af5553bad2389f72"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/b3bad5ea44f3fd9edb2cb491192c5900f46d45d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/eec0d8e877dc86da4946268caf73c2f7ed5d2fc6"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add source code link and some patch links related to CVE-2018-11776 which fixed in multi-branch.