### PR TITLE
[GHSA-38cr-2ph5-frr9] Apache Struts REST Plugin can potentially allow a DoS attack

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-38cr-2ph5-frr9/GHSA-38cr-2ph5-frr9.json
+++ b/advisories/github-reviewed/2018/10/GHSA-38cr-2ph5-frr9/GHSA-38cr-2ph5-frr9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-38cr-2ph5-frr9",
-  "modified": "2022-04-26T18:59:06Z",
+  "modified": "2023-01-09T05:02:50Z",
   "published": "2018-10-16T19:35:26Z",
   "aliases": [
     "CVE-2018-1327"
@@ -42,11 +42,27 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/4260bee634cb606be6071bce2383fddb510608aa"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/67ecf3a21608e20449bcb7895b22204b400fecd4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/9260720568cee9e868d2899228eceed0c3359323"
+    },
+    {
+      "type": "WEB",
       "url": "https://cwiki.apache.org/confluence/display/WW/S2-056"
     },
     {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-38cr-2ph5-frr9"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/struts/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source code link and patch links related to CVE-2018-1327.