### PR TITLE
[GHSA-vh95-rmgr-6w4m] Prototype Pollution in minimist

### DIFF
--- a/advisories/github-reviewed/2020/04/GHSA-vh95-rmgr-6w4m/GHSA-vh95-rmgr-6w4m.json
+++ b/advisories/github-reviewed/2020/04/GHSA-vh95-rmgr-6w4m/GHSA-vh95-rmgr-6w4m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vh95-rmgr-6w4m",
-  "modified": "2022-04-26T21:01:40Z",
+  "modified": "2023-11-29T20:53:47Z",
   "published": "2020-04-03T21:48:32Z",
   "aliases": [
     "CVE-2020-7598"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "minimist"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(minimist)"
-        ]
       },
       "ranges": [
         {
@@ -43,11 +38,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "minimist"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(minimist)"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**

minimist  <=0.2.3
Severity: critical
Prototype Pollution in minimist - https://github.com/advisories/GHSA-xvch-5gv4-984h
Prototype Pollution in minimist - https://github.com/advisories/GHSA-vh95-rmgr-6w4m
fix available via `npm audit fix`
node_modules/minimist
  optimist  >=0.6.0
  Depends on vulnerable versions of minimist
  node_modules/optimist