### PR TITLE
[GHSA-wrvr-8mpx-r7pp] mime Regular Expression Denial of Service when MIME lookup performed on untrusted user input

### DIFF
--- a/advisories/github-reviewed/2018/07/GHSA-wrvr-8mpx-r7pp/GHSA-wrvr-8mpx-r7pp.json
+++ b/advisories/github-reviewed/2018/07/GHSA-wrvr-8mpx-r7pp/GHSA-wrvr-8mpx-r7pp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wrvr-8mpx-r7pp",
-  "modified": "2023-09-12T18:28:52Z",
+  "modified": "2023-09-12T18:28:55Z",
   "published": "2018-07-20T16:20:52Z",
   "aliases": [
     "CVE-2017-16138"
@@ -25,10 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.0.0"
+              "introduced": "0"
             },
             {
-              "fixed": "2.0.3"
+              "fixed": "1.4.1"
             }
           ]
         }
@@ -44,10 +44,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0.0"
             },
             {
-              "fixed": "1.4.1"
+              "fixed": "2.0.3"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
npm audit report

git  *
Severity: high
Code injection in npm git - https://github.com/advisories/GHSA-9gqr-xp86-f87h
Depends on vulnerable versions of mime
No fix available
node_modules/git

mime  <1.4.1
Severity: high
mime Regular Expression Denial of Service when MIME lookup performed on untrusted user input - https://github.com/advisories/GHSA-wrvr-8mpx-r7pp
No fix available
node_modules/mime

2 high severity vulnerabilities
