### PR TITLE
[GHSA-6w3h-vq7m-v3qf] A exposure of sensitive information vulnerability exists...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-6w3h-vq7m-v3qf/GHSA-6w3h-vq7m-v3qf.json
+++ b/advisories/unreviewed/2022/05/GHSA-6w3h-vq7m-v3qf/GHSA-6w3h-vq7m-v3qf.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6w3h-vq7m-v3qf",
-  "modified": "2022-05-14T01:09:55Z",
+  "modified": "2023-02-02T05:03:11Z",
   "published": "2022-05-14T01:09:55Z",
   "aliases": [
     "CVE-2018-1000191"
   ],
+  "summary": "CVE-2018-1000191",
   "details": "A exposure of sensitive information vulnerability exists in Jenkins Black Duck Detect Plugin 1.4.0 and older in DetectPostBuildStepDescriptor.java that allows attackers with Overall/Read access to connect to an attacker-specified URL using attacker-specified credentials IDs obtained through another method, capturing credentials stored in Jenkins.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.synopsys.integration:synopsys-detect"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.4.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.4.0"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
url `https://jenkins.io/security/advisory/2018-06-04/#SECURITY-866` points to:
`https://plugins.jenkins.io/blackduck-detect/`

Then in this url, it points to the repo URL `https://github.com/jenkinsci/synopsys-detect-plugin`

From its `build.gradle` file, we extract this library name.