### PR TITLE
[GHSA-f8w9-66fp-3jgw] A reflected cross-site scripting vulnerability in Jenkins...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-f8w9-66fp-3jgw/GHSA-f8w9-66fp-3jgw.json
+++ b/advisories/unreviewed/2022/05/GHSA-f8w9-66fp-3jgw/GHSA-f8w9-66fp-3jgw.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f8w9-66fp-3jgw",
-  "modified": "2023-01-27T18:30:31Z",
+  "modified": "2023-01-27T21:16:25Z",
   "published": "2022-05-24T16:59:38Z",
   "aliases": [
     "CVE-2019-10475"
   ],
+  "summary": "CVE-2019-10475",
   "details": "A reflected cross-site scripting vulnerability in Jenkins build-metrics Plugin allows attackers to inject arbitrary HTML and JavaScript into web pages provided by this plugin.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.plugins:build-metrics"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
`https://jenkins.io/security/advisory/2019-10-23/#SECURITY-1490` points to `https://plugins.jenkins.io/build-metrics/`

And this website provide the dependency of this library: (actually there seems no patched version)
~~~
<dependency>
    <groupId>org.jenkins-ci.plugins</groupId>
    <artifactId>build-metrics</artifactId>
    <version>1.3</version>
</dependency>
~~~

