### PR TITLE
[GHSA-q44p-q588-242q] jQuery 1.4.2 allows remote attackers to conduct cross...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-q44p-q588-242q/GHSA-q44p-q588-242q.json
+++ b/advisories/unreviewed/2022/05/GHSA-q44p-q588-242q/GHSA-q44p-q588-242q.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q44p-q588-242q",
-  "modified": "2022-05-14T01:54:34Z",
+  "modified": "2023-02-02T05:04:47Z",
   "published": "2022-05-14T01:54:34Z",
   "aliases": [
     "CVE-2014-6071"
   ],
+  "summary": "CVE-2014-6071",
   "details": "jQuery 1.4.2 allows remote attackers to conduct cross-site scripting (XSS) attacks via vectors related to use of the text method inside after.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "jquery"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.4.2"
+            },
+            {
+              "fixed": "1.11.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.4.2"
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Url `https://seclists.org/fulldisclosure/2014/Sep/10` directly indicates the affected library `jquery`

Url `https://bugzilla.redhat.com/show_bug.cgi?id=1136683` indicates the fixed version of `1.11.1` 