### PR TITLE
[GHSA-9qhq-j4xm-cw48] The invokeNextValve function in identity/federation...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-9qhq-j4xm-cw48/GHSA-9qhq-j4xm-cw48.json
+++ b/advisories/unreviewed/2022/05/GHSA-9qhq-j4xm-cw48/GHSA-9qhq-j4xm-cw48.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9qhq-j4xm-cw48",
-  "modified": "2022-05-17T04:09:07Z",
+  "modified": "2023-01-28T05:01:12Z",
   "published": "2022-05-17T04:09:07Z",
   "aliases": [
     "CVE-2015-3158"
   ],
+  "summary": "CVE-2015-3158",
   "details": "The invokeNextValve function in identity/federation/bindings/tomcat/idp/AbstractIDPValve.java in PicketLink before 2.8.0.Beta1 does not properly check role based authorization, which allows remote authenticated users to gain access to restricted application resources via a (1) direct request or (2) request through an SP initiated flow.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.picketlink:picketlink-bindings-parent"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.8.0.Beta1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The affected library's repository is shown in `https://github.com/picketlink/picketlink-bindings/pull/124`

Where the group id and artifact id can be found in its `pom.xml`
~~~
  <groupId>org.picketlink</groupId>
  <version>2.7.2.Final-SNAPSHOT</version>
  <artifactId>picketlink-bindings-parent</artifactId>
  <packaging>pom</packaging>
~~~
