### PR TITLE
[GHSA-4m48-j3xj-px27] MyBatis plus v3.4.3 was discovered to contain a SQL...

### DIFF
--- a/advisories/unreviewed/2022/03/GHSA-4m48-j3xj-px27/GHSA-4m48-j3xj-px27.json
+++ b/advisories/unreviewed/2022/03/GHSA-4m48-j3xj-px27/GHSA-4m48-j3xj-px27.json
@@ -18,10 +18,20 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "Baomidou:Mybatis-plus"
+        "name": "com.baomidou:mybatis-plus"
       },
-      "versions": [
-        "3.4.3"
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.4.3"
+            }
+          ]
+        }
       ]
     }
   ],

--- a/advisories/unreviewed/2022/03/GHSA-4m48-j3xj-px27/GHSA-4m48-j3xj-px27.json
+++ b/advisories/unreviewed/2022/03/GHSA-4m48-j3xj-px27/GHSA-4m48-j3xj-px27.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4m48-j3xj-px27",
-  "modified": "2022-03-29T00:01:23Z",
+  "modified": "2023-01-27T05:01:02Z",
   "published": "2022-03-23T00:00:22Z",
   "aliases": [
     "CVE-2022-25517"
   ],
+  "summary": "CVE-2022-25517",
   "details": "MyBatis plus v3.4.3 was discovered to contain a SQL injection vulnerability via the Column parameter in /core/conditions/AbstractWrapper.java.",
   "severity": [
     {
@@ -14,7 +15,15 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "Baomidou:Mybatis-plus"
+      },
+      "versions": [
+        "3.4.3"
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
`https://www.cvedetails.com/cve/CVE-2022-25517` provides the affected library
and its maven url is `https://mvnrepository.com/artifact/com.baomidou/mybatis-plus`