### PR TITLE
[GHSA-ww39-953v-wcq6] glob-parent vulnerable to Regular Expression Denial of Service in enclosure regex

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-ww39-953v-wcq6/GHSA-ww39-953v-wcq6.json
+++ b/advisories/github-reviewed/2021/06/GHSA-ww39-953v-wcq6/GHSA-ww39-953v-wcq6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ww39-953v-wcq6",
-  "modified": "2023-11-29T00:42:41Z",
+  "modified": "2023-11-29T00:42:42Z",
   "published": "2021-06-07T21:56:34Z",
   "aliases": [
     "CVE-2020-28469"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "glob-parent"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(glob-parent).globParent"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
npm audit fix --force
npm WARN using --force Recommended protections disabled.
npm WARN audit Updating mocha to 10.2.0, which is a SemVer major change.
npm WARN audit Updating puppeteer to 21.6.1, which is a SemVer major change.
npm WARN audit Updating autoprefixer to 10.4.16, which is a SemVer major change.
npm WARN audit Updating rollup-plugin-postcss to 4.0.2, which is a SemVer major change.
npm WARN audit Updating chokidar-cli to 3.0.0, which is a SemVer major change.
npm WARN audit Updating @11ty/eleventy to 2.0.1, which is a SemVer major change.
npm WARN audit No fix available for sass-lint@*
npm WARN audit Updating webdev-infra to 1.0.41, which is a SemVer major change.
npm WARN audit Updating firebase-tools to 13.0.2, which is a SemVer major change.
npm WARN audit No fix available for remark-lint-are-links-valid@*
npm WARN audit Updating gulp to 3.9.1, which is a SemVer major change.
npm WARN audit Updating remark-cli to 12.0.0, which is a SemVer major change.
npm WARN deprecated natives@1.1.6: This module relies on Node.js's internals and will break at some point. Do not use it, and update to graceful-fs@4.x.
npm WARN deprecated graceful-fs@1.2.3: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated request-promise@3.0.0: request-promise has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
npm WARN deprecated trim@0.0.1: Use String.prototype.trim() instead
npm WARN deprecated chokidar@1.7.0: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.

added 258 packages, removed 591 packages, changed 294 packages, and audited 2467 packages in 2m

321 packages are looking for funding
  run `npm fund` for details

# npm audit report

ajv  <6.12.3
Severity: moderate
Prototype Pollution in Ajv - https://github.com/advisories/GHSA-v88g-cgmw-v5xw
fix available via `npm audit fix`
node_modules/sass-lint/node_modules/ajv
  table  3.7.10 - 4.0.2
  Depends on vulnerable versions of ajv
  node_modules/sass-lint/node_modules/table

braces  <=2.3.0
Regular Expression Denial of Service in braces - https://github.com/advisories/GHSA-g95f-p29q-9xw4
Regular Expression Denial of Service (ReDoS) in braces - https://github.com/advisories/GHSA-cwfw-4gq5-mrqx
fix available via `npm audit fix`
node_modules/remark-lint-are-links-valid/node_modules/braces
  micromatch  0.2.0 - 2.3.11
  Depends on vulnerable versions of braces
  Depends on vulnerable versions of parse-glob
  node_modules/remark-lint-are-links-valid/node_modules/micromatch
    anymatch  1.2.0 - 1.3.2
    Depends on vulnerable versions of micromatch
    node_modules/remark-lint-are-links-valid/node_modules/anymatch
      chokidar  1.0.0-rc1 - 2.1.8
      Depends on vulnerable versions of anymatch
      Depends on vulnerable versions of glob-parent
      node_modules/remark-lint-are-links-valid/node_modules/chokidar

glob-parent  <5.1.2
Severity: high
glob-parent vulnerable to Regular Expression Denial of Service in enclosure regex - https://github.com/advisories/GHSA-ww39-953v-wcq6
fix available via `npm audit fix`
node_modules/glob-base/node_modules/glob-parent
node_modules/remark-lint-are-links-valid/node_modules/glob-parent
  glob-base  *
  Depends on vulnerable versions of glob-parent
  node_modules/glob-base
    parse-glob  >=2.1.0
    Depends on vulnerable versions of glob-base
    node_modules/parse-glob

lodash  <=4.17.20
Severity: critical
Regular Expression Denial of Service (ReDoS) in lodash - https://github.com/advisories/GHSA-x5rq-j2xg-h7qm
Prototype Pollution in lodash - https://github.com/advisories/GHSA-fvqr-27wr-82fm
Prototype Pollution in lodash - https://github.com/advisories/GHSA-jf85-cpcp-j695
Command Injection in lodash - https://github.com/advisories/GHSA-35jh-r3h4-6jhm
Prototype Pollution in lodash - https://github.com/advisories/GHSA-4xc9-xhrj-v574
Regular Expression Denial of Service (ReDoS) in lodash - https://github.com/advisories/GHSA-29mw-wpgm-hmr9
fix available via `npm audit fix`
node_modules/gaze/node_modules/lodash
  globule  <=1.1.0
  Depends on vulnerable versions of glob
  Depends on vulnerable versions of lodash
  Depends on vulnerable versions of minimatch
  node_modules/gaze/node_modules/globule
    gaze  0.4.0 - 1.0.0
    Depends on vulnerable versions of globule
    node_modules/gaze
      glob-watcher  <=2.0.0
      Depends on vulnerable versions of gaze
      node_modules/glob-watcher

luxon  1.0.0 - 1.28.0
Severity: high
Luxon Inefficient Regular Expression Complexity vulnerability - https://github.com/advisories/GHSA-3xq5-wjfh-ppjc
fix available via `npm audit fix`
node_modules/luxon

merge  <2.1.1
Severity: high
Prototype Pollution in merge - https://github.com/advisories/GHSA-7wpw-2hjm-89gp
No fix available
node_modules/merge
  sass-lint  *
  Depends on vulnerable versions of eslint
  Depends on vulnerable versions of gonzales-pe-sl
  Depends on vulnerable versions of merge
  node_modules/sass-lint

minimatch  <=3.0.4
Severity: high
Regular Expression Denial of Service in minimatch - https://github.com/advisories/GHSA-hxm2-r34f-qmc5
minimatch ReDoS vulnerability - https://github.com/advisories/GHSA-f8q6-p94x-37v3
fix available via `npm audit fix --force`
Will install gulp@4.0.2, which is a breaking change
node_modules/gaze/node_modules/minimatch
node_modules/glob-stream/node_modules/minimatch
node_modules/minimatch
  glob  3.0.0 - 5.0.14
  Depends on vulnerable versions of minimatch
  node_modules/gaze/node_modules/glob
  node_modules/glob-stream/node_modules/glob
    glob-stream  0.2.0 - 5.2.0
    Depends on vulnerable versions of glob
    Depends on vulnerable versions of minimatch
    node_modules/glob-stream
      vinyl-fs  <=1.0.0
      Depends on vulnerable versions of glob-stream
      Depends on vulnerable versions of glob-watcher
      node_modules/vinyl-fs
        gulp  2.4.0 - 3.2.5 || 3.3.1 - 3.9.1
        Depends on vulnerable versions of semver
        Depends on vulnerable versions of vinyl-fs
        node_modules/gulp

minimist  1.0.0 - 1.2.5
Severity: critical
Prototype Pollution in minimist - https://github.com/advisories/GHSA-xvch-5gv4-984h
Prototype Pollution in minimist - https://github.com/advisories/GHSA-vh95-rmgr-6w4m
No fix available
node_modules/gonzales-pe-sl/node_modules/minimist
  gonzales-pe-sl  *
  Depends on vulnerable versions of minimist
  node_modules/gonzales-pe-sl

protobufjs  6.10.0 - 6.11.3
Severity: critical
protobufjs Prototype Pollution vulnerability - https://github.com/advisories/GHSA-h755-8qp9-cq85
fix available via `npm audit fix --force`
Will install @google-cloud/cloudbuild@4.1.0, which is a breaking change
node_modules/google-gax/node_modules/protobufjs
  google-gax  2.2.1-pre - 2.2.1-pre.2 || 2.11.3-pre || 2.21.1 - 3.1.3
  Depends on vulnerable versions of protobufjs
  node_modules/google-gax
    @google-cloud/cloudbuild  2.3.2 - 2.6.0
    Depends on vulnerable versions of google-gax
    node_modules/@google-cloud/cloudbuild
    @google-cloud/secret-manager  3.9.1 - 3.12.0
    Depends on vulnerable versions of google-gax
    node_modules/@google-cloud/secret-manager

request  *
Severity: moderate
Server-Side Request Forgery in Request - https://github.com/advisories/GHSA-p8p7-x288-28g6
Depends on vulnerable versions of tough-cookie
No fix available
node_modules/request
  request-promise  >=0.0.2
  Depends on vulnerable versions of request
  node_modules/request-promise
    remark-lint-are-links-valid  *
    Depends on vulnerable versions of remark
    Depends on vulnerable versions of request-promise
    node_modules/remark-lint-are-links-valid

semver  <5.7.2
Severity: moderate
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
fix available via `npm audit fix --force`
Will install gulp@4.0.2, which is a breaking change
node_modules/gulp/node_modules/semver

shelljs  <=0.8.4
Severity: high
Improper Privilege Management in shelljs - https://github.com/advisories/GHSA-64g7-mvw6-v9qj
Improper Privilege Management in shelljs - https://github.com/advisories/GHSA-4rq4-32rv-6wp6
No fix available
node_modules/shelljs
  eslint  1.4.0 - 4.0.0-rc.0
  Depends on vulnerable versions of shelljs
  node_modules/sass-lint/node_modules/eslint

tough-cookie  <4.1.3
Severity: moderate
tough-cookie Prototype Pollution vulnerability - https://github.com/advisories/GHSA-72xf-g2v4-qvf3
No fix available
node_modules/tough-cookie

trim  <0.0.3
Severity: high
Regular Expression Denial of Service in trim - https://github.com/advisories/GHSA-w5p7-h5w8-2hfq
fix available via `npm audit fix`
node_modules/trim
  remark  3.0.0 - 4.2.2
  Depends on vulnerable versions of chokidar
  Depends on vulnerable versions of trim
  node_modules/remark-lint-are-links-valid/node_modules/remark
  remark-message-control  2.0.1 - 4.2.0
  Depends on vulnerable versions of trim
  Depends on vulnerable versions of unified-message-control
  node_modules/remark-lint-are-links-valid/node_modules/remark-message-control
  node_modules/remark-message-control
  unified-message-control  <=1.0.4
  Depends on vulnerable versions of trim
  node_modules/unified-message-control
