### PR TITLE
[GHSA-q79q-94j7-5mgg] Dozer improperly uses a reflection-based approach to type...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-q79q-94j7-5mgg/GHSA-q79q-94j7-5mgg.json
+++ b/advisories/unreviewed/2022/05/GHSA-q79q-94j7-5mgg/GHSA-q79q-94j7-5mgg.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q79q-94j7-5mgg",
-  "modified": "2022-05-13T01:09:34Z",
+  "modified": "2023-02-01T05:03:31Z",
   "published": "2022-05-13T01:09:34Z",
   "aliases": [
     "CVE-2014-9515"
   ],
+  "summary": "CVE-2014-9515",
   "details": "Dozer improperly uses a reflection-based approach to type conversion, which might allow remote attackers to execute arbitrary code via a crafted serialized object.",
   "severity": [
     {
@@ -14,7 +15,22 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.github.dozermapper:dozer-parent"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
From the issue `https://github.com/DozerMapper/dozer/issues/217`

In its `pom.xml`, this library is:
~~~
    <groupId>com.github.dozermapper</groupId>
    <artifactId>dozer-parent</artifactId>
    <packaging>pom</packaging>
    <version>6.5.3-SNAPSHOT</version>
    <name>Dozer :: Parent</name>
    <description>Dozer is a powerful Java Bean to Java Bean mapper that recursively copies data from one object to another</description>
~~~