### PR TITLE
[GHSA-67hx-6x53-jw92] Babel vulnerable to arbitrary code execution when compiling specifically crafted malicious code

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-67hx-6x53-jw92/GHSA-67hx-6x53-jw92.json
+++ b/advisories/github-reviewed/2023/10/GHSA-67hx-6x53-jw92/GHSA-67hx-6x53-jw92.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-67hx-6x53-jw92",
-  "modified": "2023-10-16T13:55:36Z",
+  "modified": "2023-12-08T19:11:42Z",
   "published": "2023-10-16T13:55:36Z",
   "aliases": [
     "CVE-2023-45133"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
# npm audit report

@babel/traverse  <7.23.2
Severity: critical
Babel vulnerable to arbitrary code execution when compiling specifically crafted malicious code - https://github.com/advisories/GHSA-67hx-6x53-jw92
fix available via `npm audit fix`
node_modules/@babel/traverse

ajv  <6.12.3
Severity: moderate
Prototype Pollution in Ajv - https://github.com/advisories/GHSA-v88g-cgmw-v5xw
fix available via `npm audit fix`
node_modules/ajv
node_modules/npm/node_modules/ajv
  har-validator  3.3.0 - 5.1.0
  Depends on vulnerable versions of ajv
  node_modules/har-validator
  node_modules/npm/node_modules/har-validator

ansi-html  <0.0.8
Severity: high
Uncontrolled Resource Consumption in ansi-html - https://github.com/advisories/GHSA-whgm-jr23-g3j9
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/ansi-html
  webpack-dev-server  2.0.0-beta - 4.7.2
  Depends on vulnerable versions of ansi-html
  Depends on vulnerable versions of chokidar
  Depends on vulnerable versions of selfsigned
  Depends on vulnerable versions of sockjs
  Depends on vulnerable versions of yargs
  node_modules/webpack-dev-server
    react-scripts  >=0.3.0-alpha
    Depends on vulnerable versions of @svgr/webpack
    Depends on vulnerable versions of jest
    Depends on vulnerable versions of jest-environment-jsdom-fourteen
    Depends on vulnerable versions of react-dev-utils
    Depends on vulnerable versions of resolve-url-loader
    Depends on vulnerable versions of semver
    Depends on vulnerable versions of terser-webpack-plugin
    Depends on vulnerable versions of webpack-dev-server
    node_modules/react-scripts
      craco-less  1.9.0 - 1.17.0
      Depends on vulnerable versions of react-scripts
      node_modules/craco-less

ansi-regex  3.0.0 || 4.0.0 - 4.1.0 || 5.0.0
Severity: high
Inefficient Regular Expression Complexity in chalk/ansi-regex - https://github.com/advisories/GHSA-93q8-gq69-wqmw
Inefficient Regular Expression Complexity in chalk/ansi-regex - https://github.com/advisories/GHSA-93q8-gq69-wqmw
Inefficient Regular Expression Complexity in chalk/ansi-regex - https://github.com/advisories/GHSA-93q8-gq69-wqmw
fix available via `npm audit fix`
node_modules/ansi-regex
node_modules/npm/node_modules/cliui/node_modules/ansi-regex
node_modules/npm/node_modules/string-width/node_modules/ansi-regex
node_modules/pretty-format/node_modules/ansi-regex
node_modules/react-dev-utils/node_modules/ansi-regex
node_modules/react-dev-utils/node_modules/strip-ansi/node_modules/ansi-regex
node_modules/string-length/node_modules/ansi-regex
node_modules/strip-ansi/node_modules/ansi-regex
node_modules/webpack-dev-server/node_modules/cliui/node_modules/ansi-regex
node_modules/webpack-dev-server/node_modules/string-width/node_modules/ansi-regex

async  2.0.0 - 2.6.3
Severity: high
Prototype Pollution in async - https://github.com/advisories/GHSA-fwr7-v2mv-hh25
fix available via `npm audit fix`
node_modules/async

axios  <=1.5.1
Severity: high
Axios vulnerable to Server-Side Request Forgery - https://github.com/advisories/GHSA-4w2v-q235-vp99
Axios Cross-Site Request Forgery Vulnerability - https://github.com/advisories/GHSA-wf5p-g6vw-rhxx
axios Inefficient Regular Expression Complexity vulnerability - https://github.com/advisories/GHSA-cph5-m8f7-6c5x
Depends on vulnerable versions of follow-redirects
fix available via `npm audit fix --force`
Will install axios@1.6.2, which is a breaking change
node_modules/axios

bin-links  <=1.1.5
Global node_modules Binary Overwrite in bin-links - https://github.com/advisories/GHSA-v45m-2wcp-gg98
Symlink reference outside of node_modules in bin-links - https://github.com/advisories/GHSA-2mj8-pj3j-h362
Arbitrary File Write in bin-links - https://github.com/advisories/GHSA-gqf6-75v8-vr26
fix available via `npm audit fix`
node_modules/npm/node_modules/bin-links
  npm  <=7.1.0 || 7.21.0 - 8.5.4
  Depends on vulnerable versions of bin-links
  Depends on vulnerable versions of chownr
  Depends on vulnerable versions of hosted-git-info
  Depends on vulnerable versions of ini
  Depends on vulnerable versions of libcipm
  Depends on vulnerable versions of libnpmhook
  Depends on vulnerable versions of libnpx
  Depends on vulnerable versions of mkdirp
  Depends on vulnerable versions of node-gyp
  Depends on vulnerable versions of npm-lifecycle
  Depends on vulnerable versions of npm-profile
  Depends on vulnerable versions of npm-registry-client
  Depends on vulnerable versions of npm-registry-fetch
  Depends on vulnerable versions of npm-user-validate
  Depends on vulnerable versions of pacote
  Depends on vulnerable versions of request
  Depends on vulnerable versions of semver
  Depends on vulnerable versions of ssri
  Depends on vulnerable versions of tar
  Depends on vulnerable versions of update-notifier
  node_modules/npm

browserify-sign  2.6.0 - 4.2.1
Severity: high
browserify-sign upper bound check issue in `dsaVerify` leads to a signature forgery attack - https://github.com/advisories/GHSA-x9w5-v3q2-3rhw
fix available via `npm audit fix`
node_modules/browserify-sign

browserslist  4.0.0 - 4.16.4
Severity: moderate
Regular Expression Denial of Service in browserslist - https://github.com/advisories/GHSA-w8qv-6jwh-64r5
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/browserslist
node_modules/react-dev-utils/node_modules/browserslist
  react-dev-utils  0.4.0 - 12.0.0-next.60
  Depends on vulnerable versions of browserslist
  Depends on vulnerable versions of globby
  Depends on vulnerable versions of immer
  Depends on vulnerable versions of loader-utils
  Depends on vulnerable versions of recursive-readdir
  Depends on vulnerable versions of shell-quote
  node_modules/react-dev-utils

chownr  <1.1.0
Time-of-check Time-of-use (TOCTOU) Race Condition in chownr - https://github.com/advisories/GHSA-c6rq-rjc2-86v2
fix available via `npm audit fix`
node_modules/npm/node_modules/chownr

color-string  <1.5.5
Severity: moderate
Regular Expression Denial of Service (ReDOS) - https://github.com/advisories/GHSA-257v-vj4p-3w2h
fix available via `npm audit fix`
node_modules/color-string

debug  3.2.0 - 3.2.6 || 4.0.0 - 4.3.0
Severity: moderate
Regular Expression Denial of Service in debug - https://github.com/advisories/GHSA-gxpj-cx7g-858c
Regular Expression Denial of Service in debug - https://github.com/advisories/GHSA-gxpj-cx7g-858c
fix available via `npm audit fix`
node_modules/@babel/core/node_modules/debug
node_modules/@babel/traverse/node_modules/debug
node_modules/@typescript-eslint/typescript-estree/node_modules/debug
node_modules/eslint/node_modules/debug
node_modules/istanbul-lib-source-maps/node_modules/debug
node_modules/portfinder/node_modules/debug
node_modules/sockjs-client/node_modules/debug
node_modules/spdy-transport/node_modules/debug
node_modules/spdy/node_modules/debug
node_modules/webpack-dev-server/node_modules/debug

decode-uri-component  <0.2.1
Severity: high
decode-uri-component vulnerable to Denial of Service (DoS) - https://github.com/advisories/GHSA-w573-4hg7-7wgq
fix available via `npm audit fix`
node_modules/decode-uri-component
node_modules/npm/node_modules/decode-uri-component

dns-packet  <1.3.2
Severity: high
Potential memory exposure in dns-packet - https://github.com/advisories/GHSA-3wcq-x3mq-6r9p
fix available via `npm audit fix`
node_modules/dns-packet

dot-prop  <4.2.1
Severity: high
dot-prop Prototype Pollution vulnerability - https://github.com/advisories/GHSA-ff7x-qrg7-qggm
fix available via `npm audit fix`
node_modules/npm/node_modules/dot-prop

elliptic  <6.5.4
Severity: moderate
Elliptic Uses a Broken or Risky Cryptographic Algorithm - https://github.com/advisories/GHSA-r9p9-mrjm-926w
fix available via `npm audit fix`
node_modules/elliptic

eventsource  <1.1.1
Severity: critical
Exposure of Sensitive Information in eventsource - https://github.com/advisories/GHSA-6h5x-7c5m-7cr7
fix available via `npm audit fix`
node_modules/eventsource

follow-redirects  <=1.14.7
Severity: high
Exposure of Sensitive Information to an Unauthorized Actor in follow-redirects - https://github.com/advisories/GHSA-pw2r-vq6v-hr8c
Exposure of sensitive information in follow-redirects - https://github.com/advisories/GHSA-74fj-2j2h-c42q
fix available via `npm audit fix --force`
Will install axios@1.6.2, which is a breaking change
node_modules/follow-redirects

fstream  <1.0.12
Severity: high
Arbitrary File Overwrite in fstream - https://github.com/advisories/GHSA-xf7w-r453-m56c
fix available via `npm audit fix`
node_modules/npm/node_modules/fstream

glob-parent  <5.1.2
Severity: high
glob-parent vulnerable to Regular Expression Denial of Service in enclosure regex - https://github.com/advisories/GHSA-ww39-953v-wcq6
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/fast-glob/node_modules/glob-parent
node_modules/glob-parent
node_modules/watchpack-chokidar2/node_modules/glob-parent
node_modules/webpack-dev-server/node_modules/glob-parent
  chokidar  1.0.0-rc1 - 2.1.8
  Depends on vulnerable versions of glob-parent
  node_modules/watchpack-chokidar2/node_modules/chokidar
  node_modules/webpack-dev-server/node_modules/chokidar
    watchpack-chokidar2  *
    Depends on vulnerable versions of chokidar
    node_modules/watchpack-chokidar2
      watchpack  1.7.2 - 1.7.5
      Depends on vulnerable versions of watchpack-chokidar2
      node_modules/watchpack
  fast-glob  <=2.2.7
  Depends on vulnerable versions of glob-parent
  node_modules/fast-glob
    globby  8.0.0 - 9.2.0
    Depends on vulnerable versions of fast-glob
    node_modules/globby

got  <11.8.5
Severity: moderate
Got allows a redirect to a UNIX socket - https://github.com/advisories/GHSA-pfrx-2q88-qq97
fix available via `npm audit fix`
node_modules/npm/node_modules/got
  package-json  <=6.5.0
  Depends on vulnerable versions of got
  node_modules/npm/node_modules/package-json
    latest-version  0.2.0 - 5.1.0
    Depends on vulnerable versions of package-json
    node_modules/npm/node_modules/latest-version
      update-notifier  0.2.0 - 5.1.0
      Depends on vulnerable versions of latest-version
      node_modules/npm/node_modules/update-notifier
        libnpx  *
        Depends on vulnerable versions of update-notifier
        Depends on vulnerable versions of yargs
        node_modules/npm/node_modules/libnpx

hosted-git-info  <2.8.9
Severity: moderate
Regular Expression Denial of Service in hosted-git-info - https://github.com/advisories/GHSA-43f8-2h32-f4cj
fix available via `npm audit fix`
node_modules/hosted-git-info
node_modules/npm/node_modules/hosted-git-info

http-cache-semantics  <4.1.1
Severity: high
http-cache-semantics vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-rc47-6667-2j5j
fix available via `npm audit fix`
node_modules/npm/node_modules/http-cache-semantics
  make-fetch-happen  2.1.0 - 6.1.0
  Depends on vulnerable versions of cacache
  Depends on vulnerable versions of http-cache-semantics
  Depends on vulnerable versions of ssri
  node_modules/npm/node_modules/make-fetch-happen
  node_modules/npm/node_modules/npm-registry-fetch/node_modules/make-fetch-happen
    npm-profile  <=3.0.2
    Depends on vulnerable versions of make-fetch-happen
    node_modules/npm/node_modules/npm-profile
    npm-registry-fetch  <=5.0.1
    Depends on vulnerable versions of make-fetch-happen
    node_modules/npm/node_modules/libnpmhook/node_modules/npm-registry-fetch
    node_modules/npm/node_modules/npm-registry-fetch
      libnpmhook  <=5.0.2
      Depends on vulnerable versions of npm-registry-fetch
      node_modules/npm/node_modules/libnpmhook
    pacote  2.0.0 - 9.5.12
    Depends on vulnerable versions of make-fetch-happen
    node_modules/npm/node_modules/pacote
      libcipm  *
      Depends on vulnerable versions of npm-lifecycle
      Depends on vulnerable versions of pacote
      node_modules/npm/node_modules/libcipm

https-proxy-agent  <2.2.3
Severity: moderate
Machine-In-The-Middle in https-proxy-agent - https://github.com/advisories/GHSA-pc5p-h8pf-mvwp
fix available via `npm audit fix`
node_modules/npm/node_modules/https-proxy-agent

immer  <=9.0.5
Severity: critical
Prototype Pollution in immer - https://github.com/advisories/GHSA-c36v-fmgq-m8hx
Prototype Pollution in immer - https://github.com/advisories/GHSA-9qmh-276g-x5pj
Prototype Pollution in immer - https://github.com/advisories/GHSA-33f9-j839-rf8h
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/immer

ini  <1.3.6
Severity: high
ini before 1.3.6 vulnerable to Prototype Pollution via ini.parse - https://github.com/advisories/GHSA-qqgx-2p2h-9c37
fix available via `npm audit fix`
node_modules/ini
node_modules/npm/node_modules/ini

is-svg  2.1.0 - 4.2.2
Severity: high
ReDOS in IS-SVG - https://github.com/advisories/GHSA-r8j5-h5cx-65gg
Regular Expression Denial of Service (ReDoS) - https://github.com/advisories/GHSA-7r28-3m3f-r2pr
fix available via `npm audit fix`
node_modules/is-svg
  postcss-svgo  4.0.0-nightly.2020.1.9 - 5.0.0-rc.2
  Depends on vulnerable versions of is-svg
  Depends on vulnerable versions of svgo
  node_modules/postcss-svgo

jsdom  <=16.5.3
Severity: moderate
Insufficient Granularity of Access Control in JSDom - https://github.com/advisories/GHSA-f4c9-cqv8-9v98
Depends on vulnerable versions of request
Depends on vulnerable versions of tough-cookie
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/jest-environment-jsdom-fourteen/node_modules/jsdom
node_modules/jsdom
  jest-environment-jsdom  10.0.2 - 25.5.0
  Depends on vulnerable versions of jsdom
  node_modules/jest-environment-jsdom
    jest-config  12.1.1-alpha.2935e14d - 25.5.4
    Depends on vulnerable versions of @jest/test-sequencer
    Depends on vulnerable versions of jest-environment-jsdom
    Depends on vulnerable versions of jest-jasmine2
    node_modules/jest-config
      jest-cli  12.1.1-alpha.2935e14d || 12.1.2-alpha.6230044c - 25.5.4
      Depends on vulnerable versions of @jest/core
      Depends on vulnerable versions of jest-config
      node_modules/jest/node_modules/jest-cli
        jest  12.1.2-alpha.6230044c - 25.5.4
        Depends on vulnerable versions of jest-cli
        node_modules/jest
      jest-runner  21.0.0-alpha.1 - 25.5.4
      Depends on vulnerable versions of jest-config
      Depends on vulnerable versions of jest-jasmine2
      Depends on vulnerable versions of jest-runtime
      node_modules/jest-runner
      jest-runtime  12.1.1-alpha.2935e14d - 25.5.4
      Depends on vulnerable versions of jest-config
      node_modules/jest-runtime
        @jest/reporters  <=26.4.0
        Depends on vulnerable versions of jest-runtime
        Depends on vulnerable versions of node-notifier
        node_modules/@jest/reporters
          @jest/core  <=25.5.4
          Depends on vulnerable versions of @jest/reporters
          Depends on vulnerable versions of jest-config
          Depends on vulnerable versions of jest-runner
          Depends on vulnerable versions of jest-runtime
          node_modules/@jest/core
        @jest/test-sequencer  <=25.5.4
        Depends on vulnerable versions of jest-runner
        Depends on vulnerable versions of jest-runtime
        node_modules/@jest/test-sequencer
        jest-jasmine2  24.2.0-alpha.0 - 25.5.4
        Depends on vulnerable versions of jest-runtime
        node_modules/jest-jasmine2
  jest-environment-jsdom-fourteen  *
  Depends on vulnerable versions of jsdom
  node_modules/jest-environment-jsdom-fourteen

json-schema  <0.4.0
Severity: critical
json-schema is vulnerable to Prototype Pollution - https://github.com/advisories/GHSA-896r-f27r-55mw
fix available via `npm audit fix`
node_modules/json-schema
node_modules/npm/node_modules/json-schema
  jsprim  0.3.0 - 1.4.1 || 2.0.0 - 2.0.1
  Depends on vulnerable versions of json-schema
  node_modules/jsprim
  node_modules/npm/node_modules/jsprim

json5  >=2.0.0 <2.2.2 || <1.0.2
Severity: high
Prototype Pollution in JSON5 via Parse Method - https://github.com/advisories/GHSA-9c47-m6qq-7p4h
Prototype Pollution in JSON5 via Parse Method - https://github.com/advisories/GHSA-9c47-m6qq-7p4h
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/@babel/core/node_modules/json5
node_modules/@svgr/webpack/node_modules/json5
node_modules/adjust-sourcemap-loader/node_modules/json5
node_modules/babel-loader/node_modules/json5
node_modules/craco-less/node_modules/json5
node_modules/css-loader/node_modules/json5
node_modules/eslint-loader/node_modules/json5
node_modules/file-loader/node_modules/json5
node_modules/html-webpack-plugin/node_modules/json5
node_modules/json5
node_modules/react-dev-utils/node_modules/json5
node_modules/resolve-url-loader/node_modules/json5
node_modules/sass-loader/node_modules/json5
node_modules/url-loader/node_modules/json5
node_modules/webpack/node_modules/json5
  loader-utils  <=1.4.1 || 2.0.0 - 2.0.3
  Depends on vulnerable versions of json5
  node_modules/@svgr/webpack/node_modules/loader-utils
  node_modules/adjust-sourcemap-loader/node_modules/loader-utils
  node_modules/babel-loader/node_modules/loader-utils
  node_modules/craco-less/node_modules/loader-utils
  node_modules/css-loader/node_modules/loader-utils
  node_modules/eslint-loader/node_modules/loader-utils
  node_modules/file-loader/node_modules/loader-utils
  node_modules/html-webpack-plugin/node_modules/loader-utils
  node_modules/loader-utils
  node_modules/react-dev-utils/node_modules/loader-utils
  node_modules/resolve-url-loader/node_modules/loader-utils
  node_modules/sass-loader/node_modules/loader-utils
  node_modules/url-loader/node_modules/loader-utils
  node_modules/webpack/node_modules/loader-utils
    adjust-sourcemap-loader  0.1.0 - 2.0.0
    Depends on vulnerable versions of loader-utils
    Depends on vulnerable versions of object-path
    node_modules/adjust-sourcemap-loader
      resolve-url-loader  0.0.1-experiment-postcss || 3.0.1 - 3.1.4 || 4.0.0-alpha.1 - 4.0.0-beta.2
      Depends on vulnerable versions of adjust-sourcemap-loader
      Depends on vulnerable versions of loader-utils
      Depends on vulnerable versions of postcss
      node_modules/resolve-url-loader


lodash  <=4.17.20
Severity: high
Command Injection in lodash - https://github.com/advisories/GHSA-35jh-r3h4-6jhm
Regular Expression Denial of Service (ReDoS) in lodash - https://github.com/advisories/GHSA-29mw-wpgm-hmr9
fix available via `npm audit fix`
node_modules/lodash

mem  <4.0.0
Severity: moderate
Denial of Service in mem - https://github.com/advisories/GHSA-4xcv-9jjx-gfj3
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/npm/node_modules/mem
  os-locale  2.0.0 - 3.0.0
  Depends on vulnerable versions of mem
  node_modules/npm/node_modules/os-locale
    yargs  8.0.0-candidate.0 - 12.0.5
    Depends on vulnerable versions of os-locale
    Depends on vulnerable versions of yargs-parser
    node_modules/npm/node_modules/yargs
    node_modules/webpack-dev-server/node_modules/yargs

merge-deep  <3.0.3
Severity: critical
Prototype pollution in Merge-deep - https://github.com/advisories/GHSA-r6rj-9ch6-g264
fix available via `npm audit fix`
node_modules/merge-deep

minimatch  <3.0.5
Severity: high
minimatch ReDoS vulnerability - https://github.com/advisories/GHSA-f8q6-p94x-37v3
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/minimatch
node_modules/npm/node_modules/minimatch
  recursive-readdir  1.2.0 - 2.2.2
  Depends on vulnerable versions of minimatch
  node_modules/recursive-readdir

minimist  <=0.2.3 || 1.0.0 - 1.2.5
Severity: critical
Prototype Pollution in minimist - https://github.com/advisories/GHSA-xvch-5gv4-984h
Prototype Pollution in minimist - https://github.com/advisories/GHSA-xvch-5gv4-984h
Prototype Pollution in minimist - https://github.com/advisories/GHSA-vh95-rmgr-6w4m
Prototype Pollution in minimist - https://github.com/advisories/GHSA-vh95-rmgr-6w4m
fix available via `npm audit fix`
node_modules/@babel/core/node_modules/minimist
node_modules/@cnakazawa/watch/node_modules/minimist
node_modules/@svgr/webpack/node_modules/minimist
node_modules/adjust-sourcemap-loader/node_modules/minimist
node_modules/babel-loader/node_modules/minimist
node_modules/craco-less/node_modules/minimist
node_modules/css-loader/node_modules/minimist
node_modules/eslint-loader/node_modules/minimist
node_modules/file-loader/node_modules/minimist
node_modules/html-webpack-plugin/node_modules/minimist
node_modules/minimist
node_modules/npm/node_modules/minimist
node_modules/npm/node_modules/rc/node_modules/minimist
node_modules/portfinder/node_modules/minimist
node_modules/react-dev-utils/node_modules/minimist
node_modules/resolve-url-loader/node_modules/minimist
node_modules/sane/node_modules/minimist
node_modules/sass-loader/node_modules/minimist
node_modules/url-loader/node_modules/minimist
node_modules/webpack/node_modules/minimist
  mkdirp  0.4.1 - 0.5.1
  Depends on vulnerable versions of minimist
  node_modules/mkdirp
  node_modules/npm/node_modules/mkdirp

moment  <=2.29.3
Severity: high
Moment.js vulnerable to Inefficient Regular Expression Complexity - https://github.com/advisories/GHSA-wc69-rhjr-hc9g
Path Traversal: 'dir/../../filename' in moment.locale - https://github.com/advisories/GHSA-8hfj-j24r-96c4
fix available via `npm audit fix`
node_modules/moment

node-forge  <=1.2.1
Severity: high
Prototype Pollution in node-forge debug API. - https://github.com/advisories/GHSA-5rrq-pxf6-6jx5
URL parsing in node-forge could lead to undesired behavior. - https://github.com/advisories/GHSA-gf8q-jrpm-jvxq
Improper Verification of Cryptographic Signature in `node-forge` - https://github.com/advisories/GHSA-2r2c-g63r-vccr
Open Redirect in node-forge - https://github.com/advisories/GHSA-8fr3-hfg3-gpgp
Improper Verification of Cryptographic Signature in node-forge - https://github.com/advisories/GHSA-cfm4-qjh2-4765
Improper Verification of Cryptographic Signature in node-forge - https://github.com/advisories/GHSA-x4jg-mjrx-434g
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/node-forge
  selfsigned  1.1.1 - 1.10.14
  Depends on vulnerable versions of node-forge
  node_modules/selfsigned

node-notifier  <8.0.1
Severity: moderate
OS Command Injection in node-notifier - https://github.com/advisories/GHSA-5fw9-fq32-wv5p
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/node-notifier



npm-user-validate  <=1.0.0
Severity: high
Regular Expression Denial of Service in npm-user-validate - https://github.com/advisories/GHSA-xgh6-85xh-479p
Regular expression denial of service in npm-user-validate - https://github.com/advisories/GHSA-pw54-mh39-w3hc
fix available via `npm audit fix`
node_modules/npm/node_modules/npm-user-validate

nth-check  <2.0.1
Severity: high
Inefficient Regular Expression Complexity in nth-check - https://github.com/advisories/GHSA-rp65-9cf3-cjxr
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/nth-check
  css-select  <=3.1.0
  Depends on vulnerable versions of nth-check
  node_modules/css-select
  node_modules/renderkid/node_modules/css-select
    renderkid  1.0.0 - 2.0.5
    Depends on vulnerable versions of css-select
    node_modules/renderkid
    svgo  1.0.0 - 1.3.2
    Depends on vulnerable versions of css-select
    node_modules/svgo
      @svgr/plugin-svgo  <=5.5.0
      Depends on vulnerable versions of svgo
      node_modules/@svgr/plugin-svgo
        @svgr/webpack  4.0.0 - 5.5.0
        Depends on vulnerable versions of @svgr/plugin-svgo
        node_modules/@svgr/webpack

object-path  <=0.11.7
Severity: high
Prototype Pollution in object-path - https://github.com/advisories/GHSA-v39p-96qg-c8rf
Prototype pollution in object-path - https://github.com/advisories/GHSA-cwx2-736x-mf6w
Prototype Pollution in object-path - https://github.com/advisories/GHSA-8v63-cqqc-6r2c
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/object-path

path-parse  <1.0.7
Severity: moderate
Regular Expression Denial of Service in path-parse - https://github.com/advisories/GHSA-hj48-42vr-x3v9
fix available via `npm audit fix`
node_modules/path-parse

postcss  <=8.4.30
Severity: moderate
Regular Expression Denial of Service in postcss - https://github.com/advisories/GHSA-hwj9-h5mp-3pm3
Regular Expression Denial of Service in postcss - https://github.com/advisories/GHSA-566m-qj78-rww5
PostCSS line return parsing error - https://github.com/advisories/GHSA-7fh5-64p2-3v2j
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/postcss
node_modules/resolve-url-loader/node_modules/postcss

qs  6.5.0 - 6.5.2 || 6.7.0 - 6.7.2
Severity: high
qs vulnerable to Prototype Pollution - https://github.com/advisories/GHSA-hrpp-h998-j3pp
qs vulnerable to Prototype Pollution - https://github.com/advisories/GHSA-hrpp-h998-j3pp
fix available via `npm audit fix`
node_modules/npm/node_modules/qs
node_modules/qs
node_modules/request/node_modules/qs
  body-parser  1.19.0
  Depends on vulnerable versions of qs
  node_modules/body-parser
  express  4.17.0 - 4.17.1 || 5.0.0-alpha.1 - 5.0.0-alpha.8
  Depends on vulnerable versions of body-parser
  Depends on vulnerable versions of qs
  node_modules/express


request  *
Severity: moderate
Server-Side Request Forgery in Request - https://github.com/advisories/GHSA-p8p7-x288-28g6
Depends on vulnerable versions of tough-cookie
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/npm/node_modules/request
node_modules/request
  less  1.4.0-b1 - 2.6.1 || 2.7.2 - 3.11.3
  Depends on vulnerable versions of request
  node_modules/less
  node-gyp  <=7.1.2
  Depends on vulnerable versions of request
  Depends on vulnerable versions of semver
  Depends on vulnerable versions of tar
  node_modules/npm/node_modules/node-gyp
    npm-lifecycle  2.0.0 - 2.1.1
    Depends on vulnerable versions of node-gyp
    node_modules/npm/node_modules/npm-lifecycle
  npm-registry-client  *
  Depends on vulnerable versions of request
  Depends on vulnerable versions of ssri
  node_modules/npm/node_modules/npm-registry-client
  request-promise-core  *
  Depends on vulnerable versions of request
  node_modules/request-promise-core
    request-promise-native  >=1.0.0
    Depends on vulnerable versions of request
    Depends on vulnerable versions of request-promise-core
    Depends on vulnerable versions of tough-cookie
    node_modules/request-promise-native

semver  <=5.7.1 || 6.0.0 - 6.3.0 || 7.0.0 - 7.5.1
Severity: moderate
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/@babel/core/node_modules/semver
node_modules/@babel/helper-compilation-targets/node_modules/semver
node_modules/@babel/plugin-transform-runtime/node_modules/semver
node_modules/@babel/preset-env/node_modules/semver
node_modules/@typescript-eslint/typescript-estree/node_modules/semver
node_modules/babel-preset-react-app/node_modules/semver
node_modules/core-js-compat/node_modules/semver
node_modules/cross-spawn/node_modules/semver
node_modules/fork-ts-checker-webpack-plugin/node_modules/semver
node_modules/make-dir/node_modules/semver
node_modules/node-notifier/node_modules/semver
node_modules/normalize-package-data/node_modules/semver
node_modules/npm/node_modules/node-gyp/node_modules/semver
node_modules/npm/node_modules/semver
node_modules/react-app-rewired/node_modules/semver
node_modules/semver
  core-js-compat  3.6.0 - 3.25.0
  Depends on vulnerable versions of semver
  node_modules/core-js-compat

serialize-javascript  <3.1.0
Severity: high
Insecure serialization leading to RCE in serialize-javascript - https://github.com/advisories/GHSA-hxcc-f52p-wc94
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/serialize-javascript
  terser-webpack-plugin  <=1.4.3 || 2.0.0 - 2.3.5
  Depends on vulnerable versions of serialize-javascript
  node_modules/terser-webpack-plugin

shell-quote  <=1.7.2
Severity: critical
Improper Neutralization of Special Elements used in a Command in Shell-quote - https://github.com/advisories/GHSA-g4rg-993r-mgx7
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/shell-quote

sockjs  <0.3.20
Severity: moderate
Improper Input Validation in SocksJS-Node - https://github.com/advisories/GHSA-c9g6-9335-x697
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/sockjs

ssri  5.2.2 - 6.0.1 || 7.0.0 - 7.1.0
Severity: high
Regular Expression Denial of Service (ReDoS) - https://github.com/advisories/GHSA-vx3p-948g-6vhq
Regular Expression Denial of Service (ReDoS) - https://github.com/advisories/GHSA-vx3p-948g-6vhq
fix available via `npm audit fix`
node_modules/npm/node_modules/npm-registry-client/node_modules/ssri
node_modules/npm/node_modules/npm-registry-fetch/node_modules/ssri
node_modules/npm/node_modules/ssri
node_modules/ssri
node_modules/webpack/node_modules/ssri
  cacache  10.0.4 - 11.0.0
  Depends on vulnerable versions of ssri
  node_modules/npm/node_modules/npm-registry-fetch/node_modules/cacache

tar  <=4.4.17
Severity: high
Arbitrary File Creation/Overwrite due to insufficient absolute path sanitization - https://github.com/advisories/GHSA-3jfq-g458-7qm9
Arbitrary File Creation/Overwrite due to insufficient absolute path sanitization - https://github.com/advisories/GHSA-3jfq-g458-7qm9
Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning - https://github.com/advisories/GHSA-r628-mhmh-qjhw
Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning - https://github.com/advisories/GHSA-r628-mhmh-qjhw
Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning using symbolic links - https://github.com/advisories/GHSA-9r2w-394v-53qc
Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning using symbolic links - https://github.com/advisories/GHSA-qq89-hq3f-393p
Arbitrary File Creation/Overwrite on Windows via insufficient relative path sanitization - https://github.com/advisories/GHSA-5955-9wpr-37jh
Arbitrary File Overwrite in tar - https://github.com/advisories/GHSA-j44m-qm6p-hp7m
fix available via `npm audit fix`
node_modules/npm/node_modules/node-gyp/node_modules/tar
node_modules/npm/node_modules/tar

terser  <4.8.1
Severity: high
Terser insecure use of regular expressions leads to ReDoS - https://github.com/advisories/GHSA-4wf5-vphf-c2xc
fix available via `npm audit fix`
node_modules/terser

tmpl  <1.0.5
Severity: high
tmpl vulnerable to Inefficient Regular Expression Complexity which may lead to resource exhaustion - https://github.com/advisories/GHSA-jgrx-mgxx-jf9v
fix available via `npm audit fix`
node_modules/tmpl

tough-cookie  <4.1.3
Severity: moderate
tough-cookie Prototype Pollution vulnerability - https://github.com/advisories/GHSA-72xf-g2v4-qvf3
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/jest-environment-jsdom-fourteen/node_modules/tough-cookie
node_modules/npm/node_modules/tough-cookie
node_modules/tough-cookie

url-parse  <=1.5.8
Severity: critical
Authorization bypass in url-parse - https://github.com/advisories/GHSA-rqff-837h-mm52
Open redirect in url-parse - https://github.com/advisories/GHSA-hh27-ffr2-f2jc
Path traversal in url-parse - https://github.com/advisories/GHSA-9m6j-fcg5-2442
url-parse incorrectly parses hostname / protocol due to unstripped leading control characters. - https://github.com/advisories/GHSA-jf5r-8hm2-f872
url-parse Incorrectly parses URLs that include an '@' - https://github.com/advisories/GHSA-8v38-pw62-9cw2
Authorization Bypass Through User-Controlled Key in url-parse - https://github.com/advisories/GHSA-hgjh-723h-mx2j
fix available via `npm audit fix`
node_modules/url-parse

word-wrap  <1.2.4
Severity: moderate
word-wrap vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-j8xg-fqg3-53r7
fix available via `npm audit fix`
node_modules/word-wrap

ws  5.0.0 - 5.2.2 || 6.0.0 - 6.2.1
Severity: moderate
ReDoS in Sec-Websocket-Protocol header - https://github.com/advisories/GHSA-6fc8-4gx4-v693
ReDoS in Sec-Websocket-Protocol header - https://github.com/advisories/GHSA-6fc8-4gx4-v693
fix available via `npm audit fix`
node_modules/jest-environment-jsdom-fourteen/node_modules/ws
node_modules/webpack-dev-server/node_modules/ws
node_modules/ws

y18n  =4.0.0 || <3.2.2
Severity: high
Prototype Pollution in y18n - https://github.com/advisories/GHSA-c4w7-xm78-47vh
Prototype Pollution in y18n - https://github.com/advisories/GHSA-c4w7-xm78-47vh
fix available via `npm audit fix`
node_modules/npm/node_modules/y18n
node_modules/npm/node_modules/yargs/node_modules/y18n
node_modules/y18n

yargs-parser  6.0.0 - 13.1.1
Severity: moderate
yargs-parser Vulnerable to Prototype Pollution - https://github.com/advisories/GHSA-p9pc-299p-vxgp
fix available via `npm audit fix --force`
Will install react-scripts@5.0.1, which is a breaking change
node_modules/npm/node_modules/yargs-parser
node_modules/webpack-dev-server/node_modules/yargs-parser

117 vulnerabilities (3 low, 46 moderate, 57 high, 11 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
