### PR TITLE
[GHSA-rp65-9cf3-cjxr] Inefficient Regular Expression Complexity in nth-check

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-rp65-9cf3-cjxr/GHSA-rp65-9cf3-cjxr.json
+++ b/advisories/github-reviewed/2021/09/GHSA-rp65-9cf3-cjxr/GHSA-rp65-9cf3-cjxr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rp65-9cf3-cjxr",
-  "modified": "2023-09-13T21:49:54Z",
+  "modified": "2023-11-29T22:11:25Z",
   "published": "2021-09-20T20:47:31Z",
   "aliases": [
     "CVE-2021-3803"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "nth-check"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(nth-check).parse"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
npm audit fix --force
npm WARN using --force Recommended protections disabled.
npm WARN audit fix minimist@1.2.0 node_modules/npm/node_modules/rc/node_modules/minimist
npm WARN audit fix minimist@1.2.0 is a bundled dependency of
npm WARN audit fix minimist@1.2.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix minimist@1.2.0 It cannot be fixed automatically.
npm WARN audit fix minimist@1.2.0 Check for updates to the npm package.
npm WARN audit fix minimist@0.0.8 node_modules/npm/node_modules/minimist
npm WARN audit fix minimist@0.0.8 is a bundled dependency of
npm WARN audit fix minimist@0.0.8 npm@6.4.1 at node_modules/npm
npm WARN audit fix minimist@0.0.8 It cannot be fixed automatically.
npm WARN audit fix minimist@0.0.8 Check for updates to the npm package.
npm WARN audit fix semver@5.3.0 node_modules/npm/node_modules/node-gyp/node_modules/semver
npm WARN audit fix semver@5.3.0 is a bundled dependency of
npm WARN audit fix semver@5.3.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix semver@5.3.0 It cannot be fixed automatically.
npm WARN audit fix semver@5.3.0 Check for updates to the npm package.
npm WARN audit fix semver@5.5.0 node_modules/npm/node_modules/semver
npm WARN audit fix semver@5.5.0 is a bundled dependency of
npm WARN audit fix semver@5.5.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix semver@5.5.0 It cannot be fixed automatically.
npm WARN audit fix semver@5.5.0 Check for updates to the npm package.
npm WARN audit fix ajv@5.5.2 node_modules/npm/node_modules/ajv
npm WARN audit fix ajv@5.5.2 is a bundled dependency of
npm WARN audit fix ajv@5.5.2 npm@6.4.1 at node_modules/npm
npm WARN audit fix ajv@5.5.2 It cannot be fixed automatically.
npm WARN audit fix ajv@5.5.2 Check for updates to the npm package.
npm WARN audit fix ansi-regex@3.0.0 node_modules/npm/node_modules/cliui/node_modules/ansi-regex
npm WARN audit fix ansi-regex@3.0.0 is a bundled dependency of
npm WARN audit fix ansi-regex@3.0.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix ansi-regex@3.0.0 It cannot be fixed automatically.
npm WARN audit fix ansi-regex@3.0.0 Check for updates to the npm package.
npm WARN audit fix ansi-regex@3.0.0 node_modules/npm/node_modules/string-width/node_modules/ansi-regex
npm WARN audit fix ansi-regex@3.0.0 is a bundled dependency of
npm WARN audit fix ansi-regex@3.0.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix ansi-regex@3.0.0 It cannot be fixed automatically.
npm WARN audit fix ansi-regex@3.0.0 Check for updates to the npm package.
npm WARN audit fix chownr@1.0.1 node_modules/npm/node_modules/chownr
npm WARN audit fix chownr@1.0.1 is a bundled dependency of
npm WARN audit fix chownr@1.0.1 npm@6.4.1 at node_modules/npm
npm WARN audit fix chownr@1.0.1 It cannot be fixed automatically.
npm WARN audit fix chownr@1.0.1 Check for updates to the npm package.
npm WARN audit fix decode-uri-component@0.2.0 node_modules/npm/node_modules/decode-uri-component
npm WARN audit fix decode-uri-component@0.2.0 is a bundled dependency of
npm WARN audit fix decode-uri-component@0.2.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix decode-uri-component@0.2.0 It cannot be fixed automatically.
npm WARN audit fix decode-uri-component@0.2.0 Check for updates to the npm package.
npm WARN audit fix dot-prop@4.2.0 node_modules/npm/node_modules/dot-prop
npm WARN audit fix dot-prop@4.2.0 is a bundled dependency of
npm WARN audit fix dot-prop@4.2.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix dot-prop@4.2.0 It cannot be fixed automatically.
npm WARN audit fix dot-prop@4.2.0 Check for updates to the npm package.
npm WARN audit fix hosted-git-info@2.7.1 node_modules/npm/node_modules/hosted-git-info
npm WARN audit fix hosted-git-info@2.7.1 is a bundled dependency of
npm WARN audit fix hosted-git-info@2.7.1 npm@6.4.1 at node_modules/npm
npm WARN audit fix hosted-git-info@2.7.1 It cannot be fixed automatically.
npm WARN audit fix hosted-git-info@2.7.1 Check for updates to the npm package.
npm WARN audit fix ini@1.3.5 node_modules/npm/node_modules/ini
npm WARN audit fix ini@1.3.5 is a bundled dependency of
npm WARN audit fix ini@1.3.5 npm@6.4.1 at node_modules/npm
npm WARN audit fix ini@1.3.5 It cannot be fixed automatically.
npm WARN audit fix ini@1.3.5 Check for updates to the npm package.
npm WARN audit fix tough-cookie@2.4.3 node_modules/npm/node_modules/tough-cookie
npm WARN audit fix tough-cookie@2.4.3 is a bundled dependency of
npm WARN audit fix tough-cookie@2.4.3 npm@6.4.1 at node_modules/npm
npm WARN audit fix tough-cookie@2.4.3 It cannot be fixed automatically.
npm WARN audit fix tough-cookie@2.4.3 Check for updates to the npm package.
npm WARN audit fix json-schema@0.2.3 node_modules/npm/node_modules/json-schema
npm WARN audit fix json-schema@0.2.3 is a bundled dependency of
npm WARN audit fix json-schema@0.2.3 npm@6.4.1 at node_modules/npm
npm WARN audit fix json-schema@0.2.3 It cannot be fixed automatically.
npm WARN audit fix json-schema@0.2.3 Check for updates to the npm package.
npm WARN audit fix mem@1.1.0 node_modules/npm/node_modules/mem
npm WARN audit fix mem@1.1.0 is a bundled dependency of
npm WARN audit fix mem@1.1.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix mem@1.1.0 It cannot be fixed automatically.
npm WARN audit fix mem@1.1.0 Check for updates to the npm package.
npm WARN audit fix minimatch@3.0.4 node_modules/npm/node_modules/minimatch
npm WARN audit fix minimatch@3.0.4 is a bundled dependency of
npm WARN audit fix minimatch@3.0.4 npm@6.4.1 at node_modules/npm
npm WARN audit fix minimatch@3.0.4 It cannot be fixed automatically.
npm WARN audit fix minimatch@3.0.4 Check for updates to the npm package.
npm WARN audit fix bin-links@1.1.2 node_modules/npm/node_modules/bin-links
npm WARN audit fix bin-links@1.1.2 is a bundled dependency of
npm WARN audit fix bin-links@1.1.2 npm@6.4.1 at node_modules/npm
npm WARN audit fix bin-links@1.1.2 It cannot be fixed automatically.
npm WARN audit fix bin-links@1.1.2 Check for updates to the npm package.
npm WARN audit fix fstream@1.0.11 node_modules/npm/node_modules/fstream
npm WARN audit fix fstream@1.0.11 is a bundled dependency of
npm WARN audit fix fstream@1.0.11 npm@6.4.1 at node_modules/npm
npm WARN audit fix fstream@1.0.11 It cannot be fixed automatically.
npm WARN audit fix fstream@1.0.11 Check for updates to the npm package.
npm WARN audit fix got@6.7.1 node_modules/npm/node_modules/got
npm WARN audit fix got@6.7.1 is a bundled dependency of
npm WARN audit fix got@6.7.1 npm@6.4.1 at node_modules/npm
npm WARN audit fix got@6.7.1 It cannot be fixed automatically.
npm WARN audit fix got@6.7.1 Check for updates to the npm package.
npm WARN audit fix http-cache-semantics@3.8.1 node_modules/npm/node_modules/http-cache-semantics
npm WARN audit fix http-cache-semantics@3.8.1 is a bundled dependency of
npm WARN audit fix http-cache-semantics@3.8.1 npm@6.4.1 at node_modules/npm
npm WARN audit fix http-cache-semantics@3.8.1 It cannot be fixed automatically.
npm WARN audit fix http-cache-semantics@3.8.1 Check for updates to the npm package.
npm WARN audit fix https-proxy-agent@2.2.1 node_modules/npm/node_modules/https-proxy-agent
npm WARN audit fix https-proxy-agent@2.2.1 is a bundled dependency of
npm WARN audit fix https-proxy-agent@2.2.1 npm@6.4.1 at node_modules/npm
npm WARN audit fix https-proxy-agent@2.2.1 It cannot be fixed automatically.
npm WARN audit fix https-proxy-agent@2.2.1 Check for updates to the npm package.
npm WARN audit fix npm-registry-fetch@3.1.1 node_modules/npm/node_modules/libnpmhook/node_modules/npm-registry-fetch
npm WARN audit fix npm-registry-fetch@3.1.1 is a bundled dependency of
npm WARN audit fix npm-registry-fetch@3.1.1 npm@6.4.1 at node_modules/npm
npm WARN audit fix npm-registry-fetch@3.1.1 It cannot be fixed automatically.
npm WARN audit fix npm-registry-fetch@3.1.1 Check for updates to the npm package.
npm WARN audit fix npm-registry-fetch@1.1.0 node_modules/npm/node_modules/npm-registry-fetch
npm WARN audit fix npm-registry-fetch@1.1.0 is a bundled dependency of
npm WARN audit fix npm-registry-fetch@1.1.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix npm-registry-fetch@1.1.0 It cannot be fixed automatically.
npm WARN audit fix npm-registry-fetch@1.1.0 Check for updates to the npm package.
npm WARN audit fix tar@4.4.6 node_modules/npm/node_modules/tar
npm WARN audit fix tar@4.4.6 is a bundled dependency of
npm WARN audit fix tar@4.4.6 npm@6.4.1 at node_modules/npm
npm WARN audit fix tar@4.4.6 It cannot be fixed automatically.
npm WARN audit fix tar@4.4.6 Check for updates to the npm package.
npm WARN audit fix tar@2.2.1 node_modules/npm/node_modules/node-gyp/node_modules/tar
npm WARN audit fix tar@2.2.1 is a bundled dependency of
npm WARN audit fix tar@2.2.1 npm@6.4.1 at node_modules/npm
npm WARN audit fix tar@2.2.1 It cannot be fixed automatically.
npm WARN audit fix tar@2.2.1 Check for updates to the npm package.
npm WARN audit fix ssri@5.3.0 node_modules/npm/node_modules/npm-registry-client/node_modules/ssri
npm WARN audit fix ssri@5.3.0 is a bundled dependency of
npm WARN audit fix ssri@5.3.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix ssri@5.3.0 It cannot be fixed automatically.
npm WARN audit fix ssri@5.3.0 Check for updates to the npm package.
npm WARN audit fix ssri@5.3.0 node_modules/npm/node_modules/npm-registry-fetch/node_modules/ssri
npm WARN audit fix ssri@5.3.0 is a bundled dependency of
npm WARN audit fix ssri@5.3.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix ssri@5.3.0 It cannot be fixed automatically.
npm WARN audit fix ssri@5.3.0 Check for updates to the npm package.
npm WARN audit fix ssri@6.0.0 node_modules/npm/node_modules/ssri
npm WARN audit fix ssri@6.0.0 is a bundled dependency of
npm WARN audit fix ssri@6.0.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix ssri@6.0.0 It cannot be fixed automatically.
npm WARN audit fix ssri@6.0.0 Check for updates to the npm package.
npm WARN audit fix npm-user-validate@1.0.0 node_modules/npm/node_modules/npm-user-validate
npm WARN audit fix npm-user-validate@1.0.0 is a bundled dependency of
npm WARN audit fix npm-user-validate@1.0.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix npm-user-validate@1.0.0 It cannot be fixed automatically.
npm WARN audit fix npm-user-validate@1.0.0 Check for updates to the npm package.
npm WARN audit fix qs@6.5.2 node_modules/npm/node_modules/qs
npm WARN audit fix qs@6.5.2 is a bundled dependency of
npm WARN audit fix qs@6.5.2 npm@6.4.1 at node_modules/npm
npm WARN audit fix qs@6.5.2 It cannot be fixed automatically.
npm WARN audit fix qs@6.5.2 Check for updates to the npm package.
npm WARN audit fix request@2.88.0 node_modules/npm/node_modules/request
npm WARN audit fix request@2.88.0 is a bundled dependency of
npm WARN audit fix request@2.88.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix request@2.88.0 It cannot be fixed automatically.
npm WARN audit fix request@2.88.0 Check for updates to the npm package.
npm WARN audit fix y18n@4.0.0 node_modules/npm/node_modules/y18n
npm WARN audit fix y18n@4.0.0 is a bundled dependency of
npm WARN audit fix y18n@4.0.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix y18n@4.0.0 It cannot be fixed automatically.
npm WARN audit fix y18n@4.0.0 Check for updates to the npm package.
npm WARN audit fix y18n@3.2.1 node_modules/npm/node_modules/yargs/node_modules/y18n
npm WARN audit fix y18n@3.2.1 is a bundled dependency of
npm WARN audit fix y18n@3.2.1 npm@6.4.1 at node_modules/npm
npm WARN audit fix y18n@3.2.1 It cannot be fixed automatically.
npm WARN audit fix y18n@3.2.1 Check for updates to the npm package.
npm WARN audit fix yargs-parser@9.0.2 node_modules/npm/node_modules/yargs-parser
npm WARN audit fix yargs-parser@9.0.2 is a bundled dependency of
npm WARN audit fix yargs-parser@9.0.2 npm@6.4.1 at node_modules/npm
npm WARN audit fix yargs-parser@9.0.2 It cannot be fixed automatically.
npm WARN audit fix yargs-parser@9.0.2 Check for updates to the npm package.
npm WARN audit fix mkdirp@0.5.1 node_modules/npm/node_modules/mkdirp
npm WARN audit fix mkdirp@0.5.1 is a bundled dependency of
npm WARN audit fix mkdirp@0.5.1 npm@6.4.1 at node_modules/npm
npm WARN audit fix mkdirp@0.5.1 It cannot be fixed automatically.
npm WARN audit fix mkdirp@0.5.1 Check for updates to the npm package.
npm WARN audit fix node-gyp@3.8.0 node_modules/npm/node_modules/node-gyp
npm WARN audit fix node-gyp@3.8.0 is a bundled dependency of
npm WARN audit fix node-gyp@3.8.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix node-gyp@3.8.0 It cannot be fixed automatically.
npm WARN audit fix node-gyp@3.8.0 Check for updates to the npm package.
npm WARN audit fix har-validator@5.1.0 node_modules/npm/node_modules/har-validator
npm WARN audit fix har-validator@5.1.0 is a bundled dependency of
npm WARN audit fix har-validator@5.1.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix har-validator@5.1.0 It cannot be fixed automatically.
npm WARN audit fix har-validator@5.1.0 Check for updates to the npm package.
npm WARN audit fix jsprim@1.4.1 node_modules/npm/node_modules/jsprim
npm WARN audit fix jsprim@1.4.1 is a bundled dependency of
npm WARN audit fix jsprim@1.4.1 npm@6.4.1 at node_modules/npm
npm WARN audit fix jsprim@1.4.1 It cannot be fixed automatically.
npm WARN audit fix jsprim@1.4.1 Check for updates to the npm package.
npm WARN audit fix os-locale@2.1.0 node_modules/npm/node_modules/os-locale
npm WARN audit fix os-locale@2.1.0 is a bundled dependency of
npm WARN audit fix os-locale@2.1.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix os-locale@2.1.0 It cannot be fixed automatically.
npm WARN audit fix os-locale@2.1.0 Check for updates to the npm package.
npm WARN audit fix package-json@4.0.1 node_modules/npm/node_modules/package-json
npm WARN audit fix package-json@4.0.1 is a bundled dependency of
npm WARN audit fix package-json@4.0.1 npm@6.4.1 at node_modules/npm
npm WARN audit fix package-json@4.0.1 It cannot be fixed automatically.
npm WARN audit fix package-json@4.0.1 Check for updates to the npm package.
npm WARN audit fix make-fetch-happen@4.0.1 node_modules/npm/node_modules/make-fetch-happen
npm WARN audit fix make-fetch-happen@4.0.1 is a bundled dependency of
npm WARN audit fix make-fetch-happen@4.0.1 npm@6.4.1 at node_modules/npm
npm WARN audit fix make-fetch-happen@4.0.1 It cannot be fixed automatically.
npm WARN audit fix make-fetch-happen@4.0.1 Check for updates to the npm package.
npm WARN audit fix make-fetch-happen@3.0.0 node_modules/npm/node_modules/npm-registry-fetch/node_modules/make-fetch-happen
npm WARN audit fix make-fetch-happen@3.0.0 is a bundled dependency of
npm WARN audit fix make-fetch-happen@3.0.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix make-fetch-happen@3.0.0 It cannot be fixed automatically.
npm WARN audit fix make-fetch-happen@3.0.0 Check for updates to the npm package.
npm WARN audit fix libnpmhook@4.0.1 node_modules/npm/node_modules/libnpmhook
npm WARN audit fix libnpmhook@4.0.1 is a bundled dependency of
npm WARN audit fix libnpmhook@4.0.1 npm@6.4.1 at node_modules/npm
npm WARN audit fix libnpmhook@4.0.1 It cannot be fixed automatically.
npm WARN audit fix libnpmhook@4.0.1 Check for updates to the npm package.
npm WARN audit fix npm-registry-client@8.6.0 node_modules/npm/node_modules/npm-registry-client
npm WARN audit fix npm-registry-client@8.6.0 is a bundled dependency of
npm WARN audit fix npm-registry-client@8.6.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix npm-registry-client@8.6.0 It cannot be fixed automatically.
npm WARN audit fix npm-registry-client@8.6.0 Check for updates to the npm package.
npm WARN audit fix cacache@10.0.4 node_modules/npm/node_modules/npm-registry-fetch/node_modules/cacache
npm WARN audit fix cacache@10.0.4 is a bundled dependency of
npm WARN audit fix cacache@10.0.4 npm@6.4.1 at node_modules/npm
npm WARN audit fix cacache@10.0.4 It cannot be fixed automatically.
npm WARN audit fix cacache@10.0.4 Check for updates to the npm package.
npm WARN audit fix yargs@11.0.0 node_modules/npm/node_modules/yargs
npm WARN audit fix yargs@11.0.0 is a bundled dependency of
npm WARN audit fix yargs@11.0.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix yargs@11.0.0 It cannot be fixed automatically.
npm WARN audit fix yargs@11.0.0 Check for updates to the npm package.
npm WARN audit fix npm-lifecycle@2.1.0 node_modules/npm/node_modules/npm-lifecycle
npm WARN audit fix npm-lifecycle@2.1.0 is a bundled dependency of
npm WARN audit fix npm-lifecycle@2.1.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix npm-lifecycle@2.1.0 It cannot be fixed automatically.
npm WARN audit fix npm-lifecycle@2.1.0 Check for updates to the npm package.
npm WARN audit fix latest-version@3.1.0 node_modules/npm/node_modules/latest-version
npm WARN audit fix latest-version@3.1.0 is a bundled dependency of
npm WARN audit fix latest-version@3.1.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix latest-version@3.1.0 It cannot be fixed automatically.
npm WARN audit fix latest-version@3.1.0 Check for updates to the npm package.
npm WARN audit fix pacote@8.1.6 node_modules/npm/node_modules/pacote
npm WARN audit fix pacote@8.1.6 is a bundled dependency of
npm WARN audit fix pacote@8.1.6 npm@6.4.1 at node_modules/npm
npm WARN audit fix pacote@8.1.6 It cannot be fixed automatically.
npm WARN audit fix pacote@8.1.6 Check for updates to the npm package.
npm WARN audit fix npm-profile@3.0.2 node_modules/npm/node_modules/npm-profile
npm WARN audit fix npm-profile@3.0.2 is a bundled dependency of
npm WARN audit fix npm-profile@3.0.2 npm@6.4.1 at node_modules/npm
npm WARN audit fix npm-profile@3.0.2 It cannot be fixed automatically.
npm WARN audit fix npm-profile@3.0.2 Check for updates to the npm package.
npm WARN audit fix libnpx@10.2.0 node_modules/npm/node_modules/libnpx
npm WARN audit fix libnpx@10.2.0 is a bundled dependency of
npm WARN audit fix libnpx@10.2.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix libnpx@10.2.0 It cannot be fixed automatically.
npm WARN audit fix libnpx@10.2.0 Check for updates to the npm package.
npm WARN audit fix libcipm@2.0.2 node_modules/npm/node_modules/libcipm
npm WARN audit fix libcipm@2.0.2 is a bundled dependency of
npm WARN audit fix libcipm@2.0.2 npm@6.4.1 at node_modules/npm
npm WARN audit fix libcipm@2.0.2 It cannot be fixed automatically.
npm WARN audit fix libcipm@2.0.2 Check for updates to the npm package.
npm WARN audit fix update-notifier@2.5.0 node_modules/npm/node_modules/update-notifier
npm WARN audit fix update-notifier@2.5.0 is a bundled dependency of
npm WARN audit fix update-notifier@2.5.0 npm@6.4.1 at node_modules/npm
npm WARN audit fix update-notifier@2.5.0 It cannot be fixed automatically.
npm WARN audit fix update-notifier@2.5.0 Check for updates to the npm package.
npm WARN audit Updating axios to 1.6.2, which is a SemVer major change.
npm WARN audit Updating react-scripts to 5.0.1, which is a SemVer major change.
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: react-starter-kit@1.0.0
npm WARN Found: react-scripts@3.4.1
npm WARN node_modules/react-scripts
npm WARN   peer react-scripts@">=2.1.3" from react-app-rewired@2.1.6
npm WARN   node_modules/react-app-rewired
npm WARN     dev react-app-rewired@"^2.1.6" from the root project
npm WARN   1 more (the root project)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer react-scripts@"^4.0.0" from craco-less@1.20.0
npm WARN node_modules/craco-less
npm WARN   craco-less@"^1.17.0" from the root project
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: react-starter-kit@1.0.0
npm WARN Found: react-scripts@3.4.1
npm WARN node_modules/react-scripts
npm WARN   peer react-scripts@">=2.1.3" from react-app-rewired@2.1.6
npm WARN   node_modules/react-app-rewired
npm WARN     dev react-app-rewired@"^2.1.6" from the root project
npm WARN   1 more (the root project)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer react-scripts@"^4.0.0" from @craco/craco@6.4.5
npm WARN node_modules/@craco/craco
npm WARN   peer @craco/craco@"^6.0.0" from craco-less@1.20.0
npm WARN   node_modules/craco-less
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: react-app-rewire-less@2.1.3
npm WARN Found: react-app-rewired@2.1.6
npm WARN node_modules/react-app-rewired
npm WARN   dev react-app-rewired@"^2.1.6" from the root project
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer react-app-rewired@"^1.5.2" from react-app-rewire-less@2.1.3
npm WARN node_modules/react-app-rewire-less
npm WARN   dev react-app-rewire-less@"^2.1.3" from the root project
npm WARN 
npm WARN Conflicting peer dependency: react-app-rewired@1.6.2
npm WARN node_modules/react-app-rewired
npm WARN   peer react-app-rewired@"^1.5.2" from react-app-rewire-less@2.1.3
npm WARN   node_modules/react-app-rewire-less
npm WARN     dev react-app-rewire-less@"^2.1.3" from the root project
npm WARN deprecated rollup-plugin-terser@7.0.2: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
npm WARN deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
npm WARN deprecated chokidar@2.1.8: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
npm WARN deprecated workbox-cacheable-response@6.6.0: workbox-background-sync@6.6.0
npm WARN deprecated domexception@2.0.1: Use your platform's native DOMException instead
npm WARN deprecated abab@2.0.6: Use your platform's native atob() and btoa() methods instead
npm WARN deprecated @babel/plugin-proposal-private-methods@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
npm WARN deprecated @babel/plugin-proposal-numeric-separator@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
npm WARN deprecated @babel/plugin-proposal-class-properties@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
npm WARN deprecated @babel/plugin-proposal-nullish-coalescing-operator@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
npm WARN deprecated @babel/plugin-proposal-optional-chaining@7.21.0: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.

added 807 packages, removed 635 packages, changed 850 packages, and audited 2557 packages in 3m

258 packages are looking for funding
  run `npm fund` for details

# npm audit report

ansi-regex  3.0.0 || 4.0.0 - 4.1.0
Severity: high
Inefficient Regular Expression Complexity in chalk/ansi-regex - https://github.com/advisories/GHSA-93q8-gq69-wqmw
Inefficient Regular Expression Complexity in chalk/ansi-regex - https://github.com/advisories/GHSA-93q8-gq69-wqmw
fix available via `npm audit fix`
node_modules/npm/node_modules/string-width/node_modules/ansi-regex
node_modules/npm/node_modules/yargs/node_modules/ansi-regex

glob-parent  <5.1.2
Severity: high
glob-parent vulnerable to Regular Expression Denial of Service in enclosure regex - https://github.com/advisories/GHSA-ww39-953v-wcq6
fix available via `npm audit fix`
node_modules/watchpack-chokidar2/node_modules/glob-parent
  chokidar  1.0.0-rc1 - 2.1.8
  Depends on vulnerable versions of glob-parent
  node_modules/watchpack-chokidar2/node_modules/chokidar
    watchpack-chokidar2  *
    Depends on vulnerable versions of chokidar
    node_modules/watchpack-chokidar2
      watchpack  1.7.2 - 1.7.5
      Depends on vulnerable versions of watchpack-chokidar2
      node_modules/watchpack

got  <11.8.5
Severity: moderate
Got allows a redirect to a UNIX socket - https://github.com/advisories/GHSA-pfrx-2q88-qq97
fix available via `npm audit fix --force`
Will install react-app-rewire-less@2.1.2, which is a breaking change
node_modules/npm/node_modules/got
  package-json  <=6.5.0
  Depends on vulnerable versions of got
  node_modules/npm/node_modules/package-json
    latest-version  0.2.0 - 5.1.0
    Depends on vulnerable versions of package-json
    node_modules/npm/node_modules/latest-version
      update-notifier  0.2.0 - 5.1.0
      Depends on vulnerable versions of latest-version
      node_modules/npm/node_modules/update-notifier
        libnpx  *
        Depends on vulnerable versions of update-notifier
        node_modules/npm/node_modules/libnpx
          npm  <=7.0.0-rc.4 || 7.0.1 - 8.5.4
          Depends on vulnerable versions of libcipm
          Depends on vulnerable versions of libnpm
          Depends on vulnerable versions of libnpmaccess
          Depends on vulnerable versions of libnpmhook
          Depends on vulnerable versions of libnpmorg
          Depends on vulnerable versions of libnpmsearch
          Depends on vulnerable versions of libnpmteam
          Depends on vulnerable versions of libnpx
          Depends on vulnerable versions of node-gyp
          Depends on vulnerable versions of npm-lifecycle
          Depends on vulnerable versions of npm-profile
          Depends on vulnerable versions of npm-registry-fetch
          Depends on vulnerable versions of pacote
          Depends on vulnerable versions of request
          Depends on vulnerable versions of semver
          Depends on vulnerable versions of update-notifier
          node_modules/npm
            react-app-rewire-less  >=2.1.3
            Depends on vulnerable versions of npm
            node_modules/react-app-rewire-less

http-cache-semantics  <4.1.1
Severity: high
http-cache-semantics vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-rc47-6667-2j5j
fix available via `npm audit fix --force`
Will install react-app-rewire-less@2.1.2, which is a breaking change
node_modules/npm/node_modules/http-cache-semantics
  make-fetch-happen  2.1.0 - 6.1.0
  Depends on vulnerable versions of http-cache-semantics
  node_modules/npm/node_modules/make-fetch-happen
    npm-registry-fetch  0.0.1 - 5.0.1
    Depends on vulnerable versions of make-fetch-happen
    node_modules/npm/node_modules/npm-registry-fetch
      libnpm  >=0.0.1
      Depends on vulnerable versions of libnpmaccess
      Depends on vulnerable versions of libnpmhook
      Depends on vulnerable versions of libnpmorg
      Depends on vulnerable versions of libnpmpublish
      Depends on vulnerable versions of libnpmsearch
      Depends on vulnerable versions of libnpmteam
      Depends on vulnerable versions of npm-lifecycle
      Depends on vulnerable versions of npm-profile
      Depends on vulnerable versions of npm-registry-fetch
      Depends on vulnerable versions of pacote
      node_modules/npm/node_modules/libnpm
      libnpmaccess  <=3.0.2
      Depends on vulnerable versions of npm-registry-fetch
      node_modules/npm/node_modules/libnpmaccess
      libnpmhook  <=5.0.3
      Depends on vulnerable versions of npm-registry-fetch
      node_modules/npm/node_modules/libnpmhook
      libnpmorg  <=1.0.1
      Depends on vulnerable versions of npm-registry-fetch
      node_modules/npm/node_modules/libnpmorg
      libnpmpublish  <=2.0.0
      Depends on vulnerable versions of npm-registry-fetch
      node_modules/npm/node_modules/libnpmpublish
      libnpmsearch  <=2.0.2
      Depends on vulnerable versions of npm-registry-fetch
      node_modules/npm/node_modules/libnpmsearch
      libnpmteam  <=1.0.2
      Depends on vulnerable versions of npm-registry-fetch
      node_modules/npm/node_modules/libnpmteam
      npm-profile  4.0.0 - 4.0.4
      Depends on vulnerable versions of npm-registry-fetch
      node_modules/npm/node_modules/npm-profile
      pacote  2.0.0 - 10.2.1
      Depends on vulnerable versions of make-fetch-happen
      Depends on vulnerable versions of npm-registry-fetch
      node_modules/npm/node_modules/pacote
        libcipm  *
        Depends on vulnerable versions of npm-lifecycle
        Depends on vulnerable versions of pacote
        node_modules/npm/node_modules/libcipm

json5  <1.0.2
Severity: high
Prototype Pollution in JSON5 via Parse Method - https://github.com/advisories/GHSA-9c47-m6qq-7p4h
fix available via `npm audit fix`
node_modules/json5
  loader-utils  <=1.4.1
  Depends on vulnerable versions of json5
  node_modules/loader-utils


nth-check  <2.0.1
Severity: high
Inefficient Regular Expression Complexity in nth-check - https://github.com/advisories/GHSA-rp65-9cf3-cjxr
fix available via `npm audit fix --force`
Will install react-scripts@3.0.1, which is a breaking change
node_modules/nth-check
  css-select  <=3.1.0
  Depends on vulnerable versions of nth-check
  node_modules/css-select
    svgo  1.0.0 - 1.3.2
    Depends on vulnerable versions of css-select
    node_modules/svgo
      @svgr/plugin-svgo  <=5.5.0
      Depends on vulnerable versions of svgo
      node_modules/@svgr/plugin-svgo
        @svgr/webpack  4.0.0 - 5.5.0
        Depends on vulnerable versions of @svgr/plugin-svgo
        node_modules/@svgr/webpack
          react-scripts  >=2.1.4
          Depends on vulnerable versions of @svgr/webpack
          Depends on vulnerable versions of resolve-url-loader
          node_modules/react-scripts
            @craco/craco  >=6.0.0
            Depends on vulnerable versions of react-scripts
            node_modules/@craco/craco
              craco-less  >=1.10.0
              Depends on vulnerable versions of @craco/craco
              Depends on vulnerable versions of react-scripts
              node_modules/craco-less

postcss  <8.4.31
Severity: moderate
PostCSS line return parsing error - https://github.com/advisories/GHSA-7fh5-64p2-3v2j
fix available via `npm audit fix --force`
Will install react-scripts@3.0.1, which is a breaking change
node_modules/resolve-url-loader/node_modules/postcss
  resolve-url-loader  0.0.1-experiment-postcss || 3.0.0-alpha.1 - 4.0.0
  Depends on vulnerable versions of postcss
  node_modules/resolve-url-loader

request  *
Severity: moderate
Server-Side Request Forgery in Request - https://github.com/advisories/GHSA-p8p7-x288-28g6
Depends on vulnerable versions of tough-cookie
fix available via `npm audit fix --force`
Will install react-app-rewire-less@2.1.2, which is a breaking change
node_modules/npm/node_modules/request
  node-gyp  <=7.1.2
  Depends on vulnerable versions of request
  node_modules/npm/node_modules/node-gyp
    npm-lifecycle  >=2.0.0
    Depends on vulnerable versions of node-gyp
    node_modules/npm/node_modules/npm-lifecycle

semver  <5.7.2
Severity: moderate
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
fix available via `npm audit fix --force`
Will install react-app-rewire-less@2.1.2, which is a breaking change
node_modules/npm/node_modules/semver

tough-cookie  <4.1.3
Severity: moderate
tough-cookie Prototype Pollution vulnerability - https://github.com/advisories/GHSA-72xf-g2v4-qvf3
fix available via `npm audit fix --force`
Will install react-app-rewire-less@2.1.2, which is a breaking change
node_modules/npm/node_modules/tough-cookie

42 vulnerabilities (15 moderate, 26 high, 1 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
