### PR TITLE
[GHSA-72xf-g2v4-qvf3] tough-cookie Prototype Pollution vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-72xf-g2v4-qvf3/GHSA-72xf-g2v4-qvf3.json
+++ b/advisories/github-reviewed/2023/07/GHSA-72xf-g2v4-qvf3/GHSA-72xf-g2v4-qvf3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-72xf-g2v4-qvf3",
-  "modified": "2023-07-07T21:39:57Z",
+  "modified": "2023-11-29T22:32:01Z",
   "published": "2023-07-01T06:30:16Z",
   "aliases": [
     "CVE-2023-26136"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "tough-cookie"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(tough-cookie).CookieJar.setCookieSync"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
npm audit report

glob-parent  <5.1.2
Severity: high
glob-parent vulnerable to Regular Expression Denial of Service in enclosure regex - https://github.com/advisories/GHSA-ww39-953v-wcq6
fix available via `npm audit fix --force`
Will install gulp@3.9.1, which is a breaking change
node_modules/chokidar/node_modules/glob-parent
node_modules/glob-stream/node_modules/glob-parent
  chokidar  1.0.0-rc1 - 2.1.8
  Depends on vulnerable versions of glob-parent
  node_modules/chokidar
    glob-watcher  3.0.0 - 5.0.5
    Depends on vulnerable versions of chokidar
    node_modules/glob-watcher
  glob-stream  5.3.0 - 6.1.0
  Depends on vulnerable versions of glob-parent
  node_modules/glob-stream
    vinyl-fs  2.4.2 - 3.0.3
    Depends on vulnerable versions of glob-stream
    node_modules/vinyl-fs
      gulp  >=4.0.0
      Depends on vulnerable versions of glob-watcher
      Depends on vulnerable versions of vinyl-fs
      node_modules/gulp
        gulp-imagemin  >=5.0.0
        Depends on vulnerable versions of gulp
        Depends on vulnerable versions of imagemin-gifsicle
        Depends on vulnerable versions of imagemin-mozjpeg
        Depends on vulnerable versions of imagemin-optipng
        node_modules/gulp-imagemin

got  <=11.8.3
Severity: high
Got allows a redirect to a UNIX socket - https://github.com/advisories/GHSA-pfrx-2q88-qq97
Depends on vulnerable versions of cacheable-request
fix available via `npm audit fix --force`
Will install gulp-imagemin@4.1.0, which is a breaking change
node_modules/bin-wrapper/node_modules/got
node_modules/got
  download  >=4.0.0
  Depends on vulnerable versions of got
  node_modules/bin-wrapper/node_modules/download
  node_modules/download
    bin-build  >=2.1.2
    Depends on vulnerable versions of download
    node_modules/bin-build
      gifsicle  >=3.0.0
      Depends on vulnerable versions of bin-build
      Depends on vulnerable versions of bin-wrapper
      node_modules/gifsicle
        imagemin-gifsicle  >=6.0.0
        Depends on vulnerable versions of gifsicle
        node_modules/imagemin-gifsicle
      mozjpeg  >=4.0.0
      Depends on vulnerable versions of bin-build
      Depends on vulnerable versions of bin-wrapper
      node_modules/mozjpeg
        imagemin-mozjpeg  >=7.0.0
        Depends on vulnerable versions of mozjpeg
        node_modules/imagemin-mozjpeg
      optipng-bin  >=3.0.0
      Depends on vulnerable versions of bin-build
      Depends on vulnerable versions of bin-wrapper
      node_modules/optipng-bin
        imagemin-optipng  >=6.0.0
        Depends on vulnerable versions of optipng-bin
        node_modules/imagemin-optipng
    bin-wrapper  >=0.4.0
    Depends on vulnerable versions of bin-version-check
    Depends on vulnerable versions of download
    node_modules/bin-wrapper

http-cache-semantics  <4.1.1
Severity: high
http-cache-semantics vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-rc47-6667-2j5j
fix available via `npm audit fix --force`
Will install gulp-imagemin@4.1.0, which is a breaking change
node_modules/bin-wrapper/node_modules/http-cache-semantics
  cacheable-request  0.1.0 - 2.1.4
  Depends on vulnerable versions of http-cache-semantics
  node_modules/bin-wrapper/node_modules/cacheable-request

lodash  <=4.17.20
Severity: critical
Regular Expression Denial of Service (ReDoS) in lodash - https://github.com/advisories/GHSA-x5rq-j2xg-h7qm
Prototype Pollution in lodash - https://github.com/advisories/GHSA-fvqr-27wr-82fm
Prototype Pollution in lodash - https://github.com/advisories/GHSA-jf85-cpcp-j695
Command Injection in lodash - https://github.com/advisories/GHSA-35jh-r3h4-6jhm
Prototype Pollution in lodash - https://github.com/advisories/GHSA-4xc9-xhrj-v574
Regular Expression Denial of Service (ReDoS) in lodash - https://github.com/advisories/GHSA-29mw-wpgm-hmr9
fix available via `npm audit fix`
node_modules/common-errors/node_modules/lodash
  common-errors  0.4.15 - 0.5.3
  Depends on vulnerable versions of lodash
  node_modules/common-errors

request  *
Severity: moderate
Server-Side Request Forgery in Request - https://github.com/advisories/GHSA-p8p7-x288-28g6
Depends on vulnerable versions of tough-cookie
fix available via `npm audit fix`
node_modules/request
  sign-addon  *
  Depends on vulnerable versions of request
  node_modules/sign-addon
    web-ext  >=1.0.0
    Depends on vulnerable versions of sign-addon
    node_modules/web-ext

semver-regex  <=3.1.3
Severity: high
semver-regex Regular Expression Denial of Service (ReDOS) - https://github.com/advisories/GHSA-44c6-4v22-4mhx
Regular expression denial of service in semver-regex - https://github.com/advisories/GHSA-4x5v-gmq8-25ch
fix available via `npm audit fix --force`
Will install gulp-imagemin@4.1.0, which is a breaking change
node_modules/semver-regex
  find-versions  <=3.2.0
  Depends on vulnerable versions of semver-regex
  node_modules/find-versions
    bin-version  <=4.0.0
    Depends on vulnerable versions of find-versions
    node_modules/bin-version
      bin-version-check  <=4.0.0
      Depends on vulnerable versions of bin-version
      node_modules/bin-version-check

tough-cookie  <4.1.3
Severity: moderate
tough-cookie Prototype Pollution vulnerability - https://github.com/advisories/GHSA-72xf-g2v4-qvf3
fix available via `npm audit fix`
node_modules/tough-cookie

underscore  1.3.2 - 1.12.0
Severity: critical
Arbitrary Code Execution in underscore - https://github.com/advisories/GHSA-cf4h-3jhx-xvhq
No fix available
node_modules/underscore
  filter-java-properties  *
  Depends on vulnerable versions of common-errors
  Depends on vulnerable versions of underscore
  node_modules/filter-java-properties
    gulp-filter-java-properties  *
    Depends on vulnerable versions of filter-java-properties
    node_modules/gulp-filter-java-properties

