### PR TITLE
[GHSA-428j-q447-47rw] The users/get program in the User RPC API in Apache Rave...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-428j-q447-47rw/GHSA-428j-q447-47rw.json
+++ b/advisories/unreviewed/2022/05/GHSA-428j-q447-47rw/GHSA-428j-q447-47rw.json
@@ -1,17 +1,39 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-428j-q447-47rw",
-  "modified": "2022-05-17T05:07:50Z",
+  "modified": "2023-01-28T05:03:09Z",
   "published": "2022-05-17T05:07:50Z",
   "aliases": [
     "CVE-2013-1814"
   ],
+  "summary": "CVE-2013-1814",
   "details": "The users/get program in the User RPC API in Apache Rave 0.11 through 0.20 allows remote authenticated users to obtain sensitive information about all user accounts via the offset parameter, as demonstrated by discovering password hashes in the password field of a response.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.rave:rave-web"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.11"
+            },
+            {
+              "fixed": "0.21.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.20"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
According to `https://www.exploit-db.com/exploits/24744`, the affected library corresponds to `org.apache.rave`, and `rave-web` fits the affected artifact properly.