### PR TITLE
[GHSA-97gm-mcv6-cphm] Liferay Portal through 6.2.10 allows remote authenticated...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-97gm-mcv6-cphm/GHSA-97gm-mcv6-cphm.json
+++ b/advisories/unreviewed/2022/05/GHSA-97gm-mcv6-cphm/GHSA-97gm-mcv6-cphm.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-97gm-mcv6-cphm",
-  "modified": "2022-05-17T03:05:00Z",
+  "modified": "2023-01-27T05:07:18Z",
   "published": "2022-05-17T03:05:00Z",
   "aliases": [
     "CVE-2010-5327"
   ],
+  "summary": "CVE-2010-5327",
   "details": "Liferay Portal through 6.2.10 allows remote authenticated users to execute arbitrary shell commands via a crafted Velocity template.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.liferay.portal:portal-impl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "6.2.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 6.2.10"
+      }
+    }
   ],
   "references": [
     {

--- a/advisories/unreviewed/2022/05/GHSA-97gm-mcv6-cphm/GHSA-97gm-mcv6-cphm.json
+++ b/advisories/unreviewed/2022/05/GHSA-97gm-mcv6-cphm/GHSA-97gm-mcv6-cphm.json
@@ -28,7 +28,29 @@
               "introduced": "0"
             },
             {
-              "fixed": "6.2.1"
+              "fixed": "6.2.11"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 6.2.10"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.liferay.portal:portal-service"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "6.2.11"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The fix commit `https://github.com/liferay/liferay-portal/commit/90c4e85a8f8135f069f3f05e4d54a77704769f91` indicates the affected library `com.liferay.portal:portal-impl`.
 
Additionally, I exclude a similar one `com.liferay.portal:com.liferay.portal.impl` as its 6.x version is proposed in 2019.

Their maven link:
`https://mvnrepository.com/artifact/com.liferay.portal/com.liferay.portal.impl`
`https://mvnrepository.com/artifact/com.liferay.portal/portal-impl`