### PR TITLE
[GHSA-wf5v-jhxj-q632] java/org/apache/coyote/ajp/AbstractAjpProcessor.java in...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-wf5v-jhxj-q632/GHSA-wf5v-jhxj-q632.json
+++ b/advisories/unreviewed/2022/05/GHSA-wf5v-jhxj-q632/GHSA-wf5v-jhxj-q632.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wf5v-jhxj-q632",
-  "modified": "2022-05-17T00:24:30Z",
+  "modified": "2023-02-03T05:01:39Z",
   "published": "2022-05-17T00:24:30Z",
   "aliases": [
     "CVE-2014-0095"
   ],
+  "summary": "CVE-2014-0095",
   "details": "java/org/apache/coyote/ajp/AbstractAjpProcessor.java in Apache Tomcat 8.x before 8.0.4 allows remote attackers to cause a denial of service (thread consumption) by using a \"Content-Length: 0\" AJP request to trigger a hang in request processing.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat:tomcat-coyote"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.0.0-RC1"
+            },
+            {
+              "fixed": "8.0.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The affected file corresponds to `https://github.com/apache/tomcat/blob/main/java/org/apache/coyote/ajp/AbstractAjpProtocol.java`

The affected versions is shown in the description `in Apache Tomcat 8.x before 8.0.4` and extracted from its maven URL:
`https://mvnrepository.com/artifact/org.apache.tomcat/tomcat-coyote`