### PR TITLE
[GHSA-4cj8-779h-r25h] Pivotal Spring Batch Admin, all versions, contains a...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-4cj8-779h-r25h/GHSA-4cj8-779h-r25h.json
+++ b/advisories/unreviewed/2022/05/GHSA-4cj8-779h-r25h/GHSA-4cj8-779h-r25h.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4cj8-779h-r25h",
-  "modified": "2022-05-13T01:33:25Z",
+  "modified": "2023-02-01T05:08:12Z",
   "published": "2022-05-13T01:33:25Z",
   "aliases": [
     "CVE-2018-1229"
   ],
+  "summary": "CVE-2018-1229",
   "details": "Pivotal Spring Batch Admin, all versions, contains a stored XSS vulnerability in the file upload feature. An unauthenticated malicious user with network access to Spring Batch Admin could store an arbitrary web script that would be executed by other users. This issue has not been patched because Spring Batch Admin has reached end of life.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework.batch:spring-batch-admin-manager"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.0.0.M1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
As shown in `https://spring.io/security/cve-2018-1229/`, the affected package is `spring-batch-admin`, whose package name is `org.springframework.batch:spring-batch-admin-manager`

Additionally, this vulnerability is not patched, so all its versions (in Maven) are affected.