### PR TITLE
[GHSA-g5q2-cxgq-h2rw] An information leak vulnerability exists in Gerrit...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-g5q2-cxgq-h2rw/GHSA-g5q2-cxgq-h2rw.json
+++ b/advisories/unreviewed/2022/05/GHSA-g5q2-cxgq-h2rw/GHSA-g5q2-cxgq-h2rw.json
@@ -1,17 +1,131 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g5q2-cxgq-h2rw",
-  "modified": "2022-05-24T17:35:58Z",
+  "modified": "2023-01-29T05:05:34Z",
   "published": "2022-05-24T17:35:58Z",
   "aliases": [
     "CVE-2020-8920"
   ],
+  "summary": "CVE-2020-8920",
   "details": "An information leak vulnerability exists in Gerrit versions prior to 2.14.22, 2.15.21, 2.16.25, 3.0.15, 3.1.10, 3.2.5 where an overoptimization with the FilteredRepository wrapper skips the verification of access on All-Users repositories, allowing an attacker to get read access to all users' personal information associated with their accounts.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.google.gerrit:gerrit-plugin-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.14.22"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.google.gerrit:gerrit-plugin-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.15.21"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.google.gerrit:gerrit-plugin-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.16.25"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.google.gerrit:gerrit-plugin-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.15"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.google.gerrit:gerrit-plugin-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.1.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.google.gerrit:gerrit-plugin-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.2.5"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {

--- a/advisories/unreviewed/2022/05/GHSA-g5q2-cxgq-h2rw/GHSA-g5q2-cxgq-h2rw.json
+++ b/advisories/unreviewed/2022/05/GHSA-g5q2-cxgq-h2rw/GHSA-g5q2-cxgq-h2rw.json
@@ -22,109 +22,17 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.2.0"
             },
             {
-              "fixed": "2.14.22"
+              "fixed": "2.14.22, 2.15.21, 2.16.25, 3.0.15, 3.1.10, 3.2.5"
             }
           ]
         }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "com.google.gerrit:gerrit-plugin-api"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "2.15.21"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "com.google.gerrit:gerrit-plugin-api"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "2.16.25"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "com.google.gerrit:gerrit-plugin-api"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "3.0.15"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "com.google.gerrit:gerrit-plugin-api"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "3.1.10"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "com.google.gerrit:gerrit-plugin-api"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "3.2.5"
-            }
-          ]
-        }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 3.2.5"
+      }
     }
   ],
   "references": [

--- a/advisories/unreviewed/2022/05/GHSA-g5q2-cxgq-h2rw/GHSA-g5q2-cxgq-h2rw.json
+++ b/advisories/unreviewed/2022/05/GHSA-g5q2-cxgq-h2rw/GHSA-g5q2-cxgq-h2rw.json
@@ -22,17 +22,109 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.2.0"
+              "introduced": "0"
             },
             {
-              "fixed": "2.14.22, 2.15.21, 2.16.25, 3.0.15, 3.1.10, 3.2.5"
+              "fixed": "2.14.22"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 3.2.5"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.google.gerrit:gerrit-plugin-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.15.0"
+            },
+            {
+              "fixed": "2.15.21"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.google.gerrit:gerrit-plugin-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.16.0"
+            },
+            {
+              "fixed": "2.16.25"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.google.gerrit:gerrit-plugin-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.0.0"
+            },
+            {
+              "fixed": "3.0.15"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.google.gerrit:gerrit-plugin-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.1.0"
+            },
+            {
+              "fixed": "3.1.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.google.gerrit:gerrit-plugin-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.2.0"
+            },
+            {
+              "fixed": "3.2.5"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The issue of this vulnerability is shown in `https://www.gerritcodereview.com/3.2.html#325`.

And the corresponding repo's URL is `https://gerrit.googlesource.com/gerrit/+/45071d6977932bca5a1427c8abad24710fed2e33`

After searching in maven, only three packages correspond to this vulnerability: `com.google.gerrit:gerrit-plugin-api`, `com.google.gerrit:gerrit-acceptance-framework`, and `com.google.gerrit:gerrit-extension-api`.

Thus the proper one among these three is `com.google.gerrit:gerrit-plugin-api`