### PR TITLE
[GHSA-jcxc-mh25-387r] Multiple cross-site scripting (XSS) vulnerabilities in...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-jcxc-mh25-387r/GHSA-jcxc-mh25-387r.json
+++ b/advisories/unreviewed/2022/05/GHSA-jcxc-mh25-387r/GHSA-jcxc-mh25-387r.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jcxc-mh25-387r",
-  "modified": "2022-05-14T03:13:54Z",
+  "modified": "2023-02-02T05:07:50Z",
   "published": "2022-05-14T03:13:54Z",
   "aliases": [
     "CVE-2018-7747"
   ],
+  "summary": "CVE-2018-7747",
   "details": "Multiple cross-site scripting (XSS) vulnerabilities in the Caldera Forms plugin before 1.6.0-rc.1 for WordPress allow remote attackers to inject arbitrary web script or HTML via vectors involving (1) a greeting message, (2) the email transaction log, or (3) an imported form.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "calderajs/forms"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.6.0-rc.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
In `https://www.exploit-db.com/exploits/44489`, it mentions
~~~
# Vulnerable App: https://github.com/CalderaWP/Caldera-Forms/archive/1.5.9.1.zip
~~~

And this package in npm is `calderajs/forms`  (`https://www.npmjs.com/package/@calderajs/forms`)