### PR TITLE
[GHSA-jjg9-mf63-vqrp] Cross-site scripting (XSS) vulnerability in the Flash...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-jjg9-mf63-vqrp/GHSA-jjg9-mf63-vqrp.json
+++ b/advisories/unreviewed/2022/05/GHSA-jjg9-mf63-vqrp/GHSA-jjg9-mf63-vqrp.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jjg9-mf63-vqrp",
-  "modified": "2022-05-17T01:38:30Z",
+  "modified": "2023-02-03T05:04:53Z",
   "published": "2022-05-17T01:38:30Z",
   "aliases": [
     "CVE-2012-5881"
   ],
+  "summary": "CVE-2012-5881",
   "details": "Cross-site scripting (XSS) vulnerability in the Flash component infrastructure in YUI 2.4.0 through 2.9.0 allows remote attackers to inject arbitrary web script or HTML via vectors related to charts.swf, a similar issue to CVE-2010-4207.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "yui2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.9.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
`https://clarle.github.io/yui3/support/20121030-vulnerability/` (redirected from `https://clarle.github.io/yui3/support/20121030-vulnerability/`) indicates that the affected library is `yui`, while `yui`'s versions start from 3.0.0 and the affected versions correspond to `yui2`.

~~~
https://www.npmjs.com/package/yui
https://www.npmjs.com/package/yui2
~~~
