### PR TITLE
[GHSA-q4q2-93pw-qwgf] Spring Cloud SSO Connector, version 2.1.2, contains a...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-q4q2-93pw-qwgf/GHSA-q4q2-93pw-qwgf.json
+++ b/advisories/unreviewed/2022/05/GHSA-q4q2-93pw-qwgf/GHSA-q4q2-93pw-qwgf.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q4q2-93pw-qwgf",
-  "modified": "2022-05-13T01:07:05Z",
+  "modified": "2023-02-01T05:03:08Z",
   "published": "2022-05-13T01:07:05Z",
   "aliases": [
     "CVE-2018-1256"
   ],
+  "summary": "CVE-2018-1256",
   "details": "Spring Cloud SSO Connector, version 2.1.2, contains a regression which disables issuer validation in resource servers that are not bound to the SSO service. In PCF deployments with multiple SSO service plans, a remote attacker can authenticate to unbound resource servers which use this version of the SSO Connector with tokens generated from another service plan.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.pivotal.spring.cloud:spring-cloud-sso-connector"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.1.2"
+            },
+            {
+              "fixed": "2.1.3"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "2.1.2"
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
`https://spring.io/security/cve-2018-1256/` points out the affected package `Spring Cloud SSO Connector version 2.1.2`, and its group id in maven is `io.pivotal.spring.cloud`