### PR TITLE
[GHSA-mjpc-qx7h-r8c9] X-Pack Machine Learning versions before 6.2.4 and 5.6.9...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-mjpc-qx7h-r8c9/GHSA-mjpc-qx7h-r8c9.json
+++ b/advisories/unreviewed/2022/05/GHSA-mjpc-qx7h-r8c9/GHSA-mjpc-qx7h-r8c9.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mjpc-qx7h-r8c9",
-  "modified": "2022-05-13T01:32:18Z",
+  "modified": "2023-02-01T05:08:27Z",
   "published": "2022-05-13T01:32:17Z",
   "aliases": [
     "CVE-2018-3824"
   ],
+  "summary": "CVE-2018-3824",
   "details": "X-Pack Machine Learning versions before 6.2.4 and 5.6.9 had a cross-site scripting (XSS) vulnerability. If an attacker is able to inject data into an index that has a ML job running against it, then when another user views the results of the ML job it could allow the attacker to obtain sensitive information from or perform destructive actions on behalf of that other ML user.",
   "severity": [
     {
@@ -14,7 +15,44 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.elasticsearch:elasticsearch"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "6.2.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.elasticsearch:elasticsearch"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.6.9"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
`https://discuss.elastic.co/t/elastic-stack-6-2-4-and-5-6-9-security-update/128422` points out the affected package, `org.elasticsearch:elasticsearch`, as follows:

~~~
Solutions and Mitigations
Users should upgrade to Elasticsearch version 6.2.4 or 5.6.9.
~~~

and it also points out the affected versions and patch versions.