### PR TITLE
[GHSA-r4m5-47cq-6qg8] Server-Side Request Forgery in ftp-srv

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-r4m5-47cq-6qg8/GHSA-r4m5-47cq-6qg8.json
+++ b/advisories/github-reviewed/2020/09/GHSA-r4m5-47cq-6qg8/GHSA-r4m5-47cq-6qg8.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r4m5-47cq-6qg8",
-  "modified": "2020-08-31T18:59:34Z",
+  "modified": "2023-01-09T05:04:12Z",
   "published": "2020-09-04T17:25:13Z",
   "aliases": [
 
   ],
   "summary": "Server-Side Request Forgery in ftp-srv",
-  "details": "All versions of `ftp-srv` are vulnerable to Server-Side Request Forgery (SSRF). The package fails to prevent remote clients to access other resources in the network, for example when connecting to the server through telnet. This allows attackers to access any network resources available to the server, including private resources in the hosting environment.\n\n\n## Recommendation\n\nNo fix is currently available. Consider using an alternative package until a fix is made available.",
+  "details": "All versions of `ftp-srv` from v1.0.0 onward to v4.3.3 are vulnerable to Server-Side Request Forgery (SSRF). The package fails to prevent remote clients to access other resources in the network, for example when connecting to the server through telnet. This allows attackers to access any network resources available to the server, including private resources in the hosting environment.\n\n\n## Recommendation\n\nUpgrade to patched versions\n`^2.19.6, ^3.1.2, ^4.3.4`\n\n## Workarounds\nBlacklisting the FTP Command PORT will prevent the server from exposing this behaviour through active connections until a fix is applied.\n\nconst ftp = new FtpSrv({\n  blacklist: ['PORT']\n});\n",
   "severity": [
 
   ],
@@ -22,14 +22,68 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0.0.0"
+              "introduced": "0"
+            },
+            {
+              "fixed": "^2.19.6"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.19.6"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ftp-srv"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "^3.1.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 3.1.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ftp-srv"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "^4.3.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.3.4"
+      }
     }
   ],
   "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/QuorumDMS/ftp-srv/security/advisories/GHSA-jw37-5gqr-cf9j"
+    },
     {
       "type": "WEB",
       "url": "https://www.npmjs.com/advisories/1445"


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
This looks to have been addressed in the project.  I believe the org name of the repo changed and this advisory was orphaned.

https://github.com/QuorumDMS/ftp-srv/security/advisories/GHSA-jw37-5gqr-cf9j