### PR TITLE
[GHSA-9699-fmx5-wvpf] The vulnerability allows attackers to bypass...

### DIFF
--- a/advisories/unreviewed/2023/12/GHSA-9699-fmx5-wvpf/GHSA-9699-fmx5-wvpf.json
+++ b/advisories/unreviewed/2023/12/GHSA-9699-fmx5-wvpf/GHSA-9699-fmx5-wvpf.json
@@ -1,17 +1,33 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9699-fmx5-wvpf",
-  "modified": "2023-12-26T15:30:20Z",
+  "modified": "2023-12-26T15:30:26Z",
   "published": "2023-12-26T15:30:20Z",
   "aliases": [
     "CVE-2023-51467"
   ],
-  "details": "The vulnerability allows attackers to bypass authentication to achieve a simple Server-Side Request Forgery (SSRF)\n",
+  "summary": "There is a public PoC for this CVE leading to RCE",
+  "details": "we (cyberstorm.mu) suggest bumping the severity to critical due to https://twitter.com/_0xf4n9x_/status/1732289811665559775 which shows RCE for this CVE.\n\n",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -51,7 +67,7 @@
     "cwe_ids": [
 
     ],
-    "severity": null,
+    "severity": "CRITICAL",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-12-26T15:15:08Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Severity
- Summary

**Comments**
we (cyberstorm.mu) suggest bumping the severity to critical due to https://twitter.com/_0xf4n9x_/status/1732289811665559775 which shows RCE for this CVE.

