### PR TITLE
[GHSA-67hx-6x53-jw92] Babel vulnerable to arbitrary code execution when compiling specifically crafted malicious code

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-67hx-6x53-jw92/GHSA-67hx-6x53-jw92.json
+++ b/advisories/github-reviewed/2023/10/GHSA-67hx-6x53-jw92/GHSA-67hx-6x53-jw92.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-67hx-6x53-jw92",
-  "modified": "2023-10-16T13:55:36Z",
+  "modified": "2023-12-08T19:11:42Z",
   "published": "2023-10-16T13:55:36Z",
   "aliases": [
     "CVE-2023-45133"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
# npm audit report

@babel/traverse  <7.23.2
Severity: critical
Babel vulnerable to arbitrary code execution when compiling specifically crafted malicious code - https://github.com/advisories/GHSA-67hx-6x53-jw92
fix available via `npm audit fix`
node_modules/tap/node_modules/@babel/traverse

axios  0.8.1 - 1.5.1
Severity: moderate
Axios Cross-Site Request Forgery Vulnerability - https://github.com/advisories/GHSA-wf5p-g6vw-rhxx
fix available via `npm audit fix`
node_modules/axios
  contentful-management  0.8.0 - 0.8.6 || 2.1.0 - 4.1.0 || 5.8.0 - 10.39.2
  Depends on vulnerable versions of axios
  node_modules/contentful-management
    gatsby-recipes  >=0.0.5-recipes.14780
    Depends on vulnerable versions of contentful-management
    Depends on vulnerable versions of gatsby-telemetry
    Depends on vulnerable versions of remark-parse
    node_modules/gatsby-recipes
      gatsby-cli  1.1.27 - 4.25.0
      Depends on vulnerable versions of gatsby-recipes
      Depends on vulnerable versions of gatsby-telemetry
      Depends on vulnerable versions of update-notifier
      node_modules/gatsby-cli

cross-fetch  <=2.2.5 || 3.0.0 - 3.1.4 || 3.2.0-alpha.0 - 3.2.0-alpha.2
Severity: high
Incorrect Authorization in cross-fetch - https://github.com/advisories/GHSA-7gc6-qh9x-w6h8
Depends on vulnerable versions of node-fetch
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/cross-fetch
  graphql-request  1.4.0 - 1.8.2
  Depends on vulnerable versions of cross-fetch
  node_modules/graphql-request
    graphql-config  0.0.0-experimental.0 || 1.0.8 - 3.0.0-rc.3
    Depends on vulnerable versions of graphql-request
    node_modules/graphql-config
      eslint-plugin-graphql  1.5.0 - 3.1.1
      Depends on vulnerable versions of graphql-config
      node_modules/eslint-plugin-graphql
        gatsby  <=4.25.6
        Depends on vulnerable versions of @gatsbyjs/relay-compiler
        Depends on vulnerable versions of autoprefixer
        Depends on vulnerable versions of chokidar
        Depends on vulnerable versions of css-loader
        Depends on vulnerable versions of eslint-plugin-graphql
        Depends on vulnerable versions of flat
        Depends on vulnerable versions of gatsby-telemetry
        Depends on vulnerable versions of got
        Depends on vulnerable versions of optimize-css-assets-webpack-plugin
        Depends on vulnerable versions of postcss-flexbugs-fixes
        Depends on vulnerable versions of postcss-loader
        Depends on vulnerable versions of react-dev-utils
        Depends on vulnerable versions of terser-webpack-plugin
        Depends on vulnerable versions of webpack-dev-server
        node_modules/gatsby

debug  4.0.0 - 4.3.0
Severity: moderate
Regular Expression Denial of Service in debug - https://github.com/advisories/GHSA-gxpj-cx7g-858c
fix available via `npm audit fix`
node_modules/engine.io/node_modules/debug
node_modules/socket.io-parser/node_modules/debug
node_modules/socket.io/node_modules/debug
  engine.io  3.4.0 - 4.0.5
  Depends on vulnerable versions of debug
  node_modules/engine.io
    socket.io  2.2.0 - 3.0.4
    Depends on vulnerable versions of debug
    Depends on vulnerable versions of engine.io
    Depends on vulnerable versions of socket.io-parser
    node_modules/socket.io
  socket.io-parser  3.4.0 - 4.0.2
  Depends on vulnerable versions of debug
  node_modules/socket.io-parser

eventsource  <1.1.1
Severity: critical
Exposure of Sensitive Information in eventsource - https://github.com/advisories/GHSA-6h5x-7c5m-7cr7
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/eventsource
  sockjs-client  1.0.0-beta.4 - 1.1.5
  Depends on vulnerable versions of eventsource
  node_modules/sockjs-client
    react-dev-utils  0.2.0 - 12.0.0-next.60
    Depends on vulnerable versions of recursive-readdir
    Depends on vulnerable versions of shell-quote
    Depends on vulnerable versions of sockjs-client
    node_modules/react-dev-utils

flat  <5.0.1
Severity: critical
flat vulnerable to Prototype Pollution - https://github.com/advisories/GHSA-2j2x-2gpw-g8fm
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/flat


glob-parent  <5.1.2
Severity: high
glob-parent vulnerable to Regular Expression Denial of Service in enclosure regex - https://github.com/advisories/GHSA-ww39-953v-wcq6
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/@gatsbyjs/relay-compiler/node_modules/glob-parent
node_modules/gatsby/node_modules/glob-parent
node_modules/watchpack-chokidar2/node_modules/glob-parent
node_modules/webpack-dev-server/node_modules/glob-parent
  chokidar  1.0.0-rc1 - 2.1.8
  Depends on vulnerable versions of glob-parent
  node_modules/gatsby/node_modules/chokidar
  node_modules/watchpack-chokidar2/node_modules/chokidar
  node_modules/webpack-dev-server/node_modules/chokidar
    watchpack-chokidar2  *
    Depends on vulnerable versions of chokidar
    node_modules/watchpack-chokidar2
      watchpack  1.7.2 - 1.7.5
      Depends on vulnerable versions of watchpack-chokidar2
      node_modules/watchpack
    webpack-dev-server  2.0.0-beta - 4.7.2
    Depends on vulnerable versions of chokidar
    Depends on vulnerable versions of selfsigned
    node_modules/webpack-dev-server
  fast-glob  <=2.2.7
  Depends on vulnerable versions of glob-parent
  node_modules/@gatsbyjs/relay-compiler/node_modules/fast-glob

got  <=11.8.3
Severity: high
Got allows a redirect to a UNIX socket - https://github.com/advisories/GHSA-pfrx-2q88-qq97
Depends on vulnerable versions of cacheable-request
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/gatsby/node_modules/got
node_modules/package-json/node_modules/got
  package-json  <=6.5.0
  Depends on vulnerable versions of got
  node_modules/package-json
    latest-version  0.2.0 - 5.1.0
    Depends on vulnerable versions of package-json
    node_modules/latest-version
      update-notifier  0.2.0 - 5.1.0
      Depends on vulnerable versions of latest-version
      node_modules/update-notifier

http-cache-semantics  <4.1.1
Severity: high
http-cache-semantics vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-rc47-6667-2j5j
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/gatsby/node_modules/http-cache-semantics
  cacheable-request  0.1.0 - 2.1.4
  Depends on vulnerable versions of http-cache-semantics
  node_modules/gatsby/node_modules/cacheable-request

mem  <4.0.0
Severity: moderate
Denial of Service in mem - https://github.com/advisories/GHSA-4xcv-9jjx-gfj3
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/mem
  os-locale  2.0.0 - 3.0.0
  Depends on vulnerable versions of mem
  node_modules/os-locale
    yargs  8.0.0-candidate.0 - 12.0.5
    Depends on vulnerable versions of os-locale
    Depends on vulnerable versions of yargs-parser
    node_modules/@gatsbyjs/relay-compiler/node_modules/yargs
      @gatsbyjs/relay-compiler  *
      Depends on vulnerable versions of fast-glob
      Depends on vulnerable versions of fbjs
      Depends on vulnerable versions of relay-runtime
      Depends on vulnerable versions of yargs
      node_modules/@gatsbyjs/relay-compiler

minimatch  <3.0.5
Severity: high
minimatch ReDoS vulnerability - https://github.com/advisories/GHSA-f8q6-p94x-37v3
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/recursive-readdir/node_modules/minimatch
  recursive-readdir  1.2.0 - 2.2.2
  Depends on vulnerable versions of minimatch
  node_modules/recursive-readdir

node-fetch  <=2.6.6
Severity: high
The `size` option isn't honored after following a redirect in node-fetch - https://github.com/advisories/GHSA-w7rc-rwvf-8q5r
node-fetch forwards secure headers to untrusted sites - https://github.com/advisories/GHSA-r683-j2x4-v87g
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/cross-fetch/node_modules/node-fetch
node_modules/isomorphic-fetch/node_modules/node-fetch
  isomorphic-fetch  2.0.0 - 2.2.1
  Depends on vulnerable versions of node-fetch
  node_modules/isomorphic-fetch
    fbjs  0.7.0 - 1.0.0
    Depends on vulnerable versions of isomorphic-fetch
    node_modules/fbjs
      relay-runtime  1.0.0-alpha.1 - 10.0.1
      Depends on vulnerable versions of fbjs
      node_modules/relay-runtime

node-forge  <=1.2.1
Severity: high
Prototype Pollution in node-forge debug API. - https://github.com/advisories/GHSA-5rrq-pxf6-6jx5
URL parsing in node-forge could lead to undesired behavior. - https://github.com/advisories/GHSA-gf8q-jrpm-jvxq
Improper Verification of Cryptographic Signature in `node-forge` - https://github.com/advisories/GHSA-2r2c-g63r-vccr
Open Redirect in node-forge - https://github.com/advisories/GHSA-8fr3-hfg3-gpgp
Improper Verification of Cryptographic Signature in node-forge - https://github.com/advisories/GHSA-cfm4-qjh2-4765
Improper Verification of Cryptographic Signature in node-forge - https://github.com/advisories/GHSA-x4jg-mjrx-434g
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/node-forge
  selfsigned  1.1.1 - 1.10.14
  Depends on vulnerable versions of node-forge
  node_modules/selfsigned

nth-check  <2.0.1
Severity: high
Inefficient Regular Expression Complexity in nth-check - https://github.com/advisories/GHSA-rp65-9cf3-cjxr
fix available via `npm audit fix`
node_modules/svgo/node_modules/nth-check
  css-select  <=3.1.0
  Depends on vulnerable versions of nth-check
  node_modules/svgo/node_modules/css-select
    svgo  1.0.0 - 1.3.2
    Depends on vulnerable versions of css-select
    node_modules/svgo
      postcss-svgo  <=5.0.0-rc.2
      Depends on vulnerable versions of postcss
      Depends on vulnerable versions of svgo
      node_modules/postcss-svgo

parse-path  <5.0.0
Severity: high
Authorization Bypass in parse-path - https://github.com/advisories/GHSA-3j8f-xvm3-ffx4
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/parse-path
  parse-url  <=8.0.0
  Depends on vulnerable versions of parse-path
  node_modules/parse-url
    git-up  <=6.0.0
    Depends on vulnerable versions of parse-url
    node_modules/git-up
      gatsby-telemetry  0.0.1-1595235897 || 1.1.3 - 3.24.0-next.1
      Depends on vulnerable versions of git-up
      node_modules/gatsby-telemetry
        gatsby-plugin-page-creator  2.7.1 - 4.0.0-zz-next.3 || 4.5.0-alpha-trailing-slash.45 - 4.5.0-next.3 || 4.6.0-alpha-ts-jit.26 - 4.6.0-next.3 || 4.7.0-alpha-image-service.13 - 4.7.0-next.3 || 4.8.0-alpha-image-service.24 - 4.8.0-next.2 || 4.9.0-alpha-image-cdn.32 - 4.9.0-next.1 || 4.11.0-alpha-luda.30 - 4.11.0-next.3 || 4.13.0-alpha-image-cdn-telemetry.29 - 4.13.0-next.0 || 4.15.0-alpha-wp-image-cdn-auth.42 - 4.15.0-next.2 || 4.16.0-alpha-image-cdn-caching.9 - 4.16.0-next.1 || 4.17.0-alpha-drupal-image-404.12 - 4.17.0-next.1 || 4.18.0-alpha-drupal-self-reference.18 - 4.18.0-next.1 || 4.20.0-mdxv4-rc.60 - 4.20.0-next.2 || 4.23.0-alpha-9689ff.25 - 4.23.0-next.0 || 4.24.0-alpha-heritage.25 - 4.24.0-next.2
        Depends on vulnerable versions of gatsby-telemetry
        node_modules/gatsby-plugin-page-creator


postcss  <=8.4.30
Severity: moderate
Regular Expression Denial of Service in postcss - https://github.com/advisories/GHSA-566m-qj78-rww5
PostCSS line return parsing error - https://github.com/advisories/GHSA-7fh5-64p2-3v2j
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/css-loader/node_modules/postcss
node_modules/icss-utils/node_modules/postcss
node_modules/postcss
node_modules/postcss-flexbugs-fixes/node_modules/postcss
node_modules/postcss-loader/node_modules/postcss
node_modules/postcss-modules-extract-imports/node_modules/postcss
node_modules/postcss-modules-local-by-default/node_modules/postcss
node_modules/postcss-modules-scope/node_modules/postcss
node_modules/postcss-modules-values/node_modules/postcss
  autoprefixer  1.0.20131222 - 9.8.8
  Depends on vulnerable versions of postcss
  node_modules/autoprefixer
  css-declaration-sorter  <=5.1.2
  Depends on vulnerable versions of postcss
  node_modules/css-declaration-sorter
  css-loader  0.15.0 - 1.0.1
  Depends on vulnerable versions of icss-utils
  Depends on vulnerable versions of postcss
  Depends on vulnerable versions of postcss-modules-extract-imports
  Depends on vulnerable versions of postcss-modules-local-by-default
  Depends on vulnerable versions of postcss-modules-scope
  Depends on vulnerable versions of postcss-modules-values
  node_modules/css-loader
  cssnano  <=4.1.11
  Depends on vulnerable versions of cssnano-preset-default
  Depends on vulnerable versions of postcss
  node_modules/cssnano
    optimize-css-assets-webpack-plugin  <=1.3.2 || 3.0.0 - 5.0.8
    Depends on vulnerable versions of cssnano
    node_modules/optimize-css-assets-webpack-plugin
  cssnano-preset-default  <=4.0.8
  Depends on vulnerable versions of css-declaration-sorter
  Depends on vulnerable versions of cssnano-util-raw-cache
  Depends on vulnerable versions of postcss
  Depends on vulnerable versions of postcss-calc
  Depends on vulnerable versions of postcss-colormin
  Depends on vulnerable versions of postcss-convert-values
  Depends on vulnerable versions of postcss-discard-comments
  Depends on vulnerable versions of postcss-discard-duplicates
  Depends on vulnerable versions of postcss-discard-empty
  Depends on vulnerable versions of postcss-discard-overridden
  Depends on vulnerable versions of postcss-merge-longhand
  Depends on vulnerable versions of postcss-merge-rules
  Depends on vulnerable versions of postcss-minify-font-values
  Depends on vulnerable versions of postcss-minify-gradients
  Depends on vulnerable versions of postcss-minify-params
  Depends on vulnerable versions of postcss-minify-selectors
  Depends on vulnerable versions of postcss-normalize-charset
  Depends on vulnerable versions of postcss-normalize-display-values
  Depends on vulnerable versions of postcss-normalize-positions
  Depends on vulnerable versions of postcss-normalize-repeat-style
  Depends on vulnerable versions of postcss-normalize-string
  Depends on vulnerable versions of postcss-normalize-timing-functions
  Depends on vulnerable versions of postcss-normalize-unicode
  Depends on vulnerable versions of postcss-normalize-url
  Depends on vulnerable versions of postcss-normalize-whitespace
  Depends on vulnerable versions of postcss-ordered-values
  Depends on vulnerable versions of postcss-reduce-initial
  Depends on vulnerable versions of postcss-reduce-transforms
  Depends on vulnerable versions of postcss-svgo
  Depends on vulnerable versions of postcss-unique-selectors
  node_modules/cssnano-preset-default
  cssnano-util-raw-cache  *
  Depends on vulnerable versions of postcss
  node_modules/cssnano-util-raw-cache
  icss-utils  <=3.0.1
  Depends on vulnerable versions of postcss
  node_modules/icss-utils
  postcss-calc  4.1.0 - 7.0.5
  Depends on vulnerable versions of postcss
  node_modules/postcss-calc
  postcss-colormin  <=4.0.3
  Depends on vulnerable versions of postcss
  node_modules/postcss-colormin
  postcss-convert-values  <=4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-convert-values
  postcss-discard-comments  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-discard-comments
  postcss-discard-duplicates  1.1.0 - 4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-discard-duplicates
  postcss-discard-empty  1.1.0 - 4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-discard-empty
  postcss-discard-overridden  <=4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-discard-overridden
  postcss-flexbugs-fixes  <=3.3.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-flexbugs-fixes
  postcss-loader  <=2.1.6
  Depends on vulnerable versions of postcss
  node_modules/postcss-loader
  postcss-merge-longhand  <=4.0.11
  Depends on vulnerable versions of postcss
  Depends on vulnerable versions of stylehacks
  node_modules/postcss-merge-longhand
  postcss-merge-rules  <=4.0.3
  Depends on vulnerable versions of postcss
  node_modules/postcss-merge-rules
  postcss-minify-font-values  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-minify-font-values
  postcss-minify-gradients  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-minify-gradients
  postcss-minify-params  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-minify-params
  postcss-minify-selectors  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-minify-selectors
  postcss-modules-extract-imports  <=1.2.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-modules-extract-imports
  postcss-modules-local-by-default  <=1.2.0
  Depends on vulnerable versions of postcss
  node_modules/postcss-modules-local-by-default
  postcss-modules-scope  <=1.1.0
  Depends on vulnerable versions of postcss
  node_modules/postcss-modules-scope
  postcss-modules-values  <=1.3.0
  Depends on vulnerable versions of postcss
  node_modules/postcss-modules-values
  postcss-normalize-charset  <=4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-charset
  postcss-normalize-display-values  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-display-values
  postcss-normalize-positions  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-positions
  postcss-normalize-repeat-style  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-repeat-style
  postcss-normalize-string  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-string
  postcss-normalize-timing-functions  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-timing-functions
  postcss-normalize-unicode  <=4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-unicode
  postcss-normalize-url  1.1.0 - 4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-url
  postcss-normalize-whitespace  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-whitespace
  postcss-ordered-values  <=4.1.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-ordered-values
  postcss-reduce-initial  <=4.0.3
  Depends on vulnerable versions of postcss
  node_modules/postcss-reduce-initial
  postcss-reduce-transforms  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-reduce-transforms
  postcss-unique-selectors  <=4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-unique-selectors
  stylehacks  <=4.0.3
  Depends on vulnerable versions of postcss
  node_modules/stylehacks


react-devtools-core  <4.28.4
Severity: moderate
React Developer Tools extension Improper Authorization vulnerability - https://github.com/advisories/GHSA-rxrc-rgv4-jpvx
fix available via `npm audit fix`
node_modules/tap/node_modules/react-devtools-core

serialize-javascript  <=3.0.0
Severity: high
Cross-Site Scripting in serialize-javascript - https://github.com/advisories/GHSA-h9rv-jmmf-4pgx
Insecure serialization leading to RCE in serialize-javascript - https://github.com/advisories/GHSA-hxcc-f52p-wc94
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/serialize-javascript
  terser-webpack-plugin  <=1.4.1
  Depends on vulnerable versions of serialize-javascript
  Depends on vulnerable versions of terser
  node_modules/terser-webpack-plugin

shell-quote  <=1.7.2
Severity: critical
Improper Neutralization of Special Elements used in a Command in Shell-quote - https://github.com/advisories/GHSA-g4rg-993r-mgx7
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/shell-quote

terser  <4.8.1
Severity: high
Terser insecure use of regular expressions leads to ReDoS - https://github.com/advisories/GHSA-4wf5-vphf-c2xc
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/terser

trim  <0.0.3
Severity: high
Regular Expression Denial of Service in trim - https://github.com/advisories/GHSA-w5p7-h5w8-2hfq
fix available via `npm audit fix`
node_modules/trim
  remark-parse  <=8.0.3
  Depends on vulnerable versions of trim
  node_modules/gatsby-recipes/node_modules/remark-parse

yargs-parser  6.0.0 - 13.1.1
Severity: moderate
yargs-parser Vulnerable to Prototype Pollution - https://github.com/advisories/GHSA-p9pc-299p-vxgp
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/@gatsbyjs/relay-compiler/node_modules/yargs-parser

101 vulnerabilities (1 low, 63 moderate, 29 high, 8 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
