### PR TITLE
[GHSA-6h5x-7c5m-7cr7] Exposure of Sensitive Information in eventsource

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-6h5x-7c5m-7cr7/GHSA-6h5x-7c5m-7cr7.json
+++ b/advisories/github-reviewed/2022/05/GHSA-6h5x-7c5m-7cr7/GHSA-6h5x-7c5m-7cr7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6h5x-7c5m-7cr7",
-  "modified": "2022-05-25T19:28:43Z",
+  "modified": "2023-11-28T23:43:16Z",
   "published": "2022-05-13T00:01:12Z",
   "aliases": [
     "CVE-2022-1650"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "eventsource"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(eventsource)"
-        ]
       },
       "ranges": [
         {
@@ -43,11 +38,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "eventsource"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(eventsource)"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
eventsource  <1.1.1
Severity: critical
Exposure of Sensitive Information in eventsource - https://github.com/advisories/GHSA-6h5x-7c5m-7cr7
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/eventsource
  sockjs-client  1.0.0-beta.4 - 1.1.5
  Depends on vulnerable versions of eventsource
  node_modules/sockjs-client
    react-dev-utils  0.2.0 - 12.0.0-next.60
    Depends on vulnerable versions of recursive-readdir
    Depends on vulnerable versions of shell-quote
    Depends on vulnerable versions of sockjs-client
    node_modules/react-dev-utils

