### PR TITLE
[GHSA-ww39-953v-wcq6] glob-parent vulnerable to Regular Expression Denial of Service in enclosure regex

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-ww39-953v-wcq6/GHSA-ww39-953v-wcq6.json
+++ b/advisories/github-reviewed/2021/06/GHSA-ww39-953v-wcq6/GHSA-ww39-953v-wcq6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ww39-953v-wcq6",
-  "modified": "2023-11-29T00:42:41Z",
+  "modified": "2023-11-29T00:42:42Z",
   "published": "2021-06-07T21:56:34Z",
   "aliases": [
     "CVE-2020-28469"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "glob-parent"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(glob-parent).globParent"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**

glob-parent  <5.1.2
Severity: high
glob-parent vulnerable to Regular Expression Denial of Service in enclosure regex - https://github.com/advisories/GHSA-ww39-953v-wcq6
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/@gatsbyjs/relay-compiler/node_modules/glob-parent
node_modules/gatsby/node_modules/glob-parent
node_modules/watchpack-chokidar2/node_modules/glob-parent
node_modules/webpack-dev-server/node_modules/glob-parent
  chokidar  1.0.0-rc1 - 2.1.8
  Depends on vulnerable versions of glob-parent
  node_modules/gatsby/node_modules/chokidar
  node_modules/watchpack-chokidar2/node_modules/chokidar
  node_modules/webpack-dev-server/node_modules/chokidar
    watchpack-chokidar2  *
    Depends on vulnerable versions of chokidar
    node_modules/watchpack-chokidar2
      watchpack  1.7.2 - 1.7.5
      Depends on vulnerable versions of watchpack-chokidar2
      node_modules/watchpack
    webpack-dev-server  2.0.0-beta - 4.7.2
    Depends on vulnerable versions of chokidar
    Depends on vulnerable versions of selfsigned
    node_modules/webpack-dev-server
  fast-glob  <=2.2.7
  Depends on vulnerable versions of glob-parent
  node_modules/@gatsbyjs/relay-compiler/node_modules/fast-glob
