### PR TITLE
[GHSA-r683-j2x4-v87g] node-fetch forwards secure headers to untrusted sites

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-r683-j2x4-v87g/GHSA-r683-j2x4-v87g.json
+++ b/advisories/github-reviewed/2022/01/GHSA-r683-j2x4-v87g/GHSA-r683-j2x4-v87g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r683-j2x4-v87g",
-  "modified": "2023-09-07T18:38:41Z",
+  "modified": "2023-11-29T22:08:39Z",
   "published": "2022-01-21T23:55:52Z",
   "aliases": [
     "CVE-2022-0235"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "node-fetch"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(node-fetch).fetch"
-        ]
       },
       "ranges": [
         {
@@ -43,11 +38,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "node-fetch"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(node-fetch).fetch"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
node-fetch  <=2.6.6
Severity: high
The `size` option isn't honored after following a redirect in node-fetch - https://github.com/advisories/GHSA-w7rc-rwvf-8q5r
node-fetch forwards secure headers to untrusted sites - https://github.com/advisories/GHSA-r683-j2x4-v87g
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/cross-fetch/node_modules/node-fetch
node_modules/isomorphic-fetch/node_modules/node-fetch
  isomorphic-fetch  2.0.0 - 2.2.1
  Depends on vulnerable versions of node-fetch
  node_modules/isomorphic-fetch
    fbjs  0.7.0 - 1.0.0
    Depends on vulnerable versions of isomorphic-fetch
    node_modules/fbjs
      relay-runtime  1.0.0-alpha.1 - 10.0.1
      Depends on vulnerable versions of fbjs
      node_modules/relay-runtime
