### PR TITLE
[GHSA-f8q6-p94x-37v3] minimatch ReDoS vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-f8q6-p94x-37v3/GHSA-f8q6-p94x-37v3.json
+++ b/advisories/github-reviewed/2022/10/GHSA-f8q6-p94x-37v3/GHSA-f8q6-p94x-37v3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f8q6-p94x-37v3",
-  "modified": "2023-01-23T18:54:22Z",
+  "modified": "2023-11-29T00:26:29Z",
   "published": "2022-10-18T12:00:32Z",
   "aliases": [
     "CVE-2022-3517"
@@ -19,14 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "minimatch"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(minimatch).defaults",
-          "(minimatch).braceExpand",
-          "(minimatch).match",
-          "(minimatch).Minimatch.defaults"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
minimatch  <3.0.5
Severity: high
minimatch ReDoS vulnerability - https://github.com/advisories/GHSA-f8q6-p94x-37v3
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/recursive-readdir/node_modules/minimatch
  recursive-readdir  1.2.0 - 2.2.2
  Depends on vulnerable versions of minimatch
  node_modules/recursive-readdir

