### PR TITLE
[GHSA-x4jg-mjrx-434g] Improper Verification of Cryptographic Signature in node-forge

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-x4jg-mjrx-434g/GHSA-x4jg-mjrx-434g.json
+++ b/advisories/github-reviewed/2022/03/GHSA-x4jg-mjrx-434g/GHSA-x4jg-mjrx-434g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x4jg-mjrx-434g",
-  "modified": "2022-03-30T20:07:56Z",
+  "modified": "2023-11-29T00:35:39Z",
   "published": "2022-03-18T23:10:28Z",
   "aliases": [
     "CVE-2022-24772"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "node-forge"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(node-forge).pki.rsa"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
node-forge  <=1.2.1
Severity: high
Prototype Pollution in node-forge debug API. - https://github.com/advisories/GHSA-5rrq-pxf6-6jx5
URL parsing in node-forge could lead to undesired behavior. - https://github.com/advisories/GHSA-gf8q-jrpm-jvxq
Improper Verification of Cryptographic Signature in `node-forge` - https://github.com/advisories/GHSA-2r2c-g63r-vccr
Open Redirect in node-forge - https://github.com/advisories/GHSA-8fr3-hfg3-gpgp
Improper Verification of Cryptographic Signature in node-forge - https://github.com/advisories/GHSA-cfm4-qjh2-4765
Improper Verification of Cryptographic Signature in node-forge - https://github.com/advisories/GHSA-x4jg-mjrx-434g
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/node-forge
  selfsigned  1.1.1 - 1.10.14
  Depends on vulnerable versions of node-forge
  node_modules/selfsigned
