### PR TITLE
[GHSA-rp65-9cf3-cjxr] Inefficient Regular Expression Complexity in nth-check

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-rp65-9cf3-cjxr/GHSA-rp65-9cf3-cjxr.json
+++ b/advisories/github-reviewed/2021/09/GHSA-rp65-9cf3-cjxr/GHSA-rp65-9cf3-cjxr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rp65-9cf3-cjxr",
-  "modified": "2023-09-13T21:49:54Z",
+  "modified": "2023-11-29T22:11:25Z",
   "published": "2021-09-20T20:47:31Z",
   "aliases": [
     "CVE-2021-3803"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "nth-check"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(nth-check).parse"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
nth-check  <2.0.1
Severity: high
Inefficient Regular Expression Complexity in nth-check - https://github.com/advisories/GHSA-rp65-9cf3-cjxr
fix available via `npm audit fix`
node_modules/svgo/node_modules/nth-check
  css-select  <=3.1.0
  Depends on vulnerable versions of nth-check
  node_modules/svgo/node_modules/css-select
    svgo  1.0.0 - 1.3.2
    Depends on vulnerable versions of css-select
    node_modules/svgo
      postcss-svgo  <=5.0.0-rc.2
      Depends on vulnerable versions of postcss
      Depends on vulnerable versions of svgo
      node_modules/postcss-svgo
