### PR TITLE
[GHSA-g4rg-993r-mgx7] Improper Neutralization of Special Elements used in a Command in Shell-quote

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-g4rg-993r-mgx7/GHSA-g4rg-993r-mgx7.json
+++ b/advisories/github-reviewed/2022/05/GHSA-g4rg-993r-mgx7/GHSA-g4rg-993r-mgx7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g4rg-993r-mgx7",
-  "modified": "2023-09-11T22:27:13Z",
+  "modified": "2023-11-29T22:20:43Z",
   "published": "2022-05-24T19:18:27Z",
   "aliases": [
     "CVE-2021-42740"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "shell-quote"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(shell-quote).quote"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
shell-quote  <=1.7.2
Severity: critical
Improper Neutralization of Special Elements used in a Command in Shell-quote - https://github.com/advisories/GHSA-g4rg-993r-mgx7
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/shell-quote

