### PR TITLE
[GHSA-566m-qj78-rww5] Regular Expression Denial of Service in postcss

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-566m-qj78-rww5/GHSA-566m-qj78-rww5.json
+++ b/advisories/github-reviewed/2022/01/GHSA-566m-qj78-rww5/GHSA-566m-qj78-rww5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-566m-qj78-rww5",
-  "modified": "2023-09-08T19:35:12Z",
+  "modified": "2023-09-08T19:35:15Z",
   "published": "2022-01-07T00:21:36Z",
   "aliases": [
     "CVE-2021-23382"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**

postcss  <=8.4.30
Severity: moderate
Regular Expression Denial of Service in postcss - https://github.com/advisories/GHSA-566m-qj78-rww5
PostCSS line return parsing error - https://github.com/advisories/GHSA-7fh5-64p2-3v2j
fix available via `npm audit fix --force`
Will install gatsby@5.13.1, which is a breaking change
node_modules/css-loader/node_modules/postcss
node_modules/icss-utils/node_modules/postcss
node_modules/postcss
node_modules/postcss-flexbugs-fixes/node_modules/postcss
node_modules/postcss-loader/node_modules/postcss
node_modules/postcss-modules-extract-imports/node_modules/postcss
node_modules/postcss-modules-local-by-default/node_modules/postcss
node_modules/postcss-modules-scope/node_modules/postcss
node_modules/postcss-modules-values/node_modules/postcss
  autoprefixer  1.0.20131222 - 9.8.8
  Depends on vulnerable versions of postcss
  node_modules/autoprefixer
  css-declaration-sorter  <=5.1.2
  Depends on vulnerable versions of postcss
  node_modules/css-declaration-sorter
  css-loader  0.15.0 - 1.0.1
  Depends on vulnerable versions of icss-utils
  Depends on vulnerable versions of postcss
  Depends on vulnerable versions of postcss-modules-extract-imports
  Depends on vulnerable versions of postcss-modules-local-by-default
  Depends on vulnerable versions of postcss-modules-scope
  Depends on vulnerable versions of postcss-modules-values
  node_modules/css-loader
  cssnano  <=4.1.11
  Depends on vulnerable versions of cssnano-preset-default
  Depends on vulnerable versions of postcss
  node_modules/cssnano
    optimize-css-assets-webpack-plugin  <=1.3.2 || 3.0.0 - 5.0.8
    Depends on vulnerable versions of cssnano
    node_modules/optimize-css-assets-webpack-plugin
  cssnano-preset-default  <=4.0.8
  Depends on vulnerable versions of css-declaration-sorter
  Depends on vulnerable versions of cssnano-util-raw-cache
  Depends on vulnerable versions of postcss
  Depends on vulnerable versions of postcss-calc
  Depends on vulnerable versions of postcss-colormin
  Depends on vulnerable versions of postcss-convert-values
  Depends on vulnerable versions of postcss-discard-comments
  Depends on vulnerable versions of postcss-discard-duplicates
  Depends on vulnerable versions of postcss-discard-empty
  Depends on vulnerable versions of postcss-discard-overridden
  Depends on vulnerable versions of postcss-merge-longhand
  Depends on vulnerable versions of postcss-merge-rules
  Depends on vulnerable versions of postcss-minify-font-values
  Depends on vulnerable versions of postcss-minify-gradients
  Depends on vulnerable versions of postcss-minify-params
  Depends on vulnerable versions of postcss-minify-selectors
  Depends on vulnerable versions of postcss-normalize-charset
  Depends on vulnerable versions of postcss-normalize-display-values
  Depends on vulnerable versions of postcss-normalize-positions
  Depends on vulnerable versions of postcss-normalize-repeat-style
  Depends on vulnerable versions of postcss-normalize-string
  Depends on vulnerable versions of postcss-normalize-timing-functions
  Depends on vulnerable versions of postcss-normalize-unicode
  Depends on vulnerable versions of postcss-normalize-url
  Depends on vulnerable versions of postcss-normalize-whitespace
  Depends on vulnerable versions of postcss-ordered-values
  Depends on vulnerable versions of postcss-reduce-initial
  Depends on vulnerable versions of postcss-reduce-transforms
  Depends on vulnerable versions of postcss-svgo
  Depends on vulnerable versions of postcss-unique-selectors
  node_modules/cssnano-preset-default
  cssnano-util-raw-cache  *
  Depends on vulnerable versions of postcss
  node_modules/cssnano-util-raw-cache
  icss-utils  <=3.0.1
  Depends on vulnerable versions of postcss
  node_modules/icss-utils
  postcss-calc  4.1.0 - 7.0.5
  Depends on vulnerable versions of postcss
  node_modules/postcss-calc
  postcss-colormin  <=4.0.3
  Depends on vulnerable versions of postcss
  node_modules/postcss-colormin
  postcss-convert-values  <=4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-convert-values
  postcss-discard-comments  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-discard-comments
  postcss-discard-duplicates  1.1.0 - 4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-discard-duplicates
  postcss-discard-empty  1.1.0 - 4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-discard-empty
  postcss-discard-overridden  <=4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-discard-overridden
  postcss-flexbugs-fixes  <=3.3.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-flexbugs-fixes
  postcss-loader  <=2.1.6
  Depends on vulnerable versions of postcss
  node_modules/postcss-loader
  postcss-merge-longhand  <=4.0.11
  Depends on vulnerable versions of postcss
  Depends on vulnerable versions of stylehacks
  node_modules/postcss-merge-longhand
  postcss-merge-rules  <=4.0.3
  Depends on vulnerable versions of postcss
  node_modules/postcss-merge-rules
  postcss-minify-font-values  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-minify-font-values
  postcss-minify-gradients  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-minify-gradients
  postcss-minify-params  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-minify-params
  postcss-minify-selectors  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-minify-selectors
  postcss-modules-extract-imports  <=1.2.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-modules-extract-imports
  postcss-modules-local-by-default  <=1.2.0
  Depends on vulnerable versions of postcss
  node_modules/postcss-modules-local-by-default
  postcss-modules-scope  <=1.1.0
  Depends on vulnerable versions of postcss
  node_modules/postcss-modules-scope
  postcss-modules-values  <=1.3.0
  Depends on vulnerable versions of postcss
  node_modules/postcss-modules-values
  postcss-normalize-charset  <=4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-charset
  postcss-normalize-display-values  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-display-values
  postcss-normalize-positions  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-positions
  postcss-normalize-repeat-style  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-repeat-style
  postcss-normalize-string  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-string
  postcss-normalize-timing-functions  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-timing-functions
  postcss-normalize-unicode  <=4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-unicode
  postcss-normalize-url  1.1.0 - 4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-url
  postcss-normalize-whitespace  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-normalize-whitespace
  postcss-ordered-values  <=4.1.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-ordered-values
  postcss-reduce-initial  <=4.0.3
  Depends on vulnerable versions of postcss
  node_modules/postcss-reduce-initial
  postcss-reduce-transforms  <=4.0.2
  Depends on vulnerable versions of postcss
  node_modules/postcss-reduce-transforms
  postcss-unique-selectors  <=4.0.1
  Depends on vulnerable versions of postcss
  node_modules/postcss-unique-selectors
  stylehacks  <=4.0.3
  Depends on vulnerable versions of postcss
  node_modules/stylehacks

