### PR TITLE
[GHSA-7hpj-7hhx-2fgx] msgpackr's conversion of property names to strings can trigger infinite recursion

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-7hpj-7hhx-2fgx/GHSA-7hpj-7hhx-2fgx.json
+++ b/advisories/github-reviewed/2023/12/GHSA-7hpj-7hhx-2fgx/GHSA-7hpj-7hhx-2fgx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7hpj-7hhx-2fgx",
-  "modified": "2023-12-28T21:16:20Z",
+  "modified": "2023-12-28T21:16:21Z",
   "published": "2023-12-28T21:16:20Z",
   "aliases": [
     "CVE-2023-52079"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:N/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:H"
     }
   ],
   "affected": [
@@ -57,7 +57,7 @@
     "cwe_ids": [
       "CWE-674"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2023-12-28T21:16:20Z",
     "nvd_published_at": "2023-12-28T16:16:01Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
Original reporter here, I originally found this exploit in the wild targeted against my services. This issue occurs on any configuration of msgpackr before the patch, the only requirement is for it to be set up in the chain in a position to deserialize anything the user submits. For example, if your REST API or WebSockets API takes MsgPack data through this library, it will be vulnerable to be DoS'd through this vulnerability. This is not the most common usage of msgpackr but not an entirely uncommon one.

Not sure if there should be a mention of the vuln being actively exploited.