### PR TITLE
[GHSA-g98v-hv3f-hcfr] atty potential unaligned read

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-g98v-hv3f-hcfr/GHSA-g98v-hv3f-hcfr.json
+++ b/advisories/github-reviewed/2023/06/GHSA-g98v-hv3f-hcfr/GHSA-g98v-hv3f-hcfr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g98v-hv3f-hcfr",
-  "modified": "2023-07-10T19:11:40Z",
+  "modified": "2023-07-10T19:11:44Z",
   "published": "2023-06-30T20:21:59Z",
   "aliases": [
 


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
On windows, atty dereferences a potentially unaligned pointer.

In practice however, the pointer won't be unaligned unless a custom global allocator is used.

In particular, the System allocator on windows uses HeapAlloc, which guarantees a large enough alignment.

atty is Unmaintained
A Pull Request with a fix has been provided over a year ago but the maintainer seems to be unreachable.

Last release of atty was almost 3 years ago.

Possible Alternative(s)
The below list has not been vetted in any way and may or may not contain alternatives;

std::io::IsTerminal - Stable since Rust 1.70.0\n
is-terminal - Standalone crate supporting Rust older than 1.70.0"