### PR TITLE
[GHSA-c2qf-rxjj-qqgw] semver vulnerable to Regular Expression Denial of Service

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-c2qf-rxjj-qqgw/GHSA-c2qf-rxjj-qqgw.json
+++ b/advisories/github-reviewed/2023/06/GHSA-c2qf-rxjj-qqgw/GHSA-c2qf-rxjj-qqgw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c2qf-rxjj-qqgw",
-  "modified": "2023-07-10T22:57:56Z",
+  "modified": "2023-11-05T05:04:46Z",
   "published": "2023-06-21T06:30:28Z",
   "aliases": [
     "CVE-2022-25883"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
semver  7.0.0 - 7.5.1
Severity: moderate
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
fix available via `npm audit fix --force`
Will install postman-code-generators@1.0.2, which is a breaking change
node_modules/postman-code-generators/node_modules/semver
  postman-collection  3.6.0-beta.1 - 4.1.7
  Depends on vulnerable versions of semver
  node_modules/postman-code-generators/node_modules/postman-collection
    postman-code-generators  >=1.1.0
    Depends on vulnerable versions of postman-collection
    node_modules/postman-code-generators
