### PR TITLE
[GHSA-jp4x-w63m-7wgm] Prototype Pollution in hoek

### DIFF
--- a/advisories/github-reviewed/2018/04/GHSA-jp4x-w63m-7wgm/GHSA-jp4x-w63m-7wgm.json
+++ b/advisories/github-reviewed/2018/04/GHSA-jp4x-w63m-7wgm/GHSA-jp4x-w63m-7wgm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jp4x-w63m-7wgm",
-  "modified": "2023-09-13T19:42:48Z",
+  "modified": "2023-09-13T19:42:49Z",
   "published": "2018-04-26T15:25:17Z",
   "aliases": [
     "CVE-2018-3728"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**

hoek  <4.2.1
Severity: high
Prototype Pollution in hoek - https://github.com/advisories/GHSA-jp4x-w63m-7wgm
fix available via `npm audit fix`
node_modules/hoek
  boom  <=3.1.2
  Depends on vulnerable versions of hoek
  node_modules/boom
    cryptiles  <=2.0.5
    Depends on vulnerable versions of boom
    node_modules/cryptiles
  sntp  0.0.0 || 0.1.1 - 2.0.0
  Depends on vulnerable versions of hoek
  node_modules/sntp
