### PR TITLE
[GHSA-r5hg-349q-mg2q] Buildkite Elastic CI for AWS time-of-check-time-of-use race condition vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-r5hg-349q-mg2q/GHSA-r5hg-349q-mg2q.json
+++ b/advisories/github-reviewed/2023/12/GHSA-r5hg-349q-mg2q/GHSA-r5hg-349q-mg2q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r5hg-349q-mg2q",
-  "modified": "2024-01-03T19:47:40Z",
+  "modified": "2024-01-03T19:47:42Z",
   "published": "2023-12-22T12:31:50Z",
   "aliases": [
     "CVE-2023-43741"
@@ -25,10 +25,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "6.0.0"
             },
             {
               "fixed": "6.7.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/buildkite/elastic-ci-stack-for-aws/v6"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.22.5"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Based on the info from the NVD site linked in the GHSA "versions prior to 6.7.1 and 5.22.5" are affected. The table at the bottom of the NVD site also implies that it should be versions `>= 6.0.0, < 6.7.1`

I made the same suggestion for https://github.com/github/advisory-database/pull/3265