### PR TITLE
[GHSA-7c44-7j7v-w554] Buildkite Elastic CI for AWS symbolic link following vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-7c44-7j7v-w554/GHSA-7c44-7j7v-w554.json
+++ b/advisories/github-reviewed/2023/12/GHSA-7c44-7j7v-w554/GHSA-7c44-7j7v-w554.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7c44-7j7v-w554",
-  "modified": "2024-01-03T21:45:42Z",
+  "modified": "2024-01-03T21:45:44Z",
   "published": "2023-12-22T12:31:50Z",
   "aliases": [
     "CVE-2023-43116"
@@ -25,10 +25,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.7.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/buildkite/elastic-ci-stack-for-aws/v6"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
               "introduced": "0"
             },
             {
-              "fixed": "6.7.0"
+              "fixed": "5.22.5"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Based on the info from the NVD site linked in the GHSA "versions prior to 6.7.1 and 5.22.5" are affected. The table at the bottom of the NVD site also implies that it should be versions `>= 6.0.0, < 6.7.1`

I made the same suggestion for https://github.com/github/advisory-database/pull/3264