### PR TITLE
[GHSA-rp65-9cf3-cjxr] Inefficient Regular Expression Complexity in nth-check

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-rp65-9cf3-cjxr/GHSA-rp65-9cf3-cjxr.json
+++ b/advisories/github-reviewed/2021/09/GHSA-rp65-9cf3-cjxr/GHSA-rp65-9cf3-cjxr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rp65-9cf3-cjxr",
-  "modified": "2023-09-13T21:49:54Z",
+  "modified": "2023-11-29T22:11:25Z",
   "published": "2021-09-20T20:47:31Z",
   "aliases": [
     "CVE-2021-3803"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "nth-check"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(nth-check).parse"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Vulnerability Details:
The vulnerability is assigned CVE-2022-XXXX and is related to a Regular Expression Denial of Service (ReDoS) issue in nth-check.

Proof of Concept:
The provided proof-of-concept code (PoC.js) demonstrates the exploitation of the ReDoS vulnerability. It iteratively constructs crafted CSS nth-checks, causing denial of service.