### PR TITLE
[GHSA-m5hf-m3r2-xq53] hutool-core was discovered to contain a stack overflow via NumberUtil.toBigDecimal method

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-m5hf-m3r2-xq53/GHSA-m5hf-m3r2-xq53.json
+++ b/advisories/github-reviewed/2023/12/GHSA-m5hf-m3r2-xq53/GHSA-m5hf-m3r2-xq53.json
@@ -25,17 +25,14 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "5.8.22"
             },
             {
-              "fixed": "5.8.24"
+              "last_affected": "5.8.24"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 5.8.23"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The StackOverflow results from the methods [NumberUtil.toBigDecimal(Number)](https://github.com/dromara/hutool/blob/6f9279a3132155896994dab078ba90d822334ca4/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java#L2227) and [NumberUtil.toBigDecimal(String)](https://github.com/dromara/hutool/blob/6f9279a3132155896994dab078ba90d822334ca4/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java#L2250) calling each other in case of NaN.

You can see this nicely at the alternating line numbers 2227 and 2250 in the StackTrace provided in [the issue](https://github.com/dromara/hutool/issues/3423).

The problem was created with [this commit](https://github.com/dromara/hutool/commit/c45b3fccdab453bb1c6007b52b18bd2fbdb68e99) in Aug 2, which introduced the call from toBigDecimal(String) to the other method, which has the tags 5.8.22 to 5.8.24.

[Git blame](https://github.com/dromara/hutool/blame/6f9279a3132155896994dab078ba90d822334ca4/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java#L2250) shows nicely that this commit introduced the problem, and that the methods have not been touched afterwards.

I therefor suggest to mention versions 5.8.22 to 5.8.24 as vulnerable (and no fixed version).