### PR TITLE
[GHSA-4p24-vmcr-4gqj] Bootstrap XSS vulnerability

### DIFF
--- a/advisories/github-reviewed/2019/01/GHSA-4p24-vmcr-4gqj/GHSA-4p24-vmcr-4gqj.json
+++ b/advisories/github-reviewed/2019/01/GHSA-4p24-vmcr-4gqj/GHSA-4p24-vmcr-4gqj.json
@@ -7,7 +7,7 @@
     "CVE-2016-10735"
   ],
   "summary": "Bootstrap XSS vulnerability",
-  "details": "In Bootstrap 3.x before 3.4.0 and 4.x-beta before 4.0.0-beta.2, XSS is possible in the data-target attribute. Note that this is a different vulnerability than CVE-2018-14041.\n\nSee https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0/ for more info.",
+  "details": "Since Bootstrap 2.0.4 and 3.x before 3.4.0 and 4.x-beta before 4.0.0-beta.2, XSS is possible in the data-target attribute. Note that this is a different vulnerability than CVE-2018-14041.\n\nSee https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0/ for more info.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.0.0"
+              "introduced": "2.0.4"
             },
             {
               "fixed": "3.4.0"
@@ -114,6 +114,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/twbs/bootstrap"
+    },
+    {
+      "type": "WEB",
+      "url": "https://jsbin.com/dahojakupe/edit?html,output"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
we used the demonstration example from https://github.com/twbs/bootstrap/issues/20184#issuecomment-324985479 and proofed, that also version 2.0.4 and above are affected, but 2.0.3 and below not, see https://jsbin.com/dahojakupe/edit?html,output