### PR TITLE
[GHSA-3wqf-4x89-9g79] Bootstrap vulnerable to Cross-Site Scripting (XSS)

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-3wqf-4x89-9g79/GHSA-3wqf-4x89-9g79.json
+++ b/advisories/github-reviewed/2022/05/GHSA-3wqf-4x89-9g79/GHSA-3wqf-4x89-9g79.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3wqf-4x89-9g79",
-  "modified": "2023-05-22T18:22:16Z",
+  "modified": "2023-05-22T18:22:17Z",
   "published": "2022-05-13T01:07:54Z",
   "aliases": [
     "CVE-2018-14040"
   ],
   "summary": "Bootstrap vulnerable to Cross-Site Scripting (XSS)",
-  "details": "In Bootstrap 4.x before 4.1.2, XSS is possible in the collapse data-parent attribute.",
+  "details": "From Bootstrap 2.3.0 to 3.4.0 and 4.x before 4.1.2, XSS is possible in the collapse data-parent attribute.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -52,6 +52,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "bootstrap"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.3.0"
+            },
+            {
+              "fixed": "3.4.0"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
@@ -81,55 +100,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://blog.getbootstrap.com/2018/07/12/bootstrap-4-1-2/"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/bootstrap/CVE-2018-14040.yml"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/twbs/bootstrap/blob/v3.4.1/js/collapse.js#L140"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/twbs/bootstrap/blob/v3.4.1/js/scrollspy.js#L56"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/twbs/bootstrap/blob/v3.4.1/js/tooltip.js#L352"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/52e0e6b5df827ee7f1e68f7cc3babe61af3b2160f5d74a85469b7b0e@%3Cdev.superset.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r3dc0cac8d856bca02bd6997355d7ff83027dcfc82f8646a29b89b714@%3Cissues.hbase.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2018/08/msg00027.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://seclists.org/bugtraq/2019/May/18"
+      "url": "https://www.tenable.com/security/tns-2021-14"
     },
     {
       "type": "WEB",
@@ -137,7 +108,59 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.tenable.com/security/tns-2021-14"
+      "url": "https://seclists.org/bugtraq/2019/May/18"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2018/08/msg00027.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r3dc0cac8d856bca02bd6997355d7ff83027dcfc82f8646a29b89b714@%3Cissues.hbase.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/52e0e6b5df827ee7f1e68f7cc3babe61af3b2160f5d74a85469b7b0e@%3Cdev.superset.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://jsbin.com/xixaqeyofi/edit?html,output"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/twbs/bootstrap/blob/v3.4.1/js/tooltip.js#L352"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/twbs/bootstrap/blob/v3.4.1/js/scrollspy.js#L56"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/twbs/bootstrap/blob/v3.4.1/js/collapse.js#L140"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/bootstrap/CVE-2018-14040.yml"
+    },
+    {
+      "type": "WEB",
+      "url": "https://blog.getbootstrap.com/2018/07/12/bootstrap-4-1-2/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
I used the demonstration example from https://github.com/twbs/bootstrap/issues/26625#issuecomment-393057193 and proofed, that also version 2.3.0 and above are affected, but 3.4.0 is not, see https://jsbin.com/xixaqeyofi/edit?html,output