### PR TITLE
[GHSA-vfxf-76hv-v4w4] User-provided environment values allow execution on macOS agents

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-vfxf-76hv-v4w4/GHSA-vfxf-76hv-v4w4.json
+++ b/advisories/github-reviewed/2024/01/GHSA-vfxf-76hv-v4w4/GHSA-vfxf-76hv-v4w4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vfxf-76hv-v4w4",
-  "modified": "2024-01-03T21:30:17Z",
+  "modified": "2024-01-03T21:30:18Z",
   "published": "2024-01-03T21:30:17Z",
   "aliases": [
 
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "https://github.com/gravitational/teleport"
+        "name": "github.com/gravitational/teleport"
       },
       "ranges": [
         {
@@ -34,7 +34,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "https://github.com/gravitational/teleport"
+        "name": "github.com/gravitational/teleport"
       },
       "ranges": [
         {
@@ -53,7 +53,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "https://github.com/gravitational/teleport"
+        "name": "github.com/gravitational/teleport"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Removed protocol information from package names as this is the usual procedure with other GHSAs. Moreover, having package names starting with "https://" leads to import warnings in OWASP Dependency-Track, e.g.:

`[GitHubAdvisoryMirrorTask] Unable to create purl from GitHub Vulnerability. Skipping GO : https://github.com/gravitational/teleport for: GHSA-vfxf-76hv-v4w4`