### PR TITLE
[GHSA-pj7m-g53m-7638] Bootstrap Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2018/09/GHSA-pj7m-g53m-7638/GHSA-pj7m-g53m-7638.json
+++ b/advisories/github-reviewed/2018/09/GHSA-pj7m-g53m-7638/GHSA-pj7m-g53m-7638.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pj7m-g53m-7638",
-  "modified": "2023-01-23T21:30:26Z",
+  "modified": "2023-01-31T05:06:54Z",
   "published": "2018-09-13T15:49:56Z",
   "aliases": [
     "CVE-2018-14041"
   ],
   "summary": "Bootstrap Cross-site Scripting vulnerability",
-  "details": "In Bootstrap before 4.1.2, XSS is possible in the data-target property of scrollspy. This is similar to CVE-2018-14042.",
+  "details": "In Bootstrap 4.0.0 up to 4.1.2, XSS is possible in the data-target property of scrollspy. This is similar to CVE-2018-14042.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -29,25 +29,6 @@
             },
             {
               "fixed": "4.1.2"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "bootstrap"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "3.4.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
I used the example of https://github.com/twbs/bootstrap/issues/26627#issuecomment-393058335 and modified the bootstrap version to one below the formerly stated patched version 3.4.0 and couldn't verify the issue see https://jsbin.com/jafujoqage/edit?html,output