### PR TITLE
[GHSA-6qjf-7g3j-qx25] Neos CMS Cross Site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-6qjf-7g3j-qx25/GHSA-6qjf-7g3j-qx25.json
+++ b/advisories/github-reviewed/2023/09/GHSA-6qjf-7g3j-qx25/GHSA-6qjf-7g3j-qx25.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6qjf-7g3j-qx25",
-  "modified": "2023-09-22T20:40:11Z",
+  "modified": "2023-11-04T05:04:20Z",
   "published": "2023-09-19T00:30:13Z",
   "aliases": [
     "CVE-2023-37611"
@@ -18,7 +18,95 @@
     {
       "package": {
         "ecosystem": "Packagist",
-        "name": "neos/neos-ui"
+        "name": "neos/media-browser"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.3.0"
+            },
+            {
+              "fixed": "8.3.9"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 8.3.8"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "neos/media-browser"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.2.0"
+            },
+            {
+              "fixed": "8.2.11"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 8.2.10"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "neos/media-browser"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.1.0"
+            },
+            {
+              "fixed": "8.1.11"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 8.1.10"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "neos/media-browser"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.0.0"
+            },
+            {
+              "fixed": "8.0.16"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 8.0.15"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "neos/media-browser"
       },
       "ranges": [
         {
@@ -28,11 +116,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "8.3.3"
+              "fixed": "7.3.19"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 7.3.18"
+      }
     }
   ],
   "references": [
@@ -50,7 +141,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/neos/neos-ui"
+      "url": "https://github.com/neos/neos-development-collection"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
The Neos team has fixed the vulnerability in the affected package (neos/media-browser). We have adapted the security advisory to the correct affected versions and packages. 

Please note, that we use a mono-repo with subsplit repos to release single packages.

Please see the respective issue and pr:
- Issue: https://github.com/neos/neos-development-collection/issues/4833
- PR: https://github.com/neos/neos-development-collection/pull/4812

And the releases:
- https://github.com/neos/neos-development-collection/releases/tag/7.3.19
- https://github.com/neos/neos-development-collection/releases/tag/8.0.16
- https://github.com/neos/neos-development-collection/releases/tag/8.1.11
- https://github.com/neos/neos-development-collection/releases/tag/8.2.11
- https://github.com/neos/neos-development-collection/releases/tag/8.3.9