### PR TITLE
[GHSA-ghjv-mh6x-7q6h] avo vulnerable to stored cross-site scripting (XSS) in key_value field

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-ghjv-mh6x-7q6h/GHSA-ghjv-mh6x-7q6h.json
+++ b/advisories/github-reviewed/2024/01/GHSA-ghjv-mh6x-7q6h/GHSA-ghjv-mh6x-7q6h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ghjv-mh6x-7q6h",
-  "modified": "2024-01-16T15:24:00Z",
+  "modified": "2024-01-16T15:24:01Z",
   "published": "2024-01-16T15:24:00Z",
   "aliases": [
     "CVE-2024-22191"
@@ -25,17 +25,33 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.0.0"
             },
             {
               "fixed": "3.2.4"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 3.2.3"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "avo"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.47.0"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
@@ -46,6 +62,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/avo-hq/avo/commit/51bb80b181cd8e31744bdc4e7f9b501c81172347"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/avo-hq/avo/commit/fc92a05a8556b1787c8694643286a1afa6a71258"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Fix was backported to 2.x in https://github.com/avo-hq/avo/pull/2382 and the security-advisory updated to reflect this: https://github.com/avo-hq/avo/security/advisories/GHSA-ghjv-mh6x-7q6h