### PR TITLE
[GHSA-8r7x-qq55-74v2] user/view.php in Moodle through 2.1.10, 2.2.x before 2.2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-8r7x-qq55-74v2/GHSA-8r7x-qq55-74v2.json
+++ b/advisories/unreviewed/2022/05/GHSA-8r7x-qq55-74v2/GHSA-8r7x-qq55-74v2.json
@@ -1,22 +1,52 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8r7x-qq55-74v2",
-  "modified": "2022-05-13T01:12:57Z",
+  "modified": "2023-02-01T05:04:00Z",
   "published": "2022-05-13T01:12:57Z",
   "aliases": [
     "CVE-2013-1830"
   ],
+  "summary": "CVE-2013-1830 in Moodle",
   "details": "user/view.php in Moodle through 2.1.10, 2.2.x before 2.2.8, 2.3.x before 2.3.5, and 2.4.x before 2.4.2 does not enforce the forceloginforprofiles setting, which allows remote attackers to obtain sensitive course-profile information by leveraging the guest role, as demonstrated by a Google search.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.1.10"
+            },
+            {
+              "fixed": "4.3.2"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "2.1.10"
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-1830"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/3ecc63e9dbe29c6a5a8f65fa8e7980ba0fffb5a8"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",
@@ -41,7 +71,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-284"
     ],
     "severity": "MODERATE",
     "github_reviewed": false,


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- References
- Source code location
- Summary

**Comments**
add patch commit for this CVE:https://github.com/moodle/moodle/commit/3ecc63e9dbe29c6a5a8f65fa8e7980ba0fffb5a8, which is for v4.3.2.
The commit msg has explicitly shown its patch identity: "MDL-37481 user: fixed bug when logged in as guest".

update the cwe: 284, but a better one should be 264, which can not be retrieved in github advisory database now.