### PR TITLE
[GHSA-xmwv-mqh8-4xgw] mod/lti/service.php in Moodle through 2.3.11, 2.4.x...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-xmwv-mqh8-4xgw/GHSA-xmwv-mqh8-4xgw.json
+++ b/advisories/unreviewed/2022/05/GHSA-xmwv-mqh8-4xgw/GHSA-xmwv-mqh8-4xgw.json
@@ -1,22 +1,71 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xmwv-mqh8-4xgw",
-  "modified": "2022-05-13T01:12:40Z",
+  "modified": "2023-02-01T05:03:57Z",
   "published": "2022-05-13T01:12:40Z",
   "aliases": [
     "CVE-2014-3542"
   ],
+  "summary": " CVE-2014-3542 in Moodle",
   "details": "mod/lti/service.php in Moodle through 2.3.11, 2.4.x before 2.4.11, 2.5.x before 2.5.7, 2.6.x before 2.6.4, and 2.7.x before 2.7.1 allows remote attackers to read arbitrary files via an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.3.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.3.11"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.4.11"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-3542"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/78ed99ec7e5e75b283e844adb058140d6ba0ff14"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",
@@ -33,7 +82,8 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-200"
+      "CWE-200",
+      "CWE-611"
     ],
     "severity": "MODERATE",
     "github_reviewed": false,


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- References
- Source code location
- Summary

**Comments**
add patch commit for v4.3.2: https://github.com/moodle/moodle/commit/78ed99ec7e5e75b283e844adb058140d6ba0ff14. the commit msg has shown: `MDL-45463 mod_lti: Prevent XML entity injections from provider`.