### PR TITLE
[GHSA-g8vp-2v5p-9qfh] Cross-site scripting (XSS) in Action messages on Avo

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-g8vp-2v5p-9qfh/GHSA-g8vp-2v5p-9qfh.json
+++ b/advisories/github-reviewed/2024/01/GHSA-g8vp-2v5p-9qfh/GHSA-g8vp-2v5p-9qfh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g8vp-2v5p-9qfh",
-  "modified": "2024-01-17T22:34:03Z",
+  "modified": "2024-01-17T22:34:04Z",
   "published": "2024-01-17T22:34:03Z",
   "aliases": [
     "CVE-2024-22411"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.0.0.beta1"
             },
             {
               "fixed": "3.0.2"
@@ -33,6 +33,28 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "avo"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.47.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.46.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The original repository advisory only mentioned one specific version (3.0.0.pre12) to be affected. As this advisory causes all older versions of avo to be flagged as vulnerable I propose the following changes which I verified manually (see linked repository).

I verified the vulnerability as described for version 3.0.0.pre12 (https://github.com/tamaloa/avo-CVE-2024-22411/commit/ae0df1d51469c59e456c86a18d7d25f2f93b14d9).

I also verified that version 2.47.0 is NOT vulnerable (https://github.com/tamaloa/avo-CVE-2024-22411/commit/bb1dc89dcaeb26c643ff91b4719f4959bf0b0103).

Maybe the initial reporter (@stevegeek) could add insight if really only 3.0.0.pre12 was affected or more versions. Unfortunately on a quick look I could not find a tag / commit connected to this version and thus was unable to verify the actual code changes.