### PR TITLE
[GHSA-xr24-jp5c-6c4v] lib/setuplib.php in Moodle through 2.1.10, 2.2.x before 2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-xr24-jp5c-6c4v/GHSA-xr24-jp5c-6c4v.json
+++ b/advisories/unreviewed/2022/05/GHSA-xr24-jp5c-6c4v/GHSA-xr24-jp5c-6c4v.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xr24-jp5c-6c4v",
-  "modified": "2022-05-13T01:12:57Z",
+  "modified": "2023-02-01T05:04:02Z",
   "published": "2022-05-13T01:12:57Z",
   "aliases": [
     "CVE-2013-1831"
   ],
+  "summary": "lib/setuplib.php in Moodle through 2.1.10, 2.2.x before 2.2.8, 2.3.x before 2.3.5, and 2.4.x before 2.4.2 allows remote attackers to obtain sensitive information via an invalid request",
   "details": "lib/setuplib.php in Moodle through 2.1.10, 2.2.x before 2.2.8, 2.3.x before 2.3.5, and 2.4.x before 2.4.2 allows remote attackers to obtain sensitive information via an invalid request, which reveals the absolute path in an exception message.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.1.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.2.0"
+            },
+            {
+              "fixed": "2.2.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.3.0"
+            },
+            {
+              "fixed": "2.3.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.4.0"
+            },
+            {
+              "fixed": "2.4.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-1831"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/8d220cb552d9c55b98aef70e2f40ef560efeb79b"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit for v2.5.0-beta: https://github.com/moodle/moodle/commit/8d220cb552d9c55b98aef70e2f40ef560efeb79b. 
The commit msg shows "MDL-36901: Remove system paths from exceptions." which is consistent with its CVE desc:`allows remote attackers to obtain sensitive information via an invalid request, which reveals the absolute path in an exception message.`