### PR TITLE
[GHSA-prrh-679x-79qh] notes/edit.php in Moodle 1.9.x through 1.9.19, 2.x...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-prrh-679x-79qh/GHSA-prrh-679x-79qh.json
+++ b/advisories/unreviewed/2022/05/GHSA-prrh-679x-79qh/GHSA-prrh-679x-79qh.json
@@ -1,22 +1,125 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-prrh-679x-79qh",
-  "modified": "2022-05-13T01:12:58Z",
+  "modified": "2023-02-01T05:03:54Z",
   "published": "2022-05-13T01:12:58Z",
   "aliases": [
     "CVE-2013-1834"
   ],
+  "summary": "notes/edit.php in Moodle 1.9.x through 1.9.19, 2.x through 2.1.10, 2.2.x before 2.2.8, 2.3.x before 2.3.5, and 2.4.x before 2.4.2 allows remote authenticated users to reassign notes via a modified (1) userid or (2) courseid field.",
   "details": "notes/edit.php in Moodle 1.9.x through 1.9.19, 2.x through 2.1.10, 2.2.x before 2.2.8, 2.3.x before 2.3.5, and 2.4.x before 2.4.2 allows remote authenticated users to reassign notes via a modified (1) userid or (2) courseid field.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.9.19"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0"
+            },
+            {
+              "last_affected": "2.1.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.2.0"
+            },
+            {
+              "fixed": "2.2.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.3.0"
+            },
+            {
+              "fixed": "2.3.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.4.0"
+            },
+            {
+              "fixed": "2.4.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-1834"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/6a9235c998dab2ec0ddc49898a59dd5089156cb0"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",
@@ -41,7 +144,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-284"
     ],
     "severity": "MODERATE",
     "github_reviewed": false,


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- References
- Source code location
- Summary

**Comments**
add patch commit on Github repo: https://github.com/moodle/moodle/commit/6a9235c998dab2ec0ddc49898a59dd5089156cb0, which is a mirror of that on git org.

Another issue: I found that when searching cwe, we cannot assign CWE-264 for vulns in Github Advisory. So I use CWE-284 to replace it since both refer to access control vuln.