### PR TITLE
[GHSA-664q-mrxx-2x2v] Moodle 2.x through 2.1.10, 2.2.x before 2.2.8, 2.3.x...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-664q-mrxx-2x2v/GHSA-664q-mrxx-2x2v.json
+++ b/advisories/unreviewed/2022/05/GHSA-664q-mrxx-2x2v/GHSA-664q-mrxx-2x2v.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-664q-mrxx-2x2v",
-  "modified": "2022-05-13T01:12:58Z",
+  "modified": "2023-02-01T05:04:02Z",
   "published": "2022-05-13T01:12:58Z",
   "aliases": [
     "CVE-2013-1836"
   ],
+  "summary": "Moodle 2.x through 2.1.10, 2.2.x before 2.2.8, 2.3.x before 2.3.5, and 2.4.x before 2.4.2 does not properly manage privileges for WebDAV repositories, which allows remote authenticated users to read, modify, or delete arbitrary site-wide repositories by leveraging certain read access.",
   "details": "Moodle 2.x through 2.1.10, 2.2.x before 2.2.8, 2.3.x before 2.3.5, and 2.4.x before 2.4.2 does not properly manage privileges for WebDAV repositories, which allows remote authenticated users to read, modify, or delete arbitrary site-wide repositories by leveraging certain read access.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0"
+            },
+            {
+              "last_affected": "2.1.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.2.0"
+            },
+            {
+              "fixed": "2.2.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.3.0"
+            },
+            {
+              "fixed": "2.3.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.4.0"
+            },
+            {
+              "fixed": "2.4.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-1836"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/ac5fc5953426befb1232106ade9e42ff239d9b63"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit https://github.com/moodle/moodle/commit/ac5fc5953426befb1232106ade9e42ff239d9b63,
and update vuln version range.