### PR TITLE
[GHSA-c24v-8rfc-w8vw] Vite dev server option `server.fs.deny` can be bypassed when hosted on case-insensitive filesystem

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-c24v-8rfc-w8vw/GHSA-c24v-8rfc-w8vw.json
+++ b/advisories/github-reviewed/2024/01/GHSA-c24v-8rfc-w8vw/GHSA-c24v-8rfc-w8vw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c24v-8rfc-w8vw",
-  "modified": "2024-01-19T21:58:47Z",
+  "modified": "2024-01-19T21:58:48Z",
   "published": "2024-01-19T21:58:47Z",
   "aliases": [
     "CVE-2024-23331"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:L/A:H"
     }
   ],
   "affected": [
@@ -144,11 +144,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-178",
-      "CWE-200",
-      "CWE-284"
+
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-01-19T21:58:47Z",
     "nvd_published_at": "2024-01-19T20:15:14Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity

**Comments**
#3Nami 