### PR TITLE
[GHSA-pfh2-hfmq-phg5] json-path Out-of-bounds Write vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-pfh2-hfmq-phg5/GHSA-pfh2-hfmq-phg5.json
+++ b/advisories/github-reviewed/2023/12/GHSA-pfh2-hfmq-phg5/GHSA-pfh2-hfmq-phg5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pfh2-hfmq-phg5",
-  "modified": "2024-01-09T19:28:14Z",
+  "modified": "2024-01-18T05:06:30Z",
   "published": "2023-12-27T21:31:01Z",
   "aliases": [
     "CVE-2023-51074"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
     }
   ],
   "affected": [
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.8.0"
+              "fixed": "2.9.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.8.0"
+      }
     }
   ],
   "references": [
@@ -53,7 +56,7 @@
     "cwe_ids": [
       "CWE-787"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-01-09T19:28:14Z",
     "nvd_published_at": "2023-12-27T21:15:08Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
- A fixed version (2.9.0) was published.
- NIST NVD record has updated severity to 5.3 MEDIUM.