### PR TITLE
[GHSA-6w63-h3fj-q4vw] fast-xml-parser vulnerable to Regex Injection via Doctype Entities

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-6w63-h3fj-q4vw/GHSA-6w63-h3fj-q4vw.json
+++ b/advisories/github-reviewed/2023/06/GHSA-6w63-h3fj-q4vw/GHSA-6w63-h3fj-q4vw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6w63-h3fj-q4vw",
-  "modified": "2023-06-06T17:33:13Z",
+  "modified": "2023-11-29T00:29:33Z",
   "published": "2023-06-06T17:33:13Z",
   "aliases": [
     "CVE-2023-34104"
@@ -20,17 +20,12 @@
         "ecosystem": "npm",
         "name": "fast-xml-parser"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(fast-xml-parser).XMLParser"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.1.3"
             },
             {
               "fixed": "4.2.4"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Up until version 4.1.2, the entity name is parsed using `RegExp("^\\s([a-zA-z0-0]+)[ \t](['\"])([^&]+)\\2");` - see https://github.com/NaturalIntelligence/fast-xml-parser/blob/v4.1.2/src/xmlparser/DocTypeReader.js#L108C35-L108C45
In this implementation, the entity name regex is constructed as follows ```RegExp( `&${match[1]};`,"g"),```. Since `match[1]` is `[a-zA-z0-0]+`. It is not possible to construct a vulnerable regular expression.
Starting 4.1.3, the implementation changes to the following vulnerable implementation - https://github.com/NaturalIntelligence/fast-xml-parser/blob/v4.1.3/src/xmlparser/DocTypeReader.js#L62 