### PR TITLE
[GHSA-rcjc-c4pj-xxrp] Apache Derby: LDAP injection vulnerability in authenticator

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-rcjc-c4pj-xxrp/GHSA-rcjc-c4pj-xxrp.json
+++ b/advisories/github-reviewed/2023/11/GHSA-rcjc-c4pj-xxrp/GHSA-rcjc-c4pj-xxrp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rcjc-c4pj-xxrp",
-  "modified": "2023-11-30T15:50:57Z",
+  "modified": "2023-11-30T15:50:59Z",
   "published": "2023-11-20T09:30:31Z",
   "aliases": [
     "CVE-2022-46337"
@@ -26,6 +26,63 @@
           "events": [
             {
               "introduced": "10.1.1.0"
+            },
+            {
+              "fixed": "10.14.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.derby:derby"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.15.0.0"
+            },
+            {
+              "fixed": "10.15.2.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.derby:derby"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.16.0.0"
+            },
+            {
+              "fixed": "10.16.1.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.derby:derby"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.17.0.0"
             },
             {
               "fixed": "10.17.1.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The fix range information from NVD is incomplete. Per the upstream project, patches have been backported all the way to 10.14: https://issues.apache.org/jira/browse/DERBY-7147