### PR TITLE
[GHSA-wmmc-qjq2-vvm2] Moodle is vulnerable to Sensitive Information Disclosure

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-wmmc-qjq2-vvm2/GHSA-wmmc-qjq2-vvm2.json
+++ b/advisories/github-reviewed/2022/05/GHSA-wmmc-qjq2-vvm2/GHSA-wmmc-qjq2-vvm2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wmmc-qjq2-vvm2",
-  "modified": "2023-08-17T22:58:00Z",
+  "modified": "2023-08-17T22:58:01Z",
   "published": "2022-05-13T01:12:58Z",
   "aliases": [
     "CVE-2013-2080"
@@ -77,6 +77,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-2080"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/5df9bc3998095299c6862973866252649a5e0866"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add patch commit for v2.5.0-rc1: https://github.com/moodle/moodle/commit/5df9bc3998095299c6862973866252649a5e0866. 
The commit msg mentioned: `MDL-37475 core_grade:fixed the handling of show totals`, which matches existing ref link: `http://git.moodle.org/gw?p=moodle.git&a=search&h=HEAD&st=commit&s=MDL-37475`
