### PR TITLE
[GHSA-m63h-q4x3-6hwj] Moodle is vulnerable to Improper Input Validation in MoodleQuickForm class

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-m63h-q4x3-6hwj/GHSA-m63h-q4x3-6hwj.json
+++ b/advisories/github-reviewed/2022/05/GHSA-m63h-q4x3-6hwj/GHSA-m63h-q4x3-6hwj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m63h-q4x3-6hwj",
-  "modified": "2023-08-17T22:57:53Z",
+  "modified": "2023-08-17T22:57:54Z",
   "published": "2022-05-13T01:12:59Z",
   "aliases": [
     "CVE-2013-2083"
@@ -96,6 +96,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-2083"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/d5909fd1447bc6f05dbf37d7c9eb72b79004e24a"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add patch commit for v2.5.0-rc1: https://github.com/moodle/moodle/commit/d5909fd1447bc6f05dbf37d7c9eb72b79004e24a.