### PR TITLE
[GHSA-f9m9-494r-w36p] mod/chat/chat_ajax.php in Moodle through 2.3.11, 2.4.x...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-f9m9-494r-w36p/GHSA-f9m9-494r-w36p.json
+++ b/advisories/unreviewed/2022/05/GHSA-f9m9-494r-w36p/GHSA-f9m9-494r-w36p.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f9m9-494r-w36p",
-  "modified": "2022-05-13T01:12:50Z",
+  "modified": "2023-02-01T05:03:59Z",
   "published": "2022-05-13T01:12:50Z",
   "aliases": [
     "CVE-2014-0122"
   ],
+  "summary": "mod/chat/chat_ajax.php in Moodle through 2.3.11, 2.4.x before 2.4.9, 2.5.x before 2.5.5, and 2.6.x before 2.6.2 does not properly check for the mod/chat:chat capability during chat sessions",
   "details": "mod/chat/chat_ajax.php in Moodle through 2.3.11, 2.4.x before 2.4.9, 2.5.x before 2.5.5, and 2.6.x before 2.6.2 does not properly check for the mod/chat:chat capability during chat sessions, which allows remote authenticated users to bypass intended access restrictions in opportunistic circumstances by remaining in a chat session after an intra-session capability removal by an administrator.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.3.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.4.0"
+            },
+            {
+              "fixed": "2.4.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.5"
+            },
+            {
+              "fixed": "2.5.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0122"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/5c45ea0c6bf2fdf4dddfaef9fc5ff12e6b426a3f"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit for v2.7.0-beta: https://github.com/moodle/moodle/commit/5c45ea0c6bf2fdf4dddfaef9fc5ff12e6b426a3f.
the commit msg has shown it's a fix for `MDL-44082`.
update vvr as well.