### PR TITLE
[GHSA-2vhr-4mhq-m35c] The wiki subsystem in Moodle through 2.3.11, 2.4.x before...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-2vhr-4mhq-m35c/GHSA-2vhr-4mhq-m35c.json
+++ b/advisories/unreviewed/2022/05/GHSA-2vhr-4mhq-m35c/GHSA-2vhr-4mhq-m35c.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2vhr-4mhq-m35c",
-  "modified": "2022-05-13T01:12:50Z",
+  "modified": "2023-02-01T05:04:01Z",
   "published": "2022-05-13T01:12:50Z",
   "aliases": [
     "CVE-2014-0123"
   ],
+  "summary": "The wiki subsystem in Moodle through 2.3.11, 2.4.x before 2.4.9, 2.5.x before 2.5.5, and 2.6.x before 2.6.2 does not properly restrict (1) view and (2) edit access, which allows remote authenticated users to perform wiki operations by leveraging the student role and using the Recent Activity block to reach the individual wiki of an arbitrary student.",
   "details": "The wiki subsystem in Moodle through 2.3.11, 2.4.x before 2.4.9, 2.5.x before 2.5.5, and 2.6.x before 2.6.2 does not properly restrict (1) view and (2) edit access, which allows remote authenticated users to perform wiki operations by leveraging the student role and using the Recent Activity block to reach the individual wiki of an arbitrary student.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.3.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.4.0"
+            },
+            {
+              "fixed": "2.4.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.5"
+            },
+            {
+              "fixed": "2.5.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0123"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/3a7b9b76c2d3c58237bec56b3b537e05c23970ad"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/3a7b9b76c2d3c58237bec56b3b537e05c23970ad. 
the commit msg has shown it's a fix for `MDL-39990`. 
update vvr as well.