### PR TITLE
[GHSA-j465-7mp6-3xg3] repository/alfresco/lib.php in Moodle through 2.3.11, 2.4...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-j465-7mp6-3xg3/GHSA-j465-7mp6-3xg3.json
+++ b/advisories/unreviewed/2022/05/GHSA-j465-7mp6-3xg3/GHSA-j465-7mp6-3xg3.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j465-7mp6-3xg3",
-  "modified": "2022-05-13T01:12:50Z",
+  "modified": "2023-02-01T05:03:59Z",
   "published": "2022-05-13T01:12:50Z",
   "aliases": [
     "CVE-2014-0125"
   ],
+  "summary": "repository/alfresco/lib.php in Moodle through 2.3.11, 2.4.x before 2.4.9, 2.5.x before 2.5.5, and 2.6.x before 2.6.2 places a session key in a URL",
   "details": "repository/alfresco/lib.php in Moodle through 2.3.11, 2.4.x before 2.4.9, 2.5.x before 2.5.5, and 2.6.x before 2.6.2 places a session key in a URL, which allows remote attackers to bypass intended Alfresco Repository file restrictions by impersonating a file's owner.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.3.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.4.0"
+            },
+            {
+              "fixed": "2.4.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.0"
+            },
+            {
+              "fixed": "2.5.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0125"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/f4f0aa27d43527c15070d00bc96be879876ccc38"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/f4f0aa27d43527c15070d00bc96be879876ccc38. 
the commit msg has shown it's a fix for `MDL-29409`. 
update vvr as well.