### PR TITLE
[GHSA-48rq-vj58-2mh6] login/token.php in Moodle through 2.3.11, 2.4.x before 2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-48rq-vj58-2mh6/GHSA-48rq-vj58-2mh6.json
+++ b/advisories/unreviewed/2022/05/GHSA-48rq-vj58-2mh6/GHSA-48rq-vj58-2mh6.json
@@ -1,22 +1,109 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-48rq-vj58-2mh6",
-  "modified": "2022-05-13T01:12:51Z",
+  "modified": "2023-02-01T05:03:53Z",
   "published": "2022-05-13T01:12:51Z",
   "aliases": [
     "CVE-2014-0214"
   ],
+  "summary": "login/token.php in Moodle through 2.3.11, 2.4.x before 2.4.10, 2.5.x before 2.5.6, and 2.6.x before 2.6.3 creates a MoodleMobile web-service token with an infinite lifetime, which makes it easier for remote attackers to hijack sessions via a brute-force attack.",
   "details": "login/token.php in Moodle through 2.3.11, 2.4.x before 2.4.10, 2.5.x before 2.5.6, and 2.6.x before 2.6.3 creates a MoodleMobile web-service token with an infinite lifetime, which makes it easier for remote attackers to hijack sessions via a brute-force attack.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.5.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.3.11"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.4.0"
+            },
+            {
+              "fixed": "2.4.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.0"
+            },
+            {
+              "fixed": "2.5.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0214"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/679e323aaab2a968b8e87862e1658814645db525"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/679e323aaab2a968b8e87862e1658814645db525. 
the commit msg has shown it's a fix for `MDL-43119`. 
update vvr as well.