### PR TITLE
[GHSA-c3vx-v4x8-x894] enrol/index.php in Moodle 2.6.x before 2.6.3 does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-c3vx-v4x8-x894/GHSA-c3vx-v4x8-x894.json
+++ b/advisories/unreviewed/2022/05/GHSA-c3vx-v4x8-x894/GHSA-c3vx-v4x8-x894.json
@@ -1,22 +1,49 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c3vx-v4x8-x894",
-  "modified": "2022-05-13T01:12:51Z",
+  "modified": "2023-02-01T05:04:01Z",
   "published": "2022-05-13T01:12:51Z",
   "aliases": [
     "CVE-2014-0217"
   ],
+  "summary": "enrol/index.php in Moodle 2.6.x before 2.6.3 does not check for the moodle/course:viewhiddencourses capability before listing hidden courses, which allows remote attackers to obtain sensitive name and summary information about these courses by leveraging the guest role and visiting a crafted URL.",
   "details": "enrol/index.php in Moodle 2.6.x before 2.6.3 does not check for the moodle/course:viewhiddencourses capability before listing hidden courses, which allows remote attackers to obtain sensitive name and summary information about these courses by leveraging the guest role and visiting a crafted URL.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.6.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0217"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/eaea796e70f6630494d3772684604ab6e907f4ac"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/eaea796e70f6630494d3772684604ab6e907f4ac. 
the commit msg has shown it's a fix for `MDL-45126`. 
update vvr as well.