### PR TITLE
[GHSA-ch68-5r37-p7c3] Cross-site scripting (XSS) vulnerability in the URL...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-ch68-5r37-p7c3/GHSA-ch68-5r37-p7c3.json
+++ b/advisories/unreviewed/2022/05/GHSA-ch68-5r37-p7c3/GHSA-ch68-5r37-p7c3.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ch68-5r37-p7c3",
-  "modified": "2022-05-13T01:12:52Z",
+  "modified": "2023-02-01T05:03:54Z",
   "published": "2022-05-13T01:12:52Z",
   "aliases": [
     "CVE-2014-0218"
   ],
+  "summary": "Cross-site scripting (XSS) vulnerability in the URL downloader repository in repository/url/lib.php in Moodle through 2.3.11, 2.4.x before 2.4.10, 2.5.x before 2.5.6, and 2.6.x before 2.6.3 allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.",
   "details": "Cross-site scripting (XSS) vulnerability in the URL downloader repository in repository/url/lib.php in Moodle through 2.3.11, 2.4.x before 2.4.10, 2.5.x before 2.5.6, and 2.6.x before 2.6.3 allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.3.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.4.0"
+            },
+            {
+              "fixed": "2.4.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.0"
+            },
+            {
+              "fixed": "2.5.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0218"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/c5e8a036c509197bb2927f47c0579992be479f35"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/c5e8a036c509197bb2927f47c0579992be479f35. 
the commit msg has shown it's a fix for `MDL-45332`. 
update vvr as well.