### PR TITLE
[GHSA-r4q3-7g4q-x89m] Spring Framework server Web DoS Vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-r4q3-7g4q-x89m/GHSA-r4q3-7g4q-x89m.json
+++ b/advisories/github-reviewed/2024/01/GHSA-r4q3-7g4q-x89m/GHSA-r4q3-7g4q-x89m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r4q3-7g4q-x89m",
-  "modified": "2024-01-23T14:44:07Z",
+  "modified": "2024-01-23T14:44:08Z",
   "published": "2024-01-22T15:30:23Z",
   "aliases": [
     "CVE-2024-22233"
@@ -25,10 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "6.1.0"
+              "introduced": "6.1.2"
             },
             {
-              "fixed": "6.1.2"
+              "fixed": "6.1.3"
             }
           ]
         }
@@ -44,10 +44,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "6.0.15"
             },
             {
-              "fixed": "6.0.15"
+              "fixed": "6.0.16"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
according to the [official announcement](https://spring.io/security/cve-2024-22233/), patched versions are `6.0.16` and `6.1.3`. and affected versions are just `6.0.15` and `6.1.2`.