### PR TITLE
[GHSA-r4q3-7g4q-x89m] Spring Framework server Web DoS Vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-r4q3-7g4q-x89m/GHSA-r4q3-7g4q-x89m.json
+++ b/advisories/github-reviewed/2024/01/GHSA-r4q3-7g4q-x89m/GHSA-r4q3-7g4q-x89m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r4q3-7g4q-x89m",
-  "modified": "2024-01-23T14:44:07Z",
+  "modified": "2024-01-23T14:44:08Z",
   "published": "2024-01-22T15:30:23Z",
   "aliases": [
     "CVE-2024-22233"
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "6.0.0"
             },
             {
               "fixed": "6.0.15"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Spring 5.x is not affected as documented on https://spring.io/security/cve-2024-22233/