### PR TITLE
[GHSA-r4q3-7g4q-x89m] Spring Framework server Web DoS Vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-r4q3-7g4q-x89m/GHSA-r4q3-7g4q-x89m.json
+++ b/advisories/github-reviewed/2024/01/GHSA-r4q3-7g4q-x89m/GHSA-r4q3-7g4q-x89m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r4q3-7g4q-x89m",
-  "modified": "2024-01-23T14:44:07Z",
+  "modified": "2024-01-23T14:44:08Z",
   "published": "2024-01-22T15:30:23Z",
   "aliases": [
     "CVE-2024-22233"
@@ -25,13 +25,16 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "6.1.0"
+              "introduced": "6.1.2"
             },
             {
-              "fixed": "6.1.2"
+              "fixed": "6.1.3"
             }
           ]
         }
+      ],
+      "versions": [
+        "6.1.2"
       ]
     },
     {
@@ -44,13 +47,16 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "6.0.15"
             },
             {
-              "fixed": "6.0.15"
+              "fixed": "6.0.16"
             }
           ]
         }
+      ],
+      "versions": [
+        "6.0.15"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Based on Spring Security Advisory:
Affected Spring Products and Versions
Spring Framework
- 6.0.15
- 6.1.2
Older versions are not affected.

[ Bonus: https://github.com/spring-projects/spring-framework/issues/32103 ]