### PR TITLE
[GHSA-pvcr-v8j8-j5q3] 'github.com/lestrrat-go/jwx' add missing patched version

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-pvcr-v8j8-j5q3/GHSA-pvcr-v8j8-j5q3.json
+++ b/advisories/github-reviewed/2024/01/GHSA-pvcr-v8j8-j5q3/GHSA-pvcr-v8j8-j5q3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pvcr-v8j8-j5q3",
-  "modified": "2024-01-09T21:52:54Z",
+  "modified": "2024-01-24T13:35:50Z",
   "published": "2024-01-09T16:18:48Z",
   "aliases": [
     "CVE-2024-21664"
@@ -26,6 +26,9 @@
           "events": [
             {
               "introduced": "1.0.8"
+            },
+            {
+              "fixed": "1.2.28"
             }
           ]
         }


### PR DESCRIPTION
The initial advisory report didn't include a `patched` version for non-v2 modules of `github.com/lestrrat-go/jwx`. As mentioned in the release notes of (github.com/lestrrat-go/jwx)[https://github.com/lestrrat-go/jwx/releases], the new version v1.2.28 also fixes this vulnerability GHSA-pvcr-v8j8-j5q3:

```
v1.2.28 09 Jan 2024
[Security Fixes]
  * [jws] JWS messages formated in full JSON format (i.e. not the compact format, which
    consists of three base64 strings concatenated with a '.') with missing "protected"
    headers could cause a panic, thereby introducing a possiblity of a DoS.

    This has been fixed so that the `jws.Parse` function succeeds in parsing a JWS message
    lacking a protected header. Calling `jws.Verify` on this same JWS message will result
    in a failed verification attempt. Note that this behavior will differ slightly when
    parsing JWS messages in compact form, which result in an error.
```