### PR TITLE
[GHSA-xpw8-rcwv-8f8p] io.netty:netty-codec-http2 vulnerable to HTTP/2 Rapid Reset Attack

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-xpw8-rcwv-8f8p/GHSA-xpw8-rcwv-8f8p.json
+++ b/advisories/github-reviewed/2023/10/GHSA-xpw8-rcwv-8f8p/GHSA-xpw8-rcwv-8f8p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xpw8-rcwv-8f8p",
-  "modified": "2023-11-06T22:08:35Z",
+  "modified": "2023-11-06T22:08:37Z",
   "published": "2023-10-10T22:22:54Z",
   "aliases": [
 


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Please add CVE-2023-44487 as the CVE-ID as written in https://github.com/netty/netty/security/advisories/GHSA-xpw8-rcwv-8f8p.