### PR TITLE
[GHSA-267j-cwvg-j28c] mod/assign/externallib.php in Moodle 2.6.x before 2.6.2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-267j-cwvg-j28c/GHSA-267j-cwvg-j28c.json
+++ b/advisories/unreviewed/2022/05/GHSA-267j-cwvg-j28c/GHSA-267j-cwvg-j28c.json
@@ -1,22 +1,49 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-267j-cwvg-j28c",
-  "modified": "2022-05-13T01:12:51Z",
+  "modified": "2023-02-01T05:03:59Z",
   "published": "2022-05-13T01:12:51Z",
   "aliases": [
     "CVE-2014-2572"
   ],
+  "summary": "mod/assign/externallib.php in Moodle 2.6.x before 2.6.2 does not properly handle assignment web-service parameters, which might allow remote authenticated users to modify grade metadata via unspecified vectors.",
   "details": "mod/assign/externallib.php in Moodle 2.6.x before 2.6.2 does not properly handle assignment web-service parameters, which might allow remote authenticated users to modify grade metadata via unspecified vectors.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.6.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-2572"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/695a18b6aa9661f812a1a745a888df5acdbd7bc6"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/695a18b6aa9661f812a1a745a888df5acdbd7bc6. 
the commit msg has shown it's a fix for `MDL-43468`. 
update vvr as well.