### PR TITLE
[GHSA-4c5g-w3gf-rf4f] Moodle through 2.3.11, 2.4.x before 2.4.11, 2.5.x before...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-4c5g-w3gf-rf4f/GHSA-4c5g-w3gf-rf4f.json
+++ b/advisories/unreviewed/2022/05/GHSA-4c5g-w3gf-rf4f/GHSA-4c5g-w3gf-rf4f.json
@@ -1,22 +1,125 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4c5g-w3gf-rf4f",
-  "modified": "2022-05-13T01:12:40Z",
+  "modified": "2023-02-01T05:03:58Z",
   "published": "2022-05-13T01:12:40Z",
   "aliases": [
     "CVE-2014-3546"
   ],
+  "summary": "Moodle through 2.3.11, 2.4.x before 2.4.11, 2.5.x before 2.5.7, 2.6.x before 2.6.4, and 2.7.x before 2.7.1 does not enforce certain capability requirements in (1) notes/index.php and (2) user/edit.php, which allows remote attackers to obtain potentially sensitive username and course information via a modified URL.",
   "details": "Moodle through 2.3.11, 2.4.x before 2.4.11, 2.5.x before 2.5.7, 2.6.x before 2.6.4, and 2.7.x before 2.7.1 does not enforce certain capability requirements in (1) notes/index.php and (2) user/edit.php, which allows remote attackers to obtain potentially sensitive username and course information via a modified URL.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.3.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.4.0"
+            },
+            {
+              "fixed": "2.4.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.0"
+            },
+            {
+              "fixed": "2.5.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-3546"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/9dbf62d23017a91fcbf63bba7f2eb4835f77b8c9"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/9dbf62d23017a91fcbf63bba7f2eb4835f77b8c9. 
the commit msg has shown it's a fix for `MDL-45760`. 
update vvr as well.