### PR TITLE
[GHSA-59j6-8g7w-prf7] lib/classes/grades_external.php in Moodle 2.7.x before 2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-59j6-8g7w-prf7/GHSA-59j6-8g7w-prf7.json
+++ b/advisories/unreviewed/2022/05/GHSA-59j6-8g7w-prf7/GHSA-59j6-8g7w-prf7.json
@@ -1,22 +1,45 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-59j6-8g7w-prf7",
-  "modified": "2022-05-13T01:12:41Z",
+  "modified": "2023-02-01T05:03:58Z",
   "published": "2022-05-13T01:12:41Z",
   "aliases": [
     "CVE-2014-7831"
   ],
+  "summary": "lib/classes/grades_external.php in Moodle 2.7.x before 2.7.3 does not consider the moodle/grade:viewhidden capability before displaying hidden grades, which allows remote authenticated users to obtain sensitive information by leveraging the student role to access the get_grades web service.",
   "details": "lib/classes/grades_external.php in Moodle 2.7.x before 2.7.3 does not consider the moodle/grade:viewhidden capability before displaying hidden grades, which allows remote authenticated users to obtain sensitive information by leveraging the student role to access the get_grades web service.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7831"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/a0095e5a893190ec28f63a89deba7fd89ad1839a. 
the commit msg has shown it's a fix for `MDL-47766`. 
update vvr as well.