### PR TITLE
[GHSA-557f-2hv4-7jjm] mod/forum/externallib.php in Moodle 2.6.x before 2.6.6...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-557f-2hv4-7jjm/GHSA-557f-2hv4-7jjm.json
+++ b/advisories/unreviewed/2022/05/GHSA-557f-2hv4-7jjm/GHSA-557f-2hv4-7jjm.json
@@ -1,22 +1,68 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-557f-2hv4-7jjm",
-  "modified": "2022-05-13T01:12:41Z",
+  "modified": "2023-02-01T05:03:58Z",
   "published": "2022-05-13T01:12:41Z",
   "aliases": [
     "CVE-2014-7834"
   ],
+  "summary": "mod/forum/externallib.php in Moodle 2.6.x before 2.6.6 and 2.7.x before 2.7.3 does not verify group permissions, which allows remote authenticated users to access a forum via the forum_get_discussions web service.",
   "details": "mod/forum/externallib.php in Moodle 2.6.x before 2.6.6 and 2.7.x before 2.7.3 does not verify group permissions, which allows remote authenticated users to access a forum via the forum_get_discussions web service.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7834"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/40afeb4044c9718bf175c347f0f9099a037ce9f0"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/40afeb4044c9718bf175c347f0f9099a037ce9f0. 
the commit msg has shown it's a fix for `MDL-45303`. 
update vvr as well.