### PR TITLE
[GHSA-vrf6-q7qj-69v5] webservice/upload.php in Moodle 2.6.x before 2.6.6 and 2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-vrf6-q7qj-69v5/GHSA-vrf6-q7qj-69v5.json
+++ b/advisories/unreviewed/2022/05/GHSA-vrf6-q7qj-69v5/GHSA-vrf6-q7qj-69v5.json
@@ -1,22 +1,68 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vrf6-q7qj-69v5",
-  "modified": "2022-05-13T01:12:43Z",
+  "modified": "2023-02-01T05:03:52Z",
   "published": "2022-05-13T01:12:43Z",
   "aliases": [
     "CVE-2014-7835"
   ],
+  "summary": "webservice/upload.php in Moodle 2.6.x before 2.6.6 and 2.7.x before 2.7.3 does not ensure that a file upload is for a private or draft area, which allows remote authenticated users to upload files containing JavaScript, and consequently conduct cross-site scripting (XSS) attacks, by specifying the profile-picture area.",
   "details": "webservice/upload.php in Moodle 2.6.x before 2.6.6 and 2.7.x before 2.7.3 does not ensure that a file upload is for a private or draft area, which allows remote authenticated users to upload files containing JavaScript, and consequently conduct cross-site scripting (XSS) attacks, by specifying the profile-picture area.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7835"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/76ae1f6068f63149acc2d8c362af94067f4a227d"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/76ae1f6068f63149acc2d8c362af94067f4a227d. 
the commit msg has shown it's a fix for `MDL-47868`. 
update vvr as well.