### PR TITLE
[GHSA-p3hj-cfhm-7g6v] mod/wiki/admin.php in Moodle through 2.4.11, 2.5.x before...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-p3hj-cfhm-7g6v/GHSA-p3hj-cfhm-7g6v.json
+++ b/advisories/unreviewed/2022/05/GHSA-p3hj-cfhm-7g6v/GHSA-p3hj-cfhm-7g6v.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p3hj-cfhm-7g6v",
-  "modified": "2022-05-13T01:12:43Z",
+  "modified": "2023-02-01T05:03:58Z",
   "published": "2022-05-13T01:12:43Z",
   "aliases": [
     "CVE-2014-7837"
   ],
+  "summary": "mod/wiki/admin.php in Moodle through 2.4.11, 2.5.x before 2.5.9, 2.6.x before 2.6.6, and 2.7.x before 2.7.3 allows remote authenticated users to remove wiki pages by leveraging delete access within a different subwiki.",
   "details": "mod/wiki/admin.php in Moodle through 2.4.11, 2.5.x before 2.5.9, 2.6.x before 2.6.6, and 2.7.x before 2.7.3 allows remote authenticated users to remove wiki pages by leveraging delete access within a different subwiki.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.0"
+            },
+            {
+              "fixed": "2.5.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.4.11"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7837"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/a481e32f02cdabd2b76aaa06d1d513ffe480e71b"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/a481e32f02cdabd2b76aaa06d1d513ffe480e71b. 
the commit msg has shown it's a fix for `MDL-47949`. 
update vvr as well.