### PR TITLE
[GHSA-9v64-447r-wch6] Moodle Temporary Passwords are Brute Force-able

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9v64-447r-wch6/GHSA-9v64-447r-wch6.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9v64-447r-wch6/GHSA-9v64-447r-wch6.json
@@ -1,39 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9v64-447r-wch6",
-  "modified": "2023-08-15T22:32:55Z",
+  "modified": "2023-08-15T22:32:56Z",
   "published": "2022-05-13T01:12:43Z",
   "aliases": [
     "CVE-2014-7845"
   ],
-  "summary": "Moodle Temporary Passwords are Brute Force-able",
+  "summary": "mod/wiki/admin.php in Moodle through 2.4.11, 2.5.x before 2.5.9, 2.6.x before 2.6.6, and 2.7.x before 2.7.3 allows remote authenticated users to remove wiki pages by leveraging delete access within a different subwiki.",
   "details": "The generate_password function in Moodle through 2.4.11, 2.5.x before 2.5.9, 2.6.x before 2.6.6, and 2.7.x before 2.7.3 does not provide a sufficient number of possible temporary passwords, which allows remote attackers to obtain access via a brute-force attack.",
   "severity": [
 
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "Packagist",
-        "name": "moodle/moodle"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.7.0"
-            },
-            {
-              "fixed": "2.7.3"
-            }
-          ]
-        }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 2.7.2"
-      }
-    },
     {
       "package": {
         "ecosystem": "Packagist",
@@ -51,10 +29,26 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 2.6.5"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.3"
+            }
+          ]
+        }
+      ]
     },
     {
       "package": {
@@ -73,16 +67,40 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 2.5.8"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.4.11"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7845"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/40a04658232d898223462f84d8cd35510338acbe"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/40a04658232d898223462f84d8cd35510338acbe. 
the commit msg has shown it's a fix for `MDL-47050`. 
update vvr as well.