### PR TITLE
[GHSA-468q-9cmp-76wc] tag/tag_autocomplete.php in Moodle through 2.4.11, 2.5.x...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-468q-9cmp-76wc/GHSA-468q-9cmp-76wc.json
+++ b/advisories/unreviewed/2022/05/GHSA-468q-9cmp-76wc/GHSA-468q-9cmp-76wc.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-468q-9cmp-76wc",
-  "modified": "2022-05-13T01:12:43Z",
+  "modified": "2023-02-01T05:03:52Z",
   "published": "2022-05-13T01:12:43Z",
   "aliases": [
     "CVE-2014-7846"
   ],
+  "summary": "tag/tag_autocomplete.php in Moodle through 2.4.11, 2.5.x before 2.5.9, 2.6.x before 2.6.6, and 2.7.x before 2.7.3 does not consider the moodle/tag:edit capability before adding a tag, which allows remote authenticated users to bypass intended access restrictions via an AJAX request.",
   "details": "tag/tag_autocomplete.php in Moodle through 2.4.11, 2.5.x before 2.5.9, 2.6.x before 2.6.6, and 2.7.x before 2.7.3 does not consider the moodle/tag:edit capability before adding a tag, which allows remote authenticated users to bypass intended access restrictions via an AJAX request.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.5.9"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.4.11"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7846"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/5d0b3b21d6dbabe9e15cd646753a58ee25bd5f73"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/5d0b3b21d6dbabe9e15cd646753a58ee25bd5f73. 
the commit msg has shown it's a fix for `MDL-47965`. 
update vvr as well.