### PR TITLE
[GHSA-6vjg-2q57-rgfw] iplookup/index.php in Moodle through 2.4.11, 2.5.x before...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-6vjg-2q57-rgfw/GHSA-6vjg-2q57-rgfw.json
+++ b/advisories/unreviewed/2022/05/GHSA-6vjg-2q57-rgfw/GHSA-6vjg-2q57-rgfw.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6vjg-2q57-rgfw",
-  "modified": "2022-05-13T01:12:43Z",
+  "modified": "2023-02-01T05:03:58Z",
   "published": "2022-05-13T01:12:43Z",
   "aliases": [
     "CVE-2014-7847"
   ],
+  "summary": "iplookup/index.php in Moodle through 2.4.11, 2.5.x before 2.5.9, 2.6.x before 2.6.6, and 2.7.x before 2.7.3 allows remote attackers to cause a denial of service (resource consumption) by triggering the calculation of an estimated latitude and longitude for an IP address.",
   "details": "iplookup/index.php in Moodle through 2.4.11, 2.5.x before 2.5.9, 2.6.x before 2.6.6, and 2.7.x before 2.7.3 allows remote attackers to cause a denial of service (resource consumption) by triggering the calculation of an estimated latitude and longitude for an IP address.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.5.9"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.4.11"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7847"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/eb46bf2f4e80f4421255f6aee00b73448ba582a7"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/eb46bf2f4e80f4421255f6aee00b73448ba582a7. 
the commit msg has shown it's a fix for `MDL-47321`. 
update vvr as well.