### PR TITLE
[GHSA-47cw-whh9-j2fq] lib/phpunit/bootstrap.php in Moodle 2.6.x before 2.6.6...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-47cw-whh9-j2fq/GHSA-47cw-whh9-j2fq.json
+++ b/advisories/unreviewed/2022/05/GHSA-47cw-whh9-j2fq/GHSA-47cw-whh9-j2fq.json
@@ -1,22 +1,68 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-47cw-whh9-j2fq",
-  "modified": "2022-05-13T01:12:43Z",
+  "modified": "2023-02-01T05:03:53Z",
   "published": "2022-05-13T01:12:43Z",
   "aliases": [
     "CVE-2014-7848"
   ],
+  "summary": "lib/phpunit/bootstrap.php in Moodle 2.6.x before 2.6.6 and 2.7.x before 2.7.3 allows remote attackers to obtain sensitive information via a direct request, which reveals the full path in an error message.",
   "details": "lib/phpunit/bootstrap.php in Moodle 2.6.x before 2.6.6 and 2.7.x before 2.7.3 allows remote attackers to obtain sensitive information via a direct request, which reveals the full path in an error message.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7848"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/1993cc02b6b05f45ff1776813567c6b3f91480f4"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/1993cc02b6b05f45ff1776813567c6b3f91480f4. 
the commit msg has shown it's a fix for `MDL-47287`. 
update vvr as well.