### PR TITLE
Update GHSA-r4q3-7g4q-x89m.json CVE-2024-22233

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-r4q3-7g4q-x89m/GHSA-r4q3-7g4q-x89m.json
+++ b/advisories/github-reviewed/2024/01/GHSA-r4q3-7g4q-x89m/GHSA-r4q3-7g4q-x89m.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.springframework:spring-core"
+        "name": "org.springframework:spring-webmvc"
       },
       "ranges": [
         {
@@ -40,7 +40,29 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.springframework:spring-core"
+        "name": "org.springframework:spring-security-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.1.2"
+            },
+            {
+              "fixed": "6.1.3"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "6.1.2"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework:spring-webmvc"
       },
       "ranges": [
         {
@@ -57,6 +79,116 @@
       ],
       "versions": [
         "6.0.15"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework:spring-security-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.15"
+            },
+            {
+              "fixed": "6.0.16"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "6.0.15"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework.boot:spring-boot-starter-web"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.1.7"
+            },
+            {
+              "fixed": "3.1.8"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "3.1.7"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework.boot:spring-boot-starter-security"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.1.7"
+            },
+            {
+              "fixed": "3.1.8"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "3.1.7"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework.boot:spring-boot-starter-web"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.2.1"
+            },
+            {
+              "fixed": "3.2.2"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "3.2.1"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework.boot:spring-boot-starter-security"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.2.1"
+            },
+            {
+              "fixed": "3.2.2"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "3.2.1"
       ]
     }
   ],


### PR DESCRIPTION
spring-core is not affected by this vulnerability. Rather, applications must be using spring-webmvc with spring-security-core (used or available in classpath). Since expressing such a condition is not possible with this schema, my edit would still result in false positives.