### PR TITLE
[GHSA-crcq-pw8h-9xwf] lib/setup.php in Moodle through 2.4.11, 2.5.x before 2.5...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-crcq-pw8h-9xwf/GHSA-crcq-pw8h-9xwf.json
+++ b/advisories/unreviewed/2022/05/GHSA-crcq-pw8h-9xwf/GHSA-crcq-pw8h-9xwf.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-crcq-pw8h-9xwf",
-  "modified": "2022-05-13T01:12:43Z",
+  "modified": "2023-02-01T05:03:58Z",
   "published": "2022-05-13T01:12:43Z",
   "aliases": [
     "CVE-2014-9059"
   ],
+  "summary": "classes/GoogleSpell.php in the PHP Spellchecker (aka Google Spellchecker) addon before 2.0.6.1 for TinyMCE, as used in Moodle 2.1.x before 2.1.10, 2.2.x before 2.2.7, 2.3.x before 2.3.4, and 2.4.x before 2.4.1 and other products, does not properly handle control characters, which allows remote attackers to trigger arbitrary outbound HTTP requests via a crafted string.",
   "details": "lib/setup.php in Moodle through 2.4.11, 2.5.x before 2.5.9, 2.6.x before 2.6.6, and 2.7.x before 2.7.3 does not provide charset information in HTTP headers, which might allow remote attackers to conduct cross-site scripting (XSS) attacks via UTF-7 characters during interaction with AJAX scripts.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.4.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.0"
+            },
+            {
+              "fixed": "2.5.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-9059"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/3c98b7a5ad1bb596a738e550fc3bf966d6415fe0"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/3c98b7a5ad1bb596a738e550fc3bf966d6415fe0. 
the commit msg has shown it's a fix for `MDL-47966`. 
update vvr as well.