### PR TITLE
[GHSA-c87j-9rrq-h3j8] The LTI module in Moodle through 2.4.11, 2.5.x before 2.5...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-c87j-9rrq-h3j8/GHSA-c87j-9rrq-h3j8.json
+++ b/advisories/unreviewed/2022/05/GHSA-c87j-9rrq-h3j8/GHSA-c87j-9rrq-h3j8.json
@@ -1,22 +1,109 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c87j-9rrq-h3j8",
-  "modified": "2022-05-13T01:12:43Z",
+  "modified": "2023-02-01T05:03:58Z",
   "published": "2022-05-13T01:12:43Z",
   "aliases": [
     "CVE-2014-9060"
   ],
+  "summary": "The LTI module in Moodle through 2.4.11, 2.5.x before 2.5.9, 2.6.x before 2.6.6, and 2.7.x before 2.7.3 does not properly restrict the parameters used in a return URL, which allows remote attackers to trigger the generation of arbitrary messages via a modified URL, related to mod/lti/locallib.php and mod/lti/return.php.",
   "details": "The LTI module in Moodle through 2.4.11, 2.5.x before 2.5.9, 2.6.x before 2.6.6, and 2.7.x before 2.7.3 does not properly restrict the parameters used in a return URL, which allows remote attackers to trigger the generation of arbitrary messages via a modified URL, related to mod/lti/locallib.php and mod/lti/return.php.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.1.10"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.4.11"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.0"
+            },
+            {
+              "fixed": "2.5.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-9060"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/edc89dfecb3f6891cea019baf2aecce51b3de41a"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/edc89dfecb3f6891cea019baf2aecce51b3de41a. 
the commit msg has shown it's a fix for `MDL-47927`. 
update vvr as well.