### PR TITLE
[GHSA-frhc-9hwc-x7j3] mod/lti/ajax.php in Moodle through 2.5.9, 2.6.x before 2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-frhc-9hwc-x7j3/GHSA-frhc-9hwc-x7j3.json
+++ b/advisories/unreviewed/2022/05/GHSA-frhc-9hwc-x7j3/GHSA-frhc-9hwc-x7j3.json
@@ -1,22 +1,87 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-frhc-9hwc-x7j3",
-  "modified": "2022-05-13T01:12:43Z",
+  "modified": "2023-02-01T05:03:58Z",
   "published": "2022-05-13T01:12:43Z",
   "aliases": [
     "CVE-2015-0211"
   ],
+  "summary": "The LTI module in Moodle through 2.4.11, 2.5.x before 2.5.9, 2.6.x before 2.6.6, and 2.7.x before 2.7.3 does not properly restrict the parameters used in a return URL, which allows remote attackers to trigger the generation of arbitrary messages via a modified URL, related to mod/lti/locallib.php and mod/lti/return.php.",
   "details": "mod/lti/ajax.php in Moodle through 2.5.9, 2.6.x before 2.6.7, 2.7.x before 2.7.4, and 2.8.x before 2.8.2 does not consider the moodle/course:manageactivities and mod/lti:addinstance capabilities before proceeding with registered-tool list searches, which allows remote authenticated users to obtain sensitive information via requests to the LTI Ajax service.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.5.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-0211"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/da4c33f510aabc0d7443c29a7c097cfd54b6c4a4"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/da4c33f510aabc0d7443c29a7c097cfd54b6c4a4. 
the commit msg has shown it's a fix for `MDL-47920`. 
update vvr as well.