### PR TITLE
[GHSA-4jm2-c9jr-6prf] message/externallib.php in Moodle through 2.5.9, 2.6.x...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-4jm2-c9jr-6prf/GHSA-4jm2-c9jr-6prf.json
+++ b/advisories/unreviewed/2022/05/GHSA-4jm2-c9jr-6prf/GHSA-4jm2-c9jr-6prf.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4jm2-c9jr-6prf",
-  "modified": "2022-05-13T01:12:44Z",
+  "modified": "2023-02-01T05:03:59Z",
   "published": "2022-05-13T01:12:44Z",
   "aliases": [
     "CVE-2015-0214"
   ],
+  "summary": "Multiple cross-site request forgery (CSRF) vulnerabilities in (1) editcategories.html and (2) editcategories.php in the Glossary module in Moodle through 2.5.9, 2.6.x before 2.6.7, 2.7.x before 2.7.4, and 2.8.x before 2.8.2 allow remote attackers to hijack the authentication of unspecified victims.",
   "details": "message/externallib.php in Moodle through 2.5.9, 2.6.x before 2.6.7, 2.7.x before 2.7.4, and 2.8.x before 2.8.2 allows remote authenticated users to bypass a messaging-disabled setting via a web-services request, as demonstrated by a people-search request.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.5.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-0214"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/436bbf8975f0daef329c6483ec595dbf9b39ee56"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/436bbf8975f0daef329c6483ec595dbf9b39ee56. 
the commit msg has shown it's a fix for `MDL-48329`. 
update vvr as well.