### PR TITLE
[GHSA-2jcw-r79x-4r5v] access.php in the Lesson module in Moodle 2.8.x before 2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-2jcw-r79x-4r5v/GHSA-2jcw-r79x-4r5v.json
+++ b/advisories/unreviewed/2022/05/GHSA-2jcw-r79x-4r5v/GHSA-2jcw-r79x-4r5v.json
@@ -1,22 +1,49 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2jcw-r79x-4r5v",
-  "modified": "2022-05-13T01:12:49Z",
+  "modified": "2023-02-01T05:03:52Z",
   "published": "2022-05-13T01:12:49Z",
   "aliases": [
     "CVE-2015-0216"
   ],
+  "summary": "access.php in the Lesson module in Moodle 2.8.x before 2.8.2 does not set the RISK_XSS bit for graders, which allows remote authenticated users to conduct cross-site scripting (XSS) attacks via crafted essay feedback.",
   "details": "access.php in the Lesson module in Moodle 2.8.x before 2.8.2 does not set the RISK_XSS bit for graders, which allows remote authenticated users to conduct cross-site scripting (XSS) attacks via crafted essay feedback.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-0216"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/b9c86823c70a1cba20bca1c4b5b032ee1559e22d"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/b9c86823c70a1cba20bca1c4b5b032ee1559e22d. 
the commit msg has shown it's a fix for `MDL-48034`. 
update vvr as well.