### PR TITLE
[GHSA-gphj-63h8-r9vq] Directory traversal vulnerability in the...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-gphj-63h8-r9vq/GHSA-gphj-63h8-r9vq.json
+++ b/advisories/unreviewed/2022/05/GHSA-gphj-63h8-r9vq/GHSA-gphj-63h8-r9vq.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gphj-63h8-r9vq",
-  "modified": "2022-05-13T01:12:45Z",
+  "modified": "2023-02-01T05:03:59Z",
   "published": "2022-05-13T01:12:45Z",
   "aliases": [
     "CVE-2015-1493"
   ],
+  "summary": "Directory traversal vulnerability in the min_get_slash_argument function in lib/configonlylib.php in Moodle through 2.5.9, 2.6.x before 2.6.8, 2.7.x before 2.7.5, and 2.8.x before 2.8.3 allows remote authenticated users to read arbitrary files via a .. (dot dot) in the file parameter, as demonstrated by reading PHP scripts.",
   "details": "Directory traversal vulnerability in the min_get_slash_argument function in lib/configonlylib.php in Moodle through 2.5.9, 2.6.x before 2.6.8, 2.7.x before 2.7.5, and 2.8.x before 2.8.3 allows remote authenticated users to read arbitrary files via a .. (dot dot) in the file parameter, as demonstrated by reading PHP scripts.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.5.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-1493"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/af9a7937cc085f96bdbc4724cadec6eeae0242fc"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/af9a7937cc085f96bdbc4724cadec6eeae0242fc. 
the commit msg has shown it's a fix for `MDL-48980`. 
update vvr as well.