### PR TITLE
[GHSA-35pr-gqm6-r366] message/index.php in Moodle through 2.5.9, 2.6.x before 2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-35pr-gqm6-r366/GHSA-35pr-gqm6-r366.json
+++ b/advisories/unreviewed/2022/05/GHSA-35pr-gqm6-r366/GHSA-35pr-gqm6-r366.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-35pr-gqm6-r366",
-  "modified": "2022-05-13T01:12:45Z",
+  "modified": "2023-02-01T05:03:52Z",
   "published": "2022-05-13T01:12:45Z",
   "aliases": [
     "CVE-2015-2266"
   ],
+  "summary": "message/index.php in Moodle through 2.5.9, 2.6.x before 2.6.9, 2.7.x before 2.7.6, and 2.8.x before 2.8.4 does not consider the moodle/site:readallmessages capability before accessing arbitrary conversations, which allows remote authenticated users to obtain sensitive personal-contact and unread-message-count information via a modified URL.",
   "details": "message/index.php in Moodle through 2.5.9, 2.6.x before 2.6.9, 2.7.x before 2.7.6, and 2.8.x before 2.8.4 does not consider the moodle/site:readallmessages capability before accessing arbitrary conversations, which allows remote authenticated users to obtain sensitive personal-contact and unread-message-count information via a modified URL.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.5.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-2266"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/553319be03c4ef8e62499841c8d5d94c6786ed6d"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/553319be03c4ef8e62499841c8d5d94c6786ed6d. 
the commit msg has shown it's a fix for `MDL-49204`. 
update vvr as well.