### PR TITLE
[GHSA-cm4r-58pj-h2ph] mdeploy.php in Moodle through 2.5.9, 2.6.x before 2.6.9,...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-cm4r-58pj-h2ph/GHSA-cm4r-58pj-h2ph.json
+++ b/advisories/unreviewed/2022/05/GHSA-cm4r-58pj-h2ph/GHSA-cm4r-58pj-h2ph.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cm4r-58pj-h2ph",
-  "modified": "2022-05-13T01:12:45Z",
+  "modified": "2023-02-01T05:03:53Z",
   "published": "2022-05-13T01:12:45Z",
   "aliases": [
     "CVE-2015-2267"
   ],
+  "summary": "mdeploy.php in Moodle through 2.5.9, 2.6.x before 2.6.9, 2.7.x before 2.7.6, and 2.8.x before 2.8.4 allows remote authenticated users to bypass intended access restrictions and extract archives to arbitrary directories via a crafted dataroot value.",
   "details": "mdeploy.php in Moodle through 2.5.9, 2.6.x before 2.6.9, 2.7.x before 2.7.6, and 2.8.x before 2.8.4 allows remote authenticated users to bypass intended access restrictions and extract archives to arbitrary directories via a crafted dataroot value.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.5.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-2267"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/8d9bdd28e049ca6b6b2a4ab8f142097c2f907df6"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/8d9bdd28e049ca6b6b2a4ab8f142097c2f907df6. 
the commit msg has shown it's a fix for `MDL-49087`. 
update vvr as well.