### PR TITLE
[GHSA-36cm-vrqh-8p98] filter/urltolink/filter.php in Moodle through 2.5.9, 2.6...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-36cm-vrqh-8p98/GHSA-36cm-vrqh-8p98.json
+++ b/advisories/unreviewed/2022/05/GHSA-36cm-vrqh-8p98/GHSA-36cm-vrqh-8p98.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-36cm-vrqh-8p98",
-  "modified": "2022-05-13T01:12:45Z",
+  "modified": "2023-02-01T05:03:53Z",
   "published": "2022-05-13T01:12:45Z",
   "aliases": [
     "CVE-2015-2268"
   ],
+  "summary": "filter/urltolink/filter.php in Moodle through 2.5.9, 2.6.x before 2.6.9, 2.7.x before 2.7.6, and 2.8.x before 2.8.4 allows remote authenticated users to cause a denial of service (CPU consumption or partial outage) via a crafted string that is matched against an improper regular expression.",
   "details": "filter/urltolink/filter.php in Moodle through 2.5.9, 2.6.x before 2.6.9, 2.7.x before 2.7.6, and 2.8.x before 2.8.4 allows remote authenticated users to cause a denial of service (CPU consumption or partial outage) via a crafted string that is matched against an improper regular expression.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.5.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-2268"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/07323f50ffc71f8ba1b2914ec8947451e32a61c1"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/07323f50ffc71f8ba1b2914ec8947451e32a61c1. 
the commit msg has shown it's a fix for `MDL-38466`. 
update vvr as well.