### PR TITLE
[GHSA-fp4h-j22r-vwcv] lib/moodlelib.php in Moodle through 2.5.9, 2.6.x before 2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-fp4h-j22r-vwcv/GHSA-fp4h-j22r-vwcv.json
+++ b/advisories/unreviewed/2022/05/GHSA-fp4h-j22r-vwcv/GHSA-fp4h-j22r-vwcv.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fp4h-j22r-vwcv",
-  "modified": "2022-05-13T01:12:45Z",
+  "modified": "2023-02-01T05:03:52Z",
   "published": "2022-05-13T01:12:45Z",
   "aliases": [
     "CVE-2015-2270"
   ],
+  "summary": "lib/moodlelib.php in Moodle through 2.5.9, 2.6.x before 2.6.9, 2.7.x before 2.7.6, and 2.8.x before 2.8.4, when the theme uses the blocks-regions feature, establishes the course state at an incorrect point in the login-validation process, which allows remote attackers to obtain sensitive course information via unspecified vectors.",
   "details": "lib/moodlelib.php in Moodle through 2.5.9, 2.6.x before 2.6.9, 2.7.x before 2.7.6, and 2.8.x before 2.8.4, when the theme uses the blocks-regions feature, establishes the course state at an incorrect point in the login-validation process, which allows remote attackers to obtain sensitive course information via unspecified vectors.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.5.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-2270"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/1edd3d6fbfcc7ac757579a7953f03e3401c0c32d"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/1edd3d6fbfcc7ac757579a7953f03e3401c0c32d. 
the commit msg has shown it's a fix for `MDL-48804`. 
update vvr as well.