### PR TITLE
[GHSA-v3wp-35g3-m9mm] tag/user.php in Moodle through 2.5.9, 2.6.x before 2.6.9,...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-v3wp-35g3-m9mm/GHSA-v3wp-35g3-m9mm.json
+++ b/advisories/unreviewed/2022/05/GHSA-v3wp-35g3-m9mm/GHSA-v3wp-35g3-m9mm.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v3wp-35g3-m9mm",
-  "modified": "2022-05-13T01:12:45Z",
+  "modified": "2023-02-01T05:03:52Z",
   "published": "2022-05-13T01:12:45Z",
   "aliases": [
     "CVE-2015-2271"
   ],
+  "summary": "tag/user.php in Moodle through 2.5.9, 2.6.x before 2.6.9, 2.7.x before 2.7.6, and 2.8.x before 2.8.4 does not consider the moodle/tag:flag capability before proceeding with a flaginappropriate action, which allows remote authenticated users to bypass intended access restrictions via the \"Flag as inappropriate\" feature.",
   "details": "tag/user.php in Moodle through 2.5.9, 2.6.x before 2.6.9, 2.7.x before 2.7.6, and 2.8.x before 2.8.4 does not consider the moodle/tag:flag capability before proceeding with a flaginappropriate action, which allows remote authenticated users to bypass intended access restrictions via the \"Flag as inappropriate\" feature.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.5.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-2271"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/b771b31e20cbf3d39aab877c648cf387e77173ba"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/b771b31e20cbf3d39aab877c648cf387e77173ba. 
the commit msg has shown it's a fix for `MDL-49084`. 
update vvr as well.