### PR TITLE
[GHSA-p6mc-m468-83gw] Prototype Pollution in lodash

### DIFF
--- a/advisories/github-reviewed/2020/07/GHSA-p6mc-m468-83gw/GHSA-p6mc-m468-83gw.json
+++ b/advisories/github-reviewed/2020/07/GHSA-p6mc-m468-83gw/GHSA-p6mc-m468-83gw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p6mc-m468-83gw",
-  "modified": "2023-10-24T20:06:48Z",
+  "modified": "2024-01-24T22:57:08Z",
   "published": "2020-07-15T19:15:48Z",
   "aliases": [
     "CVE-2020-8203"
@@ -19,16 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "lodash"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash).pick",
-          "(lodash).set",
-          "(lodash).setWith",
-          "(lodash).update",
-          "(lodash).updateWith",
-          "(lodash).zipObjectDeep"
-        ]
       },
       "ranges": [
         {
@@ -49,16 +39,6 @@
         "ecosystem": "npm",
         "name": "lodash-es"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash).pick",
-          "(lodash).set",
-          "(lodash).setWith",
-          "(lodash).update",
-          "(lodash).updateWith",
-          "(lodash).zipObjectDeep"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -78,11 +58,6 @@
         "ecosystem": "npm",
         "name": "lodash.pick"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.pick)"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -91,7 +66,7 @@
               "introduced": "3.7.0"
             },
             {
-              "fixed": "4.17.19"
+              "fixed": "4.4.0"
             }
           ]
         }
@@ -102,11 +77,6 @@
         "ecosystem": "npm",
         "name": "lodash.set"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.set)"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -115,7 +85,7 @@
               "introduced": "3.7.0"
             },
             {
-              "fixed": "4.17.19"
+              "fixed": "4.3.2"
             }
           ]
         }
@@ -126,11 +96,6 @@
         "ecosystem": "npm",
         "name": "lodash.setwith"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.setwith)"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -139,7 +104,7 @@
               "introduced": "3.7.0"
             },
             {
-              "fixed": "4.17.19"
+              "fixed": "4.3.2"
             }
           ]
         }
@@ -150,11 +115,6 @@
         "ecosystem": "npm",
         "name": "lodash.update"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.update)"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -163,7 +123,7 @@
               "introduced": "3.7.0"
             },
             {
-              "fixed": "4.17.19"
+              "fixed": "4.10.2"
             }
           ]
         }
@@ -174,11 +134,6 @@
         "ecosystem": "npm",
         "name": "lodash.updatewith"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.updatewith)"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -187,7 +142,7 @@
               "introduced": "3.7.0"
             },
             {
-              "fixed": "4.17.19"
+              "fixed": "4.10.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
`lodash.pick`, `lodash.set`, `lodash.updatewith` etc. are not on the same version as `lodash` itself. I changed the affected versions of these subset packages to reflect their latest versions.