### PR TITLE
[GHSA-5659-g9p4-354f] login/token.php in Moodle through 2.5.9, 2.6.x before 2.6...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5659-g9p4-354f/GHSA-5659-g9p4-354f.json
+++ b/advisories/unreviewed/2022/05/GHSA-5659-g9p4-354f/GHSA-5659-g9p4-354f.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5659-g9p4-354f",
-  "modified": "2022-05-13T01:12:45Z",
+  "modified": "2023-02-01T05:03:58Z",
   "published": "2022-05-13T01:12:45Z",
   "aliases": [
     "CVE-2015-2272"
   ],
+  "summary": "login/token.php in Moodle through 2.5.9, 2.6.x before 2.6.9, 2.7.x before 2.7.6, and 2.8.x before 2.8.4 allows remote authenticated users to bypass a forced-password-change requirement by creating a web-services token.",
   "details": "login/token.php in Moodle through 2.5.9, 2.6.x before 2.6.9, 2.7.x before 2.7.6, and 2.8.x before 2.8.4 allows remote authenticated users to bypass a forced-password-change requirement by creating a web-services token.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.5.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-2272"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/bd3b68c8a7a08b4fef407f68cef14b30dd88336e"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/bd3b68c8a7a08b4fef407f68cef14b30dd88336e. 
the commit msg has shown it's a fix for `MDL-48691`. 
update vvr as well.