### PR TITLE
[GHSA-h798-h7ff-93xv] Moodle Arbitrary Redirect

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-h798-h7ff-93xv/GHSA-h798-h7ff-93xv.json
+++ b/advisories/github-reviewed/2022/05/GHSA-h798-h7ff-93xv/GHSA-h798-h7ff-93xv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h798-h7ff-93xv",
-  "modified": "2023-12-07T19:53:54Z",
+  "modified": "2023-12-07T19:53:56Z",
   "published": "2022-05-13T01:12:46Z",
   "aliases": [
     "CVE-2015-3175"
@@ -100,6 +100,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/db200a8e9f88c8c4a2141ac264062dca74ee2f29"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/moodle/moodle/commit/dd0607b7bbaff38cc62e4d00658c02da3fdbb4c8"
     },
     {
@@ -129,7 +133,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-601"
     ],
     "severity": "MODERATE",
     "github_reviewed": true,


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- References

**Comments**
update the cwe according to the info on nvd.
add patch commit: https://github.com/moodle/moodle/commit/db200a8e9f88c8c4a2141ac264062dca74ee2f29. 
the commit msg has shown it's a fix for `MDL-49179`. 
