### PR TITLE
[GHSA-622h-cjgg-5mx6] files/externallib.php in Moodle through 2.5.9, 2.6.x...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-622h-cjgg-5mx6/GHSA-622h-cjgg-5mx6.json
+++ b/advisories/unreviewed/2022/05/GHSA-622h-cjgg-5mx6/GHSA-622h-cjgg-5mx6.json
@@ -1,22 +1,106 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-622h-cjgg-5mx6",
-  "modified": "2022-05-13T01:12:46Z",
+  "modified": "2023-02-01T05:03:59Z",
   "published": "2022-05-13T01:12:46Z",
   "aliases": [
     "CVE-2015-3181"
   ],
+  "summary": "files/externallib.php in Moodle through 2.5.9, 2.6.x before 2.6.11, 2.7.x before 2.7.8, and 2.8.x before 2.8.6 does not consider the moodle/user:manageownfiles capability before approving a private-file upload, which allows remote authenticated users to bypass intended file-management restrictions by using web services to perform uploads after this capability has been revoked.",
   "details": "files/externallib.php in Moodle through 2.5.9, 2.6.x before 2.6.11, 2.7.x before 2.7.8, and 2.8.x before 2.8.6 does not consider the moodle/user:manageownfiles capability before approving a private-file upload, which allows remote authenticated users to bypass intended file-management restrictions by using web services to perform uploads after this capability has been revoked.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.5.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            },
+            {
+              "fixed": "2.6.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.6"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-3181"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/57d9a750e3da6708dba13513e9b05e84a895ad9f"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/57d9a750e3da6708dba13513e9b05e84a895ad9f. 
the commit msg has shown it's a fix for `MDL-49994`. 
update vvr as well.