### PR TITLE
[GHSA-2hw2-h3mf-c2j9] Open redirect vulnerability in the clean_param function...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-2hw2-h3mf-c2j9/GHSA-2hw2-h3mf-c2j9.json
+++ b/advisories/unreviewed/2022/05/GHSA-2hw2-h3mf-c2j9/GHSA-2hw2-h3mf-c2j9.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2hw2-h3mf-c2j9",
-  "modified": "2022-05-13T01:12:46Z",
+  "modified": "2023-02-01T05:04:00Z",
   "published": "2022-05-13T01:12:46Z",
   "aliases": [
     "CVE-2015-3272"
   ],
+  "summary": "Open redirect vulnerability in the clean_param function in lib/moodlelib.php in Moodle through 2.6.11, 2.7.x before 2.7.9, 2.8.x before 2.8.7, and 2.9.x before 2.9.1 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via vectors involving an HTTP Referer header that has a substring match with a local URL.",
   "details": "Open redirect vulnerability in the clean_param function in lib/moodlelib.php in Moodle through 2.6.11, 2.7.x before 2.7.9, 2.8.x before 2.8.7, and 2.9.x before 2.9.1 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via vectors involving an HTTP Referer header that has a substring match with a local URL.",
   "severity": [
     {
@@ -14,12 +15,95 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.6.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.9.0"
+            },
+            {
+              "fixed": "2.9.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-3272"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/0339f2c4c1eb34b598b9eee99c3e5436f7533693"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/0339f2c4c1eb34b598b9eee99c3e5436f7533693. 
the commit msg has shown it's a fix for `MDL-50688`. 
update vvr as well.