### PR TITLE
[GHSA-mm9q-3847-m48x] The lesson module in Moodle through 2.6.11, 2.7.x before...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-mm9q-3847-m48x/GHSA-mm9q-3847-m48x.json
+++ b/advisories/unreviewed/2022/05/GHSA-mm9q-3847-m48x/GHSA-mm9q-3847-m48x.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mm9q-3847-m48x",
-  "modified": "2022-05-13T01:12:47Z",
+  "modified": "2023-02-01T05:04:00Z",
   "published": "2022-05-13T01:12:47Z",
   "aliases": [
     "CVE-2015-5264"
   ],
+  "summary": "The lesson module in Moodle through 2.6.11, 2.7.x before 2.7.10, 2.8.x before 2.8.8, and 2.9.x before 2.9.2 allows remote authenticated users to bypass intended access restrictions and enter additional answer attempts by leveraging the student role.",
   "details": "The lesson module in Moodle through 2.6.11, 2.7.x before 2.7.10, 2.8.x before 2.8.8, and 2.9.x before 2.9.2 allows remote authenticated users to bypass intended access restrictions and enter additional answer attempts by leveraging the student role.",
   "severity": [
     {
@@ -14,12 +15,95 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.6.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.9.0"
+            },
+            {
+              "fixed": "2.9.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5264"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/cd3a6a78b67abf5c9eb355ddc7899b1b2a9b20ac"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/cd3a6a78b67abf5c9eb355ddc7899b1b2a9b20ac. 
the commit msg has shown it's a fix for `MDL-50516`. 
update vvr as well.