### PR TITLE
[GHSA-44xp-wj24-9xxj] The wiki component in Moodle through 2.6.11, 2.7.x before...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-44xp-wj24-9xxj/GHSA-44xp-wj24-9xxj.json
+++ b/advisories/unreviewed/2022/05/GHSA-44xp-wj24-9xxj/GHSA-44xp-wj24-9xxj.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-44xp-wj24-9xxj",
-  "modified": "2022-05-13T01:12:47Z",
+  "modified": "2023-02-01T05:03:59Z",
   "published": "2022-05-13T01:12:47Z",
   "aliases": [
     "CVE-2015-5265"
   ],
+  "summary": "The wiki component in Moodle through 2.6.11, 2.7.x before 2.7.10, 2.8.x before 2.8.8, and 2.9.x before 2.9.2 does not consider the mod/wiki:managefiles capability before authorizing file management, which allows remote authenticated users to delete arbitrary files by using a manage-files button in a text editor.",
   "details": "The wiki component in Moodle through 2.6.11, 2.7.x before 2.7.10, 2.8.x before 2.8.8, and 2.9.x before 2.9.2 does not consider the mod/wiki:managefiles capability before authorizing file management, which allows remote authenticated users to delete arbitrary files by using a manage-files button in a text editor.",
   "severity": [
     {
@@ -14,12 +15,95 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.6.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.9.0"
+            },
+            {
+              "fixed": "2.9.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5265"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/40a154551fcdf0b9ea906f4d1313df29754f1fa1"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/40a154551fcdf0b9ea906f4d1313df29754f1fa1. 
the commit msg has shown it's a fix for `MDL-48371`. 
update vvr as well.