### PR TITLE
[GHSA-454r-4cjv-vc9h] The enrol_meta_sync function in enrol/meta/locallib.php...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-454r-4cjv-vc9h/GHSA-454r-4cjv-vc9h.json
+++ b/advisories/unreviewed/2022/05/GHSA-454r-4cjv-vc9h/GHSA-454r-4cjv-vc9h.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-454r-4cjv-vc9h",
-  "modified": "2022-05-13T01:12:47Z",
+  "modified": "2023-02-01T05:03:52Z",
   "published": "2022-05-13T01:12:47Z",
   "aliases": [
     "CVE-2015-5266"
   ],
+  "summary": "The enrol_meta_sync function in enrol/meta/locallib.php in Moodle through 2.6.11, 2.7.x before 2.7.10, 2.8.x before 2.8.8, and 2.9.x before 2.9.2 allows remote authenticated users to obtain manager privileges in opportunistic circumstances by leveraging incorrect role processing during a long-running sync script.",
   "details": "The enrol_meta_sync function in enrol/meta/locallib.php in Moodle through 2.6.11, 2.7.x before 2.7.10, 2.8.x before 2.8.8, and 2.9.x before 2.9.2 allows remote authenticated users to obtain manager privileges in opportunistic circumstances by leveraging incorrect role processing during a long-running sync script.",
   "severity": [
     {
@@ -14,12 +15,95 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.6.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.9.0"
+            },
+            {
+              "fixed": "2.9.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5266"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/f06d8d94a1f20d4f79376b2dc9e4707835386d97"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/f06d8d94a1f20d4f79376b2dc9e4707835386d97. 
the commit msg has shown it's a fix for `MDL-50744`. 
update vvr as well.