### PR TITLE
[GHSA-382v-gxj9-ffhc] lib/moodlelib.php in Moodle through 2.6.11, 2.7.x before...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-382v-gxj9-ffhc/GHSA-382v-gxj9-ffhc.json
+++ b/advisories/unreviewed/2022/05/GHSA-382v-gxj9-ffhc/GHSA-382v-gxj9-ffhc.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-382v-gxj9-ffhc",
-  "modified": "2022-05-13T01:12:47Z",
+  "modified": "2023-02-01T05:03:53Z",
   "published": "2022-05-13T01:12:47Z",
   "aliases": [
     "CVE-2015-5267"
   ],
+  "summary": "lib/moodlelib.php in Moodle through 2.6.11, 2.7.x before 2.7.10, 2.8.x before 2.8.8, and 2.9.x before 2.9.2 relies on the PHP mt_rand function to implement the random_string and complex_random_string functions, which makes it easier for remote attackers to predict password-recovery tokens via a brute-force approach.",
   "details": "lib/moodlelib.php in Moodle through 2.6.11, 2.7.x before 2.7.10, 2.8.x before 2.8.8, and 2.9.x before 2.9.2 relies on the PHP mt_rand function to implement the random_string and complex_random_string functions, which makes it easier for remote attackers to predict password-recovery tokens via a brute-force approach.",
   "severity": [
     {
@@ -14,12 +15,95 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.6.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.9.0"
+            },
+            {
+              "fixed": "2.9.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5267"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/e4ac3879c2d1f8fe66caa74ff1544248bccef61e"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/e4ac3879c2d1f8fe66caa74ff1544248bccef61e. 
the commit msg has shown it's a fix for `MDL-50860`. 
update vvr as well.