### PR TITLE
[GHSA-h34c-px28-rjgw] The rating component in Moodle through 2.6.11, 2.7.x...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-h34c-px28-rjgw/GHSA-h34c-px28-rjgw.json
+++ b/advisories/unreviewed/2022/05/GHSA-h34c-px28-rjgw/GHSA-h34c-px28-rjgw.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h34c-px28-rjgw",
-  "modified": "2022-05-13T01:12:47Z",
+  "modified": "2023-02-01T05:03:52Z",
   "published": "2022-05-13T01:12:47Z",
   "aliases": [
     "CVE-2015-5268"
   ],
+  "summary": "The rating component in Moodle through 2.6.11, 2.7.x before 2.7.10, 2.8.x before 2.8.8, and 2.9.x before 2.9.2 mishandles group-based authorization checks, which allows remote authenticated users to obtain sensitive information by reading a rating value.",
   "details": "The rating component in Moodle through 2.6.11, 2.7.x before 2.7.10, 2.8.x before 2.8.8, and 2.9.x before 2.9.2 mishandles group-based authorization checks, which allows remote authenticated users to obtain sensitive information by reading a rating value.",
   "severity": [
     {
@@ -14,12 +15,95 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.6.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.9.0"
+            },
+            {
+              "fixed": "2.9.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5268"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/731c2712e746053b1ca06b50118632305b447e02"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/731c2712e746053b1ca06b50118632305b447e02. 
the commit msg has shown it's a fix for `MDL-50173`. 
update vvr as well.