### PR TITLE
[GHSA-c2r4-f8qv-2v7v] mod_scorm in Moodle through 2.6.11, 2.7.x before 2.7.11,...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-c2r4-f8qv-2v7v/GHSA-c2r4-f8qv-2v7v.json
+++ b/advisories/unreviewed/2022/05/GHSA-c2r4-f8qv-2v7v/GHSA-c2r4-f8qv-2v7v.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c2r4-f8qv-2v7v",
-  "modified": "2022-05-13T01:12:49Z",
+  "modified": "2023-02-01T05:04:00Z",
   "published": "2022-05-13T01:12:49Z",
   "aliases": [
     "CVE-2015-5341"
   ],
+  "summary": "mod_scorm in Moodle through 2.6.11, 2.7.x before 2.7.11, 2.8.x before 2.8.9, and 2.9.x before 2.9.3 mishandles availability dates, which allows remote authenticated users to bypass intended access restrictions and read SCORM contents via unspecified vectors.",
   "details": "mod_scorm in Moodle through 2.6.11, 2.7.x before 2.7.11, 2.8.x before 2.8.9, and 2.9.x before 2.9.3 mishandles availability dates, which allows remote authenticated users to bypass intended access restrictions and read SCORM contents via unspecified vectors.",
   "severity": [
     {
@@ -14,12 +15,95 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.6.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.9.0"
+            },
+            {
+              "fixed": "2.9.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5341"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/03b1f63d40d09c206f641b246110c2371d3068a2"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/03b1f63d40d09c206f641b246110c2371d3068a2. 
the commit msg has shown it's a fix for `MDL-50837`. 
update vvr as well.