### PR TITLE
[GHSA-6xpm-q8x9-j3rw] The choice module in Moodle through 2.6.11, 2.7.x before...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-6xpm-q8x9-j3rw/GHSA-6xpm-q8x9-j3rw.json
+++ b/advisories/unreviewed/2022/05/GHSA-6xpm-q8x9-j3rw/GHSA-6xpm-q8x9-j3rw.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6xpm-q8x9-j3rw",
-  "modified": "2022-05-13T01:12:50Z",
+  "modified": "2023-02-01T05:03:53Z",
   "published": "2022-05-13T01:12:50Z",
   "aliases": [
     "CVE-2015-5342"
   ],
+  "summary": "The choice module in Moodle through 2.6.11, 2.7.x before 2.7.11, 2.8.x before 2.8.9, and 2.9.x before 2.9.3 allows remote authenticated users to bypass intended access restrictions by visiting a URL to add or delete responses in the closed state.",
   "details": "The choice module in Moodle through 2.6.11, 2.7.x before 2.7.11, 2.8.x before 2.8.9, and 2.9.x before 2.9.3 allows remote authenticated users to bypass intended access restrictions by visiting a URL to add or delete responses in the closed state.",
   "severity": [
     {
@@ -14,12 +15,95 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.6.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.9.0"
+            },
+            {
+              "fixed": "2.9.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5342"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/265ddbf30c2a8df2e9becaaa38c2e4b262eb886f"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/265ddbf30c2a8df2e9becaaa38c2e4b262eb886f. 
the commit msg has shown it's a fix for `MDL-51569`. 
update vvr as well.