### PR TITLE
[GHSA-m882-j7gq-v9p7] lib/ajax/getnavbranch.php in Moodle through 2.6.11, 2.7.x...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-m882-j7gq-v9p7/GHSA-m882-j7gq-v9p7.json
+++ b/advisories/unreviewed/2022/05/GHSA-m882-j7gq-v9p7/GHSA-m882-j7gq-v9p7.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m882-j7gq-v9p7",
-  "modified": "2022-05-13T01:12:38Z",
+  "modified": "2023-02-01T05:03:59Z",
   "published": "2022-05-13T01:12:38Z",
   "aliases": [
     "CVE-2016-2158"
   ],
+  "summary": "lib/ajax/getnavbranch.php in Moodle through 2.6.11, 2.7.x before 2.7.13, 2.8.x before 2.8.11, 2.9.x before 2.9.5, and 3.0.x before 3.0.3, when the forcelogin feature is enabled, allows remote attackers to obtain sensitive category-detail information from the navigation branch by leveraging the guest role for an Ajax request.",
   "details": "lib/ajax/getnavbranch.php in Moodle through 2.6.11, 2.7.x before 2.7.13, 2.8.x before 2.8.11, 2.9.x before 2.9.5, and 3.0.x before 3.0.3, when the forcelogin feature is enabled, allows remote attackers to obtain sensitive category-detail information from the navigation branch by leveraging the guest role for an Ajax request.",
   "severity": [
     {
@@ -14,12 +15,152 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.9.0"
+            },
+            {
+              "fixed": "2.9.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "fixed": "2.8.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.9.0"
+            },
+            {
+              "fixed": "2.9.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.0.0"
+            },
+            {
+              "fixed": "3.0.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "2.6.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "fixed": "2.7.13"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-2158"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/7b9fbb1cf4228b39f81454cdb8370e7853fbe184"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/7b9fbb1cf4228b39f81454cdb8370e7853fbe184. 
the commit msg has shown it's a fix for `MDL-52774`. 
update vvr as well.