### PR TITLE
[GHSA-r9pc-g29w-f86j] Moodle sensitive information disclosure

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-r9pc-g29w-f86j/GHSA-r9pc-g29w-f86j.json
+++ b/advisories/github-reviewed/2022/05/GHSA-r9pc-g29w-f86j/GHSA-r9pc-g29w-f86j.json
@@ -117,6 +117,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-2190"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/1688564a6eee6000013f6e185f704049283ae375"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/moodle/moodle"
     },


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/1688564a6eee6000013f6e185f704049283ae375. 
the commit msg has shown it's a fix for `MDL-52651`. 