### PR TITLE
[GHSA-gr8j-qm8r-rfgg] The "restore teacher" feature in Moodle 3.0 through 3.0.3...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-gr8j-qm8r-rfgg/GHSA-gr8j-qm8r-rfgg.json
+++ b/advisories/unreviewed/2022/05/GHSA-gr8j-qm8r-rfgg/GHSA-gr8j-qm8r-rfgg.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gr8j-qm8r-rfgg",
-  "modified": "2022-05-13T01:12:38Z",
+  "modified": "2023-02-01T05:03:52Z",
   "published": "2022-05-13T01:12:38Z",
   "aliases": [
     "CVE-2016-3733"
   ],
+  "summary": "The \"restore teacher\" feature in Moodle 3.0 through 3.0.3, 2.9 through 2.9.5, 2.8 through 2.8.11, 2.7 through 2.7.13, and earlier allows remote authenticated users to overwrite the course idnumber.",
   "details": "The \"restore teacher\" feature in Moodle 3.0 through 3.0.3, 2.9 through 2.9.5, 2.8 through 2.8.11, 2.7 through 2.7.13, and earlier allows remote authenticated users to overwrite the course idnumber.",
   "severity": [
     {
@@ -14,7 +15,82 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.0.0"
+            },
+            {
+              "last_affected": "3.0.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.9.0"
+            },
+            {
+              "last_affected": "2.9.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "last_affected": "2.8.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "last_affected": "2.7.13"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,7 +99,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/f824aceb50274e21c99056ed608dba8556b90e31"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1335933"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/f824aceb50274e21c99056ed608dba8556b90e31. 
the commit msg has shown it's a fix for `MDL-51369`. 
update vvr as well.