### PR TITLE
[GHSA-r867-v437-4rrm] Cross-site request forgery (CSRF) vulnerability in...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-r867-v437-4rrm/GHSA-r867-v437-4rrm.json
+++ b/advisories/unreviewed/2022/05/GHSA-r867-v437-4rrm/GHSA-r867-v437-4rrm.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r867-v437-4rrm",
-  "modified": "2022-05-13T01:12:38Z",
+  "modified": "2023-02-01T05:03:59Z",
   "published": "2022-05-13T01:12:38Z",
   "aliases": [
     "CVE-2016-3734"
   ],
+  "summary": "Cross-site request forgery (CSRF) vulnerability in markposts.php in Moodle",
   "details": "Cross-site request forgery (CSRF) vulnerability in markposts.php in Moodle 3.0 through 3.0.3, 2.9 through 2.9.5, 2.8 through 2.8.11, 2.7 through 2.7.13 and earlier allows remote attackers to hijack the authentication of users for requests that marks forum posts as read.",
   "severity": [
     {
@@ -14,7 +15,82 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.0.0"
+            },
+            {
+              "last_affected": "3.0.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.9.0"
+            },
+            {
+              "last_affected": "2.9.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.8.0"
+            },
+            {
+              "last_affected": "2.8.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.7.0"
+            },
+            {
+              "last_affected": "2.7.13"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,7 +99,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/e90e0ea5700ee9b016034b74ed7f41787109d1a2"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1335933"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/e90e0ea5700ee9b016034b74ed7f41787109d1a2. 
the commit msg has shown it's a fix for `MDL-53755`. 
update vvr as well.