### PR TITLE
[GHSA-c3pr-h96w-2jjg] moodle before versions 3.5.2, 3.4.5, 3.3.8, 3.1.14 is...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-c3pr-h96w-2jjg/GHSA-c3pr-h96w-2jjg.json
+++ b/advisories/unreviewed/2022/05/GHSA-c3pr-h96w-2jjg/GHSA-c3pr-h96w-2jjg.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c3pr-h96w-2jjg",
-  "modified": "2022-05-13T01:34:31Z",
+  "modified": "2023-02-01T05:08:29Z",
   "published": "2022-05-13T01:34:31Z",
   "aliases": [
     "CVE-2018-14630"
   ],
+  "summary": "moodle before versions 3.5.2, 3.4.5, 3.3.8, 3.1.14 is vulnerable to an XML import of ddwtos could lead to intentional remote code execution. When importing legacy 'drag and drop into text' (ddwtos) type quiz questions, it was possible to inject and execute PHP code from within the imported questions, either intentionally or by importing questions from an untrusted source.",
   "details": "moodle before versions 3.5.2, 3.4.5, 3.3.8, 3.1.14 is vulnerable to an XML import of ddwtos could lead to intentional remote code execution. When importing legacy 'drag and drop into text' (ddwtos) type quiz questions, it was possible to inject and execute PHP code from within the imported questions, either intentionally or by importing questions from an untrusted source.",
   "severity": [
     {
@@ -14,7 +15,82 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.5.0"
+            },
+            {
+              "fixed": "3.5.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.4.0"
+            },
+            {
+              "fixed": "3.4.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.3.0"
+            },
+            {
+              "fixed": "3.3.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.1.0"
+            },
+            {
+              "fixed": "3.1.14"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,7 +99,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/cb8aefa658cf7ad8f002a480343afb2dea94cc08"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2018-14630"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/cb8aefa658cf7ad8f002a480343afb2dea94cc08. 
the commit msg has shown it's a fix for `MDL-62880`. 
update vvr as well.