### PR TITLE
[GHSA-qrcj-6fjw-3h9h] Moodle XSS Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-qrcj-6fjw-3h9h/GHSA-qrcj-6fjw-3h9h.json
+++ b/advisories/github-reviewed/2022/05/GHSA-qrcj-6fjw-3h9h/GHSA-qrcj-6fjw-3h9h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qrcj-6fjw-3h9h",
-  "modified": "2023-09-28T19:56:07Z",
+  "modified": "2023-09-28T19:56:10Z",
   "published": "2022-05-13T01:05:21Z",
   "aliases": [
     "CVE-2019-3847"
@@ -96,6 +96,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-3847"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/93dda3bfd3caaaa8d23fe8ede543f27ef774958d"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/93dda3bfd3caaaa8d23fe8ede543f27ef774958d. 
the commit msg has shown it's a fix for `MDL-63786`. 