### PR TITLE
[GHSA-5wg9-5w3f-hxmh] A vulnerability was found in moodle before versions 3.6.3...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5wg9-5w3f-hxmh/GHSA-5wg9-5w3f-hxmh.json
+++ b/advisories/unreviewed/2022/05/GHSA-5wg9-5w3f-hxmh/GHSA-5wg9-5w3f-hxmh.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5wg9-5w3f-hxmh",
-  "modified": "2022-05-13T01:14:32Z",
+  "modified": "2023-02-01T05:04:25Z",
   "published": "2022-05-13T01:14:32Z",
   "aliases": [
     "CVE-2019-3849"
   ],
+  "summary": "A vulnerability was found in moodle before versions 3.6.3, 3.5.5 and 3.4.8. Users could assign themselves an escalated role within courses or content accessed via LTI, by modifying the request to the LTI publisher site.",
   "details": "A vulnerability was found in moodle before versions 3.6.3, 3.5.5 and 3.4.8. Users could assign themselves an escalated role within courses or content accessed via LTI, by modifying the request to the LTI publisher site.",
   "severity": [
     {
@@ -14,7 +15,63 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.6.0"
+            },
+            {
+              "fixed": "3.6.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.4.0"
+            },
+            {
+              "fixed": "3.4.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.5.0"
+            },
+            {
+              "fixed": "3.5.5"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,7 +80,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/898d5d05a0c3ae6795db0241bf3cb5951213d45c"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-3849"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/898d5d05a0c3ae6795db0241bf3cb5951213d45c. 
the commit msg has shown it's a fix for `MDL-62702`. 
update vvr as well.