### PR TITLE
[GHSA-pj45-hp8h-289r] A vulnerability was found in moodle before versions 3.6.3...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-pj45-hp8h-289r/GHSA-pj45-hp8h-289r.json
+++ b/advisories/unreviewed/2022/05/GHSA-pj45-hp8h-289r/GHSA-pj45-hp8h-289r.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pj45-hp8h-289r",
-  "modified": "2022-05-13T01:22:27Z",
+  "modified": "2023-02-01T05:06:52Z",
   "published": "2022-05-13T01:22:27Z",
   "aliases": [
     "CVE-2019-3851"
   ],
+  "summary": "A vulnerability was found in moodle before versions 3.6.3 and 3.5.5. There was a link to site home within the the Boost theme's secure layout, meaning students could navigate out of the page.",
   "details": "A vulnerability was found in moodle before versions 3.6.3 and 3.5.5. There was a link to site home within the the Boost theme's secure layout, meaning students could navigate out of the page.",
   "severity": [
     {
@@ -14,7 +15,44 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.6.0"
+            },
+            {
+              "fixed": "3.6.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.5.0"
+            },
+            {
+              "fixed": "3.5.5"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,7 +61,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/c430bed525c4c7e6e5a1c0f7222bc323cf9b6245"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-3851"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/c430bed525c4c7e6e5a1c0f7222bc323cf9b6245. 
the commit msg has shown it's a fix for `MDL-64706`. 
update vvr as well.