### PR TITLE
[GHSA-v2rh-5v88-rgvh] A vulnerability was found in moodle before version 3.6.3....

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-v2rh-5v88-rgvh/GHSA-v2rh-5v88-rgvh.json
+++ b/advisories/unreviewed/2022/05/GHSA-v2rh-5v88-rgvh/GHSA-v2rh-5v88-rgvh.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v2rh-5v88-rgvh",
-  "modified": "2022-05-13T01:22:28Z",
+  "modified": "2023-02-01T05:06:38Z",
   "published": "2022-05-13T01:22:28Z",
   "aliases": [
     "CVE-2019-3852"
   ],
+  "summary": "A vulnerability was found in moodle before version 3.6.3. The get_with_capability_join and get_users_by_capability functions were not taking context freezing into account when checking user capabilities",
   "details": "A vulnerability was found in moodle before version 3.6.3. The get_with_capability_join and get_users_by_capability functions were not taking context freezing into account when checking user capabilities",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.6.3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,7 +42,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/54c2b176040c4cd65d921bf10123b5146eb486f5"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-3852"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patch commit: https://github.com/moodle/moodle/commit/54c2b176040c4cd65d921bf10123b5146eb486f5. 
the commit msg has shown it's a fix for `MDL-64410`. 
update vvr as well.