### PR TITLE
[GHSA-vr6v-g96p-cjc3] Moodle vulnerable to RCE

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-vr6v-g96p-cjc3/GHSA-vr6v-g96p-cjc3.json
+++ b/advisories/github-reviewed/2022/05/GHSA-vr6v-g96p-cjc3/GHSA-vr6v-g96p-cjc3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vr6v-g96p-cjc3",
-  "modified": "2023-08-21T18:35:49Z",
+  "modified": "2023-08-21T18:35:50Z",
   "published": "2022-05-24T17:18:14Z",
   "aliases": [
     "CVE-2020-10738"
@@ -118,16 +118,16 @@
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2020-10738"
     },
     {
+      "type": "WEB",
+      "url": "https://git.moodle.org/gw?p=moodle.git&a=search&h=HEAD&st=commit&s=MDL-68410"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",
       "url": "https://moodle.org/mod/forum/discuss.php?d=403513"
-    },
-    {
-      "type": "WEB",
-      "url": "http://git.moodle.org/gw?p=moodle.git&a=search&h=HEAD&st=commit&s=MDL-68410"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
update the patch link on git (from 'http' to 'https').