### PR TITLE
[GHSA-vxhx-gmhm-623c] Improper Access Control in moodle

### DIFF
--- a/advisories/github-reviewed/2021/03/GHSA-vxhx-gmhm-623c/GHSA-vxhx-gmhm-623c.json
+++ b/advisories/github-reviewed/2021/03/GHSA-vxhx-gmhm-623c/GHSA-vxhx-gmhm-623c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vxhx-gmhm-623c",
-  "modified": "2021-03-24T23:17:35Z",
+  "modified": "2023-09-12T13:19:18Z",
   "published": "2021-03-29T20:42:46Z",
   "aliases": [
     "CVE-2020-25698"
@@ -104,6 +104,14 @@
     {
       "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1895419"
+    },
+    {
+      "type": "WEB",
+      "url": "https://git.moodle.org/gw?p=moodle.git&a=search&h=HEAD&st=commit&s=MDL-67837"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moodle/moodle"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
add patch commit on git: https://git.moodle.org/gw?p=moodle.git&a=search&h=HEAD&st=commit&s=MDL-67837.
the commit msg has shown it's a fix for `MDL-67837`. 
update source code location as well.