### PR TITLE
[GHSA-vjwc-5hfh-2vv5] Use of a Broken or Risky Cryptographic Algorithm in Apache WSS4J

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-vjwc-5hfh-2vv5/GHSA-vjwc-5hfh-2vv5.json
+++ b/advisories/github-reviewed/2022/05/GHSA-vjwc-5hfh-2vv5/GHSA-vjwc-5hfh-2vv5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vjwc-5hfh-2vv5",
-  "modified": "2022-07-06T20:29:59Z",
+  "modified": "2023-01-27T05:02:22Z",
   "published": "2022-05-14T00:55:57Z",
   "aliases": [
     "CVE-2015-0226"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
     }
   ],
   "affected": [
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.ws.security:wss4j"
+        "name": "org.apache.ws.security:wss4j-ws-security-dom"
       },
       "ranges": [
         {
@@ -61,7 +61,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/ws-wss4j/commit/970b3e3756e2c75bf2379ce198365e1a7168c3c3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/ws-wss4j/commit/de5104b30ddde5fe7388ad57e1c5ace5c5509924"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2016:1376"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/ws-wss4j"
     },
     {
       "type": "WEB",
@@ -98,6 +110,10 @@
     {
       "type": "WEB",
       "url": "http://rhn.redhat.com/errata/RHSA-2015-1177.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://svn.apache.org/viewvc?view=revision&revision=1621329"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- References
- Source code location

**Comments**
added Source Code Location
updated cvss3.0 to cvss 3.1
updated package name as per fix commit. 