### PR TITLE
[GHSA-c24v-8rfc-w8vw] Vite dev server option `server.fs.deny` can be bypassed when hosted on case-insensitive filesystem

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-c24v-8rfc-w8vw/GHSA-c24v-8rfc-w8vw.json
+++ b/advisories/github-reviewed/2024/01/GHSA-c24v-8rfc-w8vw/GHSA-c24v-8rfc-w8vw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c24v-8rfc-w8vw",
-  "modified": "2024-01-19T21:58:47Z",
+  "modified": "2024-01-19T21:58:48Z",
   "published": "2024-01-19T21:58:47Z",
   "aliases": [
     "CVE-2024-23331"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
security