### PR TITLE
[GHSA-r628-mhmh-qjhw] Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-r628-mhmh-qjhw/GHSA-r628-mhmh-qjhw.json
+++ b/advisories/github-reviewed/2021/08/GHSA-r628-mhmh-qjhw/GHSA-r628-mhmh-qjhw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r628-mhmh-qjhw",
-  "modified": "2023-03-09T16:44:57Z",
+  "modified": "2023-11-29T22:29:02Z",
   "published": "2021-08-03T19:00:40Z",
   "aliases": [
     "CVE-2021-32803"
@@ -20,17 +20,12 @@
         "ecosystem": "npm",
         "name": "tar"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(tar).Unpack"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.0.0"
             },
             {
               "fixed": "3.2.3"
@@ -43,11 +38,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "tar"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(tar).Unpack"
-        ]
       },
       "ranges": [
         {
@@ -68,11 +58,6 @@
         "ecosystem": "npm",
         "name": "tar"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(tar).Unpack"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -91,11 +76,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "tar"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(tar).Unpack"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Versions before 3.0.0 doesn't have directory cache, hence aren't affected by this vulnerability.
Version 3.0.0 introduced (dirCahce)[https://github.com/isaacs/node-tar/blob/v3.0.0/lib/unpack.js#L44].
While 2.2.2 uses includes only (extract.js)[https://github.com/isaacs/node-tar/blob/v2.2.2/lib/extract.js] which doesn't have any kind of cache. 