### PR TITLE
[GHSA-p6mc-m468-83gw] Prototype Pollution in lodash

### DIFF
--- a/advisories/github-reviewed/2020/07/GHSA-p6mc-m468-83gw/GHSA-p6mc-m468-83gw.json
+++ b/advisories/github-reviewed/2020/07/GHSA-p6mc-m468-83gw/GHSA-p6mc-m468-83gw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p6mc-m468-83gw",
-  "modified": "2023-10-24T20:06:48Z",
+  "modified": "2024-01-24T22:57:08Z",
   "published": "2020-07-15T19:15:48Z",
   "aliases": [
     "CVE-2020-8203"
@@ -19,16 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "lodash"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash).pick",
-          "(lodash).set",
-          "(lodash).setWith",
-          "(lodash).update",
-          "(lodash).updateWith",
-          "(lodash).zipObjectDeep"
-        ]
       },
       "ranges": [
         {
@@ -49,16 +39,6 @@
         "ecosystem": "npm",
         "name": "lodash-es"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash).pick",
-          "(lodash).set",
-          "(lodash).setWith",
-          "(lodash).update",
-          "(lodash).updateWith",
-          "(lodash).zipObjectDeep"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -67,31 +47,26 @@
               "introduced": "3.7.0"
             },
             {
-              "fixed": "4.17.19"
+              "fixed": "4.17.20"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.17.19"
+      }
     },
     {
       "package": {
         "ecosystem": "npm",
         "name": "lodash.pick"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.pick)"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
               "introduced": "3.7.0"
-            },
-            {
-              "fixed": "4.17.19"
             }
           ]
         }
@@ -102,20 +77,12 @@
         "ecosystem": "npm",
         "name": "lodash.set"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.set)"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
               "introduced": "3.7.0"
-            },
-            {
-              "fixed": "4.17.19"
             }
           ]
         }
@@ -126,20 +93,12 @@
         "ecosystem": "npm",
         "name": "lodash.setwith"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.setwith)"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
               "introduced": "3.7.0"
-            },
-            {
-              "fixed": "4.17.19"
             }
           ]
         }
@@ -150,20 +109,12 @@
         "ecosystem": "npm",
         "name": "lodash.update"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.update)"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
               "introduced": "3.7.0"
-            },
-            {
-              "fixed": "4.17.19"
             }
           ]
         }
@@ -174,20 +125,12 @@
         "ecosystem": "npm",
         "name": "lodash.updatewith"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.updatewith)"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
               "introduced": "3.7.0"
-            },
-            {
-              "fixed": "4.17.19"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Hello! lodash used to provide “per-method packages”(https://lodash.com/per-method-packages), such as lodash.set or lodash.pick but these are deprecated and most of them were discontinued after some time (between 4.0.1 and 4.10.2 of the “master” lodash package for most of them). For example, the last lodash.pick version is 4.4.0 and is 7 years old.
lodash.pick never received the fix from the upstream lodash package and thus is still and will always be vulnerable to CVE-2020-8203 You can get more precise information about the versions here https://deps.dev/advisory/osv/GHSA-p6mc-m468-83gw 
Thank you!