### PR TITLE
[GHSA-p6mc-m468-83gw] Prototype Pollution in lodash

### DIFF
--- a/advisories/github-reviewed/2020/07/GHSA-p6mc-m468-83gw/GHSA-p6mc-m468-83gw.json
+++ b/advisories/github-reviewed/2020/07/GHSA-p6mc-m468-83gw/GHSA-p6mc-m468-83gw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p6mc-m468-83gw",
-  "modified": "2023-10-24T20:06:48Z",
+  "modified": "2024-01-24T22:57:08Z",
   "published": "2020-07-15T19:15:48Z",
   "aliases": [
     "CVE-2020-8203"
@@ -19,16 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "lodash"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash).pick",
-          "(lodash).set",
-          "(lodash).setWith",
-          "(lodash).update",
-          "(lodash).updateWith",
-          "(lodash).zipObjectDeep"
-        ]
       },
       "ranges": [
         {
@@ -48,136 +38,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "lodash-es"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash).pick",
-          "(lodash).set",
-          "(lodash).setWith",
-          "(lodash).update",
-          "(lodash).updateWith",
-          "(lodash).zipObjectDeep"
-        ]
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.7.0"
-            },
-            {
-              "fixed": "4.17.19"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "lodash.pick"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.pick)"
-        ]
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.7.0"
-            },
-            {
-              "fixed": "4.17.19"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "lodash.set"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.set)"
-        ]
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.7.0"
-            },
-            {
-              "fixed": "4.17.19"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "lodash.setwith"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.setwith)"
-        ]
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.7.0"
-            },
-            {
-              "fixed": "4.17.19"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "lodash.update"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.update)"
-        ]
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.7.0"
-            },
-            {
-              "fixed": "4.17.19"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "lodash.updatewith"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash.updatewith)"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The mentioned per-method packages lodash.pick, lodash.set, lodash.setwith, lodash.update, lodash.updatewith are not correct. The mentioned patched versions of these packages do not exist. None of these packages exist with version 4.17.19 or newer.

See their versions here: https://www.npmjs.com/search?q=keywords:lodash-modularized