### PR TITLE
[GHSA-qq89-hq3f-393p] Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning using symbolic links

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-qq89-hq3f-393p/GHSA-qq89-hq3f-393p.json
+++ b/advisories/github-reviewed/2021/08/GHSA-qq89-hq3f-393p/GHSA-qq89-hq3f-393p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qq89-hq3f-393p",
-  "modified": "2021-08-31T16:02:04Z",
+  "modified": "2023-11-29T22:27:02Z",
   "published": "2021-08-31T16:05:17Z",
   "aliases": [
     "CVE-2021-37712"
@@ -20,17 +20,12 @@
         "ecosystem": "npm",
         "name": "tar"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(tar).Unpack"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.0.0"
             },
             {
               "fixed": "4.4.18"
@@ -43,11 +38,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "tar"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(tar).Unpack"
-        ]
       },
       "ranges": [
         {
@@ -67,11 +57,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "tar"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(tar).Unpack"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Versions before 3.0.0 doesn't have directory cache, hence aren't affected by this vulnerability.
Version 3.0.0 introduced (dirCahce)[https://github.com/isaacs/node-tar/blob/v3.0.0/lib/unpack.js#L44].
While 2.2.2 uses includes only (extract.js)[https://github.com/isaacs/node-tar/blob/v2.2.2/lib/extract.js] which doesn't have any kind of cache.