### PR TITLE
[GHSA-qq89-hq3f-393p] Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning using symbolic links

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-qq89-hq3f-393p/GHSA-qq89-hq3f-393p.json
+++ b/advisories/github-reviewed/2021/08/GHSA-qq89-hq3f-393p/GHSA-qq89-hq3f-393p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qq89-hq3f-393p",
-  "modified": "2021-08-31T16:02:04Z",
+  "modified": "2023-11-29T22:27:02Z",
   "published": "2021-08-31T16:05:17Z",
   "aliases": [
     "CVE-2021-37712"
@@ -20,17 +20,12 @@
         "ecosystem": "npm",
         "name": "tar"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(tar).Unpack"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.0.0"
             },
             {
               "fixed": "4.4.18"
@@ -43,11 +38,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "tar"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(tar).Unpack"
-        ]
       },
       "ranges": [
         {
@@ -67,11 +57,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "tar"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(tar).Unpack"
-        ]
       },
       "ranges": [
         {
@@ -103,11 +88,23 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/isaacs/node-tar/commit/2f1bca027286c23e110b8dfc7efc10756fa3db5a\""
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/isaacs/node-tar/commit/3aaf19b2501bbddb145d92b3322c80dcaed3c35f"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/isaacs/node-tar/commit/b6162c7fafe797f856564ef37f4b82747f051455"
     },
     {
       "type": "WEB",
       "url": "https://github.com/isaacs/node-tar/commit/bb93ba243746f705092905da1955ac3b0509ba1e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/isaacs/node-tar/commit/d56f790bda9fea807dd80c5083f24771dbdd6eb1"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
CVE-2021-37712 was fixed by two commits for each of the maintained branches
https://github.com/isaacs/node-tar/commit/bb93ba243746f705092905da1955ac3b0509ba1e - fixes `lib/path-reservations.js`, a functionality that was introduced in v4.4.16 hence irrelevant for earlier versions.
https://github.com/isaacs/node-tar/commit/2f1bca027286c23e110b8dfc7efc10756fa3db5a - fixes `lib/unpack.js`, a functionality that was introduced in v3.0.0, and caused other vulnerabilities like CVE-2021-32803.
Hence, to the best of my understanding this vulnerability affects versions 3.0.0 and above.