### PR TITLE
[GHSA-m5hf-m3r2-xq53] hutool-core was discovered to contain a stack overflow via NumberUtil.toBigDecimal method

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-m5hf-m3r2-xq53/GHSA-m5hf-m3r2-xq53.json
+++ b/advisories/github-reviewed/2023/12/GHSA-m5hf-m3r2-xq53/GHSA-m5hf-m3r2-xq53.json
@@ -25,17 +25,14 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "5.8.22"
             },
             {
-              "fixed": "5.8.24"
+              "last_affected": "5.8.24"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 5.8.23"
-      }
+      ]
     }
   ],
   "references": [

--- a/advisories/github-reviewed/2023/12/GHSA-m5hf-m3r2-xq53/GHSA-m5hf-m3r2-xq53.json
+++ b/advisories/github-reviewed/2023/12/GHSA-m5hf-m3r2-xq53/GHSA-m5hf-m3r2-xq53.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m5hf-m3r2-xq53",
-  "modified": "2024-01-04T22:08:13Z",
+  "modified": "2024-01-09T17:11:12Z",
   "published": "2023-12-27T21:31:01Z",
   "aliases": [
     "CVE-2023-51080"
   ],
   "summary": "hutool-core was discovered to contain a stack overflow via NumberUtil.toBigDecimal method",
-  "details": "The NumberUtil.toBigDecimal method in hutool-core v5.8.23 was discovered to contain a stack overflow.",
+  "details": "The NumberUtil.toBigDecimal method in hutool-core was discovered to contain a stack overflow.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,11 +28,14 @@
               "introduced": "5.8.22"
             },
             {
-              "last_affected": "5.8.24"
+              "fixed": "5.8.25"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 5.8.24"
+      }
     }
   ],
   "references": [
@@ -43,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/dromara/hutool/issues/3423"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/dromara/hutool/commit/c45b3fccdab453bb1c6007b52b18bd2fbdb68e99"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The new version 5.8.25 adds an additional assertion to prevent the stack overflow. I have tested the fix with the unit test provided in https://github.com/dromara/hutool/issues/3423.