### PR TITLE
[GHSA-c2cc-3569-6jh2] Path traversal in ZIPFoundation

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-c2cc-3569-6jh2/GHSA-c2cc-3569-6jh2.json
+++ b/advisories/github-reviewed/2023/08/GHSA-c2cc-3569-6jh2/GHSA-c2cc-3569-6jh2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c2cc-3569-6jh2",
-  "modified": "2023-09-06T21:05:41Z",
+  "modified": "2023-11-05T05:04:20Z",
   "published": "2023-08-31T00:30:17Z",
   "aliases": [
     "CVE-2023-39138"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.9.16"
+              "fixed": "0.9.18"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.9.17"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Updated affected version range and added patched version information. 

Path traversals and symlink escapes as described in CVE-2023-39138 were fixed with version 0.9.18 of ZIP Foundation: https://github.com/weichsel/ZIPFoundation/releases/tag/0.9.18