### PR TITLE
[GHSA-7mgx-gvjw-m3w3] CrateDB authentication bypass vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-7mgx-gvjw-m3w3/GHSA-7mgx-gvjw-m3w3.json
+++ b/advisories/github-reviewed/2024/01/GHSA-7mgx-gvjw-m3w3/GHSA-7mgx-gvjw-m3w3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7mgx-gvjw-m3w3",
-  "modified": "2024-01-30T18:43:26Z",
+  "modified": "2024-01-30T18:43:27Z",
   "published": "2024-01-30T03:30:30Z",
   "aliases": [
     "CVE-2023-51982"
@@ -9,7 +9,10 @@
   "summary": "CrateDB authentication bypass vulnerability",
   "details": "CrateDB 5.5.1 is contains an authentication bypass vulnerability in the Admin UI component. After configuring password authentication and_ Local_ In the case of an address, identity authentication can be bypassed by setting the X-Real IP request header to a specific value and accessing the Admin UI directly using the default user identity.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+    }
   ],
   "affected": [
     {
@@ -127,7 +130,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2024-01-30T18:43:26Z",
     "nvd_published_at": "2024-01-30T01:15:59Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
I am the author of this vulnerability. This vulnerability does not require any user interaction or permissions. You only need to add specific fields in the request header to obtain superuser permissions for the createDB database, which completely affects confidentiality. According to the CVSS score, it should be 7.5 points.