### PR TITLE
[GHSA-m535-fq8f-38fp] The Ruby Help Desk WordPress plugin before 1.3.4 does not...

### DIFF
--- a/advisories/unreviewed/2023/05/GHSA-m535-fq8f-38fp/GHSA-m535-fq8f-38fp.json
+++ b/advisories/unreviewed/2023/05/GHSA-m535-fq8f-38fp/GHSA-m535-fq8f-38fp.json
@@ -1,22 +1,52 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m535-fq8f-38fp",
-  "modified": "2023-05-02T09:30:17Z",
+  "modified": "2023-11-09T05:01:25Z",
   "published": "2023-05-02T09:30:17Z",
   "aliases": [
     "CVE-2023-1125"
   ],
+  "summary": "IDOR in Ruby Help Desk Wordpress plugin",
   "details": "The Ruby Help Desk WordPress plugin before 1.3.4 does not ensure that the ticket being modified belongs to the user making the request, allowing an attacker to close and/or add files and replies to tickets other than their own.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "ruby-help-desk"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.3.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-1125"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://plugins.trac.wordpress.org/browser/ruby-help-desk/trunk"
+    },
+    {
+      "type": "WEB",
+      "url": "https://plugins.trac.wordpress.org/changeset/2894569/"
     },
     {
       "type": "WEB",
@@ -27,7 +57,7 @@
     "cwe_ids": [
       "CWE-639"
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-05-02T08:15:09Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- References
- Severity
- Source code location
- Summary

**Comments**
- Added Affected/Patched version
- Added CVSS/CWE
- Added Links (source, diff-source)