### PR TITLE
[GHSA-h3qr-39j9-4r5v] Data written to GitHub Actions Cache may expose secrets

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-h3qr-39j9-4r5v/GHSA-h3qr-39j9-4r5v.json
+++ b/advisories/github-reviewed/2023/05/GHSA-h3qr-39j9-4r5v/GHSA-h3qr-39j9-4r5v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h3qr-39j9-4r5v",
-  "modified": "2023-05-01T13:42:44Z",
+  "modified": "2023-11-07T05:05:20Z",
   "published": "2023-05-01T13:42:44Z",
   "aliases": [
     "CVE-2023-30853"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "GitHub Actions",
-        "name": "gradle/gradle-build-action"
+        "name": ""
       },
       "ranges": [
         {
@@ -26,9 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "2.4.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
I received this alert but I don't use this version. Please don't send scary alerts that aren't relevant.