### PR TITLE
[GHSA-v2cv-wwxq-qq97] Moby Docker cp broken with debian containers

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-v2cv-wwxq-qq97/GHSA-v2cv-wwxq-qq97.json
+++ b/advisories/github-reviewed/2022/05/GHSA-v2cv-wwxq-qq97/GHSA-v2cv-wwxq-qq97.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v2cv-wwxq-qq97",
-  "modified": "2024-02-01T21:22:37Z",
+  "modified": "2024-02-01T21:22:39Z",
   "published": "2022-05-24T16:51:39Z",
   "aliases": [
     "CVE-2019-14271"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "20.10.0-beta1"
+              "fixed": "19.03.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Patched version is considered to be incorrect.
I consider 19.03.1 is the patched version, as shown in the description text and in the commit at the following URL.
https://github.com/moby/moby/commit/fa8dd90ceb7bcb9d554d27e0b9087ab83e54bd2b