### PR TITLE
[GHSA-2cjh-75gp-34gc] livewire Cross-Site Request Forgery vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-2cjh-75gp-34gc/GHSA-2cjh-75gp-34gc.json
+++ b/advisories/github-reviewed/2024/02/GHSA-2cjh-75gp-34gc/GHSA-2cjh-75gp-34gc.json
@@ -7,7 +7,7 @@
     "CVE-2024-22859"
   ],
   "summary": "livewire Cross-Site Request Forgery vulnerability",
-  "details": "Cross-Site Request Forgery (CSRF) vulnerability in livewire before v3.0.4, allows remote attackers to execute arbitrary code getCsrfToken function.",
+  "details": "> Cross-Site Request Forgery (CSRF) vulnerability in livewire before v3.0.4, allows remote attackers to execute arbitrary code getCsrfToken function.\n\nReading the advisories this only affects livewire v3 and not v2. This advisory is hence too broad as it also includes v2.\nSuggesting to reduce the scope to only livewire v3",
   "severity": [
 
   ],


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Exclude livewire v2 from this advisory

**Edit**
I see that my reasoning from the form isn't included. So I'll add it again.

Reading the advisories it can be tracked back to a commit on the v3 tag of livewire. As such this would mean that v2 is unaffected.
Currently this advisory is scoped to also include v2, which doesn't seem correct following the above reasoning.