### PR TITLE
[GHSA-jfh8-c2jp-5v3q] Remote code injection in Log4j

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-jfh8-c2jp-5v3q/GHSA-jfh8-c2jp-5v3q.json
+++ b/advisories/github-reviewed/2021/12/GHSA-jfh8-c2jp-5v3q/GHSA-jfh8-c2jp-5v3q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jfh8-c2jp-5v3q",
-  "modified": "2022-03-25T20:56:18Z",
+  "modified": "2023-09-19T22:21:22Z",
   "published": "2021-12-10T00:40:56Z",
   "aliases": [
     "CVE-2021-44228"
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0-beta9"
             },
             {
               "fixed": "2.3.1"
@@ -121,6 +121,74 @@
     },
     {
       "type": "WEB",
+      "url": "https://logging.apache.org/log4j/2.x/manual/lookups.html#JndiLookup"
+    },
+    {
+      "type": "WEB",
+      "url": "https://logging.apache.org/log4j/2.x/manual/migration.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://logging.apache.org/log4j/2.x/security.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://msrc-blog.microsoft.com/2021/12/11/microsofts-response-to-cve-2021-44228-apache-log4j2/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.netapp.com/advisory/ntap-20211210-0007/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://support.apple.com/kb/HT213189"
+    },
+    {
+      "type": "WEB",
+      "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd"
+    },
+    {
+      "type": "WEB",
+      "url": "https://twitter.com/kurtseifried/status/1469345530182455296"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.bentley.com/en/common-vulnerability-exposure/be-2022-0001"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.debian.org/security/2021/dsa-5020"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00646.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.kb.cert.org/vuls/id/930724"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.nu11secur1ty.com/2021/12/cve-2021-44228.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/alert-cve-2021-44228.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpuapr2022.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpujan2022.html"
+    },
+    {
+      "type": "WEB",
       "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-397453.pdf"
     },
     {
@@ -190,74 +258,6 @@
     {
       "type": "WEB",
       "url": "https://logging.apache.org/log4j/2.x/changes-report.html#a2.15.0"
-    },
-    {
-      "type": "WEB",
-      "url": "https://logging.apache.org/log4j/2.x/manual/lookups.html#JndiLookup"
-    },
-    {
-      "type": "WEB",
-      "url": "https://logging.apache.org/log4j/2.x/manual/migration.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://logging.apache.org/log4j/2.x/security.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://msrc-blog.microsoft.com/2021/12/11/microsofts-response-to-cve-2021-44228-apache-log4j2/"
-    },
-    {
-      "type": "WEB",
-      "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032"
-    },
-    {
-      "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20211210-0007/"
-    },
-    {
-      "type": "WEB",
-      "url": "https://support.apple.com/kb/HT213189"
-    },
-    {
-      "type": "WEB",
-      "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd"
-    },
-    {
-      "type": "WEB",
-      "url": "https://twitter.com/kurtseifried/status/1469345530182455296"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.bentley.com/en/common-vulnerability-exposure/be-2022-0001"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.debian.org/security/2021/dsa-5020"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00646.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.kb.cert.org/vuls/id/930724"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.nu11secur1ty.com/2021/12/cve-2021-44228.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/alert-cve-2021-44228.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpuapr2022.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpujan2022.html"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to https://logging.apache.org/log4j/2.x/security.html , CVE-2021-44228 is occuring at and after 2.0-beta9, the version from 2.0-alpha1 to 2.0-beta8 is not afftected by this.