### PR TITLE
[GHSA-9gh8-877r-g477] Beetl Server-Side Template Injection vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-9gh8-877r-g477/GHSA-9gh8-877r-g477.json
+++ b/advisories/github-reviewed/2024/02/GHSA-9gh8-877r-g477/GHSA-9gh8-877r-g477.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9gh8-877r-g477",
-  "modified": "2024-02-02T18:10:29Z",
+  "modified": "2024-02-02T18:10:31Z",
   "published": "2024-02-02T03:30:32Z",
   "aliases": [
     "CVE-2024-22533"
   ],
   "summary": "Beetl Server-Side Template Injection vulnerability",
-  "details": "Before Beetl v3.15.12, the rendering template has a server-side template injection (SSTI) vulnerability. When the incoming template is controllable, it will be filtered by the DefaultNativeSecurityManager blacklist. Because blacklist filtering is not strict, the blacklist can be bypassed, leading to arbitrary code execution.",
+  "details": "Before Beetl v3.15.13.RELEASE, the rendering template has a server-side template injection (SSTI) vulnerability. When the incoming template is controllable, it will be filtered by the DefaultNativeSecurityManager blacklist. Because blacklist filtering is not strict, the blacklist can be bypassed, leading to arbitrary code execution.",
   "severity": [
 
   ],
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "com.ibeetl:beetl"
+        "name": "com.ibeetl:beetl-core"
       },
       "ranges": [
         {
@@ -25,7 +25,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "3.15.12"
+              "fixed": "3.15.13.RELEASE"
             }
           ]
         }
@@ -48,7 +48,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-1336"
     ],
     "severity": "MODERATE",
     "github_reviewed": true,


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- Description

**Comments**
Checking the Issue, it states that versions including 3.15.12 are affected.
Checking the affected source code shows that it is under the beetl-core.