### PR TITLE
[GHSA-34q3-p352-c7q8] Central Dogma Authentication Bypass Vulnerability via Session Leakage

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-34q3-p352-c7q8/GHSA-34q3-p352-c7q8.json
+++ b/advisories/github-reviewed/2024/02/GHSA-34q3-p352-c7q8/GHSA-34q3-p352-c7q8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-34q3-p352-c7q8",
-  "modified": "2024-02-02T16:55:25Z",
+  "modified": "2024-02-02T16:55:27Z",
   "published": "2024-02-02T16:55:25Z",
   "aliases": [
     "CVE-2024-1143"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N"
     }
   ],
   "affected": [
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.64.0"
+              "fixed": "0.64.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS

**Comments**
The original documentation was not correct so I fixed it.
https://github.com/line/centraldogma/security/advisories/GHSA-34q3-p352-c7q8