### PR TITLE
[GHSA-qf9m-vfgh-m389] FastAPI Content-Type Header ReDoS

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-qf9m-vfgh-m389/GHSA-qf9m-vfgh-m389.json
+++ b/advisories/github-reviewed/2024/02/GHSA-qf9m-vfgh-m389/GHSA-qf9m-vfgh-m389.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qf9m-vfgh-m389",
-  "modified": "2024-02-05T17:01:54Z",
+  "modified": "2024-02-05T17:01:55Z",
   "published": "2024-02-05T17:01:54Z",
   "aliases": [
     "CVE-2024-24762"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -64,7 +64,7 @@
     "cwe_ids": [
       "CWE-400"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2024-02-05T17:01:54Z",
     "nvd_published_at": "2024-02-05T15:15:09Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
This vulnerability, and it's fix, is actually in the underlying `python-multipart` library. This library is independent of `fastapi` and can be updated separately. The same can be said of the identical report at https://github.com/advisories/GHSA-93gm-qmq6-w238

It is quite unhelpful to have a security advisory that is not linked to the root cause.