### PR TITLE
[GHSA-cqpc-x2c6-2gmf] Unsecured WMS dynamic styling sld=<url> parameter affords blind unauthenticated SSRF

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-cqpc-x2c6-2gmf/GHSA-cqpc-x2c6-2gmf.json
+++ b/advisories/github-reviewed/2023/10/GHSA-cqpc-x2c6-2gmf/GHSA-cqpc-x2c6-2gmf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cqpc-x2c6-2gmf",
-  "modified": "2023-11-01T06:11:55Z",
+  "modified": "2023-11-10T05:04:21Z",
   "published": "2023-10-24T19:20:34Z",
   "aliases": [
     "CVE-2023-41339"
@@ -38,6 +38,44 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.geoserver:gs-wms"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.23.0"
+            },
+            {
+              "fixed": "2.23.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.geoserver.web:gs-web-app:war"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.22.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.geoserver.web:gs-web-app:war"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The war file is an artifact of the project and includes/embeds the vulnerable library and actually provides the WMS endpoint.
When used as a dependency in eg. Maven War overlays the .war dependency is not flagged by tooling such as Dependabot because the war file is not marked as vulnerable, while it is.