### PR TITLE
fix(GHSA-4crw-w8pw-2hmf): add fixed version to CVE-2022-4122

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-4crw-w8pw-2hmf/GHSA-4crw-w8pw-2hmf.json
+++ b/advisories/github-reviewed/2022/12/GHSA-4crw-w8pw-2hmf/GHSA-4crw-w8pw-2hmf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4crw-w8pw-2hmf",
-  "modified": "2022-12-12T20:44:49Z",
+  "modified": "2024-02-07T15:32:00Z",
   "published": "2022-12-08T18:30:50Z",
   "aliases": [
     "CVE-2022-4122"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "4.3.1"
+              "fixed": "4.5.0"
             }
           ]
         }
@@ -54,6 +54,7 @@
       "CWE-59"
     ],
     "severity": "MODERATE",
+    "last_known_affected_version_range": "< 4.5.0",
     "github_reviewed": true,
     "github_reviewed_at": "2022-12-08T23:39:14Z",
     "nvd_published_at": "2022-12-08T16:15:00Z"


### PR DESCRIPTION
Updates:

    Fix version of GHSA-4crw-w8pw-2hmf

Comments
This vulnerability has been patched in [https://github.com/containers/podman/pull/16315](https://github.com/containers/podman/pull/16315) and released in version `4.5.0` as per [this](
https://github.com/containers/podman/commits/v4.5.0/?after=75e3c12579d391b81d871fd1cded6cf0d043550a+139). Therefore this PR is aimed to add the fix version for this vulnerability. Thanks!