### PR TITLE
[GHSA-4vhj-98r6-424h] In Bouncy Castle JCE Provider it is possible to inject extra elements in the sequence making up the signature and still have it validate

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-4vhj-98r6-424h/GHSA-4vhj-98r6-424h.json
+++ b/advisories/github-reviewed/2018/10/GHSA-4vhj-98r6-424h/GHSA-4vhj-98r6-424h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4vhj-98r6-424h",
-  "modified": "2022-04-27T13:26:47Z",
+  "modified": "2023-11-10T05:00:48Z",
   "published": "2018-10-17T16:23:26Z",
   "aliases": [
     "CVE-2016-1000338"
@@ -32,7 +32,10 @@
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.5.6"
+      }
     },
     {
       "package": {

--- a/advisories/github-reviewed/2018/10/GHSA-4vhj-98r6-424h/GHSA-4vhj-98r6-424h.json
+++ b/advisories/github-reviewed/2018/10/GHSA-4vhj-98r6-424h/GHSA-4vhj-98r6-424h.json
@@ -32,15 +32,31 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 1.5.6"
-      }
+      ]
     },
     {
       "package": {
         "ecosystem": "Maven",
         "name": "org.bouncycastle:bcprov-jdk15"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.5.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.bouncycastle:bcprov-jdk14"
       },
       "ranges": [
         {

--- a/advisories/github-reviewed/2018/10/GHSA-4vhj-98r6-424h/GHSA-4vhj-98r6-424h.json
+++ b/advisories/github-reviewed/2018/10/GHSA-4vhj-98r6-424h/GHSA-4vhj-98r6-424h.json
@@ -47,26 +47,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.5.6"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.bouncycastle:bcprov-jdk14"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.5.6"
+              "fixed": "1.56"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
small error in version . was Affected Version < 1.56, should be < 1.5.6