### PR TITLE
[GHSA-cgr9-h9qq-x9fx] Authentication Bypass via 3rd party TYPO3 extension 'salted user password hashes'

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-cgr9-h9qq-x9fx/GHSA-cgr9-h9qq-x9fx.json
+++ b/advisories/github-reviewed/2022/05/GHSA-cgr9-h9qq-x9fx/GHSA-cgr9-h9qq-x9fx.json
@@ -1,28 +1,24 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cgr9-h9qq-x9fx",
-  "modified": "2024-02-07T22:30:03Z",
+  "modified": "2024-02-08T18:36:06Z",
   "published": "2022-05-02T06:18:14Z",
   "aliases": [
     "CVE-2010-1022"
   ],
-  "summary": "TYPO3 Authentication Bypass via Salted user password hashes extension",
+  "summary": "Authentication Bypass via 3rd party TYPO3 extension 'salted user password hashes'",
   "details": "The TYPO3 Security - Salted user password hashes (t3sec_saltedpw) extension before 0.2.13 for TYPO3 allows remote attackers to bypass authentication via unspecified vectors.",
   "severity": [
 
   ],
   "affected": [
     {
-      "package": {
-        "ecosystem": "Packagist",
-        "name": "typo3/cms-saltedpasswords"
-      },
       "ranges": [
         {
-          "type": "ECOSYSTEM",
+          "type": "SEMVER",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.1.1"
             },
             {
               "fixed": "0.2.13"
@@ -39,7 +35,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/TYPO3-CMS/saltedpasswords"
+      "url": "https://extensions.typo3.org/extension/t3sec_saltedpw"
     },
     {
       "type": "WEB",
@@ -55,7 +51,7 @@
     },
     {
       "type": "WEB",
-      "url": "http://typo3.org/teams/security/security-bulletins/typo3-sa-2010-006/"
+      "url": "https://typo3.org/security/advisory/typo3-sa-2010-006"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
* `ext:t3sec_saltedpw` is a different package in a custom ecosystem at https://extensions.typo3.org/ (not registered with OSV.dev)
* package `composer:typo3/cms-saltedpasswords` is NOT the same
* at the time of the original advisory in 2010, the Composer ecosystem did not exist yet (Composer was established in 2012)