### PR TITLE
[GHSA-2cjh-75gp-34gc] livewire Cross-Site Request Forgery vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-2cjh-75gp-34gc/GHSA-2cjh-75gp-34gc.json
+++ b/advisories/github-reviewed/2024/02/GHSA-2cjh-75gp-34gc/GHSA-2cjh-75gp-34gc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2cjh-75gp-34gc",
-  "modified": "2024-02-06T20:00:20Z",
+  "modified": "2024-02-06T20:00:21Z",
   "published": "2024-02-01T09:30:18Z",
   "aliases": [
     "CVE-2024-22859"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -53,7 +53,7 @@
     "cwe_ids": [
       "CWE-352"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2024-02-01T19:21:55Z",
     "nvd_published_at": "2024-02-01T07:15:08Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
This does not appear to be an actual vulnerability. 

The referenced commit is fixing a CSRF expiring issue, which was causing 419 errors and I cannot see how it could possibly be used for a CSRF attack. 

All of the changes are within the front end javascript, which is outside scope of CSRF, and relate to loading a fresh CSRF token from the HTML, rather than reusing the same token, which may have expired since it was retrieved.

Is there any way to get the entire CVE removed?