### PR TITLE
[GHSA-7wh2-wxc7-9ph5] WiX Toolset's .be TEMP folder is vulnerable to DLL redirection attacks that allow the attacker to escalate privileges

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-7wh2-wxc7-9ph5/GHSA-7wh2-wxc7-9ph5.json
+++ b/advisories/github-reviewed/2024/02/GHSA-7wh2-wxc7-9ph5/GHSA-7wh2-wxc7-9ph5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7wh2-wxc7-9ph5",
-  "modified": "2024-02-08T18:23:49Z",
+  "modified": "2024-02-08T18:23:50Z",
   "published": "2024-02-08T18:23:49Z",
   "aliases": [
     "CVE-2024-24810"
@@ -35,6 +35,28 @@
       ],
       "database_specific": {
         "last_known_affected_version_range": "<= 4.0.3"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "WiX"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.14.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.13.0"
       }
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
according to https://github.com/wixtoolset/issues/security/advisories/GHSA-7wh2-wxc7-9ph5 3.14.0 has also been patched, so should not be affected by the vulnerability?