### PR TITLE
[GHSA-5v34-g2px-j4fw] Improper Handling of Length Parameter Inconsistency in Apache Ant

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-5v34-g2px-j4fw/GHSA-5v34-g2px-j4fw.json
+++ b/advisories/github-reviewed/2021/08/GHSA-5v34-g2px-j4fw/GHSA-5v34-g2px-j4fw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5v34-g2px-j4fw",
-  "modified": "2022-02-08T21:08:25Z",
+  "modified": "2023-01-27T05:02:44Z",
   "published": "2021-08-02T16:56:31Z",
   "aliases": [
     "CVE-2021-36374"
@@ -52,6 +52,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "ant:ant"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.7.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It looks ant was moved from ant repo and the vulnerability also impacts ant:ant 1.7.0 and bellow.