### PR TITLE
[GHSA-88qh-8c27-5f9w] rc before 1.7.1-5 insecurely creates temporary files.

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-88qh-8c27-5f9w/GHSA-88qh-8c27-5f9w.json
+++ b/advisories/unreviewed/2022/05/GHSA-88qh-8c27-5f9w/GHSA-88qh-8c27-5f9w.json
@@ -1,17 +1,39 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-88qh-8c27-5f9w",
-  "modified": "2022-05-17T19:57:04Z",
+  "modified": "2023-01-28T05:04:36Z",
   "published": "2022-05-17T19:57:04Z",
   "aliases": [
     "CVE-2014-1936"
   ],
+  "summary": "rc before 1.7.1-5 insecurely creates temporary files.",
   "details": "rc before 1.7.1-5 insecurely creates temporary files.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "rc"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.7.1-5"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -35,7 +57,7 @@
     "cwe_ids": [
 
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2019-11-21T15:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Summary

**Comments**
Package name and version range not listed. Severity added per NIST: https://nvd.nist.gov/vuln/detail/CVE-2014-1936