### PR TITLE
[GHSA-78xj-cgh5-2h22] NPM IP package vulnerable to Server-Side Request Forgery (SSRF) attacks

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
+++ b/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-78xj-cgh5-2h22",
-  "modified": "2024-02-09T15:12:06Z",
+  "modified": "2024-02-09T15:12:07Z",
   "published": "2024-02-08T18:30:39Z",
   "aliases": [
     "CVE-2023-42282"
@@ -25,7 +25,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.1.8"
+              "last_affected": "2.0.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Version 2.0.0 is vulnerable as well