### PR TITLE
Improve GHSA-gwrp-pvrq-jmwv

### DIFF
--- a/advisories/github-reviewed/2021/04/GHSA-gwrp-pvrq-jmwv/GHSA-gwrp-pvrq-jmwv.json
+++ b/advisories/github-reviewed/2021/04/GHSA-gwrp-pvrq-jmwv/GHSA-gwrp-pvrq-jmwv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gwrp-pvrq-jmwv",
-  "modified": "2024-02-02T21:08:27Z",
+  "modified": "2024-02-09T03:22:15Z",
   "published": "2021-04-26T16:04:00Z",
   "aliases": [
     "CVE-2021-29425"
@@ -29,6 +29,177 @@
             },
             {
               "fixed": "2.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.cosium.vet:vet"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.0"
+            },
+            {
+              "last_affected": "3.22"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.diamondq.common:common-thirdparty.jcasbin"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.4.0"
+            },
+            {
+              "last_affected": "1.4.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.liferay:com.liferay.sass.compiler.jsass"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.0.1"
+            },
+            {
+              "last_affected": "1.0.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.virjar:ratel-api"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.0.0"
+            },
+            {
+              "last_affected": "1.3.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "net.hasor:cobble-lang"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.4.1"
+            },
+            {
+              "last_affected": "4.6.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.commons:commons-io"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.3.2"
+            },
+            {
+              "last_affected": "1.3.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.servicemix.bundles:org.apache.servicemix.bundles.commons-io"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.4_3"
+            },
+            {
+              "last_affected": "1.4_3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.checkerframework.annotatedlib:commons-io"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6"
+            },
+            {
+              "fixed": "2.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.smartboot.servlet:servlet-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.1.9"
+            },
+            {
+              "last_affected": "0.6"
             }
           ]
         }
@@ -227,6 +398,14 @@
     {
       "type": "WEB",
       "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+    },
+    {
+      "type": "EVIDENCE",
+      "url": "https://github.com/jensdietrich/xshady-release/tree/main/CVE-2021-29425"
+    },
+    {
+      "type": "WEB",
+      "url": "https://arxiv.org/pdf/2306.05534.pdf"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Several other components are also affected as a result of cloning (copying source code) or shading (copying source code and renaming packages). Proof-of-Vulnerability projects with tests to verify the presence of the CVE can be found here: https://github.com/jensdietrich/xshady-release/.

See https://github.com/github/advisory-database/pull/2258, especially https://github.com/github/advisory-database/pull/2258#issuecomment-1569073245, for more details.

(This PR is a second attempt at #3442, which went wrong due to a bad merge. Thanks @darakian for clarifying how `last_affected` should be applied.)