### PR TITLE
[GHSA-qf9m-vfgh-m389] FastAPI Content-Type Header ReDoS

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-qf9m-vfgh-m389/GHSA-qf9m-vfgh-m389.json
+++ b/advisories/github-reviewed/2024/02/GHSA-qf9m-vfgh-m389/GHSA-qf9m-vfgh-m389.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qf9m-vfgh-m389",
-  "modified": "2024-02-05T17:01:54Z",
+  "modified": "2024-02-05T17:01:55Z",
   "published": "2024-02-05T17:01:54Z",
   "aliases": [
     "CVE-2024-24762"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "PyPI",
-        "name": "fastapi"
+        "name": "python-multipart"
       },
       "ranges": [
         {
@@ -28,13 +28,13 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.109.1"
+              "fixed": "0.0.7"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 0.109.0"
+        "last_known_affected_version_range": "<= 0.0.6"
       }
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The vulnerability isn't in fastapi's code rather than python-multipart, and GHSA-2jv5-9r88-3w3p is a duplicate.
Notice that the fix of fastapi was to update python-multipart - https://github.com/tiangolo/fastapi/commit/9d34ad0ee8a0dfbbcce06f76c2d5d851085024fc
While python-multipart actually fixed the vulnerability - https://github.com/Kludex/python-multipart/commit/20f0ef6b4e4caf7d69a667c54dff57fe467109a4
