### PR TITLE
[GHSA-m7xj-ccqc-p4g2] Directory traversal vulnerability in Apache Tomcat 4.1.0...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-m7xj-ccqc-p4g2/GHSA-m7xj-ccqc-p4g2.json
+++ b/advisories/unreviewed/2022/05/GHSA-m7xj-ccqc-p4g2/GHSA-m7xj-ccqc-p4g2.json
@@ -1,17 +1,74 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m7xj-ccqc-p4g2",
-  "modified": "2022-05-01T23:55:04Z",
+  "modified": "2023-02-20T05:05:40Z",
   "published": "2022-05-01T23:55:04Z",
   "aliases": [
     "CVE-2008-2938"
   ],
+  "summary": "CVE-2008-2938",
   "details": "Directory traversal vulnerability in Apache Tomcat 4.1.0 through 4.1.37, 5.5.0 through 5.5.26, and 6.0.0 through 6.0.16, when allowLinking and UTF-8 are enabled, allows remote attackers to read arbitrary files via encoded directory traversal sequences in the URI, a different vulnerability than CVE-2008-2370.  NOTE: versions earlier than 6.0.18 were reported affected, but the vendor advisory lists 6.0.16 as the last affected version.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "apache/tomcat"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.1.0"
+            },
+            {
+              "fixed": "<= 4.1.37"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "apache/tomcat"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.5.0"
+            },
+            {
+              "fixed": "<= 5.5.26"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "apache/tomcat"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "<= 6.0.16"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -21,6 +78,10 @@
     {
       "type": "WEB",
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/44411"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
add patch commit https://github.com/apache/tomcat/commit/150bc791ac3ba40081425dd1c37a053fbb02b339, the msg shows it is a fix for this cve.