### PR TITLE
[GHSA-678x-xfp4-r92r] Apache Geronimo Application Server CSRF vulnerabilities

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-678x-xfp4-r92r/GHSA-678x-xfp4-r92r.json
+++ b/advisories/github-reviewed/2022/05/GHSA-678x-xfp4-r92r/GHSA-678x-xfp4-r92r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-678x-xfp4-r92r",
-  "modified": "2022-07-29T19:50:15Z",
+  "modified": "2023-01-27T05:02:34Z",
   "published": "2022-05-02T03:12:31Z",
   "aliases": [
     "CVE-2009-0039"
@@ -38,8 +38,20 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2009-0039"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/geronimo/commit/67dda0760bb0925ead201ddd5d809ff53686d63f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/geronimo/commit/aa0c2c26dde8930cad924796af7c17a13d236b16"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/geronimo/commit/f8a612df7b06729bfd6c826e1a110d4bb40dc1f5"
+    },
+    {
       "type": "PACKAGE",
-      "url": "https://svn.apache.org/viewvc/geronimo/server"
+      "url": "https://github.com/apache/geronimo"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
add 3 patches:
https://github.com/apache/geronimo/commit/aa0c2c26dde8930cad924796af7c17a13d236b16
https://github.com/apache/geronimo/commit/67dda0760bb0925ead201ddd5d809ff53686d63f
https://github.com/apache/geronimo/commit/f8a612df7b06729bfd6c826e1a110d4bb40dc1f5.
the msg shows it.