### PR TITLE
[GHSA-j65f-mvgw-prp2] Deserialization of Untrusted Data in Apache OpenJPA

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-j65f-mvgw-prp2/GHSA-j65f-mvgw-prp2.json
+++ b/advisories/github-reviewed/2022/05/GHSA-j65f-mvgw-prp2/GHSA-j65f-mvgw-prp2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j65f-mvgw-prp2",
-  "modified": "2022-07-08T19:03:11Z",
+  "modified": "2023-01-27T05:02:14Z",
   "published": "2022-05-14T03:30:19Z",
   "aliases": [
     "CVE-2013-1768"
@@ -55,6 +55,42 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-1768"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/openjpa/commit/01bc0d257b38743372af91cb88269524634db7d3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/openjpa/commit/4487017fbf57fb7aed4024e0991850bb89fc1c43"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/openjpa/commit/521fecd2d9b91c27e9f90d97e5f5479d17239eb8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/openjpa/commit/7f14c7df6b7c7ef42f0671138b9b5dd062fe99aa"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/openjpa/commit/87a4452be08b4f97274d0ccfac585ae85841e470"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/openjpa/commit/ad5cd6fb86af8809b367f709b6e041218055de2f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/openjpa/commit/b8933dc24b84e7e7430ece56bd645d425dd89f24"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/openjpa/commit/d3c68ad3bb9aa0e4e9abbfdec691abb06df642a5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/openjpa/commit/f4ca597b9a7000a88ad6bbe556283247e9f6bc14"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
add 9 patch commits:
https://github.com/apache/openjpa/commit/87a4452be08b4f97274d0ccfac585ae85841e470
https://github.com/apache/openjpa/commit/521fecd2d9b91c27e9f90d97e5f5479d17239eb8
https://github.com/apache/openjpa/commit/d3c68ad3bb9aa0e4e9abbfdec691abb06df642a5
https://github.com/apache/openjpa/commit/01bc0d257b38743372af91cb88269524634db7d3
https://github.com/apache/openjpa/commit/f4ca597b9a7000a88ad6bbe556283247e9f6bc14
https://github.com/apache/openjpa/commit/b8933dc24b84e7e7430ece56bd645d425dd89f24
https://github.com/apache/openjpa/commit/ad5cd6fb86af8809b367f709b6e041218055de2f
https://github.com/apache/openjpa/commit/4487017fbf57fb7aed4024e0991850bb89fc1c43
https://github.com/apache/openjpa/commit/7f14c7df6b7c7ef42f0671138b9b5dd062fe99aa

The msg shows "	
[CVE-2013-1768] Disable logging during brokerfactory de-serialization.  Added type checking of plugin values."