### PR TITLE
[GHSA-w6x2-jg8h-p6mp] Path Traversal in TYPO3 File Abstraction Layer Storages

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-w6x2-jg8h-p6mp/GHSA-w6x2-jg8h-p6mp.json
+++ b/advisories/github-reviewed/2024/02/GHSA-w6x2-jg8h-p6mp/GHSA-w6x2-jg8h-p6mp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w6x2-jg8h-p6mp",
-  "modified": "2024-02-13T19:08:10Z",
+  "modified": "2024-02-13T19:08:11Z",
   "published": "2024-02-13T19:08:10Z",
   "aliases": [
     "CVE-2023-30451"
@@ -159,15 +159,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/TYPO3/typo3/commit/38f0bf9a61e10365be26eb75bc23a81184dbed07"
+      "url": "https://github.com/TYPO3/typo3/commit/205115cca3d67594a12d0195c937da0e51eb494a"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/TYPO3/typo3/commit/71e652bf84b16fd3592205f61f36750ab03db74c"
+      "url": "https://github.com/TYPO3/typo3/commit/78fb9287a2f0487c39288070cb0493a5265f1789"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/TYPO3/typo3/commit/b47b6ddf5a5f3f852c6e43f837360780c12e3c47"
+      "url": "https://github.com/TYPO3/typo3/commit/accf537c7379b4359bc0f957c4d0c07baddd710a"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adjusted Git commit references...
(each of those commits references back to the CVE `Security-References: CVE-2023-30451`)