### PR TITLE
[GHSA-3w4h-r27h-4r2w] TYPO3 8.x before 8.7.25 and 9.x before 9.5.6 allows...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-3w4h-r27h-4r2w/GHSA-3w4h-r27h-4r2w.json
+++ b/advisories/unreviewed/2022/05/GHSA-3w4h-r27h-4r2w/GHSA-3w4h-r27h-4r2w.json
@@ -1,17 +1,64 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3w4h-r27h-4r2w",
-  "modified": "2022-05-24T21:59:47Z",
+  "modified": "2023-01-30T05:04:07Z",
   "published": "2022-05-24T21:59:47Z",
   "aliases": [
     "CVE-2019-11832"
   ],
-  "details": "TYPO3 8.x before 8.7.25 and 9.x before 9.5.6 allows remote code execution because it does not properly configure the applications used for image processing, as demonstrated by ImageMagick or GraphicsMagick.",
+  "summary": "TYPO3 Image Processing susceptible to Code Execution",
+  "details": "TYPO3 8.x before 8.7.25 and 9.x before 9.5.6 is susceptible to remote code execution because it does not properly configure the applications used for image processing, as demonstrated by ImageMagick or GraphicsMagick.\nFor a successful exploit, the GhostScript binary `gs` must be available on the server system.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "typo3/cms-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.0"
+            },
+            {
+              "fixed": "9.5.6"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 9.5.5"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "typo3/cms-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.0.0"
+            },
+            {
+              "fixed": "8.7.25"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 8.7.24"
+      }
+    }
   ],
   "references": [
     {
@@ -20,12 +67,25 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/TYPO3/typo3/commit/2c04eeac44733fda491f92c697f88c1337d19c79"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/TYPO3/typo3/commit/51fdb774a57ee30e8d60c0e33b4a0b92d775739e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/TYPO3/typo3/commit/e845d90b82b2f72ab12a9e37f15082297832beca"
+    },
+    {
+      "type": "WEB",
       "url": "https://typo3.org/security/advisory/typo3-core-sa-2019-012/"
     }
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-20",
+      "CWE-94"
     ],
     "severity": "HIGH",
     "github_reviewed": false,


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- References
- Summary

**Comments**
* moving from unreviewed → reviewed
* adjusted description (the exploit actually requires the `gs` binary on the web server to be successful)
* added Git commits