### PR TITLE
[GHSA-78xj-cgh5-2h22] NPM IP package vulnerable to Server-Side Request Forgery (SSRF) attacks

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
+++ b/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-78xj-cgh5-2h22",
-  "modified": "2024-02-12T20:17:03Z",
+  "modified": "2024-02-12T20:17:09Z",
   "published": "2024-02-08T18:30:39Z",
   "aliases": [
     "CVE-2023-42282"
   ],
-  "summary": "NPM IP package vulnerable to Server-Side Request Forgery (SSRF) attacks",
-  "details": "An issue in all published versions of the NPM package `ip` allows an attacker to execute arbitrary code and obtain sensitive information via the `isPublic()` function. This can lead to potential Server-Side Request Forgery (SSRF) attacks. The core issue is the function's failure to accurately distinguish between public and private IP addresses.",
+  "summary": "NPM IP package incorrectly identifies some private IP addresses as public",
+  "details": "The `isPublic()` function of all published versions of the NPM package `ip` doesn't correctly identity certain private IP addresses in uncommon formats such as `0x7F.1` as private. Instead, it reports them as public by returning `true`. This can lead to security issues such as Server-Side Request Forgery (SSRF) if `isPublic()` is used to protect sensitive code paths when passed user input.",
   "severity": [
 
   ],
@@ -58,7 +58,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-02-09T15:03:18Z",
     "nvd_published_at": "2024-02-08T17:15:10Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Severity
- Summary

**Comments**
The original report mentions remote code execution, private data exfiltration and SSRF. The issue in `ip` doesn't actually cause any of these. The core issue is that in some cases `isPublic()` reports some private ip addresses as public. If this function is used to protect critical code paths and is given user input then an attacker could do something to those critical code paths.

I believe that the original description and score are a bit alarmist giving the impression that everyone using the lib or even function is vulnerable when in reality the function has a bug if when used in secured context that can be an issue. I think that most projects that depend on this lib directly or transitively are not actually vulnerable in any way and having such a score and description generates un-needed panic and work for all their maintainers.