### PR TITLE
[GHSA-fq6h-4g8v-qqvm] CKEditor4 Cross-site Scripting vulnerability caused by incorrect CDATA detection

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-fq6h-4g8v-qqvm/GHSA-fq6h-4g8v-qqvm.json
+++ b/advisories/github-reviewed/2024/02/GHSA-fq6h-4g8v-qqvm/GHSA-fq6h-4g8v-qqvm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fq6h-4g8v-qqvm",
-  "modified": "2024-02-07T20:23:50Z",
+  "modified": "2024-02-07T20:23:51Z",
   "published": "2024-02-07T17:30:37Z",
   "aliases": [
     "CVE-2024-24815"
@@ -29,6 +29,25 @@
             },
             {
               "fixed": "4.24.0-lts"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "ckeditor/ckeditor"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.24.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
ckeditor is also a Composer package