### PR TITLE
[GHSA-xvc9-xwgj-4cq9] Integer Overflow in HeaderMap::reserve() can cause Denial of Service

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-xvc9-xwgj-4cq9/GHSA-xvc9-xwgj-4cq9.json
+++ b/advisories/github-reviewed/2022/06/GHSA-xvc9-xwgj-4cq9/GHSA-xvc9-xwgj-4cq9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xvc9-xwgj-4cq9",
-  "modified": "2023-06-13T18:20:41Z",
+  "modified": "2023-06-13T18:20:44Z",
   "published": "2022-06-16T23:08:02Z",
   "aliases": [
     "CVE-2019-25008"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "crates.io",
         "name": "http"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "http::header::HeaderMap::reserve"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
it is necessary to reject this entry because it was rejected in the original advisory.