### PR TITLE
[GHSA-78xj-cgh5-2h22] NPM IP package vulnerable to Server-Side Request Forgery (SSRF) attacks

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
+++ b/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-78xj-cgh5-2h22",
-  "modified": "2024-02-12T20:17:03Z",
+  "modified": "2024-02-12T20:17:09Z",
   "published": "2024-02-08T18:30:39Z",
   "aliases": [
     "CVE-2023-42282"
@@ -25,7 +25,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.0.0"
+              "last_affected": "1.1.8"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The linked NIST advisory states that it affects 1.1.8 and prior. https://nvd.nist.gov/vuln/detail/CVE-2023-42282
Version 2.0.0 does not yet exist, as the latest version is 1.1.8: https://www.npmjs.com/package/ip