### PR TITLE
[GHSA-78xj-cgh5-2h22] NPM IP package vulnerable to Server-Side Request Forgery (SSRF) attacks

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
+++ b/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-78xj-cgh5-2h22",
-  "modified": "2024-02-12T20:17:03Z",
+  "modified": "2024-02-12T20:17:09Z",
   "published": "2024-02-08T18:30:39Z",
   "aliases": [
     "CVE-2023-42282"
@@ -44,6 +44,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/github/advisory-database/pull/3504#issuecomment-1937179999"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/indutny/node-ip/pull/138"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/indutny/node-ip/pull/141"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adding PRs that address the issue in the repository. They can be subscribed to for updates when a fix might become available.