### PR TITLE
[GHSA-h7wm-ph43-c39p] Scrapy denial of service vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-h7wm-ph43-c39p/GHSA-h7wm-ph43-c39p.json
+++ b/advisories/github-reviewed/2022/05/GHSA-h7wm-ph43-c39p/GHSA-h7wm-ph43-c39p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h7wm-ph43-c39p",
-  "modified": "2022-06-17T21:35:13Z",
+  "modified": "2023-12-21T20:21:28Z",
   "published": "2022-05-17T01:16:31Z",
   "aliases": [
     "CVE-2017-14158"
@@ -26,9 +26,6 @@
           "events": [
             {
               "introduced": "0.7"
-            },
-            {
-              "last_affected": "2.11.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The recently released Scrapy 2.11.1 doesn't address this vulnerability, so I would include it in the range of vulnerable versions or I wouldn't specify an upper bound at all. See release notes here: https://docs.scrapy.org/en/latest/news.html
I lean toward removing the version upper bound because it is confusing in cases like now where there is Scrapy update that doesn't address the vulnerability. Additionally, fixing this vulnerability doesn't seem like a high priority based on the discussion here: https://github.com/scrapy/scrapy/issues/482
Thanks!