### PR TITLE
[GHSA-78xj-cgh5-2h22] NPM IP package vulnerable to Server-Side Request Forgery (SSRF) attacks

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
+++ b/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-78xj-cgh5-2h22",
-  "modified": "2024-02-12T20:17:03Z",
+  "modified": "2024-02-12T20:17:09Z",
   "published": "2024-02-08T18:30:39Z",
   "aliases": [
     "CVE-2023-42282"
@@ -25,10 +25,35 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.0.0"
+              "fixed": "1.1.9"
             }
           ]
         }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.1.8"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ip"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0"
+            },
+            {
+              "fixed": "2.0.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "2.0.0"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
A fix to the 1.x track was released in 1.1.9, see https://github.com/indutny/node-ip/pull/138#issuecomment-1951675086

A fix to the 2.x track was released in 2.0.1, see https://github.com/indutny/node-ip/pull/138#issuecomment-1951710634

Updating to 2.x from 1.x is in theory a breaking change, so I set the patched versions appropriately.