### PR TITLE
[GHSA-78xj-cgh5-2h22] NPM IP package vulnerable to Server-Side Request Forgery (SSRF) attacks

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
+++ b/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-78xj-cgh5-2h22",
-  "modified": "2024-02-12T20:17:03Z",
+  "modified": "2024-02-12T20:17:09Z",
   "published": "2024-02-08T18:30:39Z",
   "aliases": [
     "CVE-2023-42282"
@@ -25,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.0.0"
+              "fixed": "1.1.9, 2.0.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.0.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The vulnerability seems to have been fixed:

* 1.1.9 fix: https://github.com/indutny/node-ip/commits/1ecbf2fd8c0cc85e44c3b587d2de641f50dc0217/
* 2.0.1 fix: https://github.com/indutny/node-ip/commits/3b0994a74eca51df01f08c40d6a65ba0e1845d04/
