### PR TITLE
[GHSA-ggx9-4728-588r] Apache Tomcat Directory Traversal vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-ggx9-4728-588r/GHSA-ggx9-4728-588r.json
+++ b/advisories/github-reviewed/2022/05/GHSA-ggx9-4728-588r/GHSA-ggx9-4728-588r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ggx9-4728-588r",
-  "modified": "2024-02-08T21:29:22Z",
+  "modified": "2024-02-08T21:29:23Z",
   "published": "2022-05-02T03:37:48Z",
   "aliases": [
     "CVE-2009-2693"
@@ -55,6 +55,22 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2009-2693"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/1250e100bde103c0b35a974fc343d3c202576ec9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/3e1010b1a2f648581fac3d68afbf18f2979f6bf6"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/4b0e7e7a9f28e707f26fcbba3a1526e5053e6fa8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/df5a83a23affb55a78637573945c75601bc86a7a"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add some patch links related to CVE-2009-2693.