### PR TITLE
[GHSA-gvgc-rxmh-5hvw] The Double.parseDouble method in Java Runtime Environment...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-gvgc-rxmh-5hvw/GHSA-gvgc-rxmh-5hvw.json
+++ b/advisories/unreviewed/2022/05/GHSA-gvgc-rxmh-5hvw/GHSA-gvgc-rxmh-5hvw.json
@@ -1,22 +1,58 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gvgc-rxmh-5hvw",
-  "modified": "2022-05-14T02:16:07Z",
+  "modified": "2023-02-02T05:05:28Z",
   "published": "2022-05-14T02:16:07Z",
   "aliases": [
     "CVE-2010-4476"
   ],
+  "summary": "allows remote attackers to cause a denial of service via a crafted string that triggers an infinite loop of estimations during conversion to a double-precision binary floating-point number",
   "details": "The Double.parseDouble method in Java Runtime Environment (JRE) in Oracle Java SE and Java for Business 6 Update 23 and earlier, 5.0 Update 27 and earlier, and 1.4.2_29 and earlier, as used in OpenJDK, Apache, JBossweb, and other products, allows remote attackers to cause a denial of service via a crafted string that triggers an infinite loop of estimations during conversion to a double-precision binary floating-point number, as demonstrated using 2.2250738585072012e-308.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat:tomcat"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2010-4476"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/30ee060ff806b3922483d73441be9c77e736facb"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/407841c426dc52a4c6b8ccd297df6c484a540056"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/69ef147c4498397e8f644a0699cf588b45a05120"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/b0c1eeaa0d303bcb42651b222037e079d0634c01"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat/"
     },
     {
       "type": "WEB",
@@ -192,7 +228,7 @@
     },
     {
       "type": "WEB",
-      "url": "http://www.exploringbinary.com/java-hangs-when-converting-2-2250738585072012e-308"
+      "url": "http://www.exploringbinary.com/java-hangs-when-converting-2-2250738585072012e-308/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Add patch links related to CVE-2010-4476.