### PR TITLE
[GHSA-p26v-97vp-jcx6] Access controll bypass in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-p26v-97vp-jcx6/GHSA-p26v-97vp-jcx6.json
+++ b/advisories/github-reviewed/2022/05/GHSA-p26v-97vp-jcx6/GHSA-p26v-97vp-jcx6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p26v-97vp-jcx6",
-  "modified": "2023-02-14T00:43:50Z",
+  "modified": "2023-02-14T00:43:51Z",
   "published": "2022-05-14T02:56:10Z",
   "aliases": [
     "CVE-2011-1183"
@@ -42,7 +42,27 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/b06f06375a1ff20c7fb949771e77360225e3ff41"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/b7b5c63a932f6c1ea05f9b65ad9054247bb5af57"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/de54cec6dfdf375ac5b0a2c59886fa93aca6cdc7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/f3068c06885fbe0b6042faf957cc5fd69ff4c3be"
+    },
+    {
+      "type": "WEB",
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/66675"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add patch links and source code links related to CVE-2011-1183.