### PR TITLE
[GHSA-vch7-92vf-jm44] Apache Tomcat does not follow ServletSecurity annotations

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-vch7-92vf-jm44/GHSA-vch7-92vf-jm44.json
+++ b/advisories/github-reviewed/2022/05/GHSA-vch7-92vf-jm44/GHSA-vch7-92vf-jm44.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vch7-92vf-jm44",
-  "modified": "2024-01-19T19:29:42Z",
+  "modified": "2024-01-19T19:29:43Z",
   "published": "2022-05-17T02:00:34Z",
   "aliases": [
     "CVE-2011-1419"
@@ -39,11 +39,23 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/02780bbc6089a12b19d3d5e5dc810455ac6bfe92"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/tomcat/commit/0ff4905158b77787a7f3aca55c9dec93456665dc"
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/13fe121edb6f2b597d2b82725f1b01296ac78ebd"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/tomcat/commit/3e5b0455483eed55752047073e92403bfca8d3ec"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/b1d1047a4c0a7754cabf57ac0303f92e4e77ef58"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add source code link and patch links related to CVE-2011-1419.