### PR TITLE
[GHSA-h6c8-rg87-f3pc] Apache Tomcat HTTP BIO Connector Error Discloses Information From Different Requests to Remote Users

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-h6c8-rg87-f3pc/GHSA-h6c8-rg87-f3pc.json
+++ b/advisories/github-reviewed/2022/05/GHSA-h6c8-rg87-f3pc/GHSA-h6c8-rg87-f3pc.json
@@ -39,7 +39,23 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/57f9f75c5bc11c8090aed54fb74df3b3fad48c29"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/885b996773aaffa67822ebec18d69b86d5c47764"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/tomcat/commit/d2e8f2ede7dea39f75f68384f331f38f094e4ed3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/df3b24b87f8d2e6a5f4fea57f687e76a0f5124d7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/eb446820a5cf8e5a2b9d4840933a4e52bb9dd44a"
     },
     {
       "type": "WEB",
@@ -50,8 +66,8 @@
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/66676"
     },
     {
-      "type": "WEB",
-      "url": "https://github.com/apache/tomcat"
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add some patch links related to CVE-2011-1475.