### PR TITLE
[GHSA-r7c8-hghc-2mp8] Apache Tomcat Allows Replacing of XML Parser

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-r7c8-hghc-2mp8/GHSA-r7c8-hghc-2mp8.json
+++ b/advisories/github-reviewed/2022/05/GHSA-r7c8-hghc-2mp8/GHSA-r7c8-hghc-2mp8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r7c8-hghc-2mp8",
-  "modified": "2023-08-17T21:45:08Z",
+  "modified": "2023-08-17T21:45:11Z",
   "published": "2022-05-17T02:44:28Z",
   "aliases": [
     "CVE-2011-2481"
@@ -38,12 +38,56 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2011-2481"
     },
     {
-      "type": "PACKAGE",
-      "url": "https://github.com/apache/tomcat"
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/1412d6875e5828b0be71275c1f8cf84649ac1c1b"
     },
     {
       "type": "WEB",
-      "url": "https://issues.apache.org/bugzilla/show_bug.cgi?id=51395"
+      "url": "https://github.com/apache/tomcat/commit/1f83d65bf0ca9c556248a3d2753365f44a703a42"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/279e4451cb996f810fbca2f78b6340412d9daa7b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/2e74353c95e3e4d0395eb2b9f0e97218f6e43f88"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/3ab7d6be13fd59b872bb5c3745ca06035e15ba3f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/3bbcc309a04bd2e2ef4730c86c501afd1947fbc1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/525561bde5b79933a9e69933fc63c1d5cf51674c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/65cd282402881030b0c32a4b0cbfa1fbf4bbe721"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/81bb49ad58fc7b1177a86ba82abf0271d07ceeb7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/8fa210147ffd98e8971cba56395726cc4a893ad7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/a45c93e3c9139d70a207a7299f326b4831c2e544"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/c5f6aa33481fcdc9079e5abeab4ff18a984c5760"
+    },
+    {
+      "type": "WEB",
+      "url": "https://web.archive.org/web/20161127215021/http://securitytracker.com/id?1025924"
     },
     {
       "type": "WEB",
@@ -51,7 +95,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://web.archive.org/web/20161127215021/http://securitytracker.com/id?1025924"
+      "url": "https://issues.apache.org/bugzilla/show_bug.cgi?id=51395"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add some patch links related to CVE-2011-2481.