### PR TITLE
[GHSA-c38m-v4m2-524v] Apache Tomcat Allows Remote Attackers to Spoof AJP Requests

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-c38m-v4m2-524v/GHSA-c38m-v4m2-524v.json
+++ b/advisories/github-reviewed/2022/05/GHSA-c38m-v4m2-524v/GHSA-c38m-v4m2-524v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c38m-v4m2-524v",
-  "modified": "2024-01-17T22:19:29Z",
+  "modified": "2024-01-17T22:19:31Z",
   "published": "2022-05-14T01:17:02Z",
   "aliases": [
     "CVE-2011-3190"
@@ -86,7 +86,23 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/4896bbccfebc4e7ed43dd0113f9292d452575974"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/90ec9675fa080e22df5f9e3e7019a19eb2faec14"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/a2538ce78f83b7376c48d12d8247600079d789b1"
+    },
+    {
+      "type": "WEB",
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/69472"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add some patch links related to CVE-2011-3190.