### PR TITLE
[GHSA-j448-j653-r3vj] Apache Tomcat is vulnerable to HTTP request-smuggling

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-j448-j653-r3vj/GHSA-j448-j653-r3vj.json
+++ b/advisories/github-reviewed/2022/05/GHSA-j448-j653-r3vj/GHSA-j448-j653-r3vj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j448-j653-r3vj",
-  "modified": "2023-08-17T23:32:17Z",
+  "modified": "2023-08-17T23:32:18Z",
   "published": "2022-05-14T01:10:36Z",
   "aliases": [
     "CVE-2013-4286"
@@ -74,6 +74,26 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-4286"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/41b90b6ebc3e7f898a5a87d197ddf63790d33315"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/7c040003f1387795356605566be7870cf70e05dc"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/bcce3e4997a4ed06fe03e2517443f3ad8ade2dfa"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/c1c9d484a334e8704b2977ed49c33ce31a4a435a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/d0b3e252eb168fafbfb4c3efc16d4192fc8fad6c"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add some patch links related to CVE-2013-4286.