### PR TITLE
[GHSA-xh5x-j8jf-pcpx] Improper Neutralization of CRLF Sequences in HTTP Headers in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-xh5x-j8jf-pcpx/GHSA-xh5x-j8jf-pcpx.json
+++ b/advisories/github-reviewed/2022/05/GHSA-xh5x-j8jf-pcpx/GHSA-xh5x-j8jf-pcpx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xh5x-j8jf-pcpx",
-  "modified": "2022-07-07T23:02:22Z",
+  "modified": "2023-01-27T05:02:19Z",
   "published": "2022-05-14T01:10:18Z",
   "aliases": [
     "CVE-2014-0099"
@@ -74,6 +74,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0099"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/184cdc0d3f03f5737e12d21fff246d7285034597"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/fffd63a3bd3a5475379b7c074820a5463b7663b3"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add some patch links related to CVE-2014-0099.