### PR TITLE
[GHSA-547x-748v-vp6p] Dash apps vulnerable to Cross-site Scripting

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-547x-748v-vp6p/GHSA-547x-748v-vp6p.json
+++ b/advisories/github-reviewed/2024/02/GHSA-547x-748v-vp6p/GHSA-547x-748v-vp6p.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-547x-748v-vp6p",
-  "modified": "2024-02-12T15:36:11Z",
+  "modified": "2024-02-12T15:36:15Z",
   "published": "2024-02-02T06:30:31Z",
   "aliases": [
     "CVE-2024-21485"
   ],
   "summary": "Dash apps vulnerable to Cross-site Scripting",
-  "details": "Versions of the package dash-core-components before 2.13.0; all versions of the package dash-core-components; versions of the package dash before 2.15.0; all versions of the package dash-html-components; versions of the package dash-html-components before 2.0.16 are vulnerable to Cross-site Scripting (XSS) when the href of the a tag is controlled by an adversary. An authenticated attacker who stores a view that exploits this vulnerability could steal the data that's visible to another user who opens that view - not just the data already included on the page, but they could also, in theory, make additional requests and access other data accessible to this user. In some cases, they could also steal the access tokens of that user, which would allow the attacker to act as that user, including viewing other apps and resources hosted on the same server.\n\n**Note:**\n\nThis is only exploitable in Dash apps that include some mechanism to store user input to be reloaded by a different user.",
+  "details": "Versions of the npm package dash-core-components before 2.13.0; versions of the PyPI package dash-core-components before 2.0.0; versions of the package dash before 2.15.0; versions of the PyPI package dash-html-components before 2.0.0; versions of the npm package dash-html-components before 2.0.16 are vulnerable to Cross-site Scripting (XSS) when the href of the a tag is controlled by an adversary. An authenticated attacker who stores a view that exploits this vulnerability could steal the data that's visible to another user who opens that view - not just the data already included on the page, but they could also, in theory, make additional requests and access other data accessible to this user. In some cases, they could also steal the access tokens of that user, which would allow the attacker to act as that user, including viewing other apps and resources hosted on the same server.\n\n**Note:**\n\nThis is only exploitable in Dash apps that include some mechanism to store user input to be reloaded by a different user.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -47,7 +47,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.0.0"
+              "last_affected": "1.1.4"
             }
           ]
         }
@@ -66,7 +66,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.0.0"
+              "last_affected": "1.17.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
on pip dash-core-components v2 and dash-html-components v2 are just placeholder packages that import the code from the core dash package so are not vulnerable