### PR TITLE
[GHSA-vj2m-9f5j-mpr5] Vapor vulnerable to denial of service in HTTP Range Request of FileMiddleware

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-vj2m-9f5j-mpr5/GHSA-vj2m-9f5j-mpr5.json
+++ b/advisories/github-reviewed/2023/06/GHSA-vj2m-9f5j-mpr5/GHSA-vj2m-9f5j-mpr5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vj2m-9f5j-mpr5",
-  "modified": "2023-06-07T16:26:25Z",
+  "modified": "2023-06-19T16:45:07Z",
   "published": "2023-06-07T16:26:25Z",
   "aliases": [
     "CVE-2022-31005"
@@ -9,10 +9,7 @@
   "summary": "Vapor vulnerable to denial of service in HTTP Range Request of FileMiddleware",
   "details": "Vapor is an HTTP web framework for Swift and [middleware](https://docs.vapor.codes/advanced/middleware/) is a logic chain between the client and a Vapor route handler. [FileMiddleware](https://docs.vapor.codes/advanced/middleware/#file-middleware) enables the serving of assets from the Public folder of a project to the client. \n\nVapor before 4.60.3 is vulnerable to denial of service due to an integer overflow when given invalid range headers while using FileMiddleware. This is patched in 4.60.3.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    }
+
   ],
   "affected": [
     {


### PR DESCRIPTION
**Updates**
- CVSS

**Comments**
Better pertected