### PR TITLE
[GHSA-9hjv-9h75-xmpp] Improper Verification of Source of a Communication Channel in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9hjv-9h75-xmpp/GHSA-9hjv-9h75-xmpp.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9hjv-9h75-xmpp/GHSA-9hjv-9h75-xmpp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9hjv-9h75-xmpp",
-  "modified": "2023-12-08T20:08:36Z",
+  "modified": "2023-12-08T20:08:37Z",
   "published": "2022-05-14T01:18:35Z",
   "aliases": [
     "CVE-2016-0763"
@@ -83,55 +83,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2016:1087"
+      "url": "https://github.com/apache/tomcat/commit/76ebc9007567c8326217dd94844540e1e27d8468"
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2016:1088"
+      "url": "https://github.com/apache/tomcat/commit/c08641da04d31f730b56b8675301e55db97dfe88"
     },
     {
       "type": "WEB",
-      "url": "https://bto.bluecoat.com/security-advisory/sa118"
-    },
-    {
-      "type": "PACKAGE",
-      "url": "https://github.com/apache/tomcat"
-    },
-    {
-      "type": "WEB",
-      "url": "https://h20566.www2.hpe.com/portal/site/hpsc/public/kb/docDisplay?docId=emr_na-c05150442"
-    },
-    {
-      "type": "WEB",
-      "url": "https://h20566.www2.hpe.com/portal/site/hpsc/public/kb/docDisplay?docId=emr_na-c05158626"
-    },
-    {
-      "type": "WEB",
-      "url": "https://h20566.www2.hpe.com/portal/site/hpsc/public/kb/docDisplay?docId=emr_na-c05324755"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/343558d982879bf88ec20dbf707f8c11255f8e219e81d45c4f8d0551%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/343558d982879bf88ec20dbf707f8c11255f8e219e81d45c4f8d0551@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r9136ff5b13e4f1941360b5a309efee2c114a14855578c3a2cbe5d19c%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r9136ff5b13e4f1941360b5a309efee2c114a14855578c3a2cbe5d19c@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://security.gentoo.org/glsa/201705-09"
-    },
-    {
-      "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20180531-0001"
+      "url": "https://web.archive.org/web/20160404202803/http://www.securitytracker.com/id/1035069"
     },
     {
       "type": "WEB",
@@ -139,7 +99,55 @@
     },
     {
       "type": "WEB",
-      "url": "https://web.archive.org/web/20160404202803/http://www.securitytracker.com/id/1035069"
+      "url": "https://security.netapp.com/advisory/ntap-20180531-0001/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.gentoo.org/glsa/201705-09"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r9136ff5b13e4f1941360b5a309efee2c114a14855578c3a2cbe5d19c@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r9136ff5b13e4f1941360b5a309efee2c114a14855578c3a2cbe5d19c%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/343558d982879bf88ec20dbf707f8c11255f8e219e81d45c4f8d0551@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/343558d982879bf88ec20dbf707f8c11255f8e219e81d45c4f8d0551%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://h20566.www2.hpe.com/portal/site/hpsc/public/kb/docDisplay?docId=emr_na-c05324755"
+    },
+    {
+      "type": "WEB",
+      "url": "https://h20566.www2.hpe.com/portal/site/hpsc/public/kb/docDisplay?docId=emr_na-c05158626"
+    },
+    {
+      "type": "WEB",
+      "url": "https://h20566.www2.hpe.com/portal/site/hpsc/public/kb/docDisplay?docId=emr_na-c05150442"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat"
+    },
+    {
+      "type": "WEB",
+      "url": "https://bto.bluecoat.com/security-advisory/sa118"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2016:1088"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2016:1087"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch links related to CVE-2016-0763.