### PR TITLE
[GHSA-jc7p-5r39-9477] Improper Input Validation in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-jc7p-5r39-9477/GHSA-jc7p-5r39-9477.json
+++ b/advisories/github-reviewed/2022/05/GHSA-jc7p-5r39-9477/GHSA-jc7p-5r39-9477.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jc7p-5r39-9477",
-  "modified": "2022-07-06T19:46:59Z",
+  "modified": "2023-12-08T19:56:02Z",
   "published": "2022-05-13T01:14:53Z",
   "aliases": [
     "CVE-2016-6816"
@@ -121,6 +121,110 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/516bda676ac8d0284da3e0295a7df70391315360"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/cdc0a935c2173aff60039a0b85e57a461381107c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/f96f5751d418ae5a2f550be040daf9c5f7d99256"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/b8a1bf18155b552dcf9a928ba808cbadad84c236d85eab3033662cfb%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/b8a1bf18155b552dcf9a928ba808cbadad84c236d85eab3033662cfb@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r03c597a64de790ba42c167efacfa23300c3d6c9fe589ab87fe02859c%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r03c597a64de790ba42c167efacfa23300c3d6c9fe589ab87fe02859c@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r587e50b86c1a96ee301f751d50294072d142fd6dc08a8987ae9f3a9b%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r587e50b86c1a96ee301f751d50294072d142fd6dc08a8987ae9f3a9b@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r9136ff5b13e4f1941360b5a309efee2c114a14855578c3a2cbe5d19c%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r9136ff5b13e4f1941360b5a309efee2c114a14855578c3a2cbe5d19c@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.netapp.com/advisory/ntap-20180607-0001/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://svn.apache.org/viewvc?view=revision&revision=1767641"
+    },
+    {
+      "type": "WEB",
+      "url": "https://svn.apache.org/viewvc?view=revision&revision=1767645"
+    },
+    {
+      "type": "WEB",
+      "url": "https://svn.apache.org/viewvc?view=revision&revision=1767653"
+    },
+    {
+      "type": "WEB",
+      "url": "https://svn.apache.org/viewvc?view=revision&revision=1767675"
+    },
+    {
+      "type": "WEB",
+      "url": "https://svn.apache.org/viewvc?view=revision&revision=1767683"
+    },
+    {
+      "type": "WEB",
+      "url": "https://tomcat.apache.org/security-6.html#Fixed_in_Apache_Tomcat_6.0.48"
+    },
+    {
+      "type": "WEB",
+      "url": "https://tomcat.apache.org/security-7.html#Fixed_in_Apache_Tomcat_7.0.73"
+    },
+    {
+      "type": "WEB",
+      "url": "https://tomcat.apache.org/security-8.html#Fixed_in_Apache_Tomcat_8.0.39"
+    },
+    {
+      "type": "WEB",
+      "url": "https://tomcat.apache.org/security-8.html#Fixed_in_Apache_Tomcat_8.5.8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://tomcat.apache.org/security-9.html#Fixed_in_Apache_Tomcat_9.0.0.M13"
+    },
+    {
+      "type": "WEB",
+      "url": "https://usn.ubuntu.com/4557-1/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://web.archive.org/web/20161204121236/http://www.securityfocus.com/bid/94461"
+    },
+    {
+      "type": "WEB",
+      "url": "https://web.archive.org/web/20170929085438/http://www.securitytracker.com/id/1037332"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.exploit-db.com/exploits/41783/"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2017:0455"
     },
     {
@@ -130,6 +234,10 @@
     {
       "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2017:0935"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat/"
     },
     {
       "type": "WEB",
@@ -210,98 +318,6 @@
     {
       "type": "WEB",
       "url": "https://lists.apache.org/thread.html/b84ad1258a89de5c9c853c7f2d3ad77e5b8b2930be9e132d5cef6b95@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/b8a1bf18155b552dcf9a928ba808cbadad84c236d85eab3033662cfb%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/b8a1bf18155b552dcf9a928ba808cbadad84c236d85eab3033662cfb@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r03c597a64de790ba42c167efacfa23300c3d6c9fe589ab87fe02859c%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r03c597a64de790ba42c167efacfa23300c3d6c9fe589ab87fe02859c@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r587e50b86c1a96ee301f751d50294072d142fd6dc08a8987ae9f3a9b%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r587e50b86c1a96ee301f751d50294072d142fd6dc08a8987ae9f3a9b@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r9136ff5b13e4f1941360b5a309efee2c114a14855578c3a2cbe5d19c%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r9136ff5b13e4f1941360b5a309efee2c114a14855578c3a2cbe5d19c@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20180607-0001"
-    },
-    {
-      "type": "WEB",
-      "url": "https://svn.apache.org/viewvc?view=revision&revision=1767641"
-    },
-    {
-      "type": "WEB",
-      "url": "https://svn.apache.org/viewvc?view=revision&revision=1767645"
-    },
-    {
-      "type": "WEB",
-      "url": "https://svn.apache.org/viewvc?view=revision&revision=1767653"
-    },
-    {
-      "type": "WEB",
-      "url": "https://svn.apache.org/viewvc?view=revision&revision=1767675"
-    },
-    {
-      "type": "WEB",
-      "url": "https://svn.apache.org/viewvc?view=revision&revision=1767683"
-    },
-    {
-      "type": "WEB",
-      "url": "https://tomcat.apache.org/security-6.html#Fixed_in_Apache_Tomcat_6.0.48"
-    },
-    {
-      "type": "WEB",
-      "url": "https://tomcat.apache.org/security-7.html#Fixed_in_Apache_Tomcat_7.0.73"
-    },
-    {
-      "type": "WEB",
-      "url": "https://tomcat.apache.org/security-8.html#Fixed_in_Apache_Tomcat_8.0.39"
-    },
-    {
-      "type": "WEB",
-      "url": "https://tomcat.apache.org/security-8.html#Fixed_in_Apache_Tomcat_8.5.8"
-    },
-    {
-      "type": "WEB",
-      "url": "https://tomcat.apache.org/security-9.html#Fixed_in_Apache_Tomcat_9.0.0.M13"
-    },
-    {
-      "type": "WEB",
-      "url": "https://usn.ubuntu.com/4557-1"
-    },
-    {
-      "type": "WEB",
-      "url": "https://web.archive.org/web/20161204121236/http://www.securityfocus.com/bid/94461"
-    },
-    {
-      "type": "WEB",
-      "url": "https://web.archive.org/web/20170929085438/http://www.securitytracker.com/id/1037332"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.exploit-db.com/exploits/41783"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add three patch links related to CVE-2016-6816 which fixed in multi-branch.