### PR TITLE
[GHSA-78xj-cgh5-2h22] NPM IP package incorrectly identifies some private IP addresses as public

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
+++ b/advisories/github-reviewed/2024/02/GHSA-78xj-cgh5-2h22/GHSA-78xj-cgh5-2h22.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-78xj-cgh5-2h22",
-  "modified": "2024-02-20T18:30:37Z",
+  "modified": "2024-02-20T18:30:41Z",
   "published": "2024-02-08T18:30:39Z",
   "aliases": [
     "CVE-2023-42282"
   ],
   "summary": "NPM IP package incorrectly identifies some private IP addresses as public",
-  "details": "The `isPublic()` function in the NPM package `ip` doesn't correctly identify certain private IP addresses in uncommon formats such as `0x7F.1` as private. Instead, it reports them as public by returning `true`. This can lead to security issues such as Server-Side Request Forgery (SSRF) if `isPublic()` is used to protect sensitive code paths when passed user input. Versions 1.1.9 and 2.0.1 fix the issue.",
+  "details": "The `isPublic()` function in the NPM package `ip` doesn't correctly identify certain private IP addresses in uncommon formats such as `127.1`, `01200034567`, and `0::01` as private. Instead, it reports them as public by returning `true`. This can lead to security issues such as Server-Side Request Forgery (SSRF) if `isPublic()` is used to protect sensitive code paths when passed user input.",
   "severity": [
 
   ],
@@ -22,32 +22,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.0.0"
-            },
-            {
-              "fixed": "2.0.1"
-            }
-          ]
-        }
-      ],
-      "versions": [
-        "2.0.0"
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "ip"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
               "introduced": "0"
             },
             {
-              "fixed": "1.1.9"
+              "last_affected": "2.0.1"
             }
           ]
         }
@@ -70,6 +48,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/indutny/node-ip/pull/138"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/indutny/node-ip/pull/143"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- Description
- References

**Comments**
The patch https://github.com/indutny/node-ip/pull/138 does not cover all cases. See https://github.com/indutny/node-ip/pull/143