### PR TITLE
[GHSA-76w9-p8mg-j927] Out-of-bounds Write in nix

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-76w9-p8mg-j927/GHSA-76w9-p8mg-j927.json
+++ b/advisories/github-reviewed/2022/01/GHSA-76w9-p8mg-j927/GHSA-76w9-p8mg-j927.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-76w9-p8mg-j927",
-  "modified": "2023-06-13T18:32:56Z",
+  "modified": "2023-06-13T18:32:57Z",
   "published": "2022-01-06T22:07:14Z",
   "aliases": [
     "CVE-2021-45707"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -19,35 +19,6 @@
       "package": {
         "ecosystem": "crates.io",
         "name": "nix"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "nix::unistd::getgrouplist"
-        ]
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0.16.0"
-            },
-            {
-              "fixed": "0.20.2"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "crates.io",
-        "name": "nix"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "nix::unistd::getgrouplist"
-        ]
       },
       "ranges": [
         {
@@ -68,11 +39,6 @@
         "ecosystem": "crates.io",
         "name": "nix"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "nix::unistd::getgrouplist"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -82,6 +48,25 @@
             },
             {
               "fixed": "0.22.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "crates.io",
+        "name": "nix"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.16.0"
+            },
+            {
+              "fixed": "0.20.2"
             }
           ]
         }
@@ -118,7 +103,7 @@
     "cwe_ids": [
       "CWE-787"
     ],
-    "severity": "CRITICAL",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2022-01-05T23:13:23Z",
     "nvd_published_at": "2021-12-27T00:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
Updated the attack vector parameter from "Network" to "Local", and privileges required from "None" to "High", to be in line with the description reading "The issue would require editing /etc/groups to exploit, which is usually only editable by the root user."