### PR TITLE
[GHSA-6vqw-3v5j-54x4] cryptography NULL pointer deference with pkcs12.serialize_key_and_certificates when called with a non-matching certificate and private key and an hmac_hash override

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-6vqw-3v5j-54x4/GHSA-6vqw-3v5j-54x4.json
+++ b/advisories/github-reviewed/2024/02/GHSA-6vqw-3v5j-54x4/GHSA-6vqw-3v5j-54x4.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6vqw-3v5j-54x4",
-  "modified": "2024-02-21T19:33:17Z",
+  "modified": "2024-02-21T19:33:19Z",
   "published": "2024-02-21T18:04:40Z",
   "aliases": [
     "CVE-2024-26130"
   ],
-  "summary": "cryptography NULL pointer deference with pkcs12.serialize_key_and_certificates when called with a non-matching certificate and private key and an hmac_hash override",
+  "summary": "cryptography NULL pointer dereference with pkcs12.serialize_key_and_certificates when called with a non-matching certificate and private key and an hmac_hash override",
   "details": "If `pkcs12.serialize_key_and_certificates` is called with both:\n\n1. A certificate whose public key did not match the provided private key\n2. An `encryption_algorithm` with `hmac_hash` set (via `PrivateFormat.PKCS12.encryption_builder().hmac_hash(...)`\n\nThen a NULL pointer dereference would occur, crashing the Python process.\n\nThis has been resolved, and now a `ValueError` is properly raised.\n\nPatched in https://github.com/pyca/cryptography/pull/10423",
   "severity": [
     {
@@ -59,7 +59,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-476"
+
     ],
     "severity": "HIGH",
     "github_reviewed": true,

--- a/advisories/github-reviewed/2024/02/GHSA-6vqw-3v5j-54x4/GHSA-6vqw-3v5j-54x4.json
+++ b/advisories/github-reviewed/2024/02/GHSA-6vqw-3v5j-54x4/GHSA-6vqw-3v5j-54x4.json
@@ -59,7 +59,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-476"
     ],
     "severity": "HIGH",
     "github_reviewed": true,


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Typo in the title