### PR TITLE
[GHSA-m9p2-j4hg-g373] Apache Cassandra: Privilege escalation when enabling FQL/Audit logs

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-m9p2-j4hg-g373/GHSA-m9p2-j4hg-g373.json
+++ b/advisories/github-reviewed/2023/07/GHSA-m9p2-j4hg-g373/GHSA-m9p2-j4hg-g373.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m9p2-j4hg-g373",
-  "modified": "2023-07-06T23:50:30Z",
+  "modified": "2023-11-10T05:02:25Z",
   "published": "2023-07-06T21:15:06Z",
   "aliases": [
     "CVE-2023-30601"
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.0.0"
             },
             {
               "fixed": "4.0.10"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Updating the affected range to ">=4.0.0, <4.0.10"

The current affected range is just "<4.0.10", which is not matching the description: 
> This issue affects Apache Cassandra: from 4.0.0 through 4.0.9, from 4.1.0 through 4.1.1.

Also, NVD is showing range should be ">=4.0.0, <4.0.10": https://nvd.nist.gov/vuln/detail/CVE-2023-30601