### PR TITLE
[GHSA-5fg8-2547-mr8q] Misinterpretation of malicious XML input

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-5fg8-2547-mr8q/GHSA-5fg8-2547-mr8q.json
+++ b/advisories/github-reviewed/2021/08/GHSA-5fg8-2547-mr8q/GHSA-5fg8-2547-mr8q.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5fg8-2547-mr8q",
-  "modified": "2022-01-04T19:36:30Z",
+  "modified": "2023-02-01T05:05:51Z",
   "published": "2021-08-03T16:57:05Z",
   "aliases": [
     "CVE-2021-32796"
   ],
   "summary": "Misinterpretation of malicious XML input",
-  "details": "### Impact\nxmldom versions 0.6.0 and older do not correctly escape special characters when serializing elements removed from their ancestor. This may lead to unexpected syntactic changes during XML processing in some downstream applications.\n\n### Patches\nUpdate to one of the fixed versions of `@xmldom/xmldom` (`>=0.7.0`)\n\nSee issue #271 for the status of publishing `xmldom` to npm or join #270 for Q&A/discussion until it's resolved.\n\n### Workarounds\n\nDownstream applications can validate the input and reject the maliciously crafted documents.\n\n### References\n\nSimilar to this one reported on the Go standard library:\n\n- https://mattermost.com/blog/coordinated-disclosure-go-xml-vulnerabilities/\n- https://mattermost.com/blog/securing-xml-implementations-across-the-web/\n\n### For more information\n\nIf you have any questions or comments about this advisory:\n\n* Open an issue in [`xmldom/xmldom`](https://github.com/xmldom/xmldom)\n* Email us: send an email to **all** addresses that are shown by `npm owner ls @xmldom/xmldom`\n",
+  "details": "### Impact\nxmldom versions 0.6.0 and older do not correctly escape special characters when serializing elements removed from their ancestor. This may lead to unexpected syntactic changes during XML processing in some downstream applications.\n\n### Patches\nUpdate to one of the fixed versions of `@xmldom/xmldom` (`>=0.7.0`)\n\nSee issue #271 for the status of publishing `xmldom` to npm or join #270 for Q&A/discussion until it's resolved.\n\n### Workarounds\n\nDownstream applications can validate the input and reject the maliciously crafted documents.\n\n### References\n\nSimilar to this one reported on the Go standard library:\n\n- https://mattermost.com/blog/coordinated-disclosure-go-xml-vulnerabilities/\n- https://mattermost.com/blog/securing-xml-implementations-across-the-web/\n\n### For more information\n\nIf you have any questions or comments about this advisory:\n\n* Open an issue in [`xmldom/xmldom`](https://github.com/xmldom/xmldom)\n* Email us: send an email to **all** addresses that are shown by `npm owner ls @xmldom/xmldom`\n\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -19,6 +19,28 @@
       "package": {
         "ecosystem": "npm",
         "name": "xmldom"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "None"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.6.0"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@xmldom/xmldom"
       },
       "ranges": [
         {
@@ -54,11 +76,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://mattermost.com/blog/coordinated-disclosure-go-xml-vulnerabilities"
+      "url": "https://mattermost.com/blog/coordinated-disclosure-go-xml-vulnerabilities/"
     },
     {
       "type": "WEB",
-      "url": "https://mattermost.com/blog/securing-xml-implementations-across-the-web"
+      "url": "https://mattermost.com/blog/securing-xml-implementations-across-the-web/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
The version 0.7.0 for `xmldom` does not exist, `@xmldom/xmldom` does. 
Search results in npm - https://www.npmjs.com/search?q=xmldom
They both point to the same source repo - github.com/xmldom/xmldom