### PR TITLE
[GHSA-h436-432x-8fvx] Apache Commons Compress vulnerable to denial of service due to infinite loop

### DIFF
--- a/advisories/github-reviewed/2019/03/GHSA-h436-432x-8fvx/GHSA-h436-432x-8fvx.json
+++ b/advisories/github-reviewed/2019/03/GHSA-h436-432x-8fvx/GHSA-h436-432x-8fvx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h436-432x-8fvx",
-  "modified": "2023-11-02T21:36:40Z",
+  "modified": "2023-11-02T21:36:42Z",
   "published": "2019-03-14T15:41:12Z",
   "aliases": [
     "CVE-2018-1324"
@@ -67,6 +67,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1324"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/commons-compress/commit/2a2f1dc48e22a34ddb72321a4db211da91aa933b"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add patch commit https://github.com/apache/commons-compress/commit/2a2f1dc48e22a34ddb72321a4db211da91aa933b for it, mentioned in https://commons.apache.org/proper/commons-compress/security.html as well. 