### PR TITLE
[GHSA-8m36-62rw-9mxw] mapshaper Path Traversal vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-8m36-62rw-9mxw/GHSA-8m36-62rw-9mxw.json
+++ b/advisories/github-reviewed/2024/02/GHSA-8m36-62rw-9mxw/GHSA-8m36-62rw-9mxw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8m36-62rw-9mxw",
-  "modified": "2024-02-13T20:34:18Z",
+  "modified": "2024-02-22T05:08:29Z",
   "published": "2024-02-13T15:31:12Z",
   "aliases": [
     "CVE-2024-1163"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:L"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H"
     }
   ],
   "affected": [
@@ -55,9 +55,10 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-22"
+      "CWE-22",
+      "CWE-400"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2024-02-13T20:34:18Z",
     "nvd_published_at": "2024-02-13T15:15:08Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity

**Comments**
As mentioned in report: https://huntr.com/bounties/c1cbc18b-e4ab-4332-ad13-0033f0f976f5, loading /dev/urandom or any other large files may cause a dos on the server by consuming whole memory and crash the process.