### PR TITLE
[GHSA-7g45-4rm6-3mm3] Guava vulnerable to insecure use of temporary directory

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-7g45-4rm6-3mm3/GHSA-7g45-4rm6-3mm3.json
+++ b/advisories/github-reviewed/2023/06/GHSA-7g45-4rm6-3mm3/GHSA-7g45-4rm6-3mm3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7g45-4rm6-3mm3",
-  "modified": "2024-02-13T21:48:06Z",
+  "modified": "2024-02-13T21:49:15Z",
   "published": "2023-06-14T18:30:38Z",
   "aliases": [
     "CVE-2023-2976"
@@ -28,11 +28,14 @@
               "introduced": "1.0"
             },
             {
-              "fixed": "32.0.0-android"
+              "fixed": "32.0.0-jre"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 32.0.0-android"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
guava produces 2 versions of jars, one for mobile env with android suffix and jre for java outside the mobile Android envs.