### PR TITLE
[GHSA-97m3-52wr-xvv2] Dompdf's usage of vulnerable version of phenx/php-svg-lib leads to restriction bypass and potential RCE

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-97m3-52wr-xvv2/GHSA-97m3-52wr-xvv2.json
+++ b/advisories/github-reviewed/2024/02/GHSA-97m3-52wr-xvv2/GHSA-97m3-52wr-xvv2.json
@@ -18,25 +18,6 @@
     {
       "package": {
         "ecosystem": "Packagist",
-        "name": "dompdf/dompdf"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "last_affected": "2.0.4"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Packagist",
         "name": "phenx/php-svg-lib"
       },
       "ranges": [
@@ -74,8 +55,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-502",
-      "CWE-73"
+
     ],
     "severity": "CRITICAL",
     "github_reviewed": true,


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
dompdf itself is not vulnerable, it's only one of the depencies.