### PR TITLE
[GHSA-97m3-52wr-xvv2] Dompdf's usage of vulnerable version of phenx/php-svg-lib leads to restriction bypass and potential RCE

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-97m3-52wr-xvv2/GHSA-97m3-52wr-xvv2.json
+++ b/advisories/github-reviewed/2024/02/GHSA-97m3-52wr-xvv2/GHSA-97m3-52wr-xvv2.json
@@ -18,25 +18,6 @@
     {
       "package": {
         "ecosystem": "Packagist",
-        "name": "dompdf/dompdf"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "last_affected": "2.0.4"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Packagist",
         "name": "phenx/php-svg-lib"
       },
       "ranges": [
@@ -74,8 +55,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-502",
-      "CWE-73"
+
     ],
     "severity": "CRITICAL",
     "github_reviewed": true,


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This advisory was informational for Dompdf users because of a vulnerability in a tight dependency (php-svg-lib) where Dompdf exposes a larger attack surface. Any version of Dompdf is no longer vulnerable once php-svg-lib is updated to the latest release.