### PR TITLE
[GHSA-97m3-52wr-xvv2] Dompdf's usage of vulnerable version of phenx/php-svg-lib leads to restriction bypass and potential RCE

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-97m3-52wr-xvv2/GHSA-97m3-52wr-xvv2.json
+++ b/advisories/github-reviewed/2024/02/GHSA-97m3-52wr-xvv2/GHSA-97m3-52wr-xvv2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-97m3-52wr-xvv2",
-  "modified": "2024-02-23T15:27:48Z",
+  "modified": "2024-02-23T15:27:49Z",
   "published": "2024-02-22T18:15:41Z",
   "aliases": [
 


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs

**Comments**
Restoring CWEs that were accidentally removed with the previous suggestion.