### PR TITLE
[GHSA-crg9-44h2-xw35] Apache ActiveMQ is vulnerable to Remote Code Execution

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-crg9-44h2-xw35/GHSA-crg9-44h2-xw35.json
+++ b/advisories/github-reviewed/2023/10/GHSA-crg9-44h2-xw35/GHSA-crg9-44h2-xw35.json
@@ -195,6 +195,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/oscerd/nice-cve-poc/tree/main/CVE-2023-46604"
+    },
+    {
+      "type": "WEB",
       "url": "https://issues.apache.org/jira/browse/AMQ-9370"
     },
     {
@@ -207,7 +211,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20231110-0010"
+      "url": "https://security.netapp.com/advisory/ntap-20231110-0010/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Added a POC showing the vulnerability through metasploit.