### PR TITLE
[GHSA-hhj4-xc5f-6f87] Apache Guacamole 1.5.3 and older do not consistently...

### DIFF
--- a/advisories/unreviewed/2023/12/GHSA-hhj4-xc5f-6f87/GHSA-hhj4-xc5f-6f87.json
+++ b/advisories/unreviewed/2023/12/GHSA-hhj4-xc5f-6f87/GHSA-hhj4-xc5f-6f87.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hhj4-xc5f-6f87",
-  "modified": "2023-12-19T21:32:20Z",
+  "modified": "2023-12-19T21:32:27Z",
   "published": "2023-12-19T21:32:20Z",
   "aliases": [
     "CVE-2023-43826"
   ],
+  "summary": "Apache Guacamole: Integer overflow in handling of VNC image buffers",
   "details": "Apache Guacamole 1.5.3 and older do not consistently ensure that values received from a VNC server will not result in integer overflow. If a user connects to a malicious or compromised VNC server, specially-crafted data could result in memory corruption, possibly allowing arbitrary code to be executed with the privileges of the running guacd process.\n\nUsers are recommended to upgrade to version 1.5.4, which fixes this issue.\n\n",
   "severity": [
     {
@@ -14,12 +15,37 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.guacamole:guacamole-server"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.5.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.5.3"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-43826"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/guacamole-server"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
Added Title, affected version and patched version, ecosystem and package name.