### PR TITLE
[GHSA-2c7c-3mj9-8fqh] Decryption of malicious PBES2 JWE objects can consume unbounded system resources

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-2c7c-3mj9-8fqh/GHSA-2c7c-3mj9-8fqh.json
+++ b/advisories/github-reviewed/2023/11/GHSA-2c7c-3mj9-8fqh/GHSA-2c7c-3mj9-8fqh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2c7c-3mj9-8fqh",
-  "modified": "2023-11-21T22:17:19Z",
+  "modified": "2023-11-21T22:17:21Z",
   "published": "2023-11-21T22:17:19Z",
   "aliases": [
 
@@ -42,6 +42,41 @@
           "events": [
             {
               "introduced": "0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "gopkg.in/square/go-jose.v2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "gopkg.in/go-jose/go-jose.v2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.6.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Version 2 is affected by this, and is fixed in v2.6.2