### PR TITLE
[GHSA-rm97-x556-q36h] Versions of the package sanitize-html before 2.12.1 are...

### DIFF
--- a/advisories/unreviewed/2024/02/GHSA-rm97-x556-q36h/GHSA-rm97-x556-q36h.json
+++ b/advisories/unreviewed/2024/02/GHSA-rm97-x556-q36h/GHSA-rm97-x556-q36h.json
@@ -6,6 +6,7 @@
   "aliases": [
     "CVE-2024-21501"
   ],
+  "summary": "Information Exposure in sanitize-html Before 2.12.1 via Style Attribute",
   "details": "Versions of the package sanitize-html before 2.12.1 are vulnerable to Information Exposure when used on the backend and with the style attribute allowed, allowing enumeration of files in the system (including project dependencies). An attacker could exploit this vulnerability to gather details about the file system structure and dependencies of the targeted server.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "sanitize-html"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.12.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -38,8 +57,20 @@
       "url": "https://github.com/apostrophecms/apostrophe/discussions/4436"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/apostrophecms/sanitize-html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apostrophecms/sanitize-html/releases/tag/2.12.1"
+    },
+    {
       "type": "WEB",
       "url": "https://security.snyk.io/vuln/SNYK-JS-SANITIZEHTML-6256334"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.npmjs.com/package/sanitize-html"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
The patch has been released, and I have added the affected/fixed versions, along with the links.