### PR TITLE
[GHSA-ccgv-vj62-xf9h] Spring Web vulnerable to Open Redirect or Server Side Request Forgery

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-ccgv-vj62-xf9h/GHSA-ccgv-vj62-xf9h.json
+++ b/advisories/github-reviewed/2024/02/GHSA-ccgv-vj62-xf9h/GHSA-ccgv-vj62-xf9h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ccgv-vj62-xf9h",
-  "modified": "2024-02-23T18:03:49Z",
+  "modified": "2024-02-23T18:03:50Z",
   "published": "2024-02-23T06:30:31Z",
   "aliases": [
     "CVE-2024-22243"
@@ -63,7 +63,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "5.3.0"
+              "introduced": "0"
             },
             {
               "fixed": "5.3.32"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
https://spring.io/security/cve-2024-22243

> Affected Spring Products and Versions
> Spring Framework
> - 6.1.0 - 6.1.3
> - 6.0.0 - 6.0.16
> - 5.3.0 - 5.3.31
> - **Older, unsupported versions are also affected**

Versions of the Spring Framework prior to 5.3.0 are also likely to be affected.