### PR TITLE
[GHSA-r4v8-9hgx-vm6m] Cloud Foundry UAA, versions 4.19 prior to 4.19.2 and 4.12...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-r4v8-9hgx-vm6m/GHSA-r4v8-9hgx-vm6m.json
+++ b/advisories/unreviewed/2022/05/GHSA-r4v8-9hgx-vm6m/GHSA-r4v8-9hgx-vm6m.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r4v8-9hgx-vm6m",
-  "modified": "2022-05-13T01:49:00Z",
+  "modified": "2023-02-02T05:01:50Z",
   "published": "2022-05-13T01:49:00Z",
   "aliases": [
     "CVE-2018-11047"
   ],
+  "summary": "incorrectly authorizes requests to admin endpoints by accepting a valid refresh token in lieu of an access token",
   "details": "Cloud Foundry UAA, versions 4.19 prior to 4.19.2 and 4.12 prior to 4.12.4 and 4.10 prior to 4.10.2 and 4.7 prior to 4.7.6 and 4.5 prior to 4.5.7, incorrectly authorizes requests to admin endpoints by accepting a valid refresh token in lieu of an access token. Refresh tokens by design have a longer expiration time than access tokens, allowing the possessor of a refresh token to authenticate longer than expected. This affects the administrative endpoints of the UAA. i.e. /Users, /Groups, etc. However, if the user has been deleted or had groups removed, or the client was deleted, the refresh token will no longer be valid.",
   "severity": [
     {
@@ -14,7 +15,22 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.cloudfoundry.identity:cloudfoundry-identity-server"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,7 +39,35 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.cloudfoundry.org/blog/cve-2018-11047"
+      "url": "https://github.com/cloudfoundry/uaa/commit/2906057dae995024576ce6afdc20abd85569514"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cloudfoundry/uaa/commit/81aeb7a3aa048ea086c494f725d643e48dd9266"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cloudfoundry/uaa/commit/a1d523c7f150e56bf06df8b83ed1d416d6c1d3b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cloudfoundry/uaa/commit/aba1fb5f18e0d628628b2d960fc6d0cc62d86f5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cloudfoundry/uaa/commit/bbbba5aec514ad88e7d1e168a2519c80229f02f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cloudfoundry/uaa/commit/bc2a60b7d84d23f0b895598a25e101404ee55cad"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/cloudfoundry/uaa/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.cloudfoundry.org/blog/cve-2018-11047/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Add source code location and patch links related to CVE-2018-11047.