### PR TITLE
[GHSA-8v97-gv3g-32rf] Cloud Foundry Foundation UAA, versions 4.12.X and 4.13.X,...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-8v97-gv3g-32rf/GHSA-8v97-gv3g-32rf.json
+++ b/advisories/unreviewed/2022/05/GHSA-8v97-gv3g-32rf/GHSA-8v97-gv3g-32rf.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8v97-gv3g-32rf",
-  "modified": "2022-05-13T01:07:03Z",
+  "modified": "2023-02-01T05:03:06Z",
   "published": "2022-05-13T01:07:03Z",
   "aliases": [
     "CVE-2018-1262"
   ],
+  "summary": "Cloud Foundry Foundation UAA, versions 4.12.X and 4.13.X, introduced a feature which could allow privilege escalation across identity zones for clients performing offline validation. A zone administrator could configure their zone to issue tokens which impersonate another zone, granting up to admin privileges in the impersonated zone for clients performing offline token validation.",
   "details": "Cloud Foundry Foundation UAA, versions 4.12.X and 4.13.X, introduced a feature which could allow privilege escalation across identity zones for clients performing offline validation. A zone administrator could configure their zone to issue tokens which impersonate another zone, granting up to admin privileges in the impersonated zone for clients performing offline token validation.",
   "severity": [
     {
@@ -14,7 +15,22 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.cloudfoundry.identity:cloudfoundry-identity-server"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,7 +39,27 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.cloudfoundry.org/blog/cve-2018-1262"
+      "url": "https://github.com/cloudfoundry/uaa/commit/14c745aa293b8d3ce9cdd6bfbc6c0ef3f269b21"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cloudfoundry/uaa/commit/3633a832885ebf33b2e22cc1c0c8ce605e2c657"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cloudfoundry/uaa/commit/4178762a49f547534b13539ca65e1d370772c38"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cloudfoundry/uaa/commit/dccd3962f969913996ee88f653fce3b108c0205"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/cloudfoundry/uaa/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.cloudfoundry.org/blog/cve-2018-1262/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Add patch links and source code location related to CVE-2018-1262.