### PR TITLE
[GHSA-rfx6-vp9g-rh7v] jackson-databind vulnerable to remote code execution due to incorrect deserialization and blocklist bypass

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-rfx6-vp9g-rh7v/GHSA-rfx6-vp9g-rh7v.json
+++ b/advisories/github-reviewed/2018/10/GHSA-rfx6-vp9g-rh7v/GHSA-rfx6-vp9g-rh7v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rfx6-vp9g-rh7v",
-  "modified": "2023-08-28T10:52:28Z",
+  "modified": "2023-08-28T10:52:29Z",
   "published": "2018-10-18T17:42:48Z",
   "aliases": [
     "CVE-2017-17485"
@@ -62,6 +62,66 @@
     {
       "type": "WEB",
       "url": "https://github.com/FasterXML/jackson-databind/issues/1855"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/10fe7f17ea7c8da2a71e7a0c774b420a1d5c1b50"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/2235894210c75f624a3d0cd60bfb0434a20a18bf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/459107dccc9b3ea991af3e6ad0953e54b01ef7c1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/4f16f67ebd22c7522fdbb8a7eb87e3026a807d61"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/978798382ceb72229e5036aa1442943933d6d171"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/f031f27a31625d07922bdd090664c69544200a5d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/eb217dd0f87c5fb471e0668575644aa7eba9a3d3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/bb45fb16709018842f858f1a6e1118676aaa34bd"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/FasterXML/jackson-databind"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-rfx6-vp9g-rh7v"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/irsl/jackson-rce-via-spel/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.netapp.com/advisory/ntap-20180201-0003/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.debian.org/security/2018/dsa-4114"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpuoct2020.html"
     },
     {
       "type": "WEB",
@@ -130,34 +190,6 @@
     {
       "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2019:3892"
-    },
-    {
-      "type": "PACKAGE",
-      "url": "https://github.com/FasterXML/jackson-databind"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://github.com/advisories/GHSA-rfx6-vp9g-rh7v"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/irsl/jackson-rce-via-spel"
-    },
-    {
-      "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20180201-0003"
-    },
-    {
-      "type": "WEB",
-      "url": "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.debian.org/security/2018/dsa-4114"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpuoct2020.html"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add some patch links related to CVE-2017-17485.