### PR TITLE
[GHSA-667q-vj58-rj88] Exposure of Sensitive Information to an Unauthorized Actor in Jenkins

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-667q-vj58-rj88/GHSA-667q-vj58-rj88.json
+++ b/advisories/github-reviewed/2022/05/GHSA-667q-vj58-rj88/GHSA-667q-vj58-rj88.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-667q-vj58-rj88",
-  "modified": "2022-06-28T23:44:10Z",
+  "modified": "2023-12-18T12:01:31Z",
   "published": "2022-05-14T01:04:56Z",
   "aliases": [
     "CVE-2018-1999046"
@@ -62,6 +62,22 @@
     {
       "type": "WEB",
       "url": "https://github.com/jenkinsci/jenkins/commit/6867e4469525d16319b1bae9c840b933fe4e23c4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/7ac1c48ea6a41d47b4d38882be87ddd420b4f676"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/87c61f527d63acd78f0a0569086bfd786f9c35b0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/909781ca14cd8883008e7d4381232ec2d76e82e7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/e56103203c83279777f740f8719b53bf31af8808"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add some patch links related to CVE-2018-1999046.