### PR TITLE
[GHSA-vxc6-wvh8-fpxw] Jenkins before 1.551 and LTS before 1.532.2 does not...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-vxc6-wvh8-fpxw/GHSA-vxc6-wvh8-fpxw.json
+++ b/advisories/unreviewed/2022/05/GHSA-vxc6-wvh8-fpxw/GHSA-vxc6-wvh8-fpxw.json
@@ -1,17 +1,33 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vxc6-wvh8-fpxw",
-  "modified": "2022-05-17T03:53:54Z",
+  "modified": "2023-01-28T05:00:41Z",
   "published": "2022-05-17T03:53:54Z",
   "aliases": [
     "CVE-2014-2062"
   ],
+  "summary": "Jenkins before 1.551 and LTS before 1.532.2 does not invalidate the API token when a user is deleted, which allows remote authenticated users to retain access via the token.",
   "details": "Jenkins before 1.551 and LTS before 1.532.2 does not invalidate the API token when a user is deleted, which allows remote authenticated users to retain access via the token.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -21,6 +37,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/jenkinsci/jenkins/commit/5548b5220cfd496831b5721124189ff18fbb12a3"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
Add source code location and affected product related to CVE-2014-2062.