### PR TITLE
[GHSA-785g-282q-pwvx] Rack CORS Middleware has Insecure File Permissions

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-785g-282q-pwvx/GHSA-785g-282q-pwvx.json
+++ b/advisories/github-reviewed/2024/02/GHSA-785g-282q-pwvx/GHSA-785g-282q-pwvx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-785g-282q-pwvx",
-  "modified": "2024-02-26T22:15:06Z",
+  "modified": "2024-02-26T22:15:07Z",
   "published": "2024-02-26T18:30:31Z",
   "aliases": [
     "CVE-2024-27456"
@@ -17,18 +17,8 @@
         "ecosystem": "RubyGems",
         "name": "rack-cors"
       },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "last_affected": "2.0.1"
-            }
-          ]
-        }
+      "versions": [
+        "2.0.1"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
https://github.com/cyu/rack-cors/issues/274

I've also confirmed locally:

```
❯ ll rack-cors-2.0.0
total 52
drwxr-xr-x 4 jones jones 4096 Feb 27 13:54 ./
drwxr-xr-x 3 jones jones 4096 Feb 27 13:54 ../
-rw-rw-r-- 1 jones jones  540 Feb 27 13:54 .rubocop.yml
-rw-rw-r-- 1 jones jones  152 Feb 27 13:54 .travis.yml
-rw-rw-r-- 1 jones jones 2901 Feb 27 13:54 CHANGELOG.md
-rw-rw-r-- 1 jones jones  155 Feb 27 13:54 Gemfile
-rw-rw-r-- 1 jones jones 1066 Feb 27 13:54 LICENSE.txt
-rw-rw-r-- 1 jones jones 8067 Feb 27 13:54 README.md
-rw-rw-r-- 1 jones jones  494 Feb 27 13:54 Rakefile
drwxr-xr-x 3 jones jones 4096 Feb 27 13:54 lib/
-rw-rw-r-- 1 jones jones 1409 Feb 27 13:54 rack-cors.gemspec
drwxr-xr-x 4 jones jones 4096 Feb 27 13:54 test/
```