### PR TITLE
[GHSA-p5hg-3xm3-gcjg] Spring Framework allows applications to expose STOMP over WebSocket endpoints

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-p5hg-3xm3-gcjg/GHSA-p5hg-3xm3-gcjg.json
+++ b/advisories/github-reviewed/2018/10/GHSA-p5hg-3xm3-gcjg/GHSA-p5hg-3xm3-gcjg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p5hg-3xm3-gcjg",
-  "modified": "2022-04-27T15:08:22Z",
+  "modified": "2023-02-01T05:03:53Z",
   "published": "2018-10-17T20:05:59Z",
   "aliases": [
     "CVE-2018-1270"
@@ -61,51 +61,19 @@
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2018:2939"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://github.com/advisories/GHSA-p5hg-3xm3-gcjg"
+      "url": "https://github.com/spring-projects/spring-framework/commit/0009806debb578e884f6dc98bd1f2dc668020021"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/4ed49b103f64a0cecb38064f26cbf1389afc12124653da2d35166dbe@%3Cissues.activemq.apache.org%3E"
+      "url": "https://github.com/spring-projects/spring-framework/commit/b6327acec825aefadead62bd7825425b048b214c"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/6d3d34adcf3dfc48e36342aa1f18ce3c20bb8e4c458a97508d5bfed1@%3Cissues.activemq.apache.org%3E"
+      "url": "https://github.com/spring-projects/spring-framework/commit/e0de9126ed8cf25cf141d3e66420da94e350708"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/ab825fcade0b49becfa30235b3d54f4a51bb74ea96b6c9adb5d1378c@%3Cissues.activemq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/dcf8599b80e43a6b60482607adb76c64672772dc2d9209ae2170f369@%3Cissues.activemq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rf1bbc0ea4a9f014cf94df9a12a6477d24a27f52741dbc87f2fd52ff2@%3Cissues.geode.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2021/04/msg00022.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://pivotal.io/security/cve-2018-1270"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.exploit-db.com/exploits/44796"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpujul2020.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      "url": "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
     },
     {
       "type": "WEB",
@@ -113,7 +81,55 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+      "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpujul2020.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.exploit-db.com/exploits/44796/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://pivotal.io/security/cve-2018-1270"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2021/04/msg00022.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rf1bbc0ea4a9f014cf94df9a12a6477d24a27f52741dbc87f2fd52ff2@%3Cissues.geode.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/dcf8599b80e43a6b60482607adb76c64672772dc2d9209ae2170f369@%3Cissues.activemq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/ab825fcade0b49becfa30235b3d54f4a51bb74ea96b6c9adb5d1378c@%3Cissues.activemq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/6d3d34adcf3dfc48e36342aa1f18ce3c20bb8e4c458a97508d5bfed1@%3Cissues.activemq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/4ed49b103f64a0cecb38064f26cbf1389afc12124653da2d35166dbe@%3Cissues.activemq.apache.org%3E"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/spring-projects/spring-framework"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-p5hg-3xm3-gcjg"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2018:2939"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source code location and patch links related to CVE-2018-1270.