### PR TITLE
[GHSA-f93f-g33r-8pcp] Improper Restriction of XML External Entity Reference in Spring Framework

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-f93f-g33r-8pcp/GHSA-f93f-g33r-8pcp.json
+++ b/advisories/github-reviewed/2022/05/GHSA-f93f-g33r-8pcp/GHSA-f93f-g33r-8pcp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f93f-g33r-8pcp",
-  "modified": "2022-07-07T22:58:08Z",
+  "modified": "2023-01-27T05:02:11Z",
   "published": "2022-05-13T01:02:39Z",
   "aliases": [
     "CVE-2014-0225"
@@ -61,11 +61,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/44ee51a6c9c3734b3fcf9a20817117e86047d753"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/spring-projects/spring-framework/commit/8e096aeef55287dc829484996c9330cf755891a1"
     },
     {
       "type": "WEB",
       "url": "https://github.com/spring-projects/spring-framework/commit/c6503ebbf7c9e21ff022c58706dbac5417b2b5eb"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/spring-projects/spring-framework"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add one more patch link and source code location related to CVE-2014-0225.