### PR TITLE
[GHSA-vp63-rrcm-9mph] Missing XML Validation in Spring Framework

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-vp63-rrcm-9mph/GHSA-vp63-rrcm-9mph.json
+++ b/advisories/github-reviewed/2022/05/GHSA-vp63-rrcm-9mph/GHSA-vp63-rrcm-9mph.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vp63-rrcm-9mph",
-  "modified": "2022-07-07T23:18:12Z",
+  "modified": "2023-01-27T05:02:07Z",
   "published": "2022-05-13T01:02:38Z",
   "aliases": [
     "CVE-2013-7315"
@@ -43,6 +43,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/spring-projects/spring-framework/issues/15432"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/434735fbf6e7f9051af2ef027657edb99120b173"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/7576274874deeccb6da6b09a8d5bd62e8b5538b7"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/spring-projects/spring-framework"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add patch links related to CVE-2013-7315.