### PR TITLE
[GHSA-rm97-x556-q36h] Versions of the package sanitize-html before 2.12.1 are...

### DIFF
--- a/advisories/unreviewed/2024/02/GHSA-rm97-x556-q36h/GHSA-rm97-x556-q36h.json
+++ b/advisories/unreviewed/2024/02/GHSA-rm97-x556-q36h/GHSA-rm97-x556-q36h.json
@@ -6,6 +6,7 @@
   "aliases": [
     "CVE-2024-21501"
   ],
+  "summary": "Exposure of sensitive information vulnerability in sanitize-html <2.12.1",
   "details": "Versions of the package sanitize-html before 2.12.1 are vulnerable to Information Exposure when used on the backend and with the style attribute allowed, allowing enumeration of files in the system (including project dependencies). An attacker could exploit this vulnerability to gather details about the file system structure and dependencies of the targeted server.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "sanitize-html"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.12.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Missing package name and version mean no dependabot updates, right? This package is widely used so seems important to get those out