### PR TITLE
[GHSA-chcr-x7hc-8fp8] Devise-Two-Factor vulnerable to brute force attacks

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-chcr-x7hc-8fp8/GHSA-chcr-x7hc-8fp8.json
+++ b/advisories/github-reviewed/2024/01/GHSA-chcr-x7hc-8fp8/GHSA-chcr-x7hc-8fp8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-chcr-x7hc-8fp8",
-  "modified": "2024-01-12T15:13:05Z",
+  "modified": "2024-01-19T19:21:53Z",
   "published": "2024-01-12T15:13:05Z",
   "aliases": [
     "CVE-2024-0227"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The associated CVE was opened in error and we are moving it to the Rejected status. We'd like to retract this GHSA to avoid confusion from users now that we've updated the documentation and communicated the issue.