### PR TITLE
[GHSA-785g-282q-pwvx] Rack CORS Middleware has Insecure File Permissions

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-785g-282q-pwvx/GHSA-785g-282q-pwvx.json
+++ b/advisories/github-reviewed/2024/02/GHSA-785g-282q-pwvx/GHSA-785g-282q-pwvx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-785g-282q-pwvx",
-  "modified": "2024-02-27T22:19:11Z",
+  "modified": "2024-02-27T22:19:13Z",
   "published": "2024-02-26T18:30:31Z",
   "aliases": [
     "CVE-2024-27456"
@@ -17,18 +17,8 @@
         "ecosystem": "RubyGems",
         "name": "rack-cors"
       },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "last_affected": "2.0.1"
-            }
-          ]
-        }
+      "versions": [
+        "2.0.1"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Only version 2.0.1 of `rack-cors` is affected.

```
$ gem fetch rack-cors -v 2.0.0
$ tar xvf rack-cors-2.0.0.gem
$ tar tzvf data.tar.gz
-rw-rw-r-- wheel/wheel     540 2023-02-14 05:15 .rubocop.yml
-rw-rw-r-- wheel/wheel     152 2023-02-14 05:15 .travis.yml
-rw-rw-r-- wheel/wheel    2901 2023-02-14 05:15 CHANGELOG.md
-rw-rw-r-- wheel/wheel     155 2023-02-14 05:15 Gemfile
-rw-rw-r-- wheel/wheel    1066 2023-02-14 05:15 LICENSE.txt
-rw-rw-r-- wheel/wheel    8067 2023-02-14 05:15 README.md
-rw-rw-r-- wheel/wheel     494 2023-02-14 05:15 Rakefile
-rw-rw-r-- wheel/wheel    5808 2023-02-14 05:15 lib/rack/cors.rb
-rw-rw-r-- wheel/wheel    4365 2023-02-14 05:15 lib/rack/cors/resource.rb
-rw-rw-r-- wheel/wheel    1435 2023-02-14 05:15 lib/rack/cors/resources.rb
-rw-rw-r-- wheel/wheel     369 2023-02-14 05:15 lib/rack/cors/resources/cors_misconfiguration_error.rb
-rw-rw-r-- wheel/wheel    1424 2023-02-14 05:15 lib/rack/cors/result.rb
-rw-rw-r-- wheel/wheel      88 2023-02-14 05:15 lib/rack/cors/version.rb
-rw-rw-r-- wheel/wheel    1409 2023-02-14 05:15 rack-cors.gemspec
-rw-rw-r-- wheel/wheel     125 2023-02-14 05:15 test/.rubocop.yml
-rw-rw-r-- wheel/wheel   36547 2023-02-14 05:15 test/cors/expect.js
-rw-rw-r-- wheel/wheel    3819 2023-02-14 05:15 test/cors/mocha.css
-rw-rw-r-- wheel/wheel  111429 2023-02-14 05:15 test/cors/mocha.js
-rw-rw-r-- wheel/wheel     502 2023-02-14 05:15 test/cors/runner.html
-rw-rw-r-- wheel/wheel    1773 2023-02-14 05:15 test/cors/test.cors.coffee
-rw-rw-r-- wheel/wheel    2485 2023-02-14 05:15 test/cors/test.cors.js
-rw-rw-r-- wheel/wheel   17430 2023-02-14 05:15 test/unit/cors_test.rb
-rw-rw-r-- wheel/wheel    2541 2023-02-14 05:15 test/unit/dsl_test.rb
-rw-rw-r-- wheel/wheel     149 2023-02-14 05:15 test/unit/insecure.ru
-rw-rw-r-- wheel/wheel     144 2023-02-14 05:15 test/unit/non_http.ru
-rw-rw-r-- wheel/wheel    1815 2023-02-14 05:15 test/unit/test.ru
$ gem fetch rack-cors -v 2.0.1
$ tar xvf rack-cors-2.0.1.gem
$ tar tzvf data.tar.gz
-rw-rw-rw- wheel/wheel     744 2023-03-16 22:41 .github/workflows/ci.yaml
-rw-rw-rw- wheel/wheel     559 2023-03-16 22:41 .rubocop.yml
-rw-rw-rw- wheel/wheel    2992 2023-03-16 22:41 CHANGELOG.md
-rw-rw-rw- wheel/wheel     155 2023-03-16 22:41 Gemfile
-rw-rw-rw- wheel/wheel    1066 2023-03-16 22:41 LICENSE.txt
-rw-rw-rw- wheel/wheel    8087 2023-03-16 22:41 README.md
-rw-rw-rw- wheel/wheel     494 2023-03-16 22:41 Rakefile
-rw-rw-rw- wheel/wheel    5808 2023-03-16 22:41 lib/rack/cors.rb
-rw-rw-rw- wheel/wheel    4602 2023-03-16 22:41 lib/rack/cors/resource.rb
-rw-rw-rw- wheel/wheel    1435 2023-03-16 22:41 lib/rack/cors/resources.rb
-rw-rw-rw- wheel/wheel     369 2023-03-16 22:41 lib/rack/cors/resources/cors_misconfiguration_error.rb
-rw-rw-rw- wheel/wheel    1424 2023-03-16 22:41 lib/rack/cors/result.rb
-rw-rw-rw- wheel/wheel      88 2023-03-16 22:41 lib/rack/cors/version.rb
-rw-rw-rw- wheel/wheel    1409 2023-03-16 22:41 rack-cors.gemspec
-rw-rw-rw- wheel/wheel     125 2023-03-16 22:41 test/.rubocop.yml
-rw-rw-rw- wheel/wheel   36547 2023-03-16 22:41 test/cors/expect.js
-rw-rw-rw- wheel/wheel    3819 2023-03-16 22:41 test/cors/mocha.css
-rw-rw-rw- wheel/wheel  111429 2023-03-16 22:41 test/cors/mocha.js
-rw-rw-rw- wheel/wheel     502 2023-03-16 22:41 test/cors/runner.html
-rw-rw-rw- wheel/wheel    1773 2023-03-16 22:41 test/cors/test.cors.coffee
-rw-rw-rw- wheel/wheel    2485 2023-03-16 22:41 test/cors/test.cors.js
-rw-rw-rw- wheel/wheel   17430 2023-03-16 22:41 test/unit/cors_test.rb
-rw-rw-rw- wheel/wheel    2541 2023-03-16 22:41 test/unit/dsl_test.rb
-rw-rw-rw- wheel/wheel     149 2023-03-16 22:41 test/unit/insecure.ru
-rw-rw-rw- wheel/wheel     144 2023-03-16 22:41 test/unit/non_http.ru
-rw-rw-rw- wheel/wheel    1815 2023-03-16 22:41 test/unit/test.ru
```