### PR TITLE
[GHSA-jjhx-jhvp-74wq] Rails has possible ReDoS vulnerability in Accept header parsing in Action Dispatch

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-jjhx-jhvp-74wq/GHSA-jjhx-jhvp-74wq.json
+++ b/advisories/github-reviewed/2024/02/GHSA-jjhx-jhvp-74wq/GHSA-jjhx-jhvp-74wq.json
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "actionpack"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This is a vulnerability in rails actionpack, so affected packages should be registered in actionpack.