### PR TITLE
[GHSA-8h22-8cf7-hq6g] Rails has possible Sensitive Session Information Leak in Active Storage

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-8h22-8cf7-hq6g/GHSA-8h22-8cf7-hq6g.json
+++ b/advisories/github-reviewed/2024/02/GHSA-8h22-8cf7-hq6g/GHSA-8h22-8cf7-hq6g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8h22-8cf7-hq6g",
-  "modified": "2024-02-27T21:41:16Z",
+  "modified": "2024-02-27T21:41:17Z",
   "published": "2024-02-27T21:41:16Z",
   "aliases": [
     "CVE-2024-26144"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "activestorage"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "activestorage"
       },
       "ranges": [
         {
@@ -78,10 +78,6 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/rails/rails"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/actionpack/CVE-2024-26144.yml"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
This is a vulnerability in rails activestorage, so affected packages should be registered in activestorage.

The following link has been removed as it is broken.
https://github.com/rubysec/ruby-advisory-db/blob/master/gems/actionpack/CVE-2024-26144.yml