### PR TITLE
[GHSA-4qq5-mxxx-m6gg] MLflow authentication requirement bypass can allow a user to arbitrarily create an account

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-4qq5-mxxx-m6gg/GHSA-4qq5-mxxx-m6gg.json
+++ b/advisories/github-reviewed/2023/11/GHSA-4qq5-mxxx-m6gg/GHSA-4qq5-mxxx-m6gg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4qq5-mxxx-m6gg",
-  "modified": "2023-11-17T22:49:27Z",
+  "modified": "2023-11-20T16:48:03Z",
   "published": "2023-11-16T21:30:46Z",
   "aliases": [
     "CVE-2023-6014"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.5.0"
+              "fixed": "2.8.0"
             }
           ]
         }
@@ -45,8 +45,20 @@
       "url": "https://github.com/mlflow/mlflow/issues/9669"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/mlflow/mlflow/pull/9700"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mlflow/mlflow/commit/32de2154ef9f946160e5dc01a4d8a449dd0bd259"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/mlflow/mlflow"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mlflow/mlflow/releases/tag/v2.8.0"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
This vulnerability has been fixed in 2.8.0.

https://github.com/mlflow/mlflow/pull/9700
https://github.com/mlflow/mlflow/commit/32de2154ef9f946160e5dc01a4d8a449dd0bd259
https://github.com/mlflow/mlflow/releases/tag/v2.8.0