### PR TITLE
[GHSA-8h22-8cf7-hq6g] Rails has possible Sensitive Session Information Leak in Active Storage

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-8h22-8cf7-hq6g/GHSA-8h22-8cf7-hq6g.json
+++ b/advisories/github-reviewed/2024/02/GHSA-8h22-8cf7-hq6g/GHSA-8h22-8cf7-hq6g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8h22-8cf7-hq6g",
-  "modified": "2024-02-27T21:41:16Z",
+  "modified": "2024-02-27T21:41:17Z",
   "published": "2024-02-27T21:41:16Z",
   "aliases": [
     "CVE-2024-26144"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -92,7 +92,7 @@
     "cwe_ids": [
       "CWE-200"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2024-02-27T21:41:16Z",
     "nvd_published_at": "2024-02-27T16:15:46Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
I would like to propose that the impact be amended as follows.
Scope: Unchanged -> Change
Integrity: None -> Low

The `Scope` should be `Changed` as XSS vulnerabilities are.
This vulnerability leaks the user's cookie, which may affect components other than ActiveStorage.
e.g. https://github.com/advisories/GHSA-9822-6m93-xqf4

The `Integrity` should be `Low` as an innocent user may receive an HTTP response containing another user's cookie.
An attacker may be able to poison the cache with his cookie.

Thanks.