### PR TITLE
[GHSA-jjhx-jhvp-74wq] Rails has possible ReDoS vulnerability in Accept header parsing in Action Dispatch

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-jjhx-jhvp-74wq/GHSA-jjhx-jhvp-74wq.json
+++ b/advisories/github-reviewed/2024/02/GHSA-jjhx-jhvp-74wq/GHSA-jjhx-jhvp-74wq.json
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "actionpack"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
If you check the [patch][2] listed in the [original advisory][1], the vulnerability is in the actionpack gem. The rails gem acts more as a meta-gem which pulls in the other action-/active- dependencies.

[1]: https://discuss.rubyonrails.org/t/possible-redos-vulnerability-in-accept-header-parsing-in-action-dispatch/84946
[2]: https://discuss.rubyonrails.org/uploads/short-url/pGTqvLr4JwOAx0TDtrsrOsFkBpj.patch