### PR TITLE
[GHSA-9822-6m93-xqf4] Rails has possible XSS Vulnerability in Action Controller

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-9822-6m93-xqf4/GHSA-9822-6m93-xqf4.json
+++ b/advisories/github-reviewed/2024/02/GHSA-9822-6m93-xqf4/GHSA-9822-6m93-xqf4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9822-6m93-xqf4",
-  "modified": "2024-02-27T21:41:12Z",
+  "modified": "2024-02-27T21:41:13Z",
   "published": "2024-02-27T21:41:12Z",
   "aliases": [
     "CVE-2024-26143"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "actionpack"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "RubyGems",
-        "name": "rails"
+        "name": "actionpack"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The [patch][2] listed in the [original advisory][1] indicates that the vulnerability is in the actionpack gem, not the rails meta-gem.

[1]: https://discuss.rubyonrails.org/t/possible-xss-vulnerability-in-action-controller/84947
[2]: https://discuss.rubyonrails.org/uploads/short-url/xR0UfuAFkM0JshURTBlFDhVNfnI.patch