### PR TITLE
[GHSA-fp5r-v3w9-4333] JMSAppender in Log4j 1.2 is vulnerable to deserialization of untrusted data

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-fp5r-v3w9-4333/GHSA-fp5r-v3w9-4333.json
+++ b/advisories/github-reviewed/2021/12/GHSA-fp5r-v3w9-4333/GHSA-fp5r-v3w9-4333.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fp5r-v3w9-4333",
-  "modified": "2023-10-26T15:04:19Z",
+  "modified": "2023-12-22T15:07:03Z",
   "published": "2021-12-14T19:49:31Z",
   "aliases": [
     "CVE-2021-4104"
@@ -28,11 +28,14 @@
               "introduced": "1.2.0"
             },
             {
-              "last_affected": "1.2.17"
+              "fixed": "2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.2.17"
+      }
     },
     {
       "package": {
@@ -93,7 +96,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20211223-0007"
+      "url": "https://security.netapp.com/advisory/ntap-20211223-0007/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The description suggests using Log4j version 2
" Users should upgrade to Log4j 2 as it addresses numerous other issues from the previous versions."