### PR TITLE
[GHSA-ggx9-4728-588r] Apache Tomcat Directory Traversal vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-ggx9-4728-588r/GHSA-ggx9-4728-588r.json
+++ b/advisories/github-reviewed/2022/05/GHSA-ggx9-4728-588r/GHSA-ggx9-4728-588r.json
@@ -61,7 +61,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/1250e100bde103c0b35a974fc343d3c202576ec9"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/tomcat/commit/3e1010b1a2f648581fac3d68afbf18f2979f6bf6"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/4b0e7e7a9f28e707f26fcbba3a1526e5053e6fa8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/df5a83a23affb55a78637573945c75601bc86a7a"
     },
     {
       "type": "WEB",
@@ -69,55 +81,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2010:0119"
-    },
-    {
-      "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2010:0580"
-    },
-    {
-      "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2010:0582"
-    },
-    {
-      "type": "WEB",
-      "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/55855"
-    },
-    {
-      "type": "PACKAGE",
-      "url": "https://github.com/apache/tomcat"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/06cfb634bc7bf37af7d8f760f118018746ad8efbd519c4b789ac9c2e@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/8dcaf7c3894d66cb717646ea1504ea6e300021c85bb4e677dc16b1aa@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r3aacc40356defc3f248aa504b1e48e819dd0471a0a83349080c6bcbf@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r584a714f141eff7b1c358d4679288177bd4ca4558e9999d15867d4b5@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://oval.cisecurity.org/repository/search/definition/oval:org.mitre.oval:def:19355"
-    },
-    {
-      "type": "WEB",
-      "url": "https://oval.cisecurity.org/repository/search/definition/oval:org.mitre.oval:def:7017"
-    },
-    {
-      "type": "WEB",
-      "url": "https://support.hpe.com/hpesc/public/docDisplay?docId=c02241113"
-    },
-    {
-      "type": "WEB",
-      "url": "https://web.archive.org/web/20200229071135/http://www.securityfocus.com/bid/37944"
+      "url": "https://web.archive.org/web/20201206235536/http://www.securityfocus.com/archive/1/509148/100/0/threaded"
     },
     {
       "type": "WEB",
@@ -125,7 +89,55 @@
     },
     {
       "type": "WEB",
-      "url": "https://web.archive.org/web/20201206235536/http://www.securityfocus.com/archive/1/509148/100/0/threaded"
+      "url": "https://web.archive.org/web/20200229071135/http://www.securityfocus.com/bid/37944"
+    },
+    {
+      "type": "WEB",
+      "url": "https://support.hpe.com/hpesc/public/docDisplay?docId=c02241113"
+    },
+    {
+      "type": "WEB",
+      "url": "https://oval.cisecurity.org/repository/search/definition/oval:org.mitre.oval:def:7017"
+    },
+    {
+      "type": "WEB",
+      "url": "https://oval.cisecurity.org/repository/search/definition/oval:org.mitre.oval:def:19355"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r584a714f141eff7b1c358d4679288177bd4ca4558e9999d15867d4b5@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r3aacc40356defc3f248aa504b1e48e819dd0471a0a83349080c6bcbf@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/8dcaf7c3894d66cb717646ea1504ea6e300021c85bb4e677dc16b1aa@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/06cfb634bc7bf37af7d8f760f118018746ad8efbd519c4b789ac9c2e@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat"
+    },
+    {
+      "type": "WEB",
+      "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/55855"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2010:0582"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2010:0580"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2010:0119"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Find three more patch links related to CVE-2009-2693.