### PR TITLE
[GHSA-fj6c-prgj-gr3r] Improper Limitation of a Pathname to a Restricted Directory in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-fj6c-prgj-gr3r/GHSA-fj6c-prgj-gr3r.json
+++ b/advisories/github-reviewed/2022/05/GHSA-fj6c-prgj-gr3r/GHSA-fj6c-prgj-gr3r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fj6c-prgj-gr3r",
-  "modified": "2024-02-21T20:24:53Z",
+  "modified": "2024-02-21T20:24:54Z",
   "published": "2022-05-14T01:17:02Z",
   "aliases": [
     "CVE-2010-3718"
@@ -77,67 +77,31 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/835f85ed22b9f788e23b6f49893698770e9fcfe3"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/tomcat/commit/a697f7b52c4e3aea0c6763b33d413b54a518e883"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/ad2235f5b0673606d060a158d778b8613e31ebec"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/cad9cac2878d1e55887dd6fd459531a10b7b005c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/f6db636b7addb1f7a01e361559bff2da21a11812"
     },
     {
       "type": "WEB",
       "url": "https://github.com/apache/tomcat55/commit/53b9e4bf21aef92321404644bfbb22ae625c033b"
     },
     {
-      "type": "PACKAGE",
-      "url": "https://github.com/apache/tomcat"
-    },
-    {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/06cfb634bc7bf37af7d8f760f118018746ad8efbd519c4b789ac9c2e%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/06cfb634bc7bf37af7d8f760f118018746ad8efbd519c4b789ac9c2e@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/8dcaf7c3894d66cb717646ea1504ea6e300021c85bb4e677dc16b1aa%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r3aacc40356defc3f248aa504b1e48e819dd0471a0a83349080c6bcbf%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r3aacc40356defc3f248aa504b1e48e819dd0471a0a83349080c6bcbf@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r584a714f141eff7b1c358d4679288177bd4ca4558e9999d15867d4b5%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r584a714f141eff7b1c358d4679288177bd4ca4558e9999d15867d4b5@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apple.com/archives/Security-announce/2011//Oct/msg00003.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.opensuse.org/opensuse-security-announce/2011-04/msg00000.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://marc.info/?l=bugtraq&m=130168502603566&w=2"
-    },
-    {
-      "type": "WEB",
-      "url": "https://marc.info/?l=bugtraq&m=132215163318824&w=2"
-    },
-    {
-      "type": "WEB",
-      "url": "https://marc.info/?l=bugtraq&m=136485229118404&w=2"
-    },
-    {
-      "type": "WEB",
-      "url": "https://marc.info/?l=bugtraq&m=139344343412337&w=2"
+      "url": "https://tomcat.apache.org/security-6.html#Fixed_in_Apache_Tomcat_6.0.30"
     },
     {
       "type": "WEB",
@@ -145,7 +109,59 @@
     },
     {
       "type": "WEB",
-      "url": "https://tomcat.apache.org/security-6.html#Fixed_in_Apache_Tomcat_6.0.30"
+      "url": "https://marc.info/?l=bugtraq&m=139344343412337&w=2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://marc.info/?l=bugtraq&m=136485229118404&w=2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://marc.info/?l=bugtraq&m=132215163318824&w=2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://marc.info/?l=bugtraq&m=130168502603566&w=2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.opensuse.org/opensuse-security-announce/2011-04/msg00000.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apple.com/archives/Security-announce/2011//Oct/msg00003.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r584a714f141eff7b1c358d4679288177bd4ca4558e9999d15867d4b5@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r584a714f141eff7b1c358d4679288177bd4ca4558e9999d15867d4b5%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r3aacc40356defc3f248aa504b1e48e819dd0471a0a83349080c6bcbf@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r3aacc40356defc3f248aa504b1e48e819dd0471a0a83349080c6bcbf%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/8dcaf7c3894d66cb717646ea1504ea6e300021c85bb4e677dc16b1aa%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/06cfb634bc7bf37af7d8f760f118018746ad8efbd519c4b789ac9c2e@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/06cfb634bc7bf37af7d8f760f118018746ad8efbd519c4b789ac9c2e%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Find four more patch links related to CVE-2010-3718.