### PR TITLE
[GHSA-c78g-qwpw-2jgv] Improper Neutralization of Input During Web Page Generation  in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-c78g-qwpw-2jgv/GHSA-c78g-qwpw-2jgv.json
+++ b/advisories/github-reviewed/2022/05/GHSA-c78g-qwpw-2jgv/GHSA-c78g-qwpw-2jgv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c78g-qwpw-2jgv",
-  "modified": "2022-07-08T18:47:13Z",
+  "modified": "2023-02-13T16:52:48Z",
   "published": "2022-05-14T02:42:46Z",
   "aliases": [
     "CVE-2010-4172"
@@ -58,7 +58,31 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/2d536e839f6f286370a640935d3b587424e8ab67"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/2f0f80a6c36d6875c64f8c857e2e26661a3865d4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/5971f9392edc6d70808b2599b062b050fcd11d23"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/afd4b3b3904593530c338e449b49198199694f4c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/b328ce28c02ea79b5315c6ead8995ee993541430"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=656246"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add source code location and patch links related to CVE-2010-4172.