### PR TITLE
[GHSA-3p86-xgrq-m6p6] Improper Neutralization of Input During Web Page Generation in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-3p86-xgrq-m6p6/GHSA-3p86-xgrq-m6p6.json
+++ b/advisories/github-reviewed/2022/05/GHSA-3p86-xgrq-m6p6/GHSA-3p86-xgrq-m6p6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3p86-xgrq-m6p6",
-  "modified": "2024-02-21T20:38:34Z",
+  "modified": "2024-02-21T20:38:36Z",
   "published": "2022-05-03T03:25:09Z",
   "aliases": [
     "CVE-2011-0013"
@@ -77,51 +77,27 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/apache/tomcat/commit/58223c5ecc0751c3642c810f291b8f033d33b97f"
-    },
-    {
-      "type": "WEB",
       "url": "https://github.com/apache/tomcat55/commit/863d77c7d321245de019ac32252828e0a025c5b4"
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2011:0791"
+      "url": "https://github.com/apache/tomcat/commit/fce861ba7f6ed5e11f839759f1c855370c43b8d3"
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2011:0896"
+      "url": "https://github.com/apache/tomcat/commit/c8a9a43183e061f09eb5cf7cd5443cecd8699462"
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2011:0897"
+      "url": "https://github.com/apache/tomcat/commit/1930114c4122f2b6f45d6b92e7790288b17e2ad2"
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2011:1845"
+      "url": "https://github.com/apache/tomcat/commit/493ba610a8973efec6e5ca5c02d8cc9c323d4d5f"
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/security/cve/CVE-2011-0013"
-    },
-    {
-      "type": "WEB",
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=675786"
-    },
-    {
-      "type": "PACKAGE",
-      "url": "https://github.com/apache/tomcat"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/06cfb634bc7bf37af7d8f760f118018746ad8efbd519c4b789ac9c2e@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/8dcaf7c3894d66cb717646ea1504ea6e300021c85bb4e677dc16b1aa@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r3aacc40356defc3f248aa504b1e48e819dd0471a0a83349080c6bcbf@%3Cdev.tomcat.apache.org%3E"
+      "url": "https://github.com/apache/tomcat/commit/58223c5ecc0751c3642c810f291b8f033d33b97f"
     },
     {
       "type": "WEB",
@@ -162,6 +138,46 @@
     {
       "type": "WEB",
       "url": "https://web.archive.org/web/20151017023138/http://secunia.com/advisories/57126"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r3aacc40356defc3f248aa504b1e48e819dd0471a0a83349080c6bcbf@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/8dcaf7c3894d66cb717646ea1504ea6e300021c85bb4e677dc16b1aa@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/06cfb634bc7bf37af7d8f760f118018746ad8efbd519c4b789ac9c2e@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat"
+    },
+    {
+      "type": "WEB",
+      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=675786"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/security/cve/CVE-2011-0013"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2011:1845"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2011:0897"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2011:0896"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2011:0791"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add four more patch links related to CVE-2011-0013.