### PR TITLE
[GHSA-j24h-xcpc-9jw8] Eclipse IDE XXE in eclipse.platform

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-j24h-xcpc-9jw8/GHSA-j24h-xcpc-9jw8.json
+++ b/advisories/github-reviewed/2023/11/GHSA-j24h-xcpc-9jw8/GHSA-j24h-xcpc-9jw8.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.eclipse.core:org.eclipse.core.runtime"
+        "name": "org.eclipse.platform:org.eclipse.core.runtime"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.eclipse.pde:org.eclipse.pde.core"
+        "name": "org.eclipse.platform:org.eclipse.platform"
       },
       "ranges": [
         {
@@ -47,7 +47,105 @@
               "introduced": "0"
             },
             {
-              "fixed": "3.13.2400"
+              "fixed": "< 4.29.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.29.0"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.platform:org.eclipse.jface"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.31.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.platform:org.eclipse.ui.forms"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.13.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.platform:org.eclipse.ui.ide"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.21.100"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.platform:org.eclipse.urischeme"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.3.100"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.platform:org.eclipse.jdt.ui"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.30.0"
             }
           ]
         }

--- a/advisories/github-reviewed/2023/11/GHSA-j24h-xcpc-9jw8/GHSA-j24h-xcpc-9jw8.json
+++ b/advisories/github-reviewed/2023/11/GHSA-j24h-xcpc-9jw8/GHSA-j24h-xcpc-9jw8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j24h-xcpc-9jw8",
-  "modified": "2023-11-30T19:52:54Z",
+  "modified": "2023-11-30T19:52:56Z",
   "published": "2023-11-30T19:52:54Z",
   "aliases": [
     "CVE-2023-4218"
@@ -18,101 +18,6 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.ant.ui"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.core.variables"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.debug.core"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.debug.ui"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.core.resources"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
         "name": "org.eclipse.core:org.eclipse.core.runtime"
       },
       "ranges": [
@@ -123,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.29"
+              "fixed": "3.29.0"
             }
           ]
         }
@@ -132,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.ant.core"
+        "name": "org.eclipse.pde:org.eclipse.pde.core"
       },
       "ranges": [
         {
@@ -142,235 +47,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.ant.launching"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.team.ui"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.compare.examples.xml"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.help.base"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.help.ui"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.help.webapp"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.help"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.tips.ide"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.ui.cheatsheets"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.ui.intro.universal"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.ui.intro"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.update.configurator"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
+              "fixed": "3.13.2400"
             }
           ]
         }
@@ -392,11 +69,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/eclipse-pde/eclipse.pde/pull/632"
+      "url": "https://github.com/eclipse-pde/eclipse.pde/pull/632/"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/eclipse-pde/eclipse.pde/pull/667"
+      "url": "https://github.com/eclipse-pde/eclipse.pde/pull/667/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The previous entries for this CVE were incorrect, referencing version 4.29 of the Eclipse IDE project and applying them to artifacts who don't even have a version matching that release.