### PR TITLE
[GHSA-c59h-r6p8-q9wc] Next.js missing cache-control header may lead to CDN caching empty reply

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-c59h-r6p8-q9wc/GHSA-c59h-r6p8-q9wc.json
+++ b/advisories/github-reviewed/2023/10/GHSA-c59h-r6p8-q9wc/GHSA-c59h-r6p8-q9wc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c59h-r6p8-q9wc",
-  "modified": "2023-10-24T19:18:58Z",
+  "modified": "2023-11-09T05:04:04Z",
   "published": "2023-10-22T03:30:23Z",
   "aliases": [
     "CVE-2023-46298"
@@ -22,7 +22,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0.9.9"
+              "introduced": "13.0.4-canary.4"
             },
             {
               "fixed": "13.4.20-canary.13"
@@ -40,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/vercel/next.js/issues/45301"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vercel/next.js/pull/42936"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The behavior that led to the vulnerability, where getServerSideProps is not executed and an empty object is returned, was introduced in [this PR](https://github.com/vercel/next.js/pull/42936) in 2022.
The code merged from this PR was released in v13.0.4-canary.4. Therefore, I believe this vulnerability started occurring after that release.