### PR TITLE
[GHSA-785g-282q-pwvx] Rack CORS Middleware has Insecure File Permissions

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-785g-282q-pwvx/GHSA-785g-282q-pwvx.json
+++ b/advisories/github-reviewed/2024/02/GHSA-785g-282q-pwvx/GHSA-785g-282q-pwvx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-785g-282q-pwvx",
-  "modified": "2024-02-27T22:19:11Z",
+  "modified": "2024-02-27T22:19:13Z",
   "published": "2024-02-26T18:30:31Z",
   "aliases": [
     "CVE-2024-27456"
@@ -17,18 +17,8 @@
         "ecosystem": "RubyGems",
         "name": "rack-cors"
       },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "last_affected": "2.0.1"
-            }
-          ]
-        }
+      "versions": [
+        "2.0.1"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to https://github.com/cyu/rack-cors/issues/274, it only appears to be a packaging issue with the specific 2.0.1 version, not any other versions.