### PR TITLE
[GHSA-c8v6-786g-vjx6] json-jwt allows bypass of identity checks via a sign/encryption confusion attack

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-c8v6-786g-vjx6/GHSA-c8v6-786g-vjx6.json
+++ b/advisories/github-reviewed/2024/02/GHSA-c8v6-786g-vjx6/GHSA-c8v6-786g-vjx6.json
@@ -25,7 +25,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.16.3"
+              "last_affected": "1.16.5"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The [original advisory](https://github.com/P3ngu1nW/CVE_Request/blob/main/novjson-jwt.md) was published 2023-12-22, but [version 1.16.4](https://rubygems.org/gems/json-jwt/versions/1.16.4) was published on 2023-12-27. Reviewing the diffs of versions [1.16.4](https://rubygems.org/gems/json-jwt/versions/1.16.4) and [1.16.5](https://my.diffend.io/gems/json-jwt/prev/1.16.5) show no significant changes that would indicate a patch. I believe all versions are currently affected by this vulnerability.