### PR TITLE
[GHSA-2ppp-xj34-vvf7] Apache Struts's CookieInterceptor component does not use the parameter-name whitelist

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-2ppp-xj34-vvf7/GHSA-2ppp-xj34-vvf7.json
+++ b/advisories/github-reviewed/2022/05/GHSA-2ppp-xj34-vvf7/GHSA-2ppp-xj34-vvf7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2ppp-xj34-vvf7",
-  "modified": "2023-12-27T20:13:27Z",
+  "modified": "2023-12-27T20:13:28Z",
   "published": "2022-05-04T00:29:43Z",
   "aliases": [
     "CVE-2012-0392"
@@ -61,6 +61,10 @@
       "url": "https://github.com/apache/struts/commit/25e50069d60434a30395e3a98357ffba2bed427e"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/34c80dae734e70f13c0e46f9c83602fb71318e58"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/apache/struts"
     },
@@ -74,7 +78,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://web.archive.org/web/20140723153720/http://secunia.com/advisories/47393"
+      "url": "https://web.archive.org/web/20140723153720/http://secunia.com/advisories/47393/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add a patch commit for it:`https://github.com/apache/struts/commit/34c80dae734e70f13c0e46f9c83602fb71318e58`. the commit-msg shows `WW-3729 - Improves Strict DMI mode`