### PR TITLE
[GHSA-hxqq-w4mr-mc62] Apache Struts's ParameterInterceptor component does not prevent access to public constructors

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-hxqq-w4mr-mc62/GHSA-hxqq-w4mr-mc62.json
+++ b/advisories/github-reviewed/2022/05/GHSA-hxqq-w4mr-mc62/GHSA-hxqq-w4mr-mc62.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hxqq-w4mr-mc62",
-  "modified": "2023-12-27T20:24:03Z",
+  "modified": "2023-12-27T20:24:04Z",
   "published": "2022-05-04T00:29:43Z",
   "aliases": [
     "CVE-2012-0393"
@@ -61,6 +61,10 @@
       "url": "https://github.com/apache/struts/commit/25e50069d60434a30395e3a98357ffba2bed427e"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/9cad25f258bb2629d263f828574d2671366c238d"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/apache/struts"
     },
@@ -70,7 +74,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://web.archive.org/web/20140723153720/http://secunia.com/advisories/47393"
+      "url": "https://web.archive.org/web/20140723153720/http://secunia.com/advisories/47393/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add patch commit https://github.com/apache/struts/commit/9cad25f258bb2629d263f828574d2671366c238d. the code changes matches the solution in this link: https://web.archive.org/web/20120612142634/https://sec-consult.com/files/20120104-0_Apache_Struts2_Multiple_Critical_Vulnerabilities.txt, as shown in current ref links.