### PR TITLE
[GHSA-hmvj-gc9q-mg9p] Apache Struts's DebuggingInterceptor component allows remote code execution in developer mode

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-hmvj-gc9q-mg9p/GHSA-hmvj-gc9q-mg9p.json
+++ b/advisories/github-reviewed/2022/05/GHSA-hmvj-gc9q-mg9p/GHSA-hmvj-gc9q-mg9p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hmvj-gc9q-mg9p",
-  "modified": "2023-12-27T20:24:30Z",
+  "modified": "2023-12-27T20:24:32Z",
   "published": "2022-05-04T00:29:43Z",
   "aliases": [
     "CVE-2012-0394"
@@ -40,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/struts/commit/34c80dae734e70f13c0e46f9c83602fb71318e58"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/9cad25f258bb2629d263f828574d2671366c238d"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add a patch commit https://github.com/apache/struts/commit/9cad25f258bb2629d263f828574d2671366c238d. the code changes matches the recommended remediation measure in https://www.sec-consult.com/files/20120104-0_Apache_Struts2_Multiple_Critical_Vulnerabilities.txt