### PR TITLE
[GHSA-v45r-rj5x-hpg2] Cleartext Transmission of Sensitive Information in Apache CXF

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-v45r-rj5x-hpg2/GHSA-v45r-rj5x-hpg2.json
+++ b/advisories/github-reviewed/2022/05/GHSA-v45r-rj5x-hpg2/GHSA-v45r-rj5x-hpg2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v45r-rj5x-hpg2",
-  "modified": "2023-12-21T21:22:54Z",
+  "modified": "2023-12-21T21:22:55Z",
   "published": "2022-05-13T01:09:20Z",
   "aliases": [
     "CVE-2014-0035"
@@ -62,11 +62,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/apache/cxf/commit/d249721708694cbb0f431c0658166ebdcb02ec15"
+      "url": "https://github.com/apache/cxf/commit/5df3f72f1a26b7c9ac2888ab65e41f4105706580"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/apache/cxf"
+      "url": "https://github.com/apache/cxf/commit/d249721708694cbb0f431c0658166ebdcb02ec15"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/cxf/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add a patch commit https://github.com/apache/cxf/commit/5df3f72f1a26b7c9ac2888ab65e41f4105706580, the commit msg claims: `Another EncryptBeforeSigning fix
git-svn-id: https://svn.apache.org/repos/asf/cxf/trunk@1564724 13f79535-47bb-0310-9956-ffa450edef68`