### PR TITLE
[GHSA-xx68-jfcg-xmmf] Commons FileUpload Denial of service vulnerability

### DIFF
--- a/advisories/github-reviewed/2018/12/GHSA-xx68-jfcg-xmmf/GHSA-xx68-jfcg-xmmf.json
+++ b/advisories/github-reviewed/2018/12/GHSA-xx68-jfcg-xmmf/GHSA-xx68-jfcg-xmmf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xx68-jfcg-xmmf",
-  "modified": "2023-09-29T12:05:17Z",
+  "modified": "2023-09-29T12:05:19Z",
   "published": "2018-12-21T17:51:42Z",
   "aliases": [
     "CVE-2014-0050"
@@ -80,6 +80,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0050"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/commons-fileupload/commit/c61ff05b3241cb14d989b67209e57aa71540417a"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add a patch commit https://github.com/apache/commons-fileupload/commit/c61ff05b3241cb14d989b67209e57aa71540417a for apache/commons-fileupload, the commit msg shows it.