### PR TITLE
[GHSA-c78g-qwpw-2jgv] Improper Neutralization of Input During Web Page Generation  in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-c78g-qwpw-2jgv/GHSA-c78g-qwpw-2jgv.json
+++ b/advisories/github-reviewed/2022/05/GHSA-c78g-qwpw-2jgv/GHSA-c78g-qwpw-2jgv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c78g-qwpw-2jgv",
-  "modified": "2022-07-08T18:47:13Z",
+  "modified": "2023-02-13T16:52:48Z",
   "published": "2022-05-14T02:42:46Z",
   "aliases": [
     "CVE-2010-4172"
@@ -55,6 +55,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2010-4172"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/5971f9392edc6d70808b2599b062b050fcd11d23"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
"Add a patch https://github.com/apache/tomcat/commit/5971f9392edc6d70808b2599b062b050fcd11d23, of which the commit message claims `Fix CVE-2010-4172. Multiple XSS in Manager web application

git-svn-id: https://svn.apache.org/repos/asf/tomcat/trunk@1037778 13f79535-47bb-0310-9956-ffa450edef68`"
