### PR TITLE
[GHSA-gw85-4gmf-m7rh] Exposure of Sensitive Information to an Unauthorized Actor in Apache HttpClient

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-gw85-4gmf-m7rh/GHSA-gw85-4gmf-m7rh.json
+++ b/advisories/github-reviewed/2022/05/GHSA-gw85-4gmf-m7rh/GHSA-gw85-4gmf-m7rh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gw85-4gmf-m7rh",
-  "modified": "2022-07-13T17:20:15Z",
+  "modified": "2023-01-27T05:02:23Z",
   "published": "2022-05-17T05:39:03Z",
   "aliases": [
     "CVE-2011-1498"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2011-1498"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/httpcomponents-client/commit/a572756592c969affd0ce87885724e74839176fb"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
"Add a patch https://github.com/apache/httpcomponents-client/commit/a572756592c969affd0ce87885724e74839176fb, of which the commit message claims `HTTPCLIENT-1061: Proxy-Authorization header gets sent to the target host when tunneling requests through a proxy that requires authentication

git-svn-id: https://svn.apache.org/repos/asf/httpcomponents/httpclient/trunk@1074473 13f79535-47bb-0310-9956-ffa450edef68`"
