### PR TITLE
[GHSA-qxp4-27vx-xmm3] Improper Input Validation in Jetty

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-qxp4-27vx-xmm3/GHSA-qxp4-27vx-xmm3.json
+++ b/advisories/github-reviewed/2022/05/GHSA-qxp4-27vx-xmm3/GHSA-qxp4-27vx-xmm3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qxp4-27vx-xmm3",
-  "modified": "2022-07-13T18:25:43Z",
+  "modified": "2023-01-27T05:02:13Z",
   "published": "2022-05-14T01:27:35Z",
   "aliases": [
     "CVE-2011-4461"
@@ -49,6 +49,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/eclipse/jetty.project/commit/d0b81a185c260ffceecb9d7470b3ddfbfeda4c11"
+    },
+    {
+      "type": "WEB",
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/72017"
     },
     {
@@ -57,7 +61,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20190307-0004"
+      "url": "https://security.netapp.com/advisory/ntap-20190307-0004/"
     },
     {
       "type": "WEB",

--- a/advisories/github-reviewed/2022/05/GHSA-qxp4-27vx-xmm3/GHSA-qxp4-27vx-xmm3.json
+++ b/advisories/github-reviewed/2022/05/GHSA-qxp4-27vx-xmm3/GHSA-qxp4-27vx-xmm3.json
@@ -49,7 +49,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/eclipse/jetty.project/commit/d0b81a185c260ffceecb9d7470b3ddfbfeda4c11"
+      "url": "https://github.com/eclipse/jetty.project/commit/979d6dbbf9416b1a0ad965e2b8a3b11a2d208627"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/eclipse/jetty.project/commit/d0b81a185c260ffceecb9d7470b3ddfbfeda4c11, of which the commit message claims `367638: 361316: protected multipart filter from DoS`
