### PR TITLE
[GHSA-jqx5-h2hw-5q4f] Denial of Service in Apache POI

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-jqx5-h2hw-5q4f/GHSA-jqx5-h2hw-5q4f.json
+++ b/advisories/github-reviewed/2022/05/GHSA-jqx5-h2hw-5q4f/GHSA-jqx5-h2hw-5q4f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jqx5-h2hw-5q4f",
-  "modified": "2022-07-13T18:56:25Z",
+  "modified": "2023-09-26T15:50:23Z",
   "published": "2022-05-04T00:28:50Z",
   "aliases": [
     "CVE-2012-0213"
@@ -59,6 +59,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/poi/commit/25bc679244188d63de690354db0e3f301291e252"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/poi/commit/c702bc5ce58f9f11f408c7568cc96382c76641ef"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
"Add a patch https://github.com/apache/poi/commit/c702bc5ce58f9f11f408c7568cc96382c76641ef, of which the commit message claims `Fix bug #54682 - UnhandledDataStructure should sanity check before allocating, not after

git-svn-id: https://svn.apache.org/repos/asf/poi/trunk@1487555 13f79535-47bb-0310-9956-ffa450edef68`"
