### PR TITLE
[GHSA-2x83-r56g-cv47] High severity vulnerability that affects org.apache.httpcomponents:httpclient

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-2x83-r56g-cv47/GHSA-2x83-r56g-cv47.json
+++ b/advisories/github-reviewed/2018/10/GHSA-2x83-r56g-cv47/GHSA-2x83-r56g-cv47.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2x83-r56g-cv47",
-  "modified": "2020-06-16T20:53:18Z",
+  "modified": "2023-01-09T05:02:49Z",
   "published": "2018-10-17T00:05:15Z",
   "aliases": [
     "CVE-2012-6153"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2012-6153"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/httpcomponents-client/commit/6e14fc146a66e0f3eb362f45f95d1a58ee18886a"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/httpcomponents-client/commit/6e14fc146a66e0f3eb362f45f95d1a58ee18886a, of which the commit message claims `Fixed CN extraction from DN of X500 principal

git-svn-id: https://svn.apache.org/repos/asf/httpcomponents/httpclient/trunk@1411702 13f79535-47bb-0310-9956-ffa450edef68`