### PR TITLE
[GHSA-v64w-96p6-fx7w] Apache Geronimo JMX Remoting functionality allows remote code execution in 3.x before v3.0.1

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-v64w-96p6-fx7w/GHSA-v64w-96p6-fx7w.json
+++ b/advisories/github-reviewed/2022/05/GHSA-v64w-96p6-fx7w/GHSA-v64w-96p6-fx7w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v64w-96p6-fx7w",
-  "modified": "2022-07-27T21:38:21Z",
+  "modified": "2023-01-27T05:02:56Z",
   "published": "2022-05-17T04:48:11Z",
   "aliases": [
     "CVE-2013-1777"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-1777"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/geronimo/commit/ee031c5e62b0d358250d06c2aa6722518579a6c5"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/geronimo/commit/ee031c5e62b0d358250d06c2aa6722518579a6c5, of which the commit message claims `set better classloader for jmx

git-svn-id: https://svn.apache.org/repos/asf/geronimo/server/branches/3.0@1458113 13f79535-47bb-0310-9956-ffa450edef68`
