### PR TITLE
[GHSA-whmq-v94q-34p9] Improper Control of Generation of Code in Apache Struts

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-whmq-v94q-34p9/GHSA-whmq-v94q-34p9.json
+++ b/advisories/github-reviewed/2022/05/GHSA-whmq-v94q-34p9/GHSA-whmq-v94q-34p9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-whmq-v94q-34p9",
-  "modified": "2023-12-27T19:21:52Z",
+  "modified": "2023-12-27T19:21:53Z",
   "published": "2022-05-14T00:54:15Z",
   "aliases": [
     "CVE-2013-1965"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-1965"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/7e6f641ebb142663cbd1653dc49bed725edf7f56"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add a patch https://github.com/apache/struts/commit/7e6f641ebb142663cbd1653dc49bed725edf7f56, of which the commit message claims `Disable eval expressions

git-svn-id: https://svn.apache.org/repos/asf/struts/struts2/branches/STRUTS_2_3_14_X@1469249 13f79535-47bb-0310-9956-ffa450edef68`
