### PR TITLE
[GHSA-r237-w2w6-jq3p] Inefficient Algorithmic Complexity in Apache Santuario XML Security

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-r237-w2w6-jq3p/GHSA-r237-w2w6-jq3p.json
+++ b/advisories/github-reviewed/2022/05/GHSA-r237-w2w6-jq3p/GHSA-r237-w2w6-jq3p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r237-w2w6-jq3p",
-  "modified": "2023-06-01T19:51:07Z",
+  "modified": "2023-06-01T19:51:08Z",
   "published": "2022-05-13T01:05:56Z",
   "aliases": [
     "CVE-2013-2172"
@@ -55,6 +55,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-2172"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/santuario-java/commit/8e8f8bf92a43608d7d5f9e357fae19244454a61f"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/santuario-java/commit/8e8f8bf92a43608d7d5f9e357fae19244454a61f, of which the commit message claims `Don't allow non-standard c14n method

git-svn-id: https://svn.apache.org/repos/asf/santuario/xml-security-java/branches/1.5.x-fixes@1493772 13f79535-47bb-0310-9956-ffa450edef68`