### PR TITLE
[GHSA-v6c7-8qx5-8gmp] Deserialization of Untrusted Data in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-v6c7-8qx5-8gmp/GHSA-v6c7-8qx5-8gmp.json
+++ b/advisories/github-reviewed/2022/05/GHSA-v6c7-8qx5-8gmp/GHSA-v6c7-8qx5-8gmp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v6c7-8qx5-8gmp",
-  "modified": "2022-11-03T21:09:17Z",
+  "modified": "2023-02-01T05:04:17Z",
   "published": "2022-05-17T03:47:51Z",
   "aliases": [
     "CVE-2013-2185"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-2185"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/e246e5fc13307da0a5d3bbf860d64d97be1c40f8"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/tomcat/commit/e246e5fc13307da0a5d3bbf860d64d97be1c40f8, of which the commit message claims `Clean-up: Remove unnecessary code.

git-svn-id: https://svn.apache.org/repos/asf/tomcat/trunk@1470435 13f79535-47bb-0310-9956-ffa450edef68`