### PR TITLE
[GHSA-7j4h-8wpf-rqfh] Missing XML Validation in Apache Xerces2

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-7j4h-8wpf-rqfh/GHSA-7j4h-8wpf-rqfh.json
+++ b/advisories/github-reviewed/2022/05/GHSA-7j4h-8wpf-rqfh/GHSA-7j4h-8wpf-rqfh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7j4h-8wpf-rqfh",
-  "modified": "2022-07-08T19:14:49Z",
+  "modified": "2023-01-27T05:02:05Z",
   "published": "2022-05-13T01:01:06Z",
   "aliases": [
     "CVE-2013-4002"
@@ -36,6 +36,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-4002"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/xerces2-j/commit/266e837852e0f0e3c8c1ad572b6fc4dbb4ded17"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/xerces2-j/commit/628cbc7142ef9acfb61b8e571aab63504235849"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add two patches:
https://github.com/apache/xerces2-j/commit/266e837852e0f0e3c8c1ad572b6fc4dbb4ded17
https://github.com/apache/xerces2-j/commit/628cbc7142ef9acfb61b8e571aab63504235849

of which the commit messages showed the intention.
