### PR TITLE
[GHSA-92j2-5r7p-6hjw] Restlet is vulnerable to Arbitrary Java Code Execution via crafted XML

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-92j2-5r7p-6hjw/GHSA-92j2-5r7p-6hjw.json
+++ b/advisories/github-reviewed/2022/05/GHSA-92j2-5r7p-6hjw/GHSA-92j2-5r7p-6hjw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-92j2-5r7p-6hjw",
-  "modified": "2023-08-29T18:02:04Z",
+  "modified": "2023-08-29T18:02:05Z",
   "published": "2022-05-17T03:28:12Z",
   "aliases": [
     "CVE-2013-4221"
@@ -40,6 +40,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/restlet/restlet-framework-java/issues/774"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/restlet/restlet-framework-java/commit/12cc79b3953c7bd276e9f1cae2fbfdb9c1a6f07"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/restlet/restlet-framework-java/commit/b85c2ef182c69c5e2e21df008ccb249ccf80c7b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/restlet/restlet-framework-java/commit/c3015e4783c2a36e7528aa611c911b7d8c4ec5b"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add three patch commits:
https://github.com/restlet/restlet-framework-java/commit/c3015e4783c2a36e7528aa611c911b7d8c4ec5b
https://github.com/restlet/restlet-framework-java/commit/b85c2ef182c69c5e2e21df008ccb249ccf80c7b
https://github.com/restlet/restlet-framework-java/commit/12cc79b3953c7bd276e9f1cae2fbfdb9c1a6f07

The commit msg can prove their intention:

`Fixed issue #774 - Removed default support of JavaBeans XML-serialization. Reported by David Jorm, Dinis Cruz, Abraham Kang and Alvaro Munoz.`

`Fixed issue #774 - Removed default support of JavaBeans XML-serialization. Reported by David Jorm, Dinis Cruz, Abraham Kang and alavaro Munoz.`

and
 `Fixed issue #774 - Removed default support of JavaBeans XML-serialization. Reported by David Jorm, Dinis Cruz, Abraham Kang and Alvaro Munoz.`

