### PR TITLE
[GHSA-pqwh-44jj-p5rm] Hostname verification in Apache HttpClient 4.3 was disabled by default

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-pqwh-44jj-p5rm/GHSA-pqwh-44jj-p5rm.json
+++ b/advisories/github-reviewed/2022/05/GHSA-pqwh-44jj-p5rm/GHSA-pqwh-44jj-p5rm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pqwh-44jj-p5rm",
-  "modified": "2022-06-09T22:47:59Z",
+  "modified": "2023-02-03T05:03:58Z",
   "published": "2022-05-13T01:25:03Z",
   "aliases": [
     "CVE-2013-4366"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-4366"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/httpcomponents-client/commit/08140864e3e4c0994e094c4cf0507932baf6a66"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/httpcomponents-client/commit/08140864e3e4c0994e094c4cf0507932baf6a66, of which the commit message claims `Ensure X509HostnameVerifier is never null
git-svn-id: https://svn.apache.org/repos/asf/httpcomponents/httpclient/trunk@1528614 13f79535-47bb-0310-9956-ffa450edef68`
