### PR TITLE
[GHSA-4p4w-6h54-g885] Improper Input Validation in Apache Santuario XML Security

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4p4w-6h54-g885/GHSA-4p4w-6h54-g885.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4p4w-6h54-g885/GHSA-4p4w-6h54-g885.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4p4w-6h54-g885",
-  "modified": "2022-07-07T23:30:54Z",
+  "modified": "2023-06-01T19:49:43Z",
   "published": "2022-05-13T01:05:55Z",
   "aliases": [
     "CVE-2013-4517"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-4517"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/santuario-java/commit/a09b9042f7759d094f2d49f40fc7bcf145164b25"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/santuario-java/commit/a09b9042f7759d094f2d49f40fc7bcf145164b25, of which the commit message claims `Disallow doc type declarations when secure validation is enabled
Conflicts:src/main/java/org/apache/xml/security/c14n/Canonicalizer.java
git-svn-id: https://svn.apache.org/repos/asf/santuario/xml-security-java/branches/1.5.x-fixes@1537956 13f79535-47bb-0310-9956-ffa450edef68`