### PR TITLE
[GHSA-jcp9-796g-pv9p] Missing Cryptographic Step in OWASP Enterprise Security API for Java

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-jcp9-796g-pv9p/GHSA-jcp9-796g-pv9p.json
+++ b/advisories/github-reviewed/2022/05/GHSA-jcp9-796g-pv9p/GHSA-jcp9-796g-pv9p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jcp9-796g-pv9p",
-  "modified": "2022-07-07T23:29:01Z",
+  "modified": "2023-01-27T05:02:22Z",
   "published": "2022-05-17T03:56:06Z",
   "aliases": [
     "CVE-2013-5679"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-5679"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ESAPI/esapi-java-legacy/commit/41138fef5f63d9cf0d5e05d2bee2c7f682ffef3f"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/ESAPI/esapi-java-legacy/commit/41138fef5f63d9cf0d5e05d2bee2c7f682ffef3f, of which the commit message claims `Fix for Google Issue #306 and changes to address the side effects of the fix (i.e., the removal of the deprecated ESAPI 1.4 encrypt() / decrypt() methods from the Encryptor interface).`