### PR TITLE
[GHSA-8gwc-x7mg-7p7p] Apache XML Security For Java vulnerable to Infinite Loop

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-8gwc-x7mg-7p7p/GHSA-8gwc-x7mg-7p7p.json
+++ b/advisories/github-reviewed/2022/05/GHSA-8gwc-x7mg-7p7p/GHSA-8gwc-x7mg-7p7p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8gwc-x7mg-7p7p",
-  "modified": "2022-11-08T14:57:18Z",
+  "modified": "2023-01-29T05:04:00Z",
   "published": "2022-05-14T00:02:32Z",
   "aliases": [
     "CVE-2013-5823"
@@ -58,7 +58,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/santuario-java/commit/55a48497dfbf3fe63a81e67c13160b3f41ebb1f3"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/santuario-java/commit/cea3c91106fb8be35e2f1bb3f1fe0cfddd0ec710"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/santuario-java/commit/f9a61f2df9473237aa71308c28113540b4063d33"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add 2 patchs, of which the commit message claims `[SANTUARIO-334] - UnsyncByteArrayOutputStream hangs on messages larger 512 MB`