### PR TITLE
[GHSA-2g56-7jv7-wxxq] Missing Cryptographic Step in OWASP Enterprise Security API for Java

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-2g56-7jv7-wxxq/GHSA-2g56-7jv7-wxxq.json
+++ b/advisories/github-reviewed/2022/05/GHSA-2g56-7jv7-wxxq/GHSA-2g56-7jv7-wxxq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2g56-7jv7-wxxq",
-  "modified": "2022-07-08T19:39:44Z",
+  "modified": "2023-01-27T05:02:21Z",
   "published": "2022-05-14T01:37:06Z",
   "aliases": [
     "CVE-2013-5960"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/esapi/esapi-java-legacy/issues/306"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ESAPI/esapi-java-legacy/commit/b7cbc53f9cc967cf1a5a9463d8c6fef9ed6ef4f7"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/ESAPI/esapi-java-legacy/commit/b7cbc53f9cc967cf1a5a9463d8c6fef9ed6ef4f7, of which the commit message claims `Close https://github.com/ESAPI/esapi-java-legacy/issues/306. Close https://github.com/ESAPI/esapi-java-legacy/issues/359`
