### PR TITLE
[GHSA-j8qw-mwmv-28cg] Improper Limitation of a Pathname to a Restricted Directory in Apache Solr

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-j8qw-mwmv-28cg/GHSA-j8qw-mwmv-28cg.json
+++ b/advisories/github-reviewed/2022/05/GHSA-j8qw-mwmv-28cg/GHSA-j8qw-mwmv-28cg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j8qw-mwmv-28cg",
-  "modified": "2022-07-07T23:24:16Z",
+  "modified": "2023-02-15T22:16:59Z",
   "published": "2022-05-17T04:04:29Z",
   "aliases": [
     "CVE-2013-6397"
@@ -36,6 +36,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-6397"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/da34b18cb3092df4972e2b6fa5178d1059923910"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/lucene-solr"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/apache/lucene-solr/commit/da34b18cb3092df4972e2b6fa5178d1059923910, of which the commit message claims `SOLR-4882: Restrict SolrResourceLoader to only allow access to resource files below the instance dir
git-svn-id: https://svn.apache.org/repos/asf/lucene/dev/trunk@1525246 13f79535-47bb-0310-9956-ffa450edef68`
