### PR TITLE
[GHSA-998j-j6v9-5846] Apache Solr UpdateRequestHandler for XML resolves XML External Entities

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-998j-j6v9-5846/GHSA-998j-j6v9-5846.json
+++ b/advisories/github-reviewed/2022/05/GHSA-998j-j6v9-5846/GHSA-998j-j6v9-5846.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-998j-j6v9-5846",
-  "modified": "2023-08-16T09:35:42Z",
+  "modified": "2023-08-16T09:35:43Z",
   "published": "2022-05-17T04:39:49Z",
   "aliases": [
     "CVE-2013-6407"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-6407"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/f230486ce6707762c1a6e81655d0fac52887906d"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add a patch https://github.com/apache/lucene-solr/commit/f230486ce6707762c1a6e81655d0fac52887906d, of which the commit message claims `SOLR-3895, SOLR-3614: XML and XSLT UpdateRequestHandler should not try to resolve external entities; fix XML parsing in XPathEntityProcessor to correctly expand named entities, but ignore external entities

git-svn-id: https://svn.apache.org/repos/asf/lucene/dev/trunk@1390921 13f79535-47bb-0310-9956-ffa450edef68`