### PR TITLE
[GHSA-45w3-2hvv-pfxq] XML Injection in Apache Solr

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-45w3-2hvv-pfxq/GHSA-45w3-2hvv-pfxq.json
+++ b/advisories/github-reviewed/2022/05/GHSA-45w3-2hvv-pfxq/GHSA-45w3-2hvv-pfxq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-45w3-2hvv-pfxq",
-  "modified": "2022-07-07T23:22:41Z",
+  "modified": "2023-01-27T05:02:23Z",
   "published": "2022-05-17T04:39:49Z",
   "aliases": [
     "CVE-2013-6408"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-6408"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/7239a57a51ea0f4d05dd330ce5e15e4f72f72747"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/lucene-solr/commit/7239a57a51ea0f4d05dd330ce5e15e4f72f72747, of which the commit message claims `SOLR-4881: Fix DocumentAnalysisRequestHandler to correctly use EmptyEntityResolver to prevent loading of external entities like UpdateRequestHandler does

git-svn-id: https://svn.apache.org/repos/asf/lucene/dev/trunk@1487976 13f79535-47bb-0310-9956-ffa450edef68`