### PR TITLE
[GHSA-f554-x222-wgf7] Command Injection in Xstream

### DIFF
--- a/advisories/github-reviewed/2019/05/GHSA-f554-x222-wgf7/GHSA-f554-x222-wgf7.json
+++ b/advisories/github-reviewed/2019/05/GHSA-f554-x222-wgf7/GHSA-f554-x222-wgf7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f554-x222-wgf7",
-  "modified": "2021-08-04T15:07:00Z",
+  "modified": "2023-12-02T00:39:15Z",
   "published": "2019-05-29T18:05:03Z",
   "aliases": [
     "CVE-2013-7285"
@@ -61,6 +61,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-7285"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/x-stream/xstream/commit/6344867dce6767af7d0fe34fb393271a6456672d"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add a patch https://github.com/x-stream/xstream/commit/6344867dce6767af7d0fe34fb393271a6456672d, of which the commit message claims `Merge security framework from HEAD into branch.
git-svn-id: http://svn.codehaus.org/xstream/branches/v-1.4.x@2219 9830eeb5-ddf4-0310-9ef7-f4b9a3e3227e`