### PR TITLE
[GHSA-5c66-6h6g-6q6m] Insufficient Verification of Data Authenticity in Async Http Client

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-5c66-6h6g-6q6m/GHSA-5c66-6h6g-6q6m.json
+++ b/advisories/github-reviewed/2022/05/GHSA-5c66-6h6g-6q6m/GHSA-5c66-6h6g-6q6m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5c66-6h6g-6q6m",
-  "modified": "2022-07-07T23:14:08Z",
+  "modified": "2023-01-27T05:02:09Z",
   "published": "2022-05-13T01:12:18Z",
   "aliases": [
     "CVE-2013-7398"
@@ -40,6 +40,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/AsyncHttpClient/async-http-client/issues/197"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/AsyncHttpClient/async-http-client/commit/3c9152e2c75f7e8b654beec40383748a14c6b51b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/AsyncHttpClient/async-http-client/commit/a894583921c11c3b01f160ada36a8bb9d5158e9"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/AsyncHttpClient/async-http-client"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add two patches.
https://github.com/AsyncHttpClient/async-http-client/commit/3c9152e2c75f7e8b654beec40383748a14c6b51b 's commit message claims `Merge pull request #510 from wsargent/fix-197
Fix for #197 -- use a hostname verifier that does hostname verification`
another patch https://github.com/AsyncHttpClient/async-http-client/commit/a894583921c11c3b01f160ada36a8bb9d5158e9, of which the commit message claims `Use a hostname verifier that does hostname verification, backport #510, close #197`
