### PR TITLE
[GHSA-vrwc-qjmw-5rjm] ClassLoader manipulation in Apache Struts

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-vrwc-qjmw-5rjm/GHSA-vrwc-qjmw-5rjm.json
+++ b/advisories/github-reviewed/2022/05/GHSA-vrwc-qjmw-5rjm/GHSA-vrwc-qjmw-5rjm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vrwc-qjmw-5rjm",
-  "modified": "2022-11-03T22:54:35Z",
+  "modified": "2023-12-28T18:41:23Z",
   "published": "2022-05-14T00:54:15Z",
   "aliases": [
     "CVE-2014-0094"
@@ -63,6 +63,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/struts/commit/6315241719be167542962da436b38782ed730c62"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/74e26830d2849a84729b33497f729e0f033dc147"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add a patch https://github.com/apache/struts/commit/74e26830d2849a84729b33497f729e0f033dc147, of which the commit message claims `Adds additional pattern to prevent access to getClass method`
