### PR TITLE
[GHSA-5wqf-h3r3-gxvh] Uncontrolled Resource Consumption in Apache CXF

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-5wqf-h3r3-gxvh/GHSA-5wqf-h3r3-gxvh.json
+++ b/advisories/github-reviewed/2022/05/GHSA-5wqf-h3r3-gxvh/GHSA-5wqf-h3r3-gxvh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5wqf-h3r3-gxvh",
-  "modified": "2023-12-21T21:52:09Z",
+  "modified": "2023-12-21T21:52:10Z",
   "published": "2022-05-13T01:09:20Z",
   "aliases": [
     "CVE-2014-0109"
@@ -66,11 +66,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://cxf.apache.org/security-advisories.data/CVE-2014-0109.txt.asc"
+      "url": "https://github.com/apache/cxf/commit/f8ed98e684c1a67a77ae8726db05a04a4978a445"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/apache/cxf"
+      "url": "https://cxf.apache.org/security-advisories.data/CVE-2014-0109.txt.asc"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/cxf/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add a patch https://github.com/apache/cxf/commit/f8ed98e684c1a67a77ae8726db05a04a4978a445, of which the commit message claims `Update StaxInInterceptor to just create a html error message on the client side as the normal error handling works best on server side.`
