### PR TITLE
[GHSA-wr5r-m8pc-85j9] Low severity vulnerability that affects org.springframework.integration:spring-integration-ws and org.springframework.integration:spring-integration-xml

### DIFF
--- a/advisories/github-reviewed/2019/01/GHSA-wr5r-m8pc-85j9/GHSA-wr5r-m8pc-85j9.json
+++ b/advisories/github-reviewed/2019/01/GHSA-wr5r-m8pc-85j9/GHSA-wr5r-m8pc-85j9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wr5r-m8pc-85j9",
-  "modified": "2020-06-16T22:01:07Z",
+  "modified": "2023-01-09T05:03:23Z",
   "published": "2019-01-25T16:18:49Z",
   "aliases": [
     "CVE-2019-3772"
@@ -133,8 +133,16 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-3772"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-integration/commit/59c69ed40d3755ef59f80872e0ea711adbb13620"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-wr5r-m8pc-85j9"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/spring-projects/spring-integration"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/spring-projects/spring-integration/commit/59c69ed40d3755ef59f80872e0ea711adbb13620, of which the commit message claims `Allow XML components injection
**Cherry-pick to 5.0.x & 4.3.x**
* Polishing after rebase
* Copyright to 2019
* Rebase and update according upstream deps`
