### PR TITLE
[GHSA-7xr3-rgwh-pw22] Denial of service vulnerability exists when .NET and .NET Core improperly process XML documents

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-7xr3-rgwh-pw22/GHSA-7xr3-rgwh-pw22.json
+++ b/advisories/github-reviewed/2018/10/GHSA-7xr3-rgwh-pw22/GHSA-7xr3-rgwh-pw22.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7xr3-rgwh-pw22",
-  "modified": "2022-04-26T19:04:25Z",
+  "modified": "2023-01-09T05:02:48Z",
   "published": "2018-10-16T19:50:39Z",
   "aliases": [
     "CVE-2018-8030"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-8030"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/qpid-broker-j/commit/025b48f3193e2b10b1c41d2bc3bcfc9cfc238a27"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/qpid-broker-j/commit/025b48f3193e2b10b1c41d2bc3bcfc9cfc238a27, of which the commit message claims `QPID-8203: [Broker-J][AMQP 0-9] Fix maximum message size check`
