### PR TITLE
[GHSA-7px3-6f6g-hxcj] Moderate severity vulnerability that affects org.apache.solr:solr-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-7px3-6f6g-hxcj/GHSA-7px3-6f6g-hxcj.json
+++ b/advisories/github-reviewed/2018/10/GHSA-7px3-6f6g-hxcj/GHSA-7px3-6f6g-hxcj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7px3-6f6g-hxcj",
-  "modified": "2021-09-03T21:01:44Z",
+  "modified": "2023-01-09T05:02:45Z",
   "published": "2018-10-17T19:55:34Z",
   "aliases": [
     "CVE-2018-8026"
@@ -25,10 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "7.0.0"
+              "introduced": "6.0.0"
             },
             {
-              "fixed": "7.4.0"
+              "fixed": "6.6.5"
             }
           ]
         }
@@ -44,10 +44,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "6.0.0"
+              "introduced": "7.0.0"
             },
             {
-              "fixed": "6.6.5"
+              "fixed": "7.4.0"
             }
           ]
         }
@@ -58,6 +58,26 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-8026"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/1880d4824e6c5f98170b9a00aad1d437ee2aa12"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/3aa6086ed99fa7158d423dc7c33dae6da466b09"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/d1baf6ba593561f39e2da0a71a8440797005b55"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/e21d4937e0637c7b7949ac463f331da9a42c07f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/e5407c5a9710247e5f728aae36224a245a51f0b"
     },
     {
       "type": "ADVISORY",
@@ -73,7 +93,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20190307-0002"
+      "url": "https://security.netapp.com/advisory/ntap-20190307-0002/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/lucene-solr/commit/d1baf6ba593561f39e2da0a71a8440797005b55, of which the commit message claims `SOLR-12450: Don't allow referal to external resources in various config files`
Add a patch https://github.com/apache/lucene-solr/commit/e5407c5a9710247e5f728aae36224a245a51f0b, of which the commit message claims `SOLR-12450: Don't allow referal to external resources in various config files
Conflicts:
	solr/CHANGES.txt`
Add a patch https://github.com/apache/lucene-solr/commit/e21d4937e0637c7b7949ac463f331da9a42c07f, of which the commit message claims `SOLR-12450: Don't allow referal to external resources in various config files`
Add a patch https://github.com/apache/lucene-solr/commit/1880d4824e6c5f98170b9a00aad1d437ee2aa12, of which the commit message claims `SOLR-12450: Don't allow referal to external resources in various config files`
Add a patch https://github.com/apache/lucene-solr/commit/3aa6086ed99fa7158d423dc7c33dae6da466b09, of which the commit message claims `SOLR-12450: Don't allow referal to external resources in various config files Conflicts:
solr/CHANGES.txt
 Conflicts:
solr/CHANGES.txt`
