### PR TITLE
[GHSA-r86j-2gc6-2cq9] High severity vulnerability that affects org.apache.hbase:hbase-thrift

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-r86j-2gc6-2cq9/GHSA-r86j-2gc6-2cq9.json
+++ b/advisories/github-reviewed/2018/10/GHSA-r86j-2gc6-2cq9/GHSA-r86j-2gc6-2cq9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r86j-2gc6-2cq9",
-  "modified": "2021-06-10T20:41:09Z",
+  "modified": "2023-01-09T05:03:35Z",
   "published": "2018-10-18T18:05:02Z",
   "aliases": [
     "CVE-2018-8025"
@@ -105,6 +105,26 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-8025"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hbase/commit/0c42acbdf86d08af3003105a26a2201f75f2e2c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hbase/commit/30e98b4455f971c9cb3c02ac7b2daeebe4ee6f2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hbase/commit/625d4d002620139f49c8201f95b789b6a715cd4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hbase/commit/7fe07075b35a816725ba18f6dd43d3fa84e08f9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hbase/commit/bf25c1cb7221178388baaa58f0b16a408e151a6"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/hbase/commit/625d4d002620139f49c8201f95b789b6a715cd4, of which the commit message claims `HBASE-20664 Reduce the broad scope of outToken in ThriftHttpServlet
Signed-off-by: Andrew Purtell <apurtell@apache.org>`

Add a patch https://github.com/apache/hbase/commit/bf25c1cb7221178388baaa58f0b16a408e151a6, of which the commit message claims `HBASE-20664 Reduce the broad scope of outToken in ThriftHttpServlet
Signed-off-by: Andrew Purtell <apurtell@apache.org>`

Add a patch https://github.com/apache/hbase/commit/30e98b4455f971c9cb3c02ac7b2daeebe4ee6f2, of which the commit message claims `HBASE-20664 Reduce the broad scope of outToken in ThriftHttpServlet
Signed-off-by: Andrew Purtell <apurtell@apache.org>`

Add a patch https://github.com/apache/hbase/commit/7fe07075b35a816725ba18f6dd43d3fa84e08f9, of which the commit message claims `HBASE-20664 Reduce the broad scope of outToken in ThriftHttpServlet
Signed-off-by: Andrew Purtell <apurtell@apache.org>`

Add a patch https://github.com/apache/hbase/commit/0c42acbdf86d08af3003105a26a2201f75f2e2c, of which the commit message claims `HBASE-20664 Reduce the broad scope of outToken in ThriftHttpServlet
Signed-off-by: Andrew Purtell <apurtell@apache.org>`
