### PR TITLE
[GHSA-qcjv-wfcg-mmpr] Critical severity vulnerability that affects org.apache.ignite:ignite-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-qcjv-wfcg-mmpr/GHSA-qcjv-wfcg-mmpr.json
+++ b/advisories/github-reviewed/2018/10/GHSA-qcjv-wfcg-mmpr/GHSA-qcjv-wfcg-mmpr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qcjv-wfcg-mmpr",
-  "modified": "2021-09-16T19:56:17Z",
+  "modified": "2023-01-09T05:03:20Z",
   "published": "2018-10-16T20:53:54Z",
   "aliases": [
     "CVE-2018-8018"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-8018"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/ignite/commit/82a7b8209fcf56971d12cb10410a38ed632215b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/ignite/commit/bc374f85ca4a5e69572902d2167fe6bedebd40a"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/ignite/commit/82a7b8209fcf56971d12cb10410a38ed632215b, of which the commit message claims `IGNITE-8565 Client marshalling improvements`

Add a patch https://github.com/apache/ignite/commit/bc374f85ca4a5e69572902d2167fe6bedebd40a, of which the commit message claims `IGNITE-8565 Client marshalling improvements`
