### PR TITLE
[GHSA-j53j-gmr9-h8g3] Moderate severity vulnerability that affects org.apache.tika:tika-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-j53j-gmr9-h8g3/GHSA-j53j-gmr9-h8g3.json
+++ b/advisories/github-reviewed/2018/10/GHSA-j53j-gmr9-h8g3/GHSA-j53j-gmr9-h8g3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j53j-gmr9-h8g3",
-  "modified": "2021-09-14T18:17:53Z",
+  "modified": "2023-01-09T05:02:56Z",
   "published": "2018-10-17T15:50:31Z",
   "aliases": [
     "CVE-2018-8017"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-8017"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tika/commit/62926cae31a02d4f23d21148435804b96c543cc"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tika/commit/8a6a9e1344f5b10ebfa1a189dc3c30d0da2b9d4"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/tika/commit/8a6a9e1344f5b10ebfa1a189dc3c30d0da2b9d4, of which the commit message claims `fix logic in iptc parser`

Add a patch https://github.com/apache/tika/commit/62926cae31a02d4f23d21148435804b96c543cc, of which the commit message claims `fix logic in iptc parser`
