### PR TITLE
[GHSA-52gq-7j6c-xw6x] Missing Authentication for Critical Function in Apache Cassandra

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-52gq-7j6c-xw6x/GHSA-52gq-7j6c-xw6x.json
+++ b/advisories/github-reviewed/2022/05/GHSA-52gq-7j6c-xw6x/GHSA-52gq-7j6c-xw6x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-52gq-7j6c-xw6x",
-  "modified": "2022-06-29T18:54:45Z",
+  "modified": "2023-01-27T05:02:17Z",
   "published": "2022-05-13T01:53:28Z",
   "aliases": [
     "CVE-2018-8016"
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-8016"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/beobal/cassandra/commit/28ee665b3c0c9238b61a871064f024d54cddcc79"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/beobal/cassandra/commit/28ee665b3c0c9238b61a871064f024d54cddcc79, of which the commit message claims `Remove dependencies on JVM internals for JMX support
Patch by Sam Tunnicliffe; reviewed by Jason Brown for CASSANDRA-14173`
