### PR TITLE
[GHSA-25gw-4pcc-45cf] Deserialization of Untrusted Data in Apache Batik

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-25gw-4pcc-45cf/GHSA-25gw-4pcc-45cf.json
+++ b/advisories/github-reviewed/2022/05/GHSA-25gw-4pcc-45cf/GHSA-25gw-4pcc-45cf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-25gw-4pcc-45cf",
-  "modified": "2022-06-29T18:57:27Z",
+  "modified": "2024-01-08T15:13:33Z",
   "published": "2022-05-13T01:14:24Z",
   "aliases": [
     "CVE-2018-8013"
@@ -45,59 +45,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r9e90b4d1cf6ea87a79bb506541140dfbf4801f4463a7cee08126ee44%40%3Ccommits.xmlgraphics.apache.org%3E"
+      "url": "https://github.com/apache/batik/commit/f91125b26a6ca2b7a1195f1842360bed03629839"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r9e90b4d1cf6ea87a79bb506541140dfbf4801f4463a7cee08126ee44@%3Ccommits.xmlgraphics.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rc0a31867796043fbe59113fb654fe8b13309fe04f8935acb8d0fab19%40%3Ccommits.xmlgraphics.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rc0a31867796043fbe59113fb654fe8b13309fe04f8935acb8d0fab19@%3Ccommits.xmlgraphics.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2018/05/msg00016.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://mail-archives.apache.org/mod_mbox/xmlgraphics-batik-dev/201805.mbox/%3c000701d3f28f$d01860a0$704921e0$@gmail.com%3e"
-    },
-    {
-      "type": "WEB",
-      "url": "https://mail-archives.apache.org/mod_mbox/xmlgraphics-batik-dev/201805.mbox/%3c000701d3f28f%24d01860a0%24704921e0%24%40gmail.com%3e"
-    },
-    {
-      "type": "WEB",
-      "url": "https://security.gentoo.org/glsa/202401-11"
-    },
-    {
-      "type": "WEB",
-      "url": "https://usn.ubuntu.com/3661-1"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.debian.org/security/2018/dsa-4215"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpujul2020.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpuoct2020.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+      "url": "https://xmlgraphics.apache.org/security.html"
     },
     {
       "type": "WEB",
@@ -105,7 +57,63 @@
     },
     {
       "type": "WEB",
-      "url": "https://xmlgraphics.apache.org/security.html"
+      "url": "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpuoct2020.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpujul2020.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.debian.org/security/2018/dsa-4215"
+    },
+    {
+      "type": "WEB",
+      "url": "https://usn.ubuntu.com/3661-1/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.gentoo.org/glsa/202401-11"
+    },
+    {
+      "type": "WEB",
+      "url": "https://mail-archives.apache.org/mod_mbox/xmlgraphics-batik-dev/201805.mbox/%3c000701d3f28f%24d01860a0%24704921e0%24%40gmail.com%3e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://mail-archives.apache.org/mod_mbox/xmlgraphics-batik-dev/201805.mbox/%3c000701d3f28f$d01860a0$704921e0$@gmail.com%3e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2018/05/msg00016.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rc0a31867796043fbe59113fb654fe8b13309fe04f8935acb8d0fab19@%3Ccommits.xmlgraphics.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rc0a31867796043fbe59113fb654fe8b13309fe04f8935acb8d0fab19%40%3Ccommits.xmlgraphics.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r9e90b4d1cf6ea87a79bb506541140dfbf4801f4463a7cee08126ee44@%3Ccommits.xmlgraphics.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r9e90b4d1cf6ea87a79bb506541140dfbf4801f4463a7cee08126ee44%40%3Ccommits.xmlgraphics.apache.org%3E"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/batik"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/apache/batik/commit/f91125b26a6ca2b7a1195f1842360bed03629839, of which the commit message claims `BATIK-1222: Only call DOMImplementation in deserialization
git-svn-id: https://svn.apache.org/repos/asf/xmlgraphics/batik/trunk@1831241 13f79535-47bb-0310-9956-ffa450edef68`