### PR TITLE
[GHSA-rc9v-h28f-jcmf] There is a XML external entity expansion (XXE) vulnerability in Apache Solr  config files

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-rc9v-h28f-jcmf/GHSA-rc9v-h28f-jcmf.json
+++ b/advisories/github-reviewed/2018/10/GHSA-rc9v-h28f-jcmf/GHSA-rc9v-h28f-jcmf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rc9v-h28f-jcmf",
-  "modified": "2022-04-27T14:45:18Z",
+  "modified": "2023-01-09T05:03:22Z",
   "published": "2018-10-17T19:56:04Z",
   "aliases": [
     "CVE-2018-8010"
@@ -58,6 +58,26 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-8010"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/1b760114216fcdfae138a8b37f183a9293c4911"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/4ba409e0ff3dc38aad88f7b7ad69a76325272b8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/6c4e45e28494d4d4d04fb89852d18c86fa3d5f8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/6d082d5743dee7e08a86b3f2ef03bc025112512"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/96f079b4b47eaadff65c7aaf0e5bafe68e30ec3"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add five patches :
https://github.com/apache/lucene-solr/commit/6c4e45e28494d4d4d04fb89852d18c86fa3d5f8
https://github.com/apache/lucene-solr/commit/1b760114216fcdfae138a8b37f183a9293c4911
https://github.com/apache/lucene-solr/commit/4ba409e0ff3dc38aad88f7b7ad69a76325272b8
https://github.com/apache/lucene-solr/commit/96f079b4b47eaadff65c7aaf0e5bafe68e30ec3
https://github.com/apache/lucene-solr/commit/6d082d5743dee7e08a86b3f2ef03bc025112512

of which the commit messages claims`SOLR-12316: Do not allow to use absolute URIs for including other files in solrconfig.xml and schema parsing`