### PR TITLE
[GHSA-6x48-j4x4-cqw3] Path Traversal in Hadoop

### DIFF
--- a/advisories/github-reviewed/2018/12/GHSA-6x48-j4x4-cqw3/GHSA-6x48-j4x4-cqw3.json
+++ b/advisories/github-reviewed/2018/12/GHSA-6x48-j4x4-cqw3/GHSA-6x48-j4x4-cqw3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6x48-j4x4-cqw3",
-  "modified": "2022-09-14T22:27:39Z",
+  "modified": "2023-01-09T05:03:57Z",
   "published": "2018-12-21T17:50:29Z",
   "aliases": [
     "CVE-2018-8009"
@@ -121,19 +121,55 @@
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2019:3892"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://github.com/advisories/GHSA-6x48-j4x4-cqw3"
+      "url": "https://github.com/apache/hadoop/commit/11a425d11a329010d0ff8255ecbcd1eb51b642e"
     },
     {
       "type": "WEB",
-      "url": "https://hadoop.apache.org/cve_list.html#cve-2018-8009-http-cve-mitre-org-cgi-bin-cvename-cgi-name-cve-2018-8009-zip-slip-impact-on-apache-hadoop"
+      "url": "https://github.com/apache/hadoop/commit/12258c7cff8d32710fbd8b9088a930e3ce27432"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/708d94141126eac03011144a971a6411fcac16d9c248d1d535a39451@%3Csolr-user.lucene.apache.org%3E"
+      "url": "https://github.com/apache/hadoop/commit/1373e3d8ad60e4da721a292912cb69243bfdf47"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hadoop/commit/45a1c680c276c4501402f7bc4cebcf85a6fbc7f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hadoop/commit/65e55097da2bb3f2fbdf9ba1946da25fe58bec9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hadoop/commit/6a4ae6f6eeed1392a4828a5721fa1499f65bdde"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hadoop/commit/6d7d192e4799b51931e55217e02baec14d49607"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hadoop/commit/745f203e577bacb35b042206db94615141fa5e6"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hadoop/commit/bd98d4e77cf9f7b2f4b1afb4d5e5bad0f6b2fde"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hadoop/commit/cedc28d4ab2a27ba47e15ab2711218d96ec88d2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hadoop/commit/e3236a9680709de7a95ffbc11b20e1bdc95a860"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hadoop/commit/eaa2b8035b584dfcf7c79a33484eb2dffd3fdb1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hadoop/commit/fc4c20fc3469674cb584a4fb98bac7e3c2277c9"
     },
     {
       "type": "WEB",
@@ -150,6 +186,22 @@
     {
       "type": "WEB",
       "url": "https://snyk.io/research/zip-slip-vulnerability"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/708d94141126eac03011144a971a6411fcac16d9c248d1d535a39451@%3Csolr-user.lucene.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://hadoop.apache.org/cve_list.html#cve-2018-8009-http-cve-mitre-org-cgi-bin-cvename-cgi-name-cve-2018-8009-zip-slip-impact-on-apache-hadoop"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-6x48-j4x4-cqw3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2019:3892"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
add 13 patches commits:
https://github.com/apache/hadoop/commit/cedc28d4ab2a27ba47e15ab2711218d96ec88d2
https://github.com/apache/hadoop/commit/fc4c20fc3469674cb584a4fb98bac7e3c2277c9
https://github.com/apache/hadoop/commit/12258c7cff8d32710fbd8b9088a930e3ce27432
https://github.com/apache/hadoop/commit/45a1c680c276c4501402f7bc4cebcf85a6fbc7f
https://github.com/apache/hadoop/commit/11a425d11a329010d0ff8255ecbcd1eb51b642e
https://github.com/apache/hadoop/commit/eaa2b8035b584dfcf7c79a33484eb2dffd3fdb1
https://github.com/apache/hadoop/commit/e3236a9680709de7a95ffbc11b20e1bdc95a860
https://github.com/apache/hadoop/commit/6d7d192e4799b51931e55217e02baec14d49607
https://github.com/apache/hadoop/commit/6a4ae6f6eeed1392a4828a5721fa1499f65bdde
https://github.com/apache/hadoop/commit/1373e3d8ad60e4da721a292912cb69243bfdf47
https://github.com/apache/hadoop/commit/745f203e577bacb35b042206db94615141fa5e6
https://github.com/apache/hadoop/commit/65e55097da2bb3f2fbdf9ba1946da25fe58bec9
https://github.com/apache/hadoop/commit/bd98d4e77cf9f7b2f4b1afb4d5e5bad0f6b2fde

, of which the commit messages claim `Additional check when unpacking archives. Contributed by Jason Lowe and Akira Ajisaka.`

