### PR TITLE
[GHSA-898j-5cc8-cmf5] Moderate severity vulnerability that affects org.apache.storm:storm-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-898j-5cc8-cmf5/GHSA-898j-5cc8-cmf5.json
+++ b/advisories/github-reviewed/2018/10/GHSA-898j-5cc8-cmf5/GHSA-898j-5cc8-cmf5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-898j-5cc8-cmf5",
-  "modified": "2021-09-07T16:25:19Z",
+  "modified": "2023-01-09T05:02:58Z",
   "published": "2018-10-16T17:35:24Z",
   "aliases": [
     "CVE-2018-8008"
@@ -58,6 +58,22 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-8008"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/storm/commit/0fc6b522487c061f89e8cdacf09f722d3f20589"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/storm/commit/1117a37b01a1058897a34e11ff5156e465efb69"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/storm/commit/efad4cca2d7d461f5f8c08a0d7b51fabeb82d0a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/storm/commit/f61e5daf299d6c37c7ad65744d02556c94a16a4"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add four patfches:
https://github.com/apache/storm/commit/0fc6b522487c061f89e8cdacf09f722d3f20589
https://github.com/apache/storm/commit/efad4cca2d7d461f5f8c08a0d7b51fabeb82d0a
https://github.com/apache/storm/commit/1117a37b01a1058897a34e11ff5156e465efb69
https://github.com/apache/storm/commit/f61e5daf299d6c37c7ad65744d02556c94a16a4

, of which the commit message claims `STORM-3052: Allow for blobs to be unzipped/untarred`
