### PR TITLE
[GHSA-8477-3v39-ggpm] Improper Validation of Integrity Check Value in Bouncy Castle

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-8477-3v39-ggpm/GHSA-8477-3v39-ggpm.json
+++ b/advisories/github-reviewed/2022/05/GHSA-8477-3v39-ggpm/GHSA-8477-3v39-ggpm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8477-3v39-ggpm",
-  "modified": "2022-06-28T23:51:50Z",
+  "modified": "2023-01-27T05:02:14Z",
   "published": "2022-05-13T01:01:01Z",
   "aliases": [
     "CVE-2018-5382"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-5382"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/bcgit/bc-java/commit/81b00861cd5711e85fe8dce2a0e119f684120255"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/bcgit/bc-java/commit/81b00861cd5711e85fe8dce2a0e119f684120255, of which the commit message claims `Added BKS-V1 keystore. Some extra UTF-8 tests.`