### PR TITLE
[GHSA-x3cr-x949-h5jv] RDF4J vulnerable to zip slip

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-x3cr-x949-h5jv/GHSA-x3cr-x949-h5jv.json
+++ b/advisories/github-reviewed/2022/05/GHSA-x3cr-x949-h5jv/GHSA-x3cr-x949-h5jv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x3cr-x949-h5jv",
-  "modified": "2022-11-08T23:22:04Z",
+  "modified": "2023-01-29T05:03:45Z",
   "published": "2022-05-14T01:42:52Z",
   "aliases": [
     "CVE-2018-20227"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/eclipse/rdf4j/pull/1211/commits/df15a4d7a8f2789c043b27c9eafe1b30316cfa79"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/eclipse/rdf4j/commit/df15a4d7a8f2789c043b27c9eafe1b30316cfa79"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/eclipse/rdf4j/commit/df15a4d7a8f2789c043b27c9eafe1b30316cfa79, of which the commit message claims `Verify that zip file entries don't try to escape the parent dir + test
Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>`