### PR TITLE
[GHSA-rmm5-g63h-m6g9] Improper Restriction of XML External Entity Reference in pippo-core

### DIFF
--- a/advisories/github-reviewed/2018/12/GHSA-rmm5-g63h-m6g9/GHSA-rmm5-g63h-m6g9.json
+++ b/advisories/github-reviewed/2018/12/GHSA-rmm5-g63h-m6g9/GHSA-rmm5-g63h-m6g9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rmm5-g63h-m6g9",
-  "modified": "2022-09-14T22:12:35Z",
+  "modified": "2023-01-09T05:03:58Z",
   "published": "2018-12-19T19:24:39Z",
   "aliases": [
     "CVE-2018-20059"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/pippo-java/pippo/issues/486"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pippo-java/pippo/commit/9f36e5891c0b11f840e1e1561ae96d83ba9ce759"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/pippo-java/pippo/commit/9f36e5891c0b11f840e1e1561ae96d83ba9ce759, of which the commit message claims `Fix #486`
