### PR TITLE
[GHSA-m643-2pfv-xwm8] Exposure of Sensitive Information to an Unauthorized Actor in SonarSource SonarQube API

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-m643-2pfv-xwm8/GHSA-m643-2pfv-xwm8.json
+++ b/advisories/github-reviewed/2022/05/GHSA-m643-2pfv-xwm8/GHSA-m643-2pfv-xwm8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m643-2pfv-xwm8",
-  "modified": "2022-06-28T23:26:18Z",
+  "modified": "2023-01-27T05:02:21Z",
   "published": "2022-05-14T01:43:42Z",
   "aliases": [
     "CVE-2018-19413"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-19413"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/SonarSource/sonarqube/commit/7b567ba3d15ed7dd0b0bba0330686487e35af85c"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/SonarSource/sonarqube/commit/7b567ba3d15ed7dd0b0bba0330686487e35af85c, of which the commit message claims `SONAR-11305 Return external identity only to sys admin in api/users/search`
