### PR TITLE
[GHSA-rhq2-2574-78mc] Unzip function in ZipUtil.java in Hutool allows remote attackers to overwrite arbitrary files via directory traversal

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-rhq2-2574-78mc/GHSA-rhq2-2574-78mc.json
+++ b/advisories/github-reviewed/2018/10/GHSA-rhq2-2574-78mc/GHSA-rhq2-2574-78mc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rhq2-2574-78mc",
-  "modified": "2022-04-27T14:42:53Z",
+  "modified": "2023-01-09T05:03:22Z",
   "published": "2018-10-17T19:54:53Z",
   "aliases": [
     "CVE-2018-17297"
@@ -81,6 +81,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/looly/hutool/issues/162"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/looly/hutool/commit/8d7d0b7fb5ea4f7447b40131bffc1ec506a6528e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/looly/hutool/commit/9f8a801c7b98b75ee681c0988e1a58bcfdc21756"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/looly/hutool/commit/fed1a1f747a9308e2f65f8dbbff05ce62478ecc0"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/looly/hutool/commit/8d7d0b7fb5ea4f7447b40131bffc1ec506a6528e, of which the commit message claims `fix slip bug`

Add a patch https://github.com/looly/hutool/commit/fed1a1f747a9308e2f65f8dbbff05ce62478ecc0, of which the commit message claims `fix zip bug`

Add a patch https://github.com/looly/hutool/commit/9f8a801c7b98b75ee681c0988e1a58bcfdc21756, of which the commit message claims `fix path problem`
