### PR TITLE
[GHSA-3448-vfvv-xp9g] Apache Tika Denial of Service due to Infinite Loop in Tika's SQLite3Parser

### DIFF
--- a/advisories/github-reviewed/2018/12/GHSA-3448-vfvv-xp9g/GHSA-3448-vfvv-xp9g.json
+++ b/advisories/github-reviewed/2018/12/GHSA-3448-vfvv-xp9g/GHSA-3448-vfvv-xp9g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3448-vfvv-xp9g",
-  "modified": "2023-09-27T11:10:06Z",
+  "modified": "2023-09-27T11:10:39Z",
   "published": "2018-12-26T17:45:07Z",
   "aliases": [
     "CVE-2018-17197"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-17197"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tika/commit/0c49c851979163334ea05cbebdd11ff87feba62d"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add a patch https://github.com/apache/tika/commit/0c49c851979163334ea05cbebdd11ff87feba62d, of which the commit message claims `TIKA-2773 upgrade sqlite version`
