### PR TITLE
[GHSA-3jq8-jg75-rqv6] Cleartext Transmission of Sensitive Information in Apache nifi

### DIFF
--- a/advisories/github-reviewed/2018/12/GHSA-3jq8-jg75-rqv6/GHSA-3jq8-jg75-rqv6.json
+++ b/advisories/github-reviewed/2018/12/GHSA-3jq8-jg75-rqv6/GHSA-3jq8-jg75-rqv6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3jq8-jg75-rqv6",
-  "modified": "2022-09-14T22:22:35Z",
+  "modified": "2023-01-09T05:03:38Z",
   "published": "2018-12-20T22:02:45Z",
   "aliases": [
     "CVE-2018-17195"
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-17195"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/nifi/commit/246c090526143943557b15868db6e8fe3fb30cf6"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/nifi/commit/246c090526143943557b15868db6e8fe3fb30cf6, of which the commit message claims `NIFI-5595 - Added the CORS filter to the templates/upload endpoint using a URL matcher.
Explicitly allow methods GET, HEAD. These are the Spring defaults when the allowedMethods is empty but now it is explicit. This will require other methods like POST etc to be from the same origin (for the template/upload URL).
This closes #3024.