### PR TITLE
[GHSA-43fp-vwwg-qgv6] Apache NiFi Improper Input Validation vulnerability

### DIFF
--- a/advisories/github-reviewed/2018/12/GHSA-43fp-vwwg-qgv6/GHSA-43fp-vwwg-qgv6.json
+++ b/advisories/github-reviewed/2018/12/GHSA-43fp-vwwg-qgv6/GHSA-43fp-vwwg-qgv6.json
@@ -45,7 +45,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/apache/nifi/commit/1baead6f525046a613fc4fe494a0d193776ea70f,"
+      "url": "https://github.com/apache/nifi/commit/1baead6f525046a613fc4fe494a0d193776ea70f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/nifi/commit/748cf745628dab20b7e71f12b5dcfe6ed0bbf134"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add a patch https://github.com/apache/nifi/commit/748cf745628dab20b7e71f12b5dcfe6ed0bbf134, of which the commit message claims `NIFI-5628 Added content length check to OkHttpReplicationClient.
Added unit tests.
This closes #3035`