### PR TITLE
[GHSA-4qq9-rrq6-48ff] Moderate severity vulnerability that affects org.apache.nifi:nifi

### DIFF
--- a/advisories/github-reviewed/2018/12/GHSA-4qq9-rrq6-48ff/GHSA-4qq9-rrq6-48ff.json
+++ b/advisories/github-reviewed/2018/12/GHSA-4qq9-rrq6-48ff/GHSA-4qq9-rrq6-48ff.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4qq9-rrq6-48ff",
-  "modified": "2021-09-01T18:01:38Z",
+  "modified": "2023-01-09T05:02:44Z",
   "published": "2018-12-20T22:02:39Z",
   "aliases": [
     "CVE-2018-17193"
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-17193"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/nifi/commit/e62aa0252dfcf34dff0c3a9c51265b1d0f9dfc9f"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/nifi/commit/e62aa0252dfcf34dff0c3a9c51265b1d0f9dfc9f, of which the commit message claims `NIFI-5442 Get X-ProxyContextPath value from request attributes rather than directly from headers.
NIFI-5442 Populate request contextPath attribute during AccessResource before displaying on message-page.jsp.
Refactored shared code from CatchAllFilter to WebUtils.
NIFI-5442 Refactored filter and context path code to shared parent filter and subclass.
NIFI-5442 Removed unnecessary initParams from nifi-web-ui web.xml.
NIFI-5442 Added explicit dispatchers to nifi-web-ui web.xml and removed unnecessary code from AccessResource.
This closes #2908`