### PR TITLE
[GHSA-2xpp-75vr-22vq] Improper Restriction of Rendered UI Layers or Frames in Apache nifif

### DIFF
--- a/advisories/github-reviewed/2018/12/GHSA-2xpp-75vr-22vq/GHSA-2xpp-75vr-22vq.json
+++ b/advisories/github-reviewed/2018/12/GHSA-2xpp-75vr-22vq/GHSA-2xpp-75vr-22vq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2xpp-75vr-22vq",
-  "modified": "2022-09-14T22:21:45Z",
+  "modified": "2023-01-09T05:03:45Z",
   "published": "2018-12-20T22:02:24Z",
   "aliases": [
     "CVE-2018-17192"
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-17192"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/nifi/commit/dbf259508c2b8e176d8cb837177aaadbf44f0670"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/nifi/commit/dbf259508c2b8e176d8cb837177aaadbf44f0670, of which the commit message claims `NIFI-5258 - Changed addHeader to setHeader which stops X-Frame-Options being added twice to responses. Added unit test.
This closes #2791.
Signed-off-by: Andy LoPresto <alopresto@apache.org>`