### PR TITLE
[GHSA-xvch-r4wf-h8w9] Improper Certificate Validation in proton-j

### DIFF
--- a/advisories/github-reviewed/2018/11/GHSA-xvch-r4wf-h8w9/GHSA-xvch-r4wf-h8w9.json
+++ b/advisories/github-reviewed/2018/11/GHSA-xvch-r4wf-h8w9/GHSA-xvch-r4wf-h8w9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xvch-r4wf-h8w9",
-  "modified": "2022-09-14T22:05:10Z",
+  "modified": "2023-01-09T05:04:06Z",
   "published": "2018-11-21T22:22:21Z",
   "aliases": [
     "CVE-2018-17187"
@@ -42,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-17187"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/qpid-proton-j/commit/0cb8ca03cec42120dcfc434561592d89a89a805e"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/qpid-proton-j/commit/0cb8ca03cec42120dcfc434561592d89a89a805e, of which the commit message claims `PROTON-1962: update some defaults and related handling`