### PR TITLE
[GHSA-qfjv-998w-q48f] High severity vulnerability that affects org.apache.syncope:syncope-core

### DIFF
--- a/advisories/github-reviewed/2018/11/GHSA-qfjv-998w-q48f/GHSA-qfjv-998w-q48f.json
+++ b/advisories/github-reviewed/2018/11/GHSA-qfjv-998w-q48f/GHSA-qfjv-998w-q48f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qfjv-998w-q48f",
-  "modified": "2021-09-16T19:56:56Z",
+  "modified": "2023-01-09T05:03:35Z",
   "published": "2018-11-06T23:15:46Z",
   "aliases": [
     "CVE-2018-17186"
@@ -58,6 +58,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-17186"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/syncope/commit/a0f35f45f8ca5c98853ae8477fb2db81a84709a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/syncope/commit/bdb6a180dcae6f1baaff16619cb906b7292da0d"
     },
     {
       "type": "ADVISORY",

--- a/advisories/github-reviewed/2018/11/GHSA-qfjv-998w-q48f/GHSA-qfjv-998w-q48f.json
+++ b/advisories/github-reviewed/2018/11/GHSA-qfjv-998w-q48f/GHSA-qfjv-998w-q48f.json
@@ -61,6 +61,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/syncope/commit/979c28abf2587c73b57d20e4b892410fdd336f0"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/syncope/commit/a0f35f45f8ca5c98853ae8477fb2db81a84709a"
     },
     {
@@ -70,6 +74,10 @@
     {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-qfjv-998w-q48f"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/syncope"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/syncope/commit/bdb6a180dcae6f1baaff16619cb906b7292da0d, of which the commit message claims `Ensuring all XML input processing is safe - disable DTD and external entities`

Add a patch https://github.com/apache/syncope/commit/a0f35f45f8ca5c98853ae8477fb2db81a84709a, of which the commit message claims `Ensuring all XML input processing is safe - disable DTD and external entities`
