### PR TITLE
[GHSA-9h9c-f287-c6vp] Improper Control of Interaction Frequency in Apache syncope-core

### DIFF
--- a/advisories/github-reviewed/2018/11/GHSA-9h9c-f287-c6vp/GHSA-9h9c-f287-c6vp.json
+++ b/advisories/github-reviewed/2018/11/GHSA-9h9c-f287-c6vp/GHSA-9h9c-f287-c6vp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9h9c-f287-c6vp",
-  "modified": "2022-09-14T22:02:16Z",
+  "modified": "2023-01-09T05:03:46Z",
   "published": "2018-11-06T23:16:18Z",
   "aliases": [
     "CVE-2018-17184"
@@ -58,6 +58,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-17184"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/syncope/commit/36fb466afd64894170fa5e2e030ce6895120b1a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/syncope/commit/73aed0a741b1255f45893e3cada650147335073"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/syncope/commit/b25a8834db2cc7ea45707a1218e85e047568427"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/syncope/commit/73aed0a741b1255f45893e3cada650147335073, of which the commit message claims `Fixing some missing JPA entities' validation`
Add a patch https://github.com/apache/syncope/commit/36fb466afd64894170fa5e2e030ce6895120b1a, of which the commit message claims `Fixing some missing JPA entities' validation`
Add a patch https://github.com/apache/syncope/commit/b25a8834db2cc7ea45707a1218e85e047568427, of which the commit message claims `Fixing some missing JPA entities' validation`
