### PR TITLE
[GHSA-27xw-p8v6-9jjr] Spring Security vulnerable to Authorization Bypass

### DIFF
--- a/advisories/github-reviewed/2018/12/GHSA-27xw-p8v6-9jjr/GHSA-27xw-p8v6-9jjr.json
+++ b/advisories/github-reviewed/2018/12/GHSA-27xw-p8v6-9jjr/GHSA-27xw-p8v6-9jjr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-27xw-p8v6-9jjr",
-  "modified": "2022-09-14T22:14:12Z",
+  "modified": "2023-01-28T05:00:54Z",
   "published": "2018-12-20T22:01:31Z",
   "aliases": [
     "CVE-2018-15801"
@@ -58,6 +58,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-15801"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-security/commit/c70b65c5df0e170a2d34d812b83db0b7bc71ea25"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/spring-projects/spring-security/commit/c70b65c5df0e170a2d34d812b83db0b7bc71ea25, of which the commit message claims `Favor URL.toExternalForm
Converts URLs to Strings before comparing them. Uses toString(),
which delegates to toExternalForm().
Fixes: gh-6073`