### PR TITLE
[GHSA-h8w4-qv99-f7vj] High severity vulnerability that affects org.springframework.security.oauth:spring-security-oauth2

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-h8w4-qv99-f7vj/GHSA-h8w4-qv99-f7vj.json
+++ b/advisories/github-reviewed/2018/10/GHSA-h8w4-qv99-f7vj/GHSA-h8w4-qv99-f7vj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h8w4-qv99-f7vj",
-  "modified": "2021-01-14T21:22:21Z",
+  "modified": "2023-01-09T05:03:03Z",
   "published": "2018-10-19T22:00:28Z",
   "aliases": [
     "CVE-2018-15758"
@@ -99,6 +99,22 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-security-oauth/commit/4082ec7ae3d39198a47b5c803ccb20dacefb0b0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-security-oauth/commit/623776689fdcc8047f5a908c71f348e1f172a97"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-security-oauth/commit/ddd65cd9417ae1e4a69e4193a622300db38e2ef"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-security-oauth/commit/f92223afc71687bd3156298054903f50aa71fbf"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2019:2413"
     },
     {
@@ -118,7 +134,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "HIGH",
+    "severity": "CRITICAL",
     "github_reviewed": true,
     "github_reviewed_at": "2020-06-16T21:39:36Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- References
- Severity

**Comments**
Add a patch https://github.com/spring-projects/spring-security-oauth/commit/623776689fdcc8047f5a908c71f348e1f172a97, of which the commit message claims `Validate authorization request on approval
Fixes gh-1481`

Add a patch https://github.com/spring-projects/spring-security-oauth/commit/f92223afc71687bd3156298054903f50aa71fbf, of which the commit message claims `Validate authorization request on approval
Fixes gh-1481`

"Add a patch https://github.com/spring-projects/spring-security-oauth/commit/ddd65cd9417ae1e4a69e4193a622300db38e2ef, of which the commit message claims `Validate authorization request on approval
Fixes gh-1481`

Add a patch https://github.com/spring-projects/spring-security-oauth/commit/4082ec7ae3d39198a47b5c803ccb20dacefb0b0, of which the commit message claims `Validate authorization request on approval
Fixes gh-1481`