### PR TITLE
[GHSA-3qh2-mccc-q5m6] Keycloak Open Redirect

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-3qh2-mccc-q5m6/GHSA-3qh2-mccc-q5m6.json
+++ b/advisories/github-reviewed/2022/05/GHSA-3qh2-mccc-q5m6/GHSA-3qh2-mccc-q5m6.json
@@ -42,6 +42,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/keycloak/keycloak/commit/a957e118e6efb35fe7ef3a62acd66341a6523cb7"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2018:3592"
     },
     {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add a patch https://github.com/keycloak/keycloak/commit/a957e118e6efb35fe7ef3a62acd66341a6523cb7, of which the commit message claims `Redirect URLs are not normalized`
