### PR TITLE
[GHSA-cfw5-v7cw-69cw] Critical severity vulnerability that affects org.apache.directory.api:apache-ldap-api

### DIFF
--- a/advisories/github-reviewed/2018/11/GHSA-cfw5-v7cw-69cw/GHSA-cfw5-v7cw-69cw.json
+++ b/advisories/github-reviewed/2018/11/GHSA-cfw5-v7cw-69cw/GHSA-cfw5-v7cw-69cw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cfw5-v7cw-69cw",
-  "modified": "2021-09-09T17:08:40Z",
+  "modified": "2023-01-09T05:03:15Z",
   "published": "2018-11-09T17:49:49Z",
   "aliases": [
     "CVE-2018-1337"
@@ -41,8 +41,20 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1337"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/directory-ldap-api/commit/075b70a733d7af150b3d85684149ff5f029f7fd"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/directory-ldap-api/commit/5faa6a71606a22a7503d401911875ec3a355cac"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-cfw5-v7cw-69cw"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/directory-ldap-api"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/apache/directory-ldap-api/commit/075b70a733d7af150b3d85684149ff5f029f7fd, of which the commit message claims `Fixed some race condition in LdapConnection when using SSL`

Add a patch https://github.com/apache/directory-ldap-api/commit/5faa6a71606a22a7503d401911875ec3a355cac, of which the commit message claims `o Bumped up MINA version to 2.0.18
o Added the event() method to switch the handhakeFuture flag when the Handshake is completed
o The session is now seen as connected when the sessionCreated event is received
o Added some schema parser perf test
o Added some LDAP test (ignored)`