### PR TITLE
[GHSA-9r24-gp44-h3pm] High severity vulnerability that affects org.apache.tika:tika-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-9r24-gp44-h3pm/GHSA-9r24-gp44-h3pm.json
+++ b/advisories/github-reviewed/2018/10/GHSA-9r24-gp44-h3pm/GHSA-9r24-gp44-h3pm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9r24-gp44-h3pm",
-  "modified": "2021-09-08T20:54:36Z",
+  "modified": "2023-01-09T05:02:50Z",
   "published": "2018-10-17T15:43:43Z",
   "aliases": [
     "CVE-2018-1335"
@@ -42,6 +42,34 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tika/commit/302f22aff7a836868b270038e1d66002a2004869"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tika/commit/4fdc51a40bf9532d7db57d0b08c1aec3931468ad"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tika/commit/5d983aad0b68a228f180686a4135ed8c7cd589f1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tika/commit/b2d3932b847a171a85e356aa230af461a0f80d91"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tika/commit/d1bc09386405d28d6b0f0a29ce8c3e7efd72d6c7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tika/commit/e82c2efd2b1ac731b6954634741b70ecf0ed6f01"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tika/commit/ffb48dd29d0c2009490caefda75e5b57c7958c51"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2019:3140"
     },
     {
@@ -49,12 +77,16 @@
       "url": "https://github.com/advisories/GHSA-9r24-gp44-h3pm"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tika"
+    },
+    {
       "type": "WEB",
       "url": "https://lists.apache.org/thread.html/b3ed4432380af767effd4c6f27665cc7b2686acccbefeb9f55851dca@%3Cdev.tika.apache.org%3E"
     },
     {
       "type": "WEB",
-      "url": "https://www.exploit-db.com/exploits/46540"
+      "url": "https://www.exploit-db.com/exploits/46540/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/apache/tika/commit/d1bc09386405d28d6b0f0a29ce8c3e7efd72d6c7, of which the commit message claims `fix potential resource leak, continued`

Add a patch https://github.com/apache/tika/commit/4fdc51a40bf9532d7db57d0b08c1aec3931468ad, of which the commit message claims `followup fix`

Add a patch https://github.com/apache/tika/commit/e82c2efd2b1ac731b6954634741b70ecf0ed6f01, of which the commit message claims `fix potential resource leak`

Add a patch https://github.com/apache/tika/commit/302f22aff7a836868b270038e1d66002a2004869, of which the commit message claims `fix readUE7`

Add a patch https://github.com/apache/tika/commit/ffb48dd29d0c2009490caefda75e5b57c7958c51, of which the commit message claims `fix chm parser`

Add a patch https://github.com/apache/tika/commit/5d983aad0b68a228f180686a4135ed8c7cd589f1, of which the commit message claims `fix chm; remove println`

Add a patch https://github.com/apache/tika/commit/b2d3932b847a171a85e356aa230af461a0f80d91, of which the commit message claims `fix potential resource leak`
