### PR TITLE
[GHSA-p8jx-x2vw-wm33] High severity vulnerability that affects org.apache.storm:storm-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-p8jx-x2vw-wm33/GHSA-p8jx-x2vw-wm33.json
+++ b/advisories/github-reviewed/2018/10/GHSA-p8jx-x2vw-wm33/GHSA-p8jx-x2vw-wm33.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p8jx-x2vw-wm33",
-  "modified": "2021-09-16T16:13:14Z",
+  "modified": "2023-01-09T05:03:19Z",
   "published": "2018-10-17T19:48:06Z",
   "aliases": [
     "CVE-2018-1331"
@@ -60,8 +60,28 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1331"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/storm/commit/22a962073c5f12dc5ab281a15d93eb5efc31ab6"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/storm/commit/8ffa920d3894634aa078f0fdf6b02d270262caf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/storm/commit/a6bf3e421d3d37a797e3bb374fcd20a00189feb"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/storm/commit/e3652b44a377436256f77a2749ed133bbafd2fb"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-p8jx-x2vw-wm33"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/storm"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/apache/storm/commit/8ffa920d3894634aa078f0fdf6b02d270262caf, of which the commit message claims `STORM-3026: Upgrade ZK instance for security`

Add a patch https://github.com/apache/storm/commit/22a962073c5f12dc5ab281a15d93eb5efc31ab6, of which the commit message claims `STORM-3026: Upgrade ZK instance for security`

Add a patch https://github.com/apache/storm/commit/e3652b44a377436256f77a2749ed133bbafd2fb, of which the commit message claims `STORM-3026: Upgrade ZK instance for security`

Add a patch https://github.com/apache/storm/commit/a6bf3e421d3d37a797e3bb374fcd20a00189feb, of which the commit message claims `STORM-3026: Upgrade ZK instance for security`
