### PR TITLE
[GHSA-v3vf-2r98-xw8w] Exposure of Sensitive Information to an Unauthorized Actor in Apache syncope-cope

### DIFF
--- a/advisories/github-reviewed/2018/11/GHSA-v3vf-2r98-xw8w/GHSA-v3vf-2r98-xw8w.json
+++ b/advisories/github-reviewed/2018/11/GHSA-v3vf-2r98-xw8w/GHSA-v3vf-2r98-xw8w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v3vf-2r98-xw8w",
-  "modified": "2022-09-14T22:51:27Z",
+  "modified": "2023-01-09T05:03:46Z",
   "published": "2018-11-06T23:17:25Z",
   "aliases": [
     "CVE-2018-1322"
@@ -60,12 +60,28 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1322"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/syncope/commit/44a5ca0fbd357b8b5d81aa9313fb01cca30d8ad"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/syncope/commit/735579b6f987b407049ac1f1da08e675d957c3e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/syncope/commit/7b168c142b09c3b03e39f1449211e7ddf026a14"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-v3vf-2r98-xw8w"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/syncope"
+    },
+    {
       "type": "WEB",
-      "url": "https://www.exploit-db.com/exploits/45400"
+      "url": "https://www.exploit-db.com/exploits/45400/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/apache/syncope/commit/7b168c142b09c3b03e39f1449211e7ddf026a14, of which the commit message claims `Review fields usable for search and orderBy`

Add a patch https://github.com/apache/syncope/commit/44a5ca0fbd357b8b5d81aa9313fb01cca30d8ad, of which the commit message claims `Review fields usable for search and orderBy`

Add a patch https://github.com/apache/syncope/commit/735579b6f987b407049ac1f1da08e675d957c3e, of which the commit message claims `Review fields usable for search and orderBy`
