### PR TITLE
[GHSA-rrpm-pj7p-7j9q] Spring Security OAuth vulnerable to remote code execution (RCE)

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-rrpm-pj7p-7j9q/GHSA-rrpm-pj7p-7j9q.json
+++ b/advisories/github-reviewed/2018/10/GHSA-rrpm-pj7p-7j9q/GHSA-rrpm-pj7p-7j9q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rrpm-pj7p-7j9q",
-  "modified": "2022-09-14T01:00:57Z",
+  "modified": "2023-01-08T05:03:02Z",
   "published": "2018-10-18T18:05:34Z",
   "aliases": [
     "CVE-2018-1260"
@@ -99,6 +99,22 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-security-oauth/commit/1c6815ac1b26fb2f079adbe283c43a7fd0885f3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-security-oauth/commit/6b1791179c1092553aa0690da22dac4dff2fc58"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-security-oauth/commit/8e9792c1963f1aeea81ca618785eb8d71d1cd1d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-security-oauth/commit/adb1e6d19c681f394c9513799b81b527b0cb007"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2018:1809"
     },
     {
@@ -108,6 +124,10 @@
     {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-rrpm-pj7p-7j9q"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/spring-projects/spring-security-oauth"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/spring-projects/spring-security-oauth/commit/1c6815ac1b26fb2f079adbe283c43a7fd0885f3, of which the commit message claims `Remove SpelView in WhitelabelApprovalEndpoint
Fixes gh-1340`

Add a patch https://github.com/spring-projects/spring-security-oauth/commit/adb1e6d19c681f394c9513799b81b527b0cb007, of which the commit message claims `Remove SpelView in WhitelabelApprovalEndpoint
Fixes gh-1340`

Add a patch https://github.com/spring-projects/spring-security-oauth/commit/8e9792c1963f1aeea81ca618785eb8d71d1cd1d, of which the commit message claims `Remove SpelView in WhitelabelApprovalEndpoint
Fixes gh-1340`

"Add a patch https://github.com/spring-projects/spring-security-oauth/commit/6b1791179c1092553aa0690da22dac4dff2fc58, of which the commit message claims `Remove SpelView in WhitelabelApprovalEndpoint
Fixes gh-1340`