### PR TITLE
[GHSA-m929-7fr6-cvjg] Spring Data Commons, used in combination with XMLBeam, contains a property binder vulnerability caused by improper restriction of XML external entity references

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-m929-7fr6-cvjg/GHSA-m929-7fr6-cvjg.json
+++ b/advisories/github-reviewed/2018/10/GHSA-m929-7fr6-cvjg/GHSA-m929-7fr6-cvjg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m929-7fr6-cvjg",
-  "modified": "2022-04-27T13:58:00Z",
+  "modified": "2023-01-27T05:02:26Z",
   "published": "2018-10-17T17:23:36Z",
   "aliases": [
     "CVE-2018-1259"
@@ -61,11 +61,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/SvenEwald/xmlbeam/commit/f8e943f44961c14cf1316deb56280f7878702ee1"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2018:1809"
     },
     {
       "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2018:3768"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/SvenEwald/xmlbeam"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/SvenEwald/xmlbeam/commit/f8e943f44961c14cf1316deb56280f7878702ee1, of which the commit message claims `Security fixes`
