### PR TITLE
[GHSA-cxrj-66c5-9fmh] Spring Framework when used in combination with any versions of Spring Security contains an authorization bypass

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-cxrj-66c5-9fmh/GHSA-cxrj-66c5-9fmh.json
+++ b/advisories/github-reviewed/2018/10/GHSA-cxrj-66c5-9fmh/GHSA-cxrj-66c5-9fmh.json
@@ -45,7 +45,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/spring-projects/spring-security/commit/7b8fa90d96aaf751a3256fa755d5f17e081c20f"
+      "url": "https://github.com/spring-projects/spring-security/commit/fed15f2b01b763158f6650afa13059203366974"
     },
     {
       "type": "WEB",
@@ -54,10 +54,6 @@
     {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-cxrj-66c5-9fmh"
-    },
-    {
-      "type": "PACKAGE",
-      "url": "https://github.com/spring-projects/spring-security"
     },
     {
       "type": "WEB",

--- a/advisories/github-reviewed/2018/10/GHSA-cxrj-66c5-9fmh/GHSA-cxrj-66c5-9fmh.json
+++ b/advisories/github-reviewed/2018/10/GHSA-cxrj-66c5-9fmh/GHSA-cxrj-66c5-9fmh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cxrj-66c5-9fmh",
-  "modified": "2022-04-27T15:07:45Z",
+  "modified": "2023-01-28T05:00:55Z",
   "published": "2018-10-17T20:05:49Z",
   "aliases": [
     "CVE-2018-1258"
@@ -45,6 +45,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-security/commit/7b8fa90d96aaf751a3256fa755d5f17e081c20f"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2019:2413"
     },
     {
@@ -52,12 +56,16 @@
       "url": "https://github.com/advisories/GHSA-cxrj-66c5-9fmh"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/spring-projects/spring-security"
+    },
+    {
       "type": "WEB",
       "url": "https://pivotal.io/security/cve-2018-1258"
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20181018-0002"
+      "url": "https://security.netapp.com/advisory/ntap-20181018-0002/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/spring-projects/spring-security/commit/7b8fa90d96aaf751a3256fa755d5f17e081c20f, of which the commit message claims `Add accessDeniedHandler method to ExceptionHandlingSpec
This allows to configure accessDeniedHandler in ExceptionTranslationWebFilter through ServerHttpSecurity.
Issue: gh-5257`