### PR TITLE
[GHSA-q4q2-93pw-qwgf] Issuer validation regression in Spring Cloud SSO Connector

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-q4q2-93pw-qwgf/GHSA-q4q2-93pw-qwgf.json
+++ b/advisories/github-reviewed/2022/05/GHSA-q4q2-93pw-qwgf/GHSA-q4q2-93pw-qwgf.json
@@ -45,6 +45,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/pivotal-cf/spring-cloud-sso-connector/commit/ef647a2acf2363c6018e8543d665ac8862593372"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/pivotal-cf/spring-cloud-sso-connector"
+    },
+    {
+      "type": "WEB",
       "url": "https://pivotal.io/security/cve-2018-1256"
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add a patch https://github.com/pivotal-cf/spring-cloud-sso-connector/commit/ef647a2acf2363c6018e8543d665ac8862593372, of which the commit message claims `Revert commit c594317337457a7f19166244f6acc66b476be856
* Above commit creates a regression for when we make the Issuer check
without binding to a SSO service
[#157069100]
Signed-off-by: Alex Jackson <ajackson@pivotal.io>`