### PR TITLE
[GHSA-qh3m-qw6v-qvhg] Moderate severity vulnerability that affects io.vertx:vertx-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-qh3m-qw6v-qvhg/GHSA-qh3m-qw6v-qvhg.json
+++ b/advisories/github-reviewed/2018/10/GHSA-qh3m-qw6v-qvhg/GHSA-qh3m-qw6v-qvhg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qh3m-qw6v-qvhg",
-  "modified": "2020-06-16T21:51:57Z",
+  "modified": "2023-01-09T05:03:21Z",
   "published": "2018-10-17T16:20:32Z",
   "aliases": [
     "CVE-2018-12544"
@@ -40,6 +40,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/vert-x3/vertx-web/issues/1021"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vert-x3/vertx-web/commit/ac8692c618d6180a9bc012a2ac8dbec821b1a97"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vert-x3/vertx-web/commit/d814d22ade14bafec47c4447a4ba9bff090f05e"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/vert-x3/vertx-web/commit/d814d22ade14bafec47c4447a4ba9bff090f05e, of which the commit message claims `Create safe xml parsers`

Add a patch https://github.com/vert-x3/vertx-web/commit/ac8692c618d6180a9bc012a2ac8dbec821b1a97, of which the commit message claims `Create safe xml parsers
(cherry picked from commit d814d22ade14bafec47c4447a4ba9bff090f05e8)`