### PR TITLE
[GHSA-wjxj-f8rg-99wx] Improper Input Validation in Apache Thrift

### DIFF
--- a/advisories/github-reviewed/2019/01/GHSA-wjxj-f8rg-99wx/GHSA-wjxj-f8rg-99wx.json
+++ b/advisories/github-reviewed/2019/01/GHSA-wjxj-f8rg-99wx/GHSA-wjxj-f8rg-99wx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wjxj-f8rg-99wx",
-  "modified": "2023-03-01T20:05:50Z",
+  "modified": "2023-08-28T11:02:12Z",
   "published": "2019-01-17T13:56:40Z",
   "aliases": [
     "CVE-2018-1320"
@@ -61,103 +61,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2019:2413"
-    },
-    {
-      "type": "PACKAGE",
-      "url": "https://github.com/apache/thrift"
+      "url": "https://github.com/apache/thrift/commit/d973409661f820d80d72c0034d06a12348c8705e"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/apache/thrift/releases/tag/0.9.3.1"
-    },
-    {
-      "type": "WEB",
-      "url": "https://issues.apache.org/jira/browse/THRIFT-4506"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/07c3cd5a2953a4b253eee4437b1397b1603d0f886437e19b657d2c54@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/187684ac8b94d55256253f5220cb55e8bd568afdf9a8a86e9bbb66c9@%3Cdevnull.infra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/3d3b6849fcf4cd1e87703b3dde0d57aabeb9ba0193dc0cf3c97f545d@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/6b07f6f618155c777191b4fad8ade0f0cf4ed4c12a1a746ce903d816@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/8be5b16c02567fff61b1284e5df433a4e38617bc7de4804402bf62be@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/da5234b5e78f1c99190407f791dfe1bf6c58de8d30d15974a9669be3@%3Cuser.thrift.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/dbe3a39b48900318ad44494e8721f786901ba4520cd412c7698f534f@%3Cdev.storm.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/dfee89880c84874058c6a584d8128468f8d3c2ac25068ded91073adc@%3Cuser.storm.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/e825ff2f4e129c0ecdb6a19030b53c1ccdf810a8980667628d0c6a80@%3Cannounce.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r09c3dcdccf4b74ad13bda79b354e6b793255ccfe245cca1b8cee23f5@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r1015eaadef8314daa9348aa423086a732cfeb998ceb5d42605c9b0b5@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r2278846f7ab06ec07a0aa31457235e0ded9191b216cba55f3f315f16@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r261972a3b14cf6f1dcd94b1b265e9ef644a38ccdf0d0238fa0c4d459@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r3d71a6dbb063aa61ba81278fe622b20bfe7501bb3821c27695641ac3@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r4d3f1d3e333d9c2b2f6e6ae8ed8750d4de03410ac294bcd12c7eefa3@%3Ccommits.cassandra.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2019/02/msg00008.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://support.f5.com/csp/article/K36361684"
-    },
-    {
-      "type": "WEB",
-      "url": "https://web.archive.org/web/20200227094237/http://www.securityfocus.com/bid/106551"
+      "url": "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
     },
     {
       "type": "WEB",
@@ -165,7 +73,103 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+      "url": "https://web.archive.org/web/20200227094237/http://www.securityfocus.com/bid/106551"
+    },
+    {
+      "type": "WEB",
+      "url": "https://support.f5.com/csp/article/K36361684"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2019/02/msg00008.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r4d3f1d3e333d9c2b2f6e6ae8ed8750d4de03410ac294bcd12c7eefa3@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r3d71a6dbb063aa61ba81278fe622b20bfe7501bb3821c27695641ac3@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r261972a3b14cf6f1dcd94b1b265e9ef644a38ccdf0d0238fa0c4d459@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r2278846f7ab06ec07a0aa31457235e0ded9191b216cba55f3f315f16@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r1015eaadef8314daa9348aa423086a732cfeb998ceb5d42605c9b0b5@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r09c3dcdccf4b74ad13bda79b354e6b793255ccfe245cca1b8cee23f5@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/e825ff2f4e129c0ecdb6a19030b53c1ccdf810a8980667628d0c6a80@%3Cannounce.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/dfee89880c84874058c6a584d8128468f8d3c2ac25068ded91073adc@%3Cuser.storm.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/dbe3a39b48900318ad44494e8721f786901ba4520cd412c7698f534f@%3Cdev.storm.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/da5234b5e78f1c99190407f791dfe1bf6c58de8d30d15974a9669be3@%3Cuser.thrift.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/8be5b16c02567fff61b1284e5df433a4e38617bc7de4804402bf62be@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/6b07f6f618155c777191b4fad8ade0f0cf4ed4c12a1a746ce903d816@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/3d3b6849fcf4cd1e87703b3dde0d57aabeb9ba0193dc0cf3c97f545d@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/187684ac8b94d55256253f5220cb55e8bd568afdf9a8a86e9bbb66c9@%3Cdevnull.infra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/07c3cd5a2953a4b253eee4437b1397b1603d0f886437e19b657d2c54@%3Ccommits.cassandra.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/THRIFT-4506"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/thrift/releases/tag/0.9.3.1"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/thrift"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2019:2413"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/thrift/commit/d973409661f820d80d72c0034d06a12348c8705e, of which the commit message claims `THRIFT-4506: fix use of assert for correctness in Java SASL negotiation
Client: java`