### PR TITLE
[GHSA-42xw-p62x-hwcf] Improper Access Control in Apache Derby

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-42xw-p62x-hwcf/GHSA-42xw-p62x-hwcf.json
+++ b/advisories/github-reviewed/2022/05/GHSA-42xw-p62x-hwcf/GHSA-42xw-p62x-hwcf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-42xw-p62x-hwcf",
-  "modified": "2022-06-29T19:13:33Z",
+  "modified": "2023-01-27T05:02:11Z",
   "published": "2022-05-13T01:02:18Z",
   "aliases": [
     "CVE-2018-1313"
@@ -42,6 +42,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1313"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/derby/commit/4da5b2db5f3a60c1fa8ef616d88a7efe28b0c9d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/derby/commit/a2027c64e185a9ce46929f352e2db03371c1f95"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add two patches: 
https://github.com/apache/derby/commit/a2027c64e185a9ce46929f352e2db03371c1f95
https://github.com/apache/derby/commit/4da5b2db5f3a60c1fa8ef616d88a7efe28b0c9d. 
the commit msgs show their intention.