### PR TITLE
[GHSA-3pph-2595-cgfh] There is a XML external entity expansion (XXE) vulnerability in Apache Solr 

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-3pph-2595-cgfh/GHSA-3pph-2595-cgfh.json
+++ b/advisories/github-reviewed/2018/10/GHSA-3pph-2595-cgfh/GHSA-3pph-2595-cgfh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3pph-2595-cgfh",
-  "modified": "2022-04-27T14:43:36Z",
+  "modified": "2023-01-09T05:02:51Z",
   "published": "2018-10-17T19:55:46Z",
   "aliases": [
     "CVE-2018-1308"
@@ -58,6 +58,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1308"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/02c693f3713add1b4891cbaa87127de3a55c10f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/739a79338856599084617d44b6a1b424af059aa"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/lucene-solr/commit/dd3be31f7062dcb2f3b2d7f0e89df29e197dee6"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/lucene-solr/commit/02c693f3713add1b4891cbaa87127de3a55c10f, of which the commit message claims `SOLR-11971: Don't allow referal to external resources in DataImportHandler's dataConfig request parameter`
Add a patch https://github.com/apache/lucene-solr/commit/dd3be31f7062dcb2f3b2d7f0e89df29e197dee6, of which the commit message claims `SOLR-11971: Don't allow referal to external resources in DataImportHandler's dataConfig request parameter`
Add a patch https://github.com/apache/lucene-solr/commit/739a79338856599084617d44b6a1b424af059aa, of which the commit message claims `SOLR-11971: Don't allow referal to external resources in DataImportHandler's dataConfig request parameter`
