### PR TITLE
[GHSA-v49x-8hvm-q347] Exposure of Sensitive Information in Apache Pluto

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-v49x-8hvm-q347/GHSA-v49x-8hvm-q347.json
+++ b/advisories/github-reviewed/2022/05/GHSA-v49x-8hvm-q347/GHSA-v49x-8hvm-q347.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v49x-8hvm-q347",
-  "modified": "2022-11-03T21:08:10Z",
+  "modified": "2023-02-01T05:04:19Z",
   "published": "2022-05-14T01:29:43Z",
   "aliases": [
     "CVE-2018-1306"
@@ -44,12 +44,16 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1306"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/portals-pluto/commit/89f6a59a740d0a8318640ca6015e9a381c5c6b50"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/apache/portals-pluto"
     },
     {
       "type": "WEB",
-      "url": "https://www.exploit-db.com/exploits/45396"
+      "url": "https://www.exploit-db.com/exploits/45396/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/portals-pluto/commit/89f6a59a740d0a8318640ca6015e9a381c5c6b50, of which the commit message claims `Changed the temp directory used by the demo portlet.`
