### PR TITLE
[GHSA-6w3v-66mj-2qm6] Moderate severity vulnerability that affects org.apache.qpid:apache-qpid-broker-j

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-6w3v-66mj-2qm6/GHSA-6w3v-66mj-2qm6.json
+++ b/advisories/github-reviewed/2018/10/GHSA-6w3v-66mj-2qm6/GHSA-6w3v-66mj-2qm6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6w3v-66mj-2qm6",
-  "modified": "2021-09-02T18:30:03Z",
+  "modified": "2023-01-09T05:02:34Z",
   "published": "2018-10-19T16:41:46Z",
   "aliases": [
     "CVE-2018-1298"
@@ -42,6 +42,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1298"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/qpid-broker-j/commit/30ca170c42c400b41340a81c6a69d33aa19bf189"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/qpid-broker-j/commit/4b9fb37abbe882193b16595ed7b8e9d8383f59e1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/qpid-broker-j/commit/de509dd955229a395c086a7cca874dc55306648a"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/qpid-broker-j/commit/30ca170c42c400b41340a81c6a69d33aa19bf189, of which the commit message claims `QPID-8046: [Broker-J] Add more tests
Cherry picked from ca088c2`

Add a patch https://github.com/apache/qpid-broker-j/commit/4b9fb37abbe882193b16595ed7b8e9d8383f59e1, of which the commit message claims `QPID-8046: [Broker-J] [PlainNegotiator] Eliminate redundant UTF-8/UnsupportedEncodingException catch block
Cherry picked from fcca9d2`

Add a patch https://github.com/apache/qpid-broker-j/commit/de509dd955229a395c086a7cca874dc55306648a, of which the commit message claims `QPID-8046: [Broker-J] Allow SASL mechanisms PLAIN and XOAUTH2 to not require initial response
Cherry picked from 4eb2ea6`
