### PR TITLE
[GHSA-cx2v-jrjc-g54w] OpenTSDB vulnerable to OS Command Injection

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-cx2v-jrjc-g54w/GHSA-cx2v-jrjc-g54w.json
+++ b/advisories/github-reviewed/2022/05/GHSA-cx2v-jrjc-g54w/GHSA-cx2v-jrjc-g54w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cx2v-jrjc-g54w",
-  "modified": "2022-11-22T19:24:22Z",
+  "modified": "2023-02-02T05:01:55Z",
   "published": "2022-05-13T01:49:41Z",
   "aliases": [
     "CVE-2018-12972"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/OpenTSDB/opentsdb/issues/1239"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/OpenTSDB/opentsdb/commit/a6a9ec4bc8a526951bc25bb19a145782bafaa8b0"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add a patch https://github.com/OpenTSDB/opentsdb/commit/a6a9ec4bc8a526951bc25bb19a145782bafaa8b0, of which the commit message claims `Avoid double computing the expressions for the /query/exp endpoint.
Also make sure both versions of next() handle booleans.
Signed-off-by: Chris Larsen <clarsen@yahoo-inc.com>`