### PR TITLE
[GHSA-c8v6-786g-vjx6] json-jwt allows bypass of identity checks via a sign/encryption confusion attack

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-c8v6-786g-vjx6/GHSA-c8v6-786g-vjx6.json
+++ b/advisories/github-reviewed/2024/02/GHSA-c8v6-786g-vjx6/GHSA-c8v6-786g-vjx6.json
@@ -25,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.16.3"
+              "fixed": "1.16.6"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.16.3"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Developer says it's patched at 1.16.6 https://github.com/nov/json-jwt/issues/120#issuecomment-1976119331