### PR TITLE
[GHSA-chp4-rv79-68j3] Apache serialization mechanism does not have a list of classes allowed for serialization/deserialization

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-chp4-rv79-68j3/GHSA-chp4-rv79-68j3.json
+++ b/advisories/github-reviewed/2018/10/GHSA-chp4-rv79-68j3/GHSA-chp4-rv79-68j3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-chp4-rv79-68j3",
-  "modified": "2022-04-26T19:14:39Z",
+  "modified": "2023-01-09T05:03:15Z",
   "published": "2018-10-16T20:53:44Z",
   "aliases": [
     "CVE-2018-1295"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1295"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/ignite/commit/340569b8f4e14a4cb61a9407ed2d9aa4a20bdf49"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/ignite/commit/340569b8f4e14a4cb61a9407ed2d9aa4a20bdf49, of which the commit message claims `ignite-6643 Marshalling improvements`