### PR TITLE
[GHSA-rxmr-c9jm-7mm8] Exposure of Sensitive Information to an Unauthorized Actor in Apache hive

### DIFF
--- a/advisories/github-reviewed/2018/11/GHSA-rxmr-c9jm-7mm8/GHSA-rxmr-c9jm-7mm8.json
+++ b/advisories/github-reviewed/2018/11/GHSA-rxmr-c9jm-7mm8/GHSA-rxmr-c9jm-7mm8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rxmr-c9jm-7mm8",
-  "modified": "2022-09-14T22:07:44Z",
+  "modified": "2023-01-09T05:04:06Z",
   "published": "2018-11-21T22:24:22Z",
   "aliases": [
     "CVE-2018-1284"
@@ -77,6 +77,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1284"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/hive/commit/b0a58d245875dc1b3ac58a7cf1a61d3b17805e96"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/hive/commit/b0a58d245875dc1b3ac58a7cf1a61d3b17805e96, of which the commit message claims `HIVE-18879: Disallow embedded element in UDFXPathUtil needs to work if xercesImpl.jar in classpath (Daniel Dai, reviewed by Thejas Nair)`
