### PR TITLE
[GHSA-3rmv-2pg5-xvqj] Improperly Implemented Security Check for Standard in org.springframework:spring-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-3rmv-2pg5-xvqj/GHSA-3rmv-2pg5-xvqj.json
+++ b/advisories/github-reviewed/2018/10/GHSA-3rmv-2pg5-xvqj/GHSA-3rmv-2pg5-xvqj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3rmv-2pg5-xvqj",
-  "modified": "2022-06-24T19:58:14Z",
+  "modified": "2023-01-27T05:00:31Z",
   "published": "2018-10-17T20:28:00Z",
   "aliases": [
     "CVE-2018-1275"
@@ -58,6 +58,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1275"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/1db7e02de3eb0c011ee6681f5a12eb9d166fea8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/d3acf45ea4db51fa5c4cbd0bc0e7b6d9ef805e6"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/spring-projects/spring-framework/commit/d3acf45ea4db51fa5c4cbd0bc0e7b6d9ef805e6, of which the commit message claims `Modify SpEL code gen to take account of null safe refs
With this change the code generation for method and property
references is modified to include branching logic in the
case of null safe dereferencing (?.). This is complicated
by the possible usage of primitives on the left hand side
of the dereference. To cope with this case primitives are
promoted to boxed types when this situation occurs enabling
null to be passed as a possible result.
Issue: SPR-16489`

Add a patch https://github.com/spring-projects/spring-framework/commit/1db7e02de3eb0c011ee6681f5a12eb9d166fea8, of which the commit message claims `Modify SpEL code gen to take account of null safe refs
With this change the code generation for method and property
references is modified to include branching logic in the
case of null safe dereferencing (?.). This is complicated
by the possible usage of primitives on the left hand side
of the dereference. To cope with this case primitives are
promoted to boxed types when this situation occurs enabling
null to be passed as a possible result.
Issue: SPR-16489`