### PR TITLE
[GHSA-5q8m-mqmx-pxp9] Spring Data Commons contain a property path parser vulnerability caused by unlimited resource allocation

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-5q8m-mqmx-pxp9/GHSA-5q8m-mqmx-pxp9.json
+++ b/advisories/github-reviewed/2018/10/GHSA-5q8m-mqmx-pxp9/GHSA-5q8m-mqmx-pxp9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5q8m-mqmx-pxp9",
-  "modified": "2022-04-27T13:59:19Z",
+  "modified": "2023-01-27T05:02:26Z",
   "published": "2018-10-17T17:23:44Z",
   "aliases": [
     "CVE-2018-1274"
@@ -58,6 +58,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1274"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-data-commons/commit/371f6590c509c72f8e600f3d05e110941607fba"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-data-commons/commit/3d8576fe4e4e71c23b9e6796b32fd56e51182ee"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/spring-projects/spring-data-commons/commit/371f6590c509c72f8e600f3d05e110941607fba, of which the commit message claims `DATACMNS-1285 - PropertyPath now limits the depth of its parsing to 1000 segments.`

Add a patch https://github.com/spring-projects/spring-data-commons/commit/3d8576fe4e4e71c23b9e6796b32fd56e51182ee, of which the commit message claims `DATACMNS-1285 - PropertyPath now limits the depth of its parsing to 1000 segments.`
