### PR TITLE
[GHSA-4fq3-mr56-cg6r] Spring Data Commons remote code injection vulnerability

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-4fq3-mr56-cg6r/GHSA-4fq3-mr56-cg6r.json
+++ b/advisories/github-reviewed/2018/10/GHSA-4fq3-mr56-cg6r/GHSA-4fq3-mr56-cg6r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4fq3-mr56-cg6r",
-  "modified": "2022-08-11T21:46:08Z",
+  "modified": "2023-01-30T05:02:57Z",
   "published": "2018-10-17T17:23:24Z",
   "aliases": [
     "CVE-2018-1273"
@@ -58,6 +58,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1273"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-data-commons/commit/ae1dd2741ce06d44a0966ecbd6f47beabde2b65"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-data-commons/commit/b1a20ae1e82a63f99b3afc6f2aaedb3bf4dc432"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/spring-projects/spring-data-commons/commit/b1a20ae1e82a63f99b3afc6f2aaedb3bf4dc432, of which the commit message claims `DATACMNS-1282 - Switched to SimpleEvaluationContext in MapDataBinder.`
Add a patch https://github.com/spring-projects/spring-data-commons/commit/ae1dd2741ce06d44a0966ecbd6f47beabde2b65, of which the commit message claims `DATACMNS-1282 - Switched to SimpleEvaluationContext in MapDataBinder.`
