### PR TITLE
[GHSA-4487-x383-qpph] Possible privilege escalation in org.springframework:spring-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-4487-x383-qpph/GHSA-4487-x383-qpph.json
+++ b/advisories/github-reviewed/2018/10/GHSA-4487-x383-qpph/GHSA-4487-x383-qpph.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4487-x383-qpph",
-  "modified": "2022-06-24T19:57:13Z",
+  "modified": "2023-01-27T05:00:32Z",
   "published": "2018-10-17T20:27:47Z",
   "aliases": [
     "CVE-2018-1272"
@@ -58,6 +58,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1272"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/ab2410c754b67902f002bfcc0c3895bd7772d39"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/e02ff3a0da50744b0980d5d665fd242eedea767"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/spring-projects/spring-framework/commit/e02ff3a0da50744b0980d5d665fd242eedea767, of which the commit message claims `MimeTypeUtils uses SecureRandom
The prevailing current wisdom is to use the default constructor for
secure and let it pick the best algorithm for the OS.
On Java 8 (Oracle), Linux this results in ""NativePRNG"" which uses
/dev/random (potentially blocking) for the initial seed, and
/dev/urandom (non-blocking) for subsequent calls to nextInt.
Issue: SPR-16635`
Add a patch https://github.com/spring-projects/spring-framework/commit/ab2410c754b67902f002bfcc0c3895bd7772d39, of which the commit message claims `MimeTypeUtils uses SecureRandom
The prevailing current wisdom is to use the default constructor for
secure and let it pick the best algorithm for the OS.
On Java 8 (Oracle), Linux this results in ""NativePRNG"" which uses
/dev/random (potentially blocking) for the initial seed, and
/dev/urandom (non-blocking) for subsequent calls to nextInt.
Issue: SPR-16635`