### PR TITLE
[GHSA-g8hw-794c-4j9g] Path Traversal in org.springframework:spring-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-g8hw-794c-4j9g/GHSA-g8hw-794c-4j9g.json
+++ b/advisories/github-reviewed/2018/10/GHSA-g8hw-794c-4j9g/GHSA-g8hw-794c-4j9g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g8hw-794c-4j9g",
-  "modified": "2022-06-24T19:56:11Z",
+  "modified": "2023-01-27T05:00:32Z",
   "published": "2018-10-17T20:07:03Z",
   "aliases": [
     "CVE-2018-1271"
@@ -61,31 +61,35 @@
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2018:1320"
+      "url": "https://github.com/spring-projects/spring-framework/commit/0e28bee0f155b9bf240b4bafc4646e4810cb23f"
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2018:2669"
+      "url": "https://github.com/spring-projects/spring-framework/commit/13356a7ee2240f740737c5c83bdccdacc30603a"
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2018:2939"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://github.com/advisories/GHSA-g8hw-794c-4j9g"
+      "url": "https://github.com/spring-projects/spring-framework/commit/695bf2961feffd35b5560ccc982a2189dcca611"
     },
     {
       "type": "WEB",
-      "url": "https://pivotal.io/security/cve-2018-1271"
+      "url": "https://github.com/spring-projects/spring-framework/commit/91b803a2310344d925e5d4b1709bbcea9037554"
     },
     {
       "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpujul2020.html"
+      "url": "https://github.com/spring-projects/spring-framework/commit/98ad23bef8e2e04143f8f5b201380543a8d8c0c"
     },
     {
       "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      "url": "https://github.com/spring-projects/spring-framework/commit/b9ebdaaf3710db473a2e1fec8641c316483a22a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/f59ea610dfcf55cd0b42f6dd76a9b3dab0218aa"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
     },
     {
       "type": "WEB",
@@ -93,7 +97,35 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+      "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpujul2020.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://pivotal.io/security/cve-2018-1271"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/spring-projects/spring-framework"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-g8hw-794c-4j9g"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2018:2939"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2018:2669"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2018:1320"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add 7patch commits, of all which the commit messages claim `Backport clean duplicate separators in resource URLs
Issue: SPR-16616`:
https://github.com/spring-projects/spring-framework/commit/91b803a2310344d925e5d4b1709bbcea9037554
https://github.com/spring-projects/spring-framework/commit/f59ea610dfcf55cd0b42f6dd76a9b3dab0218aa
https://github.com/spring-projects/spring-framework/commit/b9ebdaaf3710db473a2e1fec8641c316483a22a
https://github.com/spring-projects/spring-framework/commit/98ad23bef8e2e04143f8f5b201380543a8d8c0c
https://github.com/spring-projects/spring-framework/commit/0e28bee0f155b9bf240b4bafc4646e4810cb23f
https://github.com/spring-projects/spring-framework/commit/13356a7ee2240f740737c5c83bdccdacc30603a
https://github.com/spring-projects/spring-framework/commit/695bf2961feffd35b5560ccc982a2189dcca611