### PR TITLE
[GHSA-qppj-fm5r-hxr3] HTTP/2 Stream Cancellation Attack

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-qppj-fm5r-hxr3/GHSA-qppj-fm5r-hxr3.json
+++ b/advisories/github-reviewed/2023/10/GHSA-qppj-fm5r-hxr3/GHSA-qppj-fm5r-hxr3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qppj-fm5r-hxr3",
-  "modified": "2024-02-09T00:30:47Z",
+  "modified": "2024-02-09T00:30:49Z",
   "published": "2023-10-10T21:28:24Z",
   "aliases": [
     "CVE-2023-44487"
@@ -15,25 +15,6 @@
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "SwiftURL",
-        "name": "github.com/apple/swift-nio-http2"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.28.0"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "Go",
@@ -261,6 +242,201 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "SwiftURL",
+        "name": "github.com/apple/swift-nio-http2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.28.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.jetty.http2:http2-common"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.3.0"
+            },
+            {
+              "fixed": "9.4.53"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 9.4.52"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.jetty.http2:http2-common"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.0.0"
+            },
+            {
+              "fixed": "10.0.17"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 10.0.16"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.jetty.http2:http2-common"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "11.0.0"
+            },
+            {
+              "fixed": "11.0.17"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 11.0.16"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.jetty.http2:http2-server"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.3.0"
+            },
+            {
+              "fixed": "9.4.53"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 9.4.52"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.jetty.http2:http2-server"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.0.0"
+            },
+            {
+              "fixed": "10.0.17"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 10.0.16"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.jetty.http2:http2-server"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "11.0.0"
+            },
+            {
+              "fixed": "11.0.17"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 11.0.16"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.jetty.http2:jetty-http2-common"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "12.0.0"
+            },
+            {
+              "fixed": "12.0.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 12.0.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.jetty.http2:jetty-http2-server"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "12.0.0"
+            },
+            {
+              "fixed": "12.0.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 12.0.1"
+      }
     }
   ],
   "references": [
@@ -275,6 +451,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-44487"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/etcd-io/etcd/issues/16740"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/golang/go/issues/63417"
     },
     {
       "type": "WEB",
@@ -294,26 +478,6 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/caddyserver/caddy/issues/5877"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/dotnet/announcements/issues/277"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/eclipse/jetty.project/issues/10679"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/etcd-io/etcd/issues/16740"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/golang/go/issues/63417"
-    },
-    {
-      "type": "WEB",
       "url": "https://github.com/haproxy/haproxy/issues/2312"
     },
     {
@@ -326,19 +490,11 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/eclipse/jetty.project/issues/10679"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/kazu-yamamoto/http2/issues/93"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/ninenines/cowboy/issues/1615"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/openresty/openresty/issues/930"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/opensearch-project/data-prepper/issues/3474"
     },
     {
       "type": "WEB",
@@ -346,7 +502,27 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/opensearch-project/data-prepper/issues/3474"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/dotnet/announcements/issues/277"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/varnishcache/varnish-cache/issues/3996"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/openresty/openresty/issues/930"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ninenines/cowboy/issues/1615"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/caddyserver/caddy/issues/5877"
     },
     {
       "type": "WEB",
@@ -367,6 +543,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/grpc/grpc-go/pull/6703"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/projectcontour/contour/pull/5826"
     },
     {
       "type": "WEB",
@@ -398,10 +578,6 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/projectcontour/contour/pull/5826"
-    },
-    {
-      "type": "WEB",
       "url": "https://github.com/kazu-yamamoto/http2/commit/f61d41a502bd0f60eb24e1ce14edc7b6df6722a1"
     },
     {
@@ -410,443 +586,119 @@
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/security/cve/cve-2023-44487"
-    },
-    {
-      "type": "WEB",
-      "url": "https://arstechnica.com/security/2023/10/how-ddosers-used-the-http-2-protocol-to-deliver-attacks-of-unprecedented-size"
-    },
-    {
-      "type": "WEB",
-      "url": "https://aws.amazon.com/security/security-bulletins/AWS-2023-011"
-    },
-    {
-      "type": "WEB",
-      "url": "https://blog.cloudflare.com/technical-breakdown-http2-rapid-reset-ddos-attack"
-    },
-    {
-      "type": "WEB",
-      "url": "https://blog.cloudflare.com/zero-day-rapid-reset-http2-record-breaking-ddos-attack"
-    },
-    {
-      "type": "WEB",
-      "url": "https://blog.litespeedtech.com/2023/10/11/rapid-reset-http-2-vulnerablilty"
-    },
-    {
-      "type": "WEB",
-      "url": "https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack"
-    },
-    {
-      "type": "WEB",
-      "url": "https://blog.vespa.ai/cve-2023-44487"
-    },
-    {
-      "type": "WEB",
-      "url": "https://bugzilla.proxmox.com/show_bug.cgi?id=4988"
-    },
-    {
-      "type": "WEB",
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2242803"
-    },
-    {
-      "type": "WEB",
-      "url": "https://bugzilla.suse.com/show_bug.cgi?id=1216123"
-    },
-    {
-      "type": "WEB",
-      "url": "https://cgit.freebsd.org/ports/commit/?id=c64c329c2c1752f46b73e3e6ce9f4329be6629f9"
-    },
-    {
-      "type": "WEB",
-      "url": "https://chaos.social/@icing/111210915918780532"
-    },
-    {
-      "type": "WEB",
-      "url": "https://cloud.google.com/blog/products/identity-security/google-cloud-mitigated-largest-ddos-attack-peaking-above-398-million-rps"
-    },
-    {
-      "type": "WEB",
-      "url": "https://cloud.google.com/blog/products/identity-security/how-it-works-the-novel-http2-rapid-reset-ddos-attack"
-    },
-    {
-      "type": "WEB",
-      "url": "https://community.traefik.io/t/is-traefik-vulnerable-to-cve-2023-44487/20125"
-    },
-    {
-      "type": "WEB",
-      "url": "https://discuss.hashicorp.com/t/hcsec-2023-32-vault-consul-and-boundary-affected-by-http-2-rapid-reset-denial-of-service-vulnerability-cve-2023-44487/59715"
-    },
-    {
-      "type": "WEB",
-      "url": "https://edg.io/lp/blog/resets-leaks-ddos-and-the-tale-of-a-hidden-cve"
-    },
-    {
-      "type": "WEB",
-      "url": "https://forums.swift.org/t/swift-nio-http2-security-update-cve-2023-44487-http-2-dos/67764"
-    },
-    {
-      "type": "WEB",
-      "url": "https://gist.github.com/adulau/7c2bfb8e9cdbe4b35a5e131c66a0c088"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/Kong/kong/discussions/11741"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://github.com/advisories/GHSA-qppj-fm5r-hxr3"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://github.com/advisories/GHSA-vx74-f528-fxqg"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://github.com/advisories/GHSA-xpw8-rcwv-8f8p"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/apache/httpd/blob/afcdbeebbff4b0c50ea26cdd16e178c0d1f24152/modules/http2/h2_mplx.c#L1101-L1113"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/apache/tomcat/tree/main/java/org/apache/coyote/http2"
-    },
-    {
-      "type": "PACKAGE",
-      "url": "https://github.com/apple/swift-nio-http2"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/arkrwn/PoC/tree/main/CVE-2023-44487"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/bcdannyboy/CVE-2023-44487"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/caddyserver/caddy/releases/tag/v2.7.5"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/dotnet/core/blob/e4613450ea0da7fd2fc6b61dfb2c1c1dec1ce9ec/release-notes/6.0/6.0.23/6.0.23.md?plain=1#L73"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/grpc/grpc-go/releases"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/icing/mod_h2/blob/0a864782af0a942aa2ad4ed960a6b32cd35bcf0a/mod_http2/README.md?plain=1#L239-L244"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/micrictor/http2-rst-stream"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/nghttp2/nghttp2/releases/tag/v1.57.0"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/oqtane/oqtane.framework/discussions/3367"
-    },
-    {
-      "type": "WEB",
-      "url": "https://go.dev/cl/534215"
-    },
-    {
-      "type": "WEB",
-      "url": "https://go.dev/cl/534235"
-    },
-    {
-      "type": "WEB",
-      "url": "https://go.dev/issue/63417"
-    },
-    {
-      "type": "WEB",
-      "url": "https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo"
-    },
-    {
-      "type": "WEB",
-      "url": "https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo/m/UDd7VKQuAAAJ"
-    },
-    {
-      "type": "WEB",
-      "url": "https://istio.io/latest/news/security/istio-security-2023-004"
-    },
-    {
-      "type": "WEB",
-      "url": "https://linkerd.io/2023/10/12/linkerd-cve-2023-44487"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread/5py8h42mxfsn8l1wy6o41xwhsjlsd87q"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00020.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00023.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00024.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00045.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00047.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2023/11/msg00001.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2023/11/msg00012.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/2MBEPPC36UBVOZZNAXFHKLFGSLCMN5LI"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/3N4NJ7FR4X4FPZUGNTQAPSTVB2HB2Y4A"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/BFQD3KUEMFBHPAPBGLWQC34L4OWL5HAZ"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/CLB4TW7KALB3EEQWNWCN7OUIWWVWWCG2"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/E72T67UPDRXHIDLO3OROR25YAMN4GGW5"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/FNA62Q767CFAFHBCDKYNPBMZWB7TWYVU"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/HT7T2R4MQKLIF4ODV4BDLPARWFPCJ5CZ"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/JIZSEFC3YKCGABA2BZW6ZJRMDZJMB7PJ"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/JMEXY22BFG5Q64HQCM5CK2Q7KDKVV4TY"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/KSEGD2IWKNUO3DWY4KQGUQM5BISRWHQE"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LKYHSZQFDNR7RSA7LHVLLIAQMVYCUGBG"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LNMZJCDHGLJJLXO4OXWJMTVQRNWOC7UL"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/VHUHTSXLXGXS7JYKBXTA3VINUPHTNGVU"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/VSRDIV77HNKUSM7SJC5BKE5JSHLHU2NK"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/WE2I52RHNNU42PX6NZ2RBUHSFFJ2LVZX"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/WLPRQ5TWUQQXYWBJM7ECYDAIL2YVKIUH"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/X6QXN4ORIVF6XBW4WWFE7VNPVC74S45Y"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/XFOIBB4YFICHDM7IBOP7PWXW3FX4HLL2"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZB43REMKRQR62NJEI7I5NQ4FSXNLBKRT"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZKQSIKIAT5TJ3WSLU3RDBQ35YX4GY4V3"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZLU6U2R2IC2K64NDPNMV55AUAO65MAF4"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3N4NJ7FR4X4FPZUGNTQAPSTVB2HB2Y4A"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/BFQD3KUEMFBHPAPBGLWQC34L4OWL5HAZ"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CLB4TW7KALB3EEQWNWCN7OUIWWVWWCG2"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/E72T67UPDRXHIDLO3OROR25YAMN4GGW5"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/FNA62Q767CFAFHBCDKYNPBMZWB7TWYVU"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HT7T2R4MQKLIF4ODV4BDLPARWFPCJ5CZ"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/JIZSEFC3YKCGABA2BZW6ZJRMDZJMB7PJ"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/JMEXY22BFG5Q64HQCM5CK2Q7KDKVV4TY"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KSEGD2IWKNUO3DWY4KQGUQM5BISRWHQE"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LKYHSZQFDNR7RSA7LHVLLIAQMVYCUGBG"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LNMZJCDHGLJJLXO4OXWJMTVQRNWOC7UL"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VHUHTSXLXGXS7JYKBXTA3VINUPHTNGVU"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VSRDIV77HNKUSM7SJC5BKE5JSHLHU2NK"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WLPRQ5TWUQQXYWBJM7ECYDAIL2YVKIUH"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/X6QXN4ORIVF6XBW4WWFE7VNPVC74S45Y"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XFOIBB4YFICHDM7IBOP7PWXW3FX4HLL2"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZB43REMKRQR62NJEI7I5NQ4FSXNLBKRT"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZKQSIKIAT5TJ3WSLU3RDBQ35YX4GY4V3"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZLU6U2R2IC2K64NDPNMV55AUAO65MAF4"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.w3.org/Archives/Public/ietf-http-wg/2023OctDec/0025.html"
-    },
-    {
-      "type": "WEB",
       "url": "https://mailman.nginx.org/pipermail/nginx-devel/2023-October/S36Q5HBXR7CAIMPLLPRSSSYR4PCMWILK.html"
     },
     {
       "type": "WEB",
-      "url": "https://martinthomson.github.io/h2-stream-limits/draft-thomson-httpbis-h2-stream-limits.html"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/VSRDIV77HNKUSM7SJC5BKE5JSHLHU2NK/"
     },
     {
       "type": "WEB",
-      "url": "https://msrc.microsoft.com/blog/2023/10/microsoft-response-to-distributed-denial-of-service-ddos-attacks-against-http/2"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/WE2I52RHNNU42PX6NZ2RBUHSFFJ2LVZX/"
     },
     {
       "type": "WEB",
-      "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-44487"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/WLPRQ5TWUQQXYWBJM7ECYDAIL2YVKIUH/"
     },
     {
       "type": "WEB",
-      "url": "https://my.f5.com/manage/s/article/K000137106"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/X6QXN4ORIVF6XBW4WWFE7VNPVC74S45Y/"
     },
     {
       "type": "WEB",
-      "url": "https://netty.io/news/2023/10/10/4-1-100-Final.html"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/XFOIBB4YFICHDM7IBOP7PWXW3FX4HLL2/"
     },
     {
       "type": "WEB",
-      "url": "https://news.ycombinator.com/item?id=37830987"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZB43REMKRQR62NJEI7I5NQ4FSXNLBKRT/"
     },
     {
       "type": "WEB",
-      "url": "https://news.ycombinator.com/item?id=37830998"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZKQSIKIAT5TJ3WSLU3RDBQ35YX4GY4V3/"
     },
     {
       "type": "WEB",
-      "url": "https://news.ycombinator.com/item?id=37831062"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZLU6U2R2IC2K64NDPNMV55AUAO65MAF4/"
     },
     {
       "type": "WEB",
-      "url": "https://news.ycombinator.com/item?id=37837043"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3N4NJ7FR4X4FPZUGNTQAPSTVB2HB2Y4A/"
     },
     {
       "type": "WEB",
-      "url": "https://openssf.org/blog/2023/10/10/http-2-rapid-reset-vulnerability-highlights-need-for-rapid-response"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/BFQD3KUEMFBHPAPBGLWQC34L4OWL5HAZ/"
     },
     {
       "type": "WEB",
-      "url": "https://seanmonstar.com/post/730794151136935936/hyper-http2-rapid-reset-unaffected"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CLB4TW7KALB3EEQWNWCN7OUIWWVWWCG2/"
     },
     {
       "type": "WEB",
-      "url": "https://security.gentoo.org/glsa/202311-09"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/E72T67UPDRXHIDLO3OROR25YAMN4GGW5/"
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20231016-0001"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/FNA62Q767CFAFHBCDKYNPBMZWB7TWYVU/"
     },
     {
       "type": "WEB",
-      "url": "https://security.paloaltonetworks.com/CVE-2023-44487"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HT7T2R4MQKLIF4ODV4BDLPARWFPCJ5CZ/"
     },
     {
       "type": "WEB",
-      "url": "https://tomcat.apache.org/security-10.html#Fixed_in_Apache_Tomcat_10.1.14"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/JIZSEFC3YKCGABA2BZW6ZJRMDZJMB7PJ/"
     },
     {
       "type": "WEB",
-      "url": "https://tomcat.apache.org/security-11.html#Fixed_in_Apache_Tomcat_11.0.0-M12"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/JMEXY22BFG5Q64HQCM5CK2Q7KDKVV4TY/"
     },
     {
       "type": "WEB",
-      "url": "https://tomcat.apache.org/security-8.html#Fixed_in_Apache_Tomcat_8.5.94"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KSEGD2IWKNUO3DWY4KQGUQM5BISRWHQE/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LKYHSZQFDNR7RSA7LHVLLIAQMVYCUGBG/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LNMZJCDHGLJJLXO4OXWJMTVQRNWOC7UL/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VHUHTSXLXGXS7JYKBXTA3VINUPHTNGVU/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VSRDIV77HNKUSM7SJC5BKE5JSHLHU2NK/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WLPRQ5TWUQQXYWBJM7ECYDAIL2YVKIUH/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/X6QXN4ORIVF6XBW4WWFE7VNPVC74S45Y/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XFOIBB4YFICHDM7IBOP7PWXW3FX4HLL2/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZB43REMKRQR62NJEI7I5NQ4FSXNLBKRT/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZKQSIKIAT5TJ3WSLU3RDBQ35YX4GY4V3/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZLU6U2R2IC2K64NDPNMV55AUAO65MAF4/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.w3.org/Archives/Public/ietf-http-wg/2023OctDec/0025.html"
     },
     {
       "type": "WEB",
@@ -858,7 +710,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.bleepingcomputer.com/news/security/new-http-2-rapid-reset-zero-day-attack-breaks-ddos-records"
+      "url": "https://www.bleepingcomputer.com/news/security/new-http-2-rapid-reset-zero-day-attack-breaks-ddos-records/"
     },
     {
       "type": "WEB",
@@ -898,11 +750,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.netlify.com/blog/netlify-successfully-mitigates-cve-2023-44487"
+      "url": "https://www.netlify.com/blog/netlify-successfully-mitigates-cve-2023-44487/"
     },
     {
       "type": "WEB",
-      "url": "https://www.nginx.com/blog/http-2-rapid-reset-attack-impacting-f5-nginx-products"
+      "url": "https://www.nginx.com/blog/http-2-rapid-reset-attack-impacting-f5-nginx-products/"
     },
     {
       "type": "WEB",
@@ -914,7 +766,331 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.theregister.com/2023/10/10/http2_rapid_reset_zeroday"
+      "url": "https://www.theregister.com/2023/10/10/http2_rapid_reset_zeroday/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://martinthomson.github.io/h2-stream-limits/draft-thomson-httpbis-h2-stream-limits.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://msrc.microsoft.com/blog/2023/10/microsoft-response-to-distributed-denial-of-service-ddos-attacks-against-http/2/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-44487"
+    },
+    {
+      "type": "WEB",
+      "url": "https://my.f5.com/manage/s/article/K000137106"
+    },
+    {
+      "type": "WEB",
+      "url": "https://netty.io/news/2023/10/10/4-1-100-Final.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://news.ycombinator.com/item?id=37830987"
+    },
+    {
+      "type": "WEB",
+      "url": "https://news.ycombinator.com/item?id=37830998"
+    },
+    {
+      "type": "WEB",
+      "url": "https://news.ycombinator.com/item?id=37831062"
+    },
+    {
+      "type": "WEB",
+      "url": "https://news.ycombinator.com/item?id=37837043"
+    },
+    {
+      "type": "WEB",
+      "url": "https://openssf.org/blog/2023/10/10/http-2-rapid-reset-vulnerability-highlights-need-for-rapid-response/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://seanmonstar.com/post/730794151136935936/hyper-http2-rapid-reset-unaffected"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.gentoo.org/glsa/202311-09"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.netapp.com/advisory/ntap-20231016-0001/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.paloaltonetworks.com/CVE-2023-44487"
+    },
+    {
+      "type": "WEB",
+      "url": "https://tomcat.apache.org/security-10.html#Fixed_in_Apache_Tomcat_10.1.14"
+    },
+    {
+      "type": "WEB",
+      "url": "https://tomcat.apache.org/security-11.html#Fixed_in_Apache_Tomcat_11.0.0-M12"
+    },
+    {
+      "type": "WEB",
+      "url": "https://tomcat.apache.org/security-8.html#Fixed_in_Apache_Tomcat_8.5.94"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/grpc/grpc-go/releases"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/dotnet/core/blob/e4613450ea0da7fd2fc6b61dfb2c1c1dec1ce9ec/release-notes/6.0/6.0.23/6.0.23.md?plain=1#L73"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/caddyserver/caddy/releases/tag/v2.7.5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/bcdannyboy/CVE-2023-44487"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/arkrwn/PoC/tree/main/CVE-2023-44487"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apple/swift-nio-http2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/tree/main/java/org/apache/coyote/http2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/httpd/blob/afcdbeebbff4b0c50ea26cdd16e178c0d1f24152/modules/http2/h2_mplx.c#L1101-L1113"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-xpw8-rcwv-8f8p"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-vx74-f528-fxqg"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-qppj-fm5r-hxr3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/Kong/kong/discussions/11741"
+    },
+    {
+      "type": "WEB",
+      "url": "https://gist.github.com/adulau/7c2bfb8e9cdbe4b35a5e131c66a0c088"
+    },
+    {
+      "type": "WEB",
+      "url": "https://forums.swift.org/t/swift-nio-http2-security-update-cve-2023-44487-http-2-dos/67764"
+    },
+    {
+      "type": "WEB",
+      "url": "https://edg.io/lp/blog/resets-leaks-ddos-and-the-tale-of-a-hidden-cve"
+    },
+    {
+      "type": "WEB",
+      "url": "https://discuss.hashicorp.com/t/hcsec-2023-32-vault-consul-and-boundary-affected-by-http-2-rapid-reset-denial-of-service-vulnerability-cve-2023-44487/59715"
+    },
+    {
+      "type": "WEB",
+      "url": "https://community.traefik.io/t/is-traefik-vulnerable-to-cve-2023-44487/20125"
+    },
+    {
+      "type": "WEB",
+      "url": "https://cloud.google.com/blog/products/identity-security/how-it-works-the-novel-http2-rapid-reset-ddos-attack"
+    },
+    {
+      "type": "WEB",
+      "url": "https://cloud.google.com/blog/products/identity-security/google-cloud-mitigated-largest-ddos-attack-peaking-above-398-million-rps/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://chaos.social/@icing/111210915918780532"
+    },
+    {
+      "type": "WEB",
+      "url": "https://cgit.freebsd.org/ports/commit/?id=c64c329c2c1752f46b73e3e6ce9f4329be6629f9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://bugzilla.suse.com/show_bug.cgi?id=1216123"
+    },
+    {
+      "type": "WEB",
+      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2242803"
+    },
+    {
+      "type": "WEB",
+      "url": "https://bugzilla.proxmox.com/show_bug.cgi?id=4988"
+    },
+    {
+      "type": "WEB",
+      "url": "https://blog.vespa.ai/cve-2023-44487/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack"
+    },
+    {
+      "type": "WEB",
+      "url": "https://blog.litespeedtech.com/2023/10/11/rapid-reset-http-2-vulnerablilty/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://blog.cloudflare.com/zero-day-rapid-reset-http2-record-breaking-ddos-attack/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://blog.cloudflare.com/technical-breakdown-http2-rapid-reset-ddos-attack/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://aws.amazon.com/security/security-bulletins/AWS-2023-011/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://arstechnica.com/security/2023/10/how-ddosers-used-the-http-2-protocol-to-deliver-attacks-of-unprecedented-size/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/security/cve/cve-2023-44487"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/VHUHTSXLXGXS7JYKBXTA3VINUPHTNGVU/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LNMZJCDHGLJJLXO4OXWJMTVQRNWOC7UL/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LKYHSZQFDNR7RSA7LHVLLIAQMVYCUGBG/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/KSEGD2IWKNUO3DWY4KQGUQM5BISRWHQE/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/JMEXY22BFG5Q64HQCM5CK2Q7KDKVV4TY/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/JIZSEFC3YKCGABA2BZW6ZJRMDZJMB7PJ/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/HT7T2R4MQKLIF4ODV4BDLPARWFPCJ5CZ/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/FNA62Q767CFAFHBCDKYNPBMZWB7TWYVU/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/E72T67UPDRXHIDLO3OROR25YAMN4GGW5/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/CLB4TW7KALB3EEQWNWCN7OUIWWVWWCG2/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/BFQD3KUEMFBHPAPBGLWQC34L4OWL5HAZ/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/3N4NJ7FR4X4FPZUGNTQAPSTVB2HB2Y4A/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/2MBEPPC36UBVOZZNAXFHKLFGSLCMN5LI/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2023/11/msg00012.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2023/11/msg00001.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00047.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00045.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00024.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00023.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00020.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread/5py8h42mxfsn8l1wy6o41xwhsjlsd87q"
+    },
+    {
+      "type": "WEB",
+      "url": "https://linkerd.io/2023/10/12/linkerd-cve-2023-44487/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://istio.io/latest/news/security/istio-security-2023-004/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo/m/UDd7VKQuAAAJ"
+    },
+    {
+      "type": "WEB",
+      "url": "https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo"
+    },
+    {
+      "type": "WEB",
+      "url": "https://go.dev/issue/63417"
+    },
+    {
+      "type": "WEB",
+      "url": "https://go.dev/cl/534235"
+    },
+    {
+      "type": "WEB",
+      "url": "https://go.dev/cl/534215"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/oqtane/oqtane.framework/discussions/3367"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nghttp2/nghttp2/releases/tag/v1.57.0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/micrictor/http2-rst-stream"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/icing/mod_h2/blob/0a864782af0a942aa2ad4ed960a6b32cd35bcf0a/mod_http2/README.md?plain=1#L239-L244"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adds Eclipse Jetty to affected products based on release announcement: https://www.eclipse.org/lists/jetty-announce/msg00181.html