### PR TITLE
[GHSA-7f3x-x4pr-wqhj] Server-Side Request Forgery in parse-url

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-7f3x-x4pr-wqhj/GHSA-7f3x-x4pr-wqhj.json
+++ b/advisories/github-reviewed/2022/06/GHSA-7f3x-x4pr-wqhj/GHSA-7f3x-x4pr-wqhj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7f3x-x4pr-wqhj",
-  "modified": "2022-07-07T17:15:41Z",
+  "modified": "2023-01-27T05:04:36Z",
   "published": "2022-06-28T00:01:02Z",
   "aliases": [
     "CVE-2022-2216"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "6.0.1"
+              "fixed": "7.0.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Patched version is wrong. According to nvd.nist.gov and description of vuln "prior to **7.0.0**"