### PR TITLE
[GHSA-j24h-xcpc-9jw8] Eclipse IDE XXE in eclipse.platform

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-j24h-xcpc-9jw8/GHSA-j24h-xcpc-9jw8.json
+++ b/advisories/github-reviewed/2023/11/GHSA-j24h-xcpc-9jw8/GHSA-j24h-xcpc-9jw8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j24h-xcpc-9jw8",
-  "modified": "2023-11-30T19:52:54Z",
+  "modified": "2023-11-30T19:52:56Z",
   "published": "2023-11-30T19:52:54Z",
   "aliases": [
     "CVE-2023-4218"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.ant.ui"
+        "name": "org.eclipse.platform:org.eclipse.core.runtime"
       },
       "ranges": [
         {
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.29"
+              "fixed": "3.29.0"
             }
           ]
         }
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.core.variables"
+        "name": "org.eclipse.platform:org.eclipse.platform"
       },
       "ranges": [
         {
@@ -47,7 +47,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.29"
+              "fixed": "4.29.0"
             }
           ]
         }
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.debug.core"
+        "name": "org.eclipse.platform:org.eclipse.jface"
       },
       "ranges": [
         {
@@ -66,7 +66,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.29"
+              "fixed": "3.31.0"
             }
           ]
         }
@@ -75,7 +75,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.debug.ui"
+        "name": "org.eclipse.platform:org.eclipse.ui.forms"
       },
       "ranges": [
         {
@@ -85,7 +85,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.29"
+              "fixed": "3.13.0"
             }
           ]
         }
@@ -94,7 +94,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.core.resources"
+        "name": "org.eclipse.platform:org.eclipse.ui.ide"
       },
       "ranges": [
         {
@@ -104,7 +104,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.29"
+              "fixed": "3.21.100"
             }
           ]
         }
@@ -113,7 +113,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.eclipse.core:org.eclipse.core.runtime"
+        "name": "org.eclipse.platform:org.eclipse.ui.workbench"
       },
       "ranges": [
         {
@@ -123,7 +123,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.29"
+              "fixed": "3.130.0"
             }
           ]
         }
@@ -132,7 +132,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.ant.core"
+        "name": "org.eclipse.platform:org.eclipse.urischeme"
       },
       "ranges": [
         {
@@ -142,7 +142,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.29"
+              "fixed": "1.3.100"
             }
           ]
         }
@@ -151,7 +151,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.ant.launching"
+        "name": "org.eclipse.jdt:org.eclipse.jdt.ui"
       },
       "ranges": [
         {
@@ -161,216 +161,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.team.ui"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.compare.examples.xml"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.help.base"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.help.ui"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.help.webapp"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.help"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.tips.ide"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.ui.cheatsheets"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.ui.intro.universal"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.ui.intro"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.eclipse.platform:org.eclipse.update.configurator"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.29"
+              "fixed": "3.30.0"
             }
           ]
         }
@@ -392,11 +183,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/eclipse-pde/eclipse.pde/pull/632"
+      "url": "https://github.com/eclipse-pde/eclipse.pde/pull/632/"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/eclipse-pde/eclipse.pde/pull/667"
+      "url": "https://github.com/eclipse-pde/eclipse.pde/pull/667/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The previous entries for this CVE were incorrect, referencing version 4.29 of the Eclipse IDE project and applying them to artifacts who don't even have a version matching that release.  See additional conversation on https://github.com/github/advisory-database/pull/3785