### PR TITLE
[GHSA-g343-63vq-2wq6] An issue in Postman version 10.22 and before on macOS...

### DIFF
--- a/advisories/unreviewed/2024/01/GHSA-g343-63vq-2wq6/GHSA-g343-63vq-2wq6.json
+++ b/advisories/unreviewed/2024/01/GHSA-g343-63vq-2wq6/GHSA-g343-63vq-2wq6.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g343-63vq-2wq6",
-  "modified": "2024-02-16T18:31:04Z",
+  "modified": "2024-02-16T18:31:05Z",
   "published": "2024-01-28T03:30:35Z",
   "aliases": [
     "CVE-2024-23738"
   ],
-  "details": "An issue in Postman version 10.22 and before on macOS allows a remote attacker to execute arbitrary code via the RunAsNode and enableNodeClilnspectArguments settings.",
+  "summary": "**DISPUTED** An issue in Postman version 10.22 and before on macOS",
+  "details": "**DISPUTED** An issue in Postman version 10.22 and before on macOS allows a remote attacker to execute arbitrary code via the RunAsNode and enableNodeClilnspectArguments settings.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,12 +15,31 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23738"
+    },
+    {
+      "type": "WEB",
+      "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-23738"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Summary

**Comments**
Mitre also has disputed this CVE as we believe this was not submitted in good faith and is inaccurate.
Ref: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-23738

I had to select Composer as an ecosystem because it was not letting me submit this improvement, please do remove that too. Thanks.