### PR TITLE
[GHSA-m864-5788-g574] A heap out-of-bounds memory write exists in FFMPEG since...

### DIFF
--- a/advisories/unreviewed/2022/09/GHSA-m864-5788-g574/GHSA-m864-5788-g574.json
+++ b/advisories/unreviewed/2022/09/GHSA-m864-5788-g574/GHSA-m864-5788-g574.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m864-5788-g574",
-  "modified": "2022-09-27T00:00:17Z",
+  "modified": "2023-07-05T05:01:49Z",
   "published": "2022-09-25T00:00:26Z",
   "aliases": [
     "CVE-2022-2566"
   ],
+  "summary": "A heap out-of-bounds memory write exists in FFMPEG since version 5.1.",
   "details": "A heap out-of-bounds memory write exists in FFMPEG since version 5.1. The size calculation in `build_open_gop_key_points()` goes through all entries in the loop and adds `sc->ctts_data[i].count` to `sc->sample_offsets_count`. This can lead to an integer overflow resulting in a small allocation with `av_calloc(). An attacker can cause remote code execution via a malicious mp4 file. We recommend upgrading past commit c953baa084607dd1d84c3bfcce3cf6a87c3e6e05",
   "severity": [
     {
@@ -14,7 +15,22 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "GitHub Actions",
+        "name": "https://github.com/FFmpeg/FFmpeg"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,7 +39,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/FFmpeg/FFmpeg/commit/6f53f0d09ea4c9c7f7354f018a87ef840315207d"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/FFmpeg/FFmpeg/commit/c953baa084607dd1d84c3bfcce3cf6a87c3e6e05"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/FFmpeg/FFmpeg"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Add one patch link related to CVE-2022-2566. 
Hello, I noticed that I have to select an Ecosystem for the submission, and as far as I know, ffmpeg does not belong to any of the available options. Therefore, I chose "github action". How should this situation be handled?