### PR TITLE
[GHSA-rxh4-5vqx-xjq8] A flaw was found in the QXL display device emulation in...

### DIFF
--- a/advisories/unreviewed/2022/04/GHSA-rxh4-5vqx-xjq8/GHSA-rxh4-5vqx-xjq8.json
+++ b/advisories/unreviewed/2022/04/GHSA-rxh4-5vqx-xjq8/GHSA-rxh4-5vqx-xjq8.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rxh4-5vqx-xjq8",
-  "modified": "2022-05-11T00:02:03Z",
+  "modified": "2023-02-02T05:07:16Z",
   "published": "2022-04-30T00:00:35Z",
   "aliases": [
     "CVE-2021-4206"
   ],
+  "summary": "A flaw was found in the QXL display device emulation in QEMU. An integer overflow in the cursor_alloc() function can lead to the allocation of a small cursor object followed by a subsequent heap-based buffer overflow. This flaw allows a malicious privileged guest user to crash the QEMU process on the host or potentially execute arbitrary code within the context of the QEMU process.",
   "details": "A flaw was found in the QXL display device emulation in QEMU. An integer overflow in the cursor_alloc() function can lead to the allocation of a small cursor object followed by a subsequent heap-based buffer overflow. This flaw allows a malicious privileged guest user to crash the QEMU process on the host or potentially execute arbitrary code within the context of the QEMU process.",
   "severity": [
     {
@@ -14,7 +15,22 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "GitHub Actions",
+        "name": "https://github.com/qemu/qemu/"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,7 +39,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/qemu/qemu/commit/dde8689d1fe82e295a278ba4bf1abd9be5c7bcab"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/qemu/qemu/commit/fa892e9abb728e76afcf27323ab29c57fb0fe7aa"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2036998"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/qemu/qemu/"
     },
     {
       "type": "WEB",
@@ -35,7 +63,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://starlabs.sg/advisories/21-4206"
+      "url": "https://starlabs.sg/advisories/21-4206/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Add two patch links related to CVE-2021-4206.
Hello, I noticed that I have to select an Ecosystem for the submission, and as far as I know, QEMU does not belong to any of the available options. Therefore, I chose "github action". How should this situation be handled?