### PR TITLE
[GHSA-h8c6-fw25-mvvx] Infinite loop in the F5 Ethernet Trailer protocol...

### DIFF
--- a/advisories/unreviewed/2022/09/GHSA-h8c6-fw25-mvvx/GHSA-h8c6-fw25-mvvx.json
+++ b/advisories/unreviewed/2022/09/GHSA-h8c6-fw25-mvvx/GHSA-h8c6-fw25-mvvx.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h8c6-fw25-mvvx",
-  "modified": "2022-09-15T00:00:15Z",
+  "modified": "2023-02-02T05:06:59Z",
   "published": "2022-09-14T00:00:48Z",
   "aliases": [
     "CVE-2022-3190"
   ],
+  "summary": "Infinite loop in the F5 Ethernet Trailer protocol dissector in Wireshark 3.6.0 to 3.6.7 and 3.4.0 to 3.4.15 allows denial of service via packet injection or crafted capture file",
   "details": "Infinite loop in the F5 Ethernet Trailer protocol dissector in Wireshark 3.6.0 to 3.6.7 and 3.4.0 to 3.4.15 allows denial of service via packet injection or crafted capture file",
   "severity": [
     {
@@ -14,12 +15,39 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "GitHub Actions",
+        "name": "https://github.com/wireshark/wireshark/"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-3190"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/wireshark/wireshark/commit/67326401a595fffbc67eeed48eb6c55d66a55f67"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/wireshark/wireshark/commit/68c3d706c7da60ebcf1244c39be8196ebe9e5726"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/wireshark/wireshark/"
     },
     {
       "type": "WEB",
@@ -31,11 +59,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CH4NUKZKPY4MFQHFBTONJK2AWES4DFDA"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CH4NUKZKPY4MFQHFBTONJK2AWES4DFDA/"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/YR5LIOF5VKS4DC2NQWXTMPPXOYJC46XC"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/YR5LIOF5VKS4DC2NQWXTMPPXOYJC46XC/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Add two patch links related to CVE-2022-3190.
Hello, I noticed that I have to select an Ecosystem for the submission, and as far as I know, Wireshark does not belong to any of the available options. Therefore, I chose "github action". How should this situation be handled?