### PR TITLE
[GHSA-p64x-8rxx-wf6q] Django `Trunc()` and `Extract()` database functions vulnerable to SQL Injection

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-p64x-8rxx-wf6q/GHSA-p64x-8rxx-wf6q.json
+++ b/advisories/github-reviewed/2022/07/GHSA-p64x-8rxx-wf6q/GHSA-p64x-8rxx-wf6q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p64x-8rxx-wf6q",
-  "modified": "2022-08-19T17:09:36Z",
+  "modified": "2023-08-24T23:33:51Z",
   "published": "2022-07-05T00:00:53Z",
   "aliases": [
     "CVE-2022-34265"
@@ -19,12 +19,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "django"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "django.db.models.functions.Trunc",
-          "django.db.models.functions.Extract"
-        ]
       },
       "ranges": [
         {
@@ -44,12 +38,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "django"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "django.db.models.functions.Trunc",
-          "django.db.models.functions.Extract"
-        ]
       },
       "ranges": [
         {
@@ -77,7 +65,23 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/django/django/commit/284b188a4194e8fa5d72a73b09a869d7dd9f0dc5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/54eb8a374d5d98594b264e8ec22337819b37443c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/585ed2f6d7e02b64747770add0e2d3749980d73c"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/django/django/commit/5e2f4ddf2940704a26a4ac782b851989668d74db"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/7d59c6d37c3b675b85d218f733ed24ca006a9d05"
     },
     {
       "type": "WEB",
@@ -89,35 +93,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://docs.djangoproject.com/en/4.0/releases/security"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://github.com/advisories/GHSA-p64x-8rxx-wf6q"
-    },
-    {
-      "type": "PACKAGE",
-      "url": "https://github.com/django/django"
-    },
-    {
-      "type": "WEB",
-      "url": "https://github.com/pypa/advisory-database/tree/main/vulns/django/PYSEC-2022-213.yaml"
-    },
-    {
-      "type": "WEB",
-      "url": "https://groups.google.com/forum/#!forum/django-announce"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HWY6DQWRVBALV73BPUVBXC3QIYUM24IK"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LTZVAKU5ALQWOKFTPISE257VCVIYGFQI"
-    },
-    {
-      "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20220818-0006"
+      "url": "https://www.djangoproject.com/weblog/2022/jul/04/security-releases/"
     },
     {
       "type": "WEB",
@@ -125,7 +101,35 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.djangoproject.com/weblog/2022/jul/04/security-releases"
+      "url": "https://security.netapp.com/advisory/ntap-20220818-0006/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LTZVAKU5ALQWOKFTPISE257VCVIYGFQI/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HWY6DQWRVBALV73BPUVBXC3QIYUM24IK/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://groups.google.com/forum/#!forum/django-announce"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pypa/advisory-database/tree/main/vulns/django/PYSEC-2022-213.yaml"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/django/django"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-p64x-8rxx-wf6q"
+    },
+    {
+      "type": "WEB",
+      "url": "https://docs.djangoproject.com/en/4.0/releases/security/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add four patch links related to CVE-2022-34265.