### PR TITLE
[GHSA-p99v-5w3c-jqq9] Django Access Control Bypass possibly leading to SSRF, RFI, and LFI attacks 

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-p99v-5w3c-jqq9/GHSA-p99v-5w3c-jqq9.json
+++ b/advisories/github-reviewed/2021/06/GHSA-p99v-5w3c-jqq9/GHSA-p99v-5w3c-jqq9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p99v-5w3c-jqq9",
-  "modified": "2023-09-05T13:14:51Z",
+  "modified": "2023-12-16T05:05:45Z",
   "published": "2021-06-10T17:21:12Z",
   "aliases": [
     "CVE-2021-33571"
@@ -88,11 +88,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/django/django/commit/e1d787f1b36d13b95187f8f425425ae1b98da188"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/django/django/commit/f27c38ab5d90f68c9dd60cabef248a570c0be8fc"
     },
     {
       "type": "WEB",
-      "url": "https://docs.djangoproject.com/en/3.2/releases/security"
+      "url": "https://docs.djangoproject.com/en/3.2/releases/security/"
     },
     {
       "type": "PACKAGE",
@@ -104,19 +108,19 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/B4SQG2EAF4WCI2SLRL6XRDJ3RPK3ZRDV"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/B4SQG2EAF4WCI2SLRL6XRDJ3RPK3ZRDV/"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/B4SQG2EAF4WCI2SLRL6XRDJ3RPK3ZRDV"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/B4SQG2EAF4WCI2SLRL6XRDJ3RPK3ZRDV/"
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20210727-0004"
+      "url": "https://security.netapp.com/advisory/ntap-20210727-0004/"
     },
     {
       "type": "WEB",
-      "url": "https://www.djangoproject.com/weblog/2021/jun/02/security-releases"
+      "url": "https://www.djangoproject.com/weblog/2021/jun/02/security-releases/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add one more patch related to CVE-2021-33571.