### PR TITLE
[GHSA-q5qw-4364-5hhm] Django Vulnerable to HTTP Response Splitting Attack

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-q5qw-4364-5hhm/GHSA-q5qw-4364-5hhm.json
+++ b/advisories/github-reviewed/2022/05/GHSA-q5qw-4364-5hhm/GHSA-q5qw-4364-5hhm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q5qw-4364-5hhm",
-  "modified": "2023-08-04T23:22:57Z",
+  "modified": "2023-09-07T05:02:48Z",
   "published": "2022-05-17T00:48:30Z",
   "aliases": [
     "CVE-2015-5144"
@@ -16,11 +16,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "django"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "django.core.validators.EmailValidator"
-        ]
       },
       "ranges": [
         {
@@ -41,12 +36,6 @@
         "ecosystem": "PyPI",
         "name": "django"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "django.core.validators.URLValidator.validate_integer",
-          "django.core.validators.EmailValidator"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -65,12 +54,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "django"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "django.core.validators.URLValidator.validate_integer",
-          "django.core.validators.EmailValidator"
-        ]
       },
       "ranges": [
         {
@@ -94,6 +77,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/django/django/commit/014247ad1922931a2f17beaf6249247298e9dc44"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/17d3a6d8044752f482453f5906026eaf12c39e8e"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/django/django/commit/1ba1cdce7d58e6740fe51955d945b56ae51d072a"
     },
     {
@@ -102,7 +93,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/django/django/commit/8f9a4d3a2bc42f14bb437defd30c7315adbff22c"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/django/django/commit/ae49b4d994656bc037513dcd064cb9ce5bb85649"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/django/django/"
     },
     {
       "type": "WEB",
@@ -122,7 +121,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.djangoproject.com/weblog/2015/jul/08/security-releases"
+      "url": "https://www.djangoproject.com/weblog/2015/jul/08/security-releases/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add more patch links related to CVE-2015-5144 which fixed in multi-branch.