### PR TITLE
[GHSA-q7q2-qf2q-rw3w] Django Vulnerable to Cache Poisoning

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-q7q2-qf2q-rw3w/GHSA-q7q2-qf2q-rw3w.json
+++ b/advisories/github-reviewed/2022/05/GHSA-q7q2-qf2q-rw3w/GHSA-q7q2-qf2q-rw3w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q7q2-qf2q-rw3w",
-  "modified": "2023-08-16T22:54:50Z",
+  "modified": "2023-08-16T22:54:51Z",
   "published": "2022-05-17T03:07:00Z",
   "aliases": [
     "CVE-2014-1418"
@@ -77,7 +77,31 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.djangoproject.com/weblog/2014/may/14/security-releases-issued"
+      "url": "https://github.com/django/django/commit/1abcf3a808b35abae5d425ed4d44cb6e886dc769"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/28e23306aa53bbbb8fb87db85f99d970b051026c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/3800f63721f6fc1c940abfb10fe21257dcf13521"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/4001ec8698f577b973c5a540801d8a0bbea1205b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/7fef18ba9e5a8b47bc24b5bb259c8bf3d3879f2a"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/django/django/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.djangoproject.com/weblog/2014/may/14/security-releases-issued/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add patch links related to CVE-2014-1418 which fixed in multi-branch.