### PR TITLE
[GHSA-5h2q-4hrp-v9rr] Django vulnerable to Improper Restriction of Operations within the Bounds of a Memory Buffer

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-5h2q-4hrp-v9rr/GHSA-5h2q-4hrp-v9rr.json
+++ b/advisories/github-reviewed/2022/05/GHSA-5h2q-4hrp-v9rr/GHSA-5h2q-4hrp-v9rr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5h2q-4hrp-v9rr",
-  "modified": "2023-04-21T20:17:54Z",
+  "modified": "2023-04-21T20:17:55Z",
   "published": "2022-05-17T05:12:01Z",
   "aliases": [
     "CVE-2012-3444"
@@ -62,6 +62,18 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/django/django/commit/b1d463468694f2e91fde67221b7996e9c52a9720"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/b2eb4787a0fff9c9993b78be5c698e85108f3446"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/c14f325c4eef628bc7bfd8873c3a72aeb0219141"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/django/django/commit/da33d67181b53fe6cc737ac1220153814a1509f6"
     },
     {
@@ -74,7 +86,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.djangoproject.com/weblog/2012/jul/30/security-releases-issued"
+      "url": "https://www.djangoproject.com/weblog/2012/jul/30/security-releases-issued/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add more patch links related to CVE-2012-3444 which fixed in multi-branch.