### PR TITLE
[GHSA-fxpg-gg9g-76gj] Moderate severity vulnerability that affects django

### DIFF
--- a/advisories/github-reviewed/2018/07/GHSA-fxpg-gg9g-76gj/GHSA-fxpg-gg9g-76gj.json
+++ b/advisories/github-reviewed/2018/07/GHSA-fxpg-gg9g-76gj/GHSA-fxpg-gg9g-76gj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fxpg-gg9g-76gj",
-  "modified": "2021-09-10T20:17:17Z",
+  "modified": "2023-04-03T19:59:18Z",
   "published": "2018-07-23T19:52:42Z",
   "aliases": [
     "CVE-2010-3082"
@@ -43,6 +43,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/django/django/commit/9e3b327aca75b4b34abf6b00f1fd3c2cf65c8db6"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=632239"
     },
     {
@@ -63,7 +67,7 @@
     },
     {
       "type": "WEB",
-      "url": "http://www.djangoproject.com/weblog/2010/sep/08/security-release"
+      "url": "http://www.djangoproject.com/weblog/2010/sep/08/security-release/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch link related to CVE-2010-3082 which fixed in multi-branch.