### PR TITLE
[GHSA-hm9r-7f84-25c9] Apache Airflow allows authenticated and DAG-view authorized users to modify some DAG run detail values when submitting notes

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-hm9r-7f84-25c9/GHSA-hm9r-7f84-25c9.json
+++ b/advisories/github-reviewed/2023/11/GHSA-hm9r-7f84-25c9/GHSA-hm9r-7f84-25c9.json
@@ -46,6 +46,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/2a0106e4edf67c5905ebfcb82a6008662ae0f7ad"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/airflow/commit/b7a46c970d638028a4a7643ad000dcee951fb9ef"
     },
     {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch links related to CVE-2023-47037 which fixed in multi-branch.