### PR TITLE
[GHSA-fpxx-xv4c-gxqp] Apache Airflow vulnerable to sensitive information exposure when expose-config is set to non-sensitive-only

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-fpxx-xv4c-gxqp/GHSA-fpxx-xv4c-gxqp.json
+++ b/advisories/github-reviewed/2023/10/GHSA-fpxx-xv4c-gxqp/GHSA-fpxx-xv4c-gxqp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fpxx-xv4c-gxqp",
-  "modified": "2023-10-19T00:09:50Z",
+  "modified": "2023-11-10T05:01:20Z",
   "published": "2023-10-14T12:30:23Z",
   "aliases": [
     "CVE-2023-45348"
@@ -43,6 +43,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/pull/34712"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/a4a0b5dd3d0ce05311c70bb9a32b66a650dbc0b4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/f044589b685855a8fce8f5376bea2564c5a001f7"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/airflow/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add patch links related to CVE-2023-45348 which fixed in multi-branch.