### PR TITLE
[GHSA-cgx2-rrmr-jx43] Apache Airflow vulnerable to sensitive information exposure when users list warnings for all DAGs

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-cgx2-rrmr-jx43/GHSA-cgx2-rrmr-jx43.json
+++ b/advisories/github-reviewed/2023/10/GHSA-cgx2-rrmr-jx43/GHSA-cgx2-rrmr-jx43.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cgx2-rrmr-jx43",
-  "modified": "2023-10-19T00:09:36Z",
+  "modified": "2023-11-05T05:01:29Z",
   "published": "2023-10-14T12:30:23Z",
   "aliases": [
     "CVE-2023-42780"
@@ -43,6 +43,22 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/pull/34355"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/3570bbfbea69e2965f91b9964ce28bc268c68129"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/358255d0bd752cf1320b884815ea527907a20828"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/85acbb4ae9bc26248ca624fa4d289feccba00836"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/cf4eb3fb9b5cf4a8369b890e39523d4c05eed161"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch links related to CVE-2023-40611 which fixed in multi-branch.