### PR TITLE
[GHSA-wpg8-mf6h-gm92] Apache Airflow Incorrect Authorization vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-wpg8-mf6h-gm92/GHSA-wpg8-mf6h-gm92.json
+++ b/advisories/github-reviewed/2023/09/GHSA-wpg8-mf6h-gm92/GHSA-wpg8-mf6h-gm92.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wpg8-mf6h-gm92",
-  "modified": "2023-11-14T19:06:12Z",
+  "modified": "2023-11-14T19:06:16Z",
   "published": "2023-09-12T18:58:34Z",
   "aliases": [
     "CVE-2023-40611"
@@ -43,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/pull/33413"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/2a0106e4edf67c5905ebfcb82a6008662ae0f7ad"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch link related to CVE-2023-40611 which fixed in multi-branch.