### PR TITLE
[GHSA-5f35-pq34-c87q] Apache Airflow missing Certificate Validation

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-5f35-pq34-c87q/GHSA-5f35-pq34-c87q.json
+++ b/advisories/github-reviewed/2023/08/GHSA-5f35-pq34-c87q/GHSA-5f35-pq34-c87q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5f35-pq34-c87q",
-  "modified": "2023-08-29T22:37:25Z",
+  "modified": "2023-11-06T05:00:39Z",
   "published": "2023-08-23T18:30:34Z",
   "aliases": [
     "CVE-2023-39441"
@@ -89,6 +89,34 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/pull/33108"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/120efc186556b1e9498f90ad436c74e5f4e138e9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/38fc9cd823feafd8ec61d5d5c7eddb9e9162f755"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/3bd8f020e8b7bdeb7f618bdbdfb3557f117b29d3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/52ca7bfc988f4c9b608f544bc3e9524fd6564639"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/cf7e0c5aa5ccc7b8a3963b14eadde0c8bc7c4eb7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/dbacacbd4d476da757de148a4e747924c34fd7fe"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/e20325db38fdfdd9db423a345b13d18aab6fe578"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch links related to CVE-2023-39441 which fixed in multi-branch.