### PR TITLE
[GHSA-2h84-3crq-vgfj] Apache Airflow Incorrect Authorization vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-2h84-3crq-vgfj/GHSA-2h84-3crq-vgfj.json
+++ b/advisories/github-reviewed/2023/07/GHSA-2h84-3crq-vgfj/GHSA-2h84-3crq-vgfj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2h84-3crq-vgfj",
-  "modified": "2023-07-21T18:00:02Z",
+  "modified": "2023-11-08T05:04:39Z",
   "published": "2023-07-12T12:31:36Z",
   "aliases": [
     "CVE-2023-35908"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "apache-airflow"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "airflow.www.auth.has_access"
-        ]
       },
       "ranges": [
         {
@@ -52,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/commit/ac65b82eeeeaa670e09a83c7da65cbac7e89f8db"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/c78e16588ee399f6eaf60425eb1ad7fa6d3fe352"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch link related to CVE-2023-35908 which fixed in multi-branch.