### PR TITLE
[GHSA-ggwr-4vr8-g7wv] Apache Airflow Path Traversal vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-ggwr-4vr8-g7wv/GHSA-ggwr-4vr8-g7wv.json
+++ b/advisories/github-reviewed/2023/07/GHSA-ggwr-4vr8-g7wv/GHSA-ggwr-4vr8-g7wv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ggwr-4vr8-g7wv",
-  "modified": "2023-07-21T18:14:14Z",
+  "modified": "2023-11-08T05:04:33Z",
   "published": "2023-07-12T12:31:36Z",
   "aliases": [
     "CVE-2023-22887"
@@ -47,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/commit/05bd90f563649f2e9c8f0c85cf5838315a665a02"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/8ff7dfbd9e76aa40b04adeb231df3820606f5ba3"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch link related to CVE-2023-22887 which fixed in multi-branch.