### PR TITLE
[GHSA-rg94-84xj-7gq3] Apache Airflow Contains Open Redirect

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-rg94-84xj-7gq3/GHSA-rg94-84xj-7gq3.json
+++ b/advisories/github-reviewed/2022/11/GHSA-rg94-84xj-7gq3/GHSA-rg94-84xj-7gq3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rg94-84xj-7gq3",
-  "modified": "2023-08-31T00:37:17Z",
+  "modified": "2023-08-31T00:37:18Z",
   "published": "2022-11-15T12:00:15Z",
   "aliases": [
     "CVE-2022-45402"
@@ -43,6 +43,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/pull/27576"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/b33d22c2243c552f4d1372bbe6b75e5fb097f567"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/f0f67e8bc9dcb9444cfc5b88ee075191785469b7"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch links related to CVE-2022-45402 which fixed in multi-branch.