### PR TITLE
[GHSA-3q8r-f3pj-3gc4] Apache Airflow may allow authenticated users who have been deactivated to continue using the UI or API

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-3q8r-f3pj-3gc4/GHSA-3q8r-f3pj-3gc4.json
+++ b/advisories/github-reviewed/2022/10/GHSA-3q8r-f3pj-3gc4/GHSA-3q8r-f3pj-3gc4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3q8r-f3pj-3gc4",
-  "modified": "2022-10-10T16:54:10Z",
+  "modified": "2023-02-01T05:01:56Z",
   "published": "2022-10-07T18:16:01Z",
   "aliases": [
     "CVE-2022-41672"
@@ -43,6 +43,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/pull/26635"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/12bfb571a895a28a58d3189b0fc10cfc1b89e24c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/59707cdf7eacb698ca375b5220af30a39ca1018c"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch links related to CVE-2022-41672 which fixed in multi-branch.