### PR TITLE
[GHSA-5rp4-749p-vx26] Apache Airflow vulnerable to Use of Externally-Controlled Format String

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-5rp4-749p-vx26/GHSA-5rp4-749p-vx26.json
+++ b/advisories/github-reviewed/2022/09/GHSA-5rp4-749p-vx26/GHSA-5rp4-749p-vx26.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5rp4-749p-vx26",
-  "modified": "2022-09-22T22:40:27Z",
+  "modified": "2023-08-30T23:32:24Z",
   "published": "2022-09-22T22:40:27Z",
   "aliases": [
     "CVE-2022-40604"
@@ -47,6 +47,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/commit/18386026c28939fa6d91d198c5489c295a05dcd2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/6f24836e5ee56c452947aa87f84a21dd4f8eb87c"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/airflow"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add patch links related to CVE-2022-40604 which fixed in multi-branch.