### PR TITLE
[GHSA-7wqf-h36w-47mc] OS Command Injection in Apache Airflow

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-7wqf-h36w-47mc/GHSA-7wqf-h36w-47mc.json
+++ b/advisories/github-reviewed/2022/11/GHSA-7wqf-h36w-47mc/GHSA-7wqf-h36w-47mc.json
@@ -45,6 +45,10 @@
       "url": "https://github.com/apache/airflow/pull/27641"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/1d4fd5c6eacab0b88f8660f9d780174434393f1a"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/apache/airflow"
     },


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch link related to CVE-2022-38649.