### PR TITLE
[GHSA-fvw2-2pf7-77vw] Apache Airflow subject to Exposure of Sensitive Information

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-fvw2-2pf7-77vw/GHSA-fvw2-2pf7-77vw.json
+++ b/advisories/github-reviewed/2022/11/GHSA-fvw2-2pf7-77vw/GHSA-fvw2-2pf7-77vw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fvw2-2pf7-77vw",
-  "modified": "2022-11-16T21:50:38Z",
+  "modified": "2023-01-28T05:03:22Z",
   "published": "2022-11-14T12:00:15Z",
   "aliases": [
     "CVE-2022-27949"
@@ -43,6 +43,22 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/pull/22754"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/09be0c5c7e847dda1d0be5776f8d5e327ff2281a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/1cbb0ad26dd17f218c6ab1c2ae59b262c443a443"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/2dc806367c3dc27df5db4b955d151e789fbc78b0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/ce8ea6691820140a0e2d9a5dad5254bc05a5a270"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch links related to CVE-2022-27949 which fixed in multi-branch.