### PR TITLE
[GHSA-ffw3-6mp6-jmvj] Improper Access Control in Apache Airflow

### DIFF
--- a/advisories/github-reviewed/2021/04/GHSA-ffw3-6mp6-jmvj/GHSA-ffw3-6mp6-jmvj.json
+++ b/advisories/github-reviewed/2021/04/GHSA-ffw3-6mp6-jmvj/GHSA-ffw3-6mp6-jmvj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ffw3-6mp6-jmvj",
-  "modified": "2023-08-30T22:07:40Z",
+  "modified": "2023-08-30T22:07:41Z",
   "published": "2021-04-07T21:05:57Z",
   "aliases": [
     "CVE-2021-26559"
@@ -42,6 +42,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-26559"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/3909232fafd09ac72b49010ecdfd6ea48f06d5cf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/5e35926c7eda0dfa11a9623e4bf5f60c2bd6b3f6"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch links related to CVE-2021-26559 which fixed in multi-branch.