### PR TITLE
[GHSA-hhx9-p69v-cx2j] Authentication bypass in Apache Airflow

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-hhx9-p69v-cx2j/GHSA-hhx9-p69v-cx2j.json
+++ b/advisories/github-reviewed/2021/05/GHSA-hhx9-p69v-cx2j/GHSA-hhx9-p69v-cx2j.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-hhx9-p69v-cx2j",
+  "modified": "2024-02-14T21:28:48Z",
+  "published": "2021-04-30T17:34:13Z",
+  "aliases": [
+    "CVE-2020-13927"
+  ],
+  "summary": "Authentication bypass in Apache Airflow",
+  "details": "The previous default setting for Airflow's Experimental API was to allow all API requests without authentication, but this poses security risks to users who miss this fact. From Airflow 1.10.11 the default has been changed to deny all requests by default and is documented at https://airflow.apache.org/docs/1.10.11/security.html#api-authentication. Note this change fixes it for new installs but existing users need to change their config to default `[api]auth_backend = airflow.api.auth.backend.deny_all` as mentioned in the Updating Guide: https://github.com/apache/airflow/blob/1.10.11/UPDATING.md#experimental-api-will-deny-all-request-by-default",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "apache-airflow"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.10.11"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-13927"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/pull/9611/commits/c8053e166d45ad519c0a1cd4480e025a759c176e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/180bca4f993b7b778a8d2c65d3d357652218922b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/9e305d6b810a2a21e2591a80a80ec41acb3afed0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://airflow.apache.org/docs/apache-airflow/1.10.11/security.html#api-authentication"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/airflow"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/releases/tag/1.10.11"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r23a81b247aa346ff193670be565b2b8ea4b17ddbc7a35fc099c1aadd%40%3Cdev.airflow.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "http://packetstormsecurity.com/files/162908/Apache-Airflow-1.10.10-Remote-Code-Execution.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://packetstormsecurity.com/files/174764/Apache-Airflow-1.10.10-Remote-Code-Execution.html"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-1188",
+      "CWE-287"
+    ],
+    "severity": "CRITICAL",
+    "github_reviewed": true,
+    "github_reviewed_at": "2021-04-20T19:30:46Z",
+    "nvd_published_at": "2020-11-10T16:15:00Z"
+  }
+}


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch links related to CVE-2020-13927 which fixed in multi-branch.