### PR TITLE
[GHSA-65x7-c272-7g7r] Use After Free in SixLabors.ImageSharp

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-65x7-c272-7g7r/GHSA-65x7-c272-7g7r.json
+++ b/advisories/github-reviewed/2024/03/GHSA-65x7-c272-7g7r/GHSA-65x7-c272-7g7r.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-65x7-c272-7g7r",
-  "modified": "2024-03-05T20:29:57Z",
+  "modified": "2024-03-05T20:29:59Z",
   "published": "2024-03-05T16:26:15Z",
   "aliases": [
     "CVE-2024-27929"
   ],
   "summary": "Use After Free in SixLabors.ImageSharp",
-  "details": "### Impact\nA heap-use-after-free flaw was found in ImageSharp's InitializeImage() function of PngDecoderCore.cs file. This vulnerability is triggered when an attacker passes a specially crafted PNG image file to ImageSharp for conversion, potentially leading to information disclosure.\n\n### Patches\nThe problem has been patched. All users are advised to upgrade to v3.1.3\n\n### Workarounds\nNone\n\n### References\nNone",
+  "details": "### Impact\nA heap-use-after-free flaw was found in ImageSharp's InitializeImage() function of PngDecoderCore.cs file. This vulnerability is triggered when an attacker passes a specially crafted PNG image file to ImageSharp for conversion, potentially leading to information disclosure.\n\n### Patches\nThe problem has been patched. All users are advised to upgrade to v3.1.3 or v2.1.7\n\n### Workarounds\nNone\n\n### References\nNone",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -32,7 +32,32 @@
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.1.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "SixLabors.ImageSharp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.1.7"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.1.6"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
This has been also fixed for `2.1.*` and the fix has been published in 2.1.7
See https://github.com/SixLabors/ImageSharp/pull/2688

The GH Advisory on the ImageSharp repository has been updated accordingly:
https://github.com/SixLabors/ImageSharp/security/advisories/GHSA-65x7-c272-7g7r

@KateCatlin will this update be also published on https://nvd.nist.gov/vuln/detail/CVE-2024-27929?