### PR TITLE
[GHSA-65x7-c272-7g7r] Use After Free in SixLabors.ImageSharp

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-65x7-c272-7g7r/GHSA-65x7-c272-7g7r.json
+++ b/advisories/github-reviewed/2024/03/GHSA-65x7-c272-7g7r/GHSA-65x7-c272-7g7r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-65x7-c272-7g7r",
-  "modified": "2024-03-05T20:29:57Z",
+  "modified": "2024-03-05T20:29:59Z",
   "published": "2024-03-05T16:26:15Z",
   "aliases": [
     "CVE-2024-27929"
@@ -29,6 +29,25 @@
             },
             {
               "fixed": "3.1.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "SixLabors.ImageSharp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.1.7"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The fix in 3.1.3 was backported to major version 2, making version 2.1.7 no longer vulnerable