### PR TITLE
[GHSA-6f9g-cxwr-q5jr] Arbitrary file read vulnerability through the Jenkins CLI can lead to RCE

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-6f9g-cxwr-q5jr/GHSA-6f9g-cxwr-q5jr.json
+++ b/advisories/github-reviewed/2024/01/GHSA-6f9g-cxwr-q5jr/GHSA-6f9g-cxwr-q5jr.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6f9g-cxwr-q5jr",
-  "modified": "2024-01-31T20:20:22Z",
+  "modified": "2024-02-09T05:12:49Z",
   "published": "2024-01-24T18:31:02Z",
   "aliases": [
     "CVE-2024-23897"
   ],
   "summary": "Arbitrary file read vulnerability through the Jenkins CLI can lead to RCE",
-  "details": "\n\nJenkins has a built-in command line interface (CLI) to access Jenkins from a script or shell environment.\n\nJenkins uses the args4j library to parse command arguments and options on the Jenkins controller when processing CLI commands. This command parser has a feature that replaces an @ character followed by a file path in an argument with the file’s contents (expandAtFiles). This feature is enabled by default and Jenkins 2.441 and earlier, LTS 2.426.2 and earlier does not disable it.\n\nThis allows attackers to read arbitrary files on the Jenkins controller file system using the default character encoding of the Jenkins controller process.\n\n* Attackers with Overall/Read permission can read entire files.\n\n* Attackers without Overall/Read permission can read the first few lines of files. The number of lines that can be read depends on available CLI commands. As of publication of this advisory, the Jenkins security team has found ways to read the first three lines of files in recent releases of Jenkins without having any plugins installed, and has not identified any plugins that would increase this line count.\n\nBinary files containing cryptographic keys used for various Jenkins features can also be read, with some limitations (see note on binary files below). As of publication, the Jenkins security team has confirmed the following possible attacks in addition to reading contents of all files with a known file path. All of them leverage attackers' ability to obtain cryptographic keys from binary files, and are therefore only applicable to instances where that is feasible.\n",
+  "details": "\nJenkins has a built-in command line interface (CLI) to access Jenkins from a script or shell environment.\n\nJenkins uses the args4j library to parse command arguments and options on the Jenkins controller when processing CLI commands. This command parser has a feature that replaces an @ character followed by a file path in an argument with the file’s contents (expandAtFiles). This feature is enabled by default and Jenkins 2.441 and earlier, LTS 2.426.2 and earlier does not disable it.\n\nThis allows attackers to read arbitrary files on the Jenkins controller file system using the default character encoding of the Jenkins controller process.\n\n* Attackers with Overall/Read permission can read entire files.\n\n* Attackers without Overall/Read permission can read the first few lines of files. The number of lines that can be read depends on available CLI commands. As of publication of this advisory, the Jenkins security team has found ways to read the first three lines of files in recent releases of Jenkins without having any plugins installed, and has not identified any plugins that would increase this line count.\n\nBinary files containing cryptographic keys used for various Jenkins features can also be read, with some limitations (see note on binary files below). As of publication, the Jenkins security team has confirmed the following possible attacks in addition to reading contents of all files with a known file path. All of them leverage attackers' ability to obtain cryptographic keys from binary files, and are therefore only applicable to instances where that is feasible.\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -42,6 +42,15 @@
         "ecosystem": "Maven",
         "name": "org.jenkins-ci.main:jenkins-core"
       },
+      "versions": [
+        "2.441"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jenkins-ci.main:jenkins-core"
+      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -56,7 +65,7 @@
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 2.440"
+        "last_known_affected_version_range": "< 2.440"
       }
     },
     {
@@ -64,8 +73,21 @@
         "ecosystem": "Maven",
         "name": "org.jenkins-ci.main:jenkins-core"
       },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.440"
+            },
+            {
+              "fixed": "2.440.1"
+            }
+          ]
+        }
+      ],
       "versions": [
-        "2.441"
+        "2.440"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
2.440.1 was released on 2024-02-21 with a fix for this.  https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3314 was updated (although there's no change log, which is messy) and https://www.jenkins.io/changelog-stable/#v2.440.1 was published.