### PR TITLE
[GHSA-86p9-x5pw-94qx] Improper Restriction of XML External Entity Reference in  iText

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-86p9-x5pw-94qx/GHSA-86p9-x5pw-94qx.json
+++ b/advisories/github-reviewed/2022/05/GHSA-86p9-x5pw-94qx/GHSA-86p9-x5pw-94qx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-86p9-x5pw-94qx",
-  "modified": "2022-06-30T19:51:56Z",
+  "modified": "2023-01-27T05:02:30Z",
   "published": "2022-05-13T01:14:24Z",
   "aliases": [
     "CVE-2017-9096"
@@ -52,6 +52,28 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.lowagie:itext"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": " "
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.1.7"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Please see itext story at: 
https://stackoverflow.com/questions/41820698/what-is-the-difference-between-itext-and-itextpdf
It is the same product with changed mname and group. 