### PR TITLE
[GHSA-c8v6-786g-vjx6] json-jwt allows bypass of identity checks via a sign/encryption confusion attack

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-c8v6-786g-vjx6/GHSA-c8v6-786g-vjx6.json
+++ b/advisories/github-reviewed/2024/02/GHSA-c8v6-786g-vjx6/GHSA-c8v6-786g-vjx6.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c8v6-786g-vjx6",
-  "modified": "2024-03-04T20:16:01Z",
+  "modified": "2024-03-04T20:16:03Z",
   "published": "2024-02-29T03:33:14Z",
   "aliases": [
     "CVE-2023-51774"
   ],
   "summary": "json-jwt allows bypass of identity checks via a sign/encryption confusion attack",
-  "details": "The json-jwt (aka JSON::JWT) gem before 1.16.6 for Ruby sometimes allows bypass of identity checks via a sign/encryption confusion attack. For example, JWE can sometimes be used to bypass JSON::JWT.decode.",
+  "details": "The json-jwt (aka JSON::JWT) gem 1.16.x before 1.16.6, 1.15.x before 1.15.3.1 for Ruby sometimes allows bypass of identity checks via a sign/encryption confusion attack. For example, JWE can sometimes be used to bypass JSON::JWT.decode.",
   "severity": [
 
   ],
@@ -25,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.16.6"
+              "fixed": "1.15.3.1, 1.16.6"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.16.6"
+      }
     }
   ],
   "references": [
@@ -40,6 +43,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/nov/json-jwt/issues/120"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nov/json-jwt/issues/121"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nov/json-jwt/commit/593ea8bcaf2629048bad8c036191f2da0a2e713c"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
@nov backported the fix from 1.16.6 to a new 1.15.3 branch, and released version 1.15.3.1 of the gem
https://github.com/nov/json-jwt/commits/v1.15.3/