### PR TITLE
[GHSA-vr64-r9qj-h27f] Reading specially crafted serializable objects from an untrusted source may cause an infinite loop and denial of service

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-vr64-r9qj-h27f/GHSA-vr64-r9qj-h27f.json
+++ b/advisories/github-reviewed/2024/02/GHSA-vr64-r9qj-h27f/GHSA-vr64-r9qj-h27f.json
@@ -7,7 +7,7 @@
     "CVE-2024-22871"
   ],
   "summary": "Reading specially crafted serializable objects from an untrusted source may cause an infinite loop and denial of service",
-  "details": "Any program on the JVM may read serialized objects via [java.io.ObjectInputStream.readObject()](https://docs.oracle.com/javase/8/docs/api/java/io/ObjectInputStream.html#readObject--). Reading serialized objects from an untrusted source is **inherently unsafe** (this affects any program running on any version of the JVM) and is a prerequisite for this vulnerability.\n\nClojure classes that represent infinite seqs (Cycle, infinite Repeat, and Iterate) do not define hashCode() and use the parent ASeq.hashCode(), which walks the seq to compute the hash, yielding an infinite loop. Classes like java.util.HashMap call hashCode() on keys during deserialization of a serialized map. \n\nThe exploit requires:\n\n1. Crafting a serialized HashMap object with an infinite seq object as a key.\n2. Sending that to a program that reads serialized objects via ObjectInputStream.readObject().\n\nThis will cause the program to enter an infinite loop on the reading thread and thus a denial of service (DoS).\n\nThe affected Clojure classes (Cycle, Repeat, Iterate) exist in Clojure 1.2.0-1.12.0-alpha8.",
+  "details": "Any program on the JVM may read serialized objects via [java.io.ObjectInputStream.readObject()](https://docs.oracle.com/javase/8/docs/api/java/io/ObjectInputStream.html#readObject--). Reading serialized objects from an untrusted source is **inherently unsafe** (this affects any program running on any version of the JVM) and is a prerequisite for this vulnerability.\n\nClojure classes that represent infinite seqs (Cycle, infinite Repeat, and Iterate) do not define hashCode() and use the parent ASeq.hashCode(), which walks the seq to compute the hash, yielding an infinite loop. Classes like java.util.HashMap call hashCode() on keys during deserialization of a serialized map. \n\nThe exploit requires:\n\n1. Crafting a serialized HashMap object with an infinite seq object as a key.\n2. Sending that to a program that reads serialized objects via ObjectInputStream.readObject().\n\nThis will cause the program to enter an infinite loop on the reading thread and thus a denial of service (DoS).\n\nThe affected Clojure classes (Cycle, Repeat, Iterate) exist in Clojure 1.7.0-1.11.1, 1.12.0-alpha1-1.12.0-alpha8.",
   "severity": [
 
   ],
@@ -22,14 +22,17 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.2.0"
+              "introduced": "1.7.0"
             },
             {
-              "last_affected": "1.12.0-alpha8"
+              "fixed": "1.11.2, 1.12.0-alpha9"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.11.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
This issue has been fixed in 1.11.2 and 1.12.0-alpha9.