### PR TITLE
[GHSA-rj98-crf4-g69w] pgAdmin 4 vulnerable to Unsafe Deserialization and Remote Code Execution by an Authenticated user

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-rj98-crf4-g69w/GHSA-rj98-crf4-g69w.json
+++ b/advisories/github-reviewed/2024/03/GHSA-rj98-crf4-g69w/GHSA-rj98-crf4-g69w.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rj98-crf4-g69w",
-  "modified": "2024-03-07T22:39:28Z",
+  "modified": "2024-03-07T22:39:29Z",
   "published": "2024-03-07T21:30:22Z",
   "aliases": [
     "CVE-2024-2044"
   ],
   "summary": "pgAdmin 4 vulnerable to Unsafe Deserialization and Remote Code Execution by an Authenticated user",
-  "details": "pgAdmin 4 uses a file-based session management approach. The session files are saved on disk as pickle objects. When a user performs a request, the value of the session cookie 'pga4_session' is used to retrieve the file, then its content is deserialised, and finally its signature verified.\nThe cookie value is split in 2 parts at the first '!' character. The first part is the session ID (sid), while the second is the session digest.\n The vulnerability lies in versions of pgAdmin prior to 8.4 where a method loads session files by concatenating the sessions folder - located inside the pgAdmin 4 DATA_DIR - with the session ID. Precisely, the two values are concatenated using the ['os.path.join'] function. It does not set a trusted base-path which should not be escaped\n",
+  "details": "pgAdmin <= 8.3 is affected by a path-traversal vulnerability while deserializing users’ sessions in the session handling code. If the server is running on Windows, an unauthenticated attacker can load and deserialize remote pickle objects and gain code execution. If the server is running on POSIX/Linux, an authenticated attacker can upload pickle objects, deserialize them and gain code execution.\n",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -51,13 +51,17 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/pgadmin-org/pgadmin4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.shielder.com/advisories/pgadmin-path-traversal_leads_to_unsafe_deserialization_and_rce/"
     }
   ],
   "database_specific": {
     "cwe_ids": [
 
     ],
-    "severity": "MODERATE",
+    "severity": "CRITICAL",
     "github_reviewed": true,
     "github_reviewed_at": "2024-03-07T22:39:27Z",
     "nvd_published_at": "2024-03-07T21:15:08Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- References
- Severity

**Comments**
The full advisory for the vulnerability is now public:
https://www.shielder.com/advisories/pgadmin-path-traversal_leads_to_unsafe_deserialization_and_rce/