### PR TITLE
[GHSA-q4hg-rmq2-52q9] Improper Locking in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2019/06/GHSA-q4hg-rmq2-52q9/GHSA-q4hg-rmq2-52q9.json
+++ b/advisories/github-reviewed/2019/06/GHSA-q4hg-rmq2-52q9/GHSA-q4hg-rmq2-52q9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q4hg-rmq2-52q9",
-  "modified": "2023-12-08T23:07:34Z",
+  "modified": "2023-12-08T23:07:35Z",
   "published": "2019-06-26T01:09:40Z",
   "aliases": [
     "CVE-2019-10072"
@@ -25,10 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "9.0.0.M1"
+              "introduced": "8.5.0"
             },
             {
-              "fixed": "9.0.20"
+              "fixed": "8.5.40"
             }
           ]
         }
@@ -44,10 +44,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "8.5.0"
+              "introduced": "9.0.0.M1"
             },
             {
-              "fixed": "8.5.40"
+              "fixed": "9.0.20"
             }
           ]
         }
@@ -61,59 +61,23 @@
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2019:3929"
+      "url": "https://github.com/apache/tomcat/commit/0bcd69c9dd8ae0ff424f2cd46de51583510b7f35"
     },
     {
       "type": "WEB",
-      "url": "https://access.redhat.com/errata/RHSA-2019:3931"
-    },
-    {
-      "type": "PACKAGE",
-      "url": "https://github.com/apache/tomcat"
+      "url": "https://github.com/apache/tomcat/commit/7f748eb6bfaba5207c89dbd7d5adf50fae847145"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/df1a2c1b87c8a6c500ecdbbaf134c7f1491c8d79d98b48c6b9f0fa6a%40%3Cannounce.tomcat.apache.org%3E"
+      "url": "https://github.com/apache/tomcat/commit/8d14c6f21d29768a39be4b6b9517060dc6606758"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/df1a2c1b87c8a6c500ecdbbaf134c7f1491c8d79d98b48c6b9f0fa6a@%3Cannounce.tomcat.apache.org%3E"
+      "url": "https://github.com/apache/tomcat/commit/ada725a50a60867af3422c8e612aecaeea856a9a"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r3bbb800a816d0a51eccc5a228c58736960a9fffafa581a225834d97d%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r3bbb800a816d0a51eccc5a228c58736960a9fffafa581a225834d97d@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r48c1444845fe15a823e1374674bfc297d5008a5453788099ea14caf0%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r48c1444845fe15a823e1374674bfc297d5008a5453788099ea14caf0@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r6ccee4e849bc77df0840c7f853f6bd09d426f6741247da2b7429d5d9%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r6ccee4e849bc77df0840c7f853f6bd09d426f6741247da2b7429d5d9@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/raba0fabaf4d56d4325ab2aca8814f0b30a237ab83d8106b115ee279a%40%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/raba0fabaf4d56d4325ab2aca8814f0b30a237ab83d8106b115ee279a@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20190625-0002"
+      "url": "https://security.netapp.com/advisory/ntap-20190625-0002/"
     },
     {
       "type": "WEB",
@@ -121,11 +85,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://usn.ubuntu.com/4128-1"
+      "url": "https://tomcat.apache.org/security-8.html"
     },
     {
       "type": "WEB",
-      "url": "https://usn.ubuntu.com/4128-2"
+      "url": "https://usn.ubuntu.com/4128-1/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://usn.ubuntu.com/4128-2/"
     },
     {
       "type": "WEB",
@@ -158,6 +126,58 @@
     {
       "type": "WEB",
       "url": "https://www.synology.com/security/advisory/Synology_SA_19_29"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/raba0fabaf4d56d4325ab2aca8814f0b30a237ab83d8106b115ee279a@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/raba0fabaf4d56d4325ab2aca8814f0b30a237ab83d8106b115ee279a%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r6ccee4e849bc77df0840c7f853f6bd09d426f6741247da2b7429d5d9@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r6ccee4e849bc77df0840c7f853f6bd09d426f6741247da2b7429d5d9%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r48c1444845fe15a823e1374674bfc297d5008a5453788099ea14caf0@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r48c1444845fe15a823e1374674bfc297d5008a5453788099ea14caf0%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r3bbb800a816d0a51eccc5a228c58736960a9fffafa581a225834d97d@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r3bbb800a816d0a51eccc5a228c58736960a9fffafa581a225834d97d%40%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/df1a2c1b87c8a6c500ecdbbaf134c7f1491c8d79d98b48c6b9f0fa6a@%3Cannounce.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/df1a2c1b87c8a6c500ecdbbaf134c7f1491c8d79d98b48c6b9f0fa6a%40%3Cannounce.tomcat.apache.org%3E"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2019:3931"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2019:3929"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch links related to CVE-2019-10072 which fixed in multi-branch.
In https://tomcat.apache.org/security-8.html shows the patch and the other two related to other branch fix.