### PR TITLE
[GHSA-4vww-mc66-62m6] HTTP Request Smuggling in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-4vww-mc66-62m6/GHSA-4vww-mc66-62m6.json
+++ b/advisories/github-reviewed/2021/08/GHSA-4vww-mc66-62m6/GHSA-4vww-mc66-62m6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4vww-mc66-62m6",
-  "modified": "2022-02-08T21:20:44Z",
+  "modified": "2023-02-03T05:04:49Z",
   "published": "2021-08-13T15:21:14Z",
   "aliases": [
     "CVE-2021-33037"
@@ -80,31 +80,43 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+      "url": "https://github.com/apache/tomcat/commit/05f9e8b00f5d9251fcd3c95dcfd6cf84177f46c8"
     },
     {
       "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpujan2022.html"
+      "url": "https://github.com/apache/tomcat/commit/19d11556d0db99df291df33605f137976d152475"
     },
     {
       "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpuapr2022.html"
+      "url": "https://github.com/apache/tomcat/commit/3202703e6d635e39b74262e81f0cb4bcbe2170dc"
     },
     {
       "type": "WEB",
-      "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
+      "url": "https://github.com/apache/tomcat/commit/45d70a86a901cbd534f8f570bed2aec9f7f7b88e"
     },
     {
       "type": "WEB",
-      "url": "https://www.debian.org/security/2021/dsa-4952"
+      "url": "https://github.com/apache/tomcat/commit/506134f957a4be2c5b4a9334f7b3435fc954dbc1"
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20210827-0007"
+      "url": "https://github.com/apache/tomcat/commit/8874fa02e9b36baa9ca6b226c0882c0190ca5a02"
     },
     {
       "type": "WEB",
-      "url": "https://security.gentoo.org/glsa/202208-34"
+      "url": "https://github.com/apache/tomcat/commit/a2c3dc4c96168743ac0bab613709a5bbdaec41d0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/da0e7cb093cf68b052d9175e469dbd0464441b0b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/eee0d024c1b3171560c92eaba79dd6eb8eb11bcd"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread/kovg1bft77xo34ksrcskh5nl50p69962"
     },
     {
       "type": "WEB",
@@ -112,7 +124,31 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread/kovg1bft77xo34ksrcskh5nl50p69962"
+      "url": "https://security.gentoo.org/glsa/202208-34"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.netapp.com/advisory/ntap-20210827-0007/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.debian.org/security/2021/dsa-4952"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpuapr2022.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpujan2022.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
     },
     {
       "type": "WEB",
@@ -145,6 +181,10 @@
     {
       "type": "WEB",
       "url": "https://kc.mcafee.com/corporate/index?page=content&id=SB10366"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add patch links and source code location related to CVE-2021-33037 which fixed in multi-branch.
https://tomcat.apache.org/security-8.html shows three patch links related to one branch.