### PR TITLE
[GHSA-vvw4-rfwf-p6hx] Exposure of Sensitive Information to an Unauthorized Actor in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-vvw4-rfwf-p6hx/GHSA-vvw4-rfwf-p6hx.json
+++ b/advisories/github-reviewed/2022/02/GHSA-vvw4-rfwf-p6hx/GHSA-vvw4-rfwf-p6hx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vvw4-rfwf-p6hx",
-  "modified": "2022-02-08T22:02:28Z",
+  "modified": "2023-09-26T17:13:32Z",
   "published": "2022-02-09T22:58:06Z",
   "aliases": [
     "CVE-2020-17527"
@@ -80,51 +80,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/21e3408671aac7e0d7e264e720cac8b1b189eb29"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/8d2fe6894d6e258a6d615d7f786acca80e6020cb"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/tomcat/commit/d56293f816d6dc9e2b47107f208fa9e95db58c65"
     },
     {
       "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpujan2022.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpuapr2022.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpuApr2021.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.debian.org/security/2021/dsa-4835"
-    },
-    {
-      "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20201210-0003"
-    },
-    {
-      "type": "WEB",
-      "url": "https://security.gentoo.org/glsa/202012-23"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2020/12/msg00022.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rd5babd13d7a350b369b2f647b4dd32ce678af42f9aba5389df1ae6ca@%3Cusers.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rce5ac9a40173651d540babce59f6f3825f12c6d4e886ba00823b11e5@%3Cannounce.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rce5ac9a40173651d540babce59f6f3825f12c6d4e886ba00823b11e5@%3Cannounce.apache.org%3E"
+      "url": "https://lists.apache.org/thread.html/rca833c6d42b7b9ce1563488c0929f29fcc95947d86e5e740258c8937@%3Cdev.tomcat.apache.org%3E"
     },
     {
       "type": "WEB",
@@ -132,7 +100,47 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rca833c6d42b7b9ce1563488c0929f29fcc95947d86e5e740258c8937@%3Cdev.tomcat.apache.org%3E"
+      "url": "https://lists.apache.org/thread.html/rce5ac9a40173651d540babce59f6f3825f12c6d4e886ba00823b11e5@%3Cannounce.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rce5ac9a40173651d540babce59f6f3825f12c6d4e886ba00823b11e5@%3Cannounce.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rd5babd13d7a350b369b2f647b4dd32ce678af42f9aba5389df1ae6ca@%3Cusers.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2020/12/msg00022.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.gentoo.org/glsa/202012-23"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.netapp.com/advisory/ntap-20201210-0003/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.debian.org/security/2021/dsa-4835"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpuApr2021.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpuapr2022.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpujan2022.html"
     },
     {
       "type": "WEB",
@@ -177,6 +185,10 @@
     {
       "type": "WEB",
       "url": "https://lists.apache.org/thread.html/r26a2a66339087fc37db3caf201e446d3e83b5cce314371e235ff1784@%3Ccommits.tomee.apache.org%3E"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add two more patch links related to CVE-2020-17527 which fixed in other branches.
https://tomcat.apache.org/security-10.html shows that.