### PR TITLE
[GHSA-2rvv-w9r2-rg7m] Information Disclosure in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-2rvv-w9r2-rg7m/GHSA-2rvv-w9r2-rg7m.json
+++ b/advisories/github-reviewed/2021/05/GHSA-2rvv-w9r2-rg7m/GHSA-2rvv-w9r2-rg7m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2rvv-w9r2-rg7m",
-  "modified": "2021-04-06T21:27:31Z",
+  "modified": "2023-01-29T05:07:30Z",
   "published": "2021-05-13T22:30:02Z",
   "aliases": [
     "CVE-2021-24122"
@@ -102,35 +102,27 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r1595889b083e05986f42b944dc43060d6b083022260b6ea64d2cec52%40%3Cannounce.tomcat.apache.org%3E"
+      "url": "https://github.com/apache/tomcat/commit/7f004ac4531c45f9a2a2d1470561fe135cf27bc2"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r1595889b083e05986f42b944dc43060d6b083022260b6ea64d2cec52@%3Cannounce.apache.org%3E"
+      "url": "https://github.com/apache/tomcat/commit/800b03140e640f8892f27021e681645e8e320177"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r1595889b083e05986f42b944dc43060d6b083022260b6ea64d2cec52@%3Cannounce.tomcat.apache.org%3E"
+      "url": "https://github.com/apache/tomcat/commit/920dddbdb981f92e8d5872a4bb126a10af5ca8a9"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r7382e1e35b9bc7c8f320b90ad77e74c13172d08034e20c18000fe710@%3Cdev.tomee.apache.org%3E"
+      "url": "https://github.com/apache/tomcat/commit/935fc5582dc25ae10bab6f9d5629ff8d996cb533"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r776c64337495bf28b7d5597268114a888e3fad6045c40a0da0c66d4d@%3Cdev.tomee.apache.org%3E"
+      "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r7e0bb9ea415724550e2b325e143b23e269579e54d66fcd7754bd0c20@%3Cdev.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rb32a73b7cb919d4f44a2596b6b951274c0004fc8b0e393d6829a45f9@%3Cusers.tomcat.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rca833c6d42b7b9ce1563488c0929f29fcc95947d86e5e740258c8937@%3Cdev.tomcat.apache.org%3E"
+      "url": "https://security.netapp.com/advisory/ntap-20210212-0008/"
     },
     {
       "type": "WEB",
@@ -138,11 +130,39 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20210212-0008"
+      "url": "https://lists.apache.org/thread.html/rca833c6d42b7b9ce1563488c0929f29fcc95947d86e5e740258c8937@%3Cdev.tomcat.apache.org%3E"
     },
     {
       "type": "WEB",
-      "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
+      "url": "https://lists.apache.org/thread.html/rb32a73b7cb919d4f44a2596b6b951274c0004fc8b0e393d6829a45f9@%3Cusers.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r7e0bb9ea415724550e2b325e143b23e269579e54d66fcd7754bd0c20@%3Cdev.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r776c64337495bf28b7d5597268114a888e3fad6045c40a0da0c66d4d@%3Cdev.tomee.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r7382e1e35b9bc7c8f320b90ad77e74c13172d08034e20c18000fe710@%3Cdev.tomee.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r1595889b083e05986f42b944dc43060d6b083022260b6ea64d2cec52@%3Cannounce.tomcat.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r1595889b083e05986f42b944dc43060d6b083022260b6ea64d2cec52@%3Cannounce.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r1595889b083e05986f42b944dc43060d6b083022260b6ea64d2cec52%40%3Cannounce.tomcat.apache.org%3E"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add source code location and patch links related to CVE-2021-24122 which fixed in multi-branches.
https://tomcat.apache.org/security-10.html shows the patch in 10.x branch.