### PR TITLE
[GHSA-wph7-x527-w3h5] Missing Release of Resource after Effective Lifetime in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2021/10/GHSA-wph7-x527-w3h5/GHSA-wph7-x527-w3h5.json
+++ b/advisories/github-reviewed/2021/10/GHSA-wph7-x527-w3h5/GHSA-wph7-x527-w3h5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wph7-x527-w3h5",
-  "modified": "2022-02-08T20:42:53Z",
+  "modified": "2023-02-03T05:04:43Z",
   "published": "2021-10-15T18:51:34Z",
   "aliases": [
     "CVE-2021-42340"
@@ -101,6 +101,22 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-42340"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/31d62426645824bdfe076a0c0eafa904d90b4fb9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/80f1438ec45e77a07b96419808971838d259eb47"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/d27535bdee95d252418201eb21e9d29476aa6b6a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/d5a6660cba7f51589468937bf3bbad4db7810371"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/apache/tomcat"
     },
@@ -122,7 +138,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20211104-0001"
+      "url": "https://security.netapp.com/advisory/ntap-20211104-0001/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch links related to CVE-2021-43240 which fixed in multi-branches.
https://tomcat.apache.org/security-10.html shows patch in 10.x branch.