### PR TITLE
[GHSA-jx7c-7mj5-9438] Apache Tomcat Race Condition vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-jx7c-7mj5-9438/GHSA-jx7c-7mj5-9438.json
+++ b/advisories/github-reviewed/2022/09/GHSA-jx7c-7mj5-9438/GHSA-jx7c-7mj5-9438.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jx7c-7mj5-9438",
-  "modified": "2022-10-06T18:20:05Z",
+  "modified": "2023-01-30T05:02:53Z",
   "published": "2022-09-29T00:00:25Z",
   "aliases": [
     "CVE-2021-43980"
@@ -96,6 +96,22 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43980"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/170e0f792bd18ff031677890ba2fe50eb7a376c1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/17f177eeb7df5938f67ef9ea580411b120195f13"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/4a00b0c0890538b9d3107eef8f2e0afadd119beb"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/9651b83a1d04583791525e5f0c4c9089f678d9fc"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add source code links and patch links related to CVE-2021-43980 which fixed in multi-branches
https://tomcat.apache.org/security-10.html shows patch in 10.X branch