### PR TITLE
[GHSA-r84p-88g2-2vx2] The documentation of Apache Tomcat 10.1.0-M1 to 10.1.0...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-r84p-88g2-2vx2/GHSA-r84p-88g2-2vx2.json
+++ b/advisories/unreviewed/2022/05/GHSA-r84p-88g2-2vx2/GHSA-r84p-88g2-2vx2.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r84p-88g2-2vx2",
-  "modified": "2022-05-21T00:00:37Z",
+  "modified": "2023-01-30T05:00:29Z",
   "published": "2022-05-13T00:01:12Z",
   "aliases": [
     "CVE-2022-29885"
   ],
+  "summary": "EncryptInterceptor error in Apache Tomcat",
   "details": "The documentation of Apache Tomcat 10.1.0-M1 to 10.1.0-M14, 10.0.0-M1 to 10.0.20, 9.0.13 to 9.0.62 and 8.5.38 to 8.5.78 for the EncryptInterceptor incorrectly stated it enabled Tomcat clustering to run over an untrusted network. This was not correct. While the EncryptInterceptor does provide confidentiality and integrity protection, it does not protect against all risks associated with running over any untrusted network, particularly DoS risks.",
   "severity": [
     {
@@ -14,12 +15,47 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat:tomcat"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-29885"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/0fa7721f11d565a2cd2e44366c388ad6a3e6357d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/36826ea638457d7e17876a70f89cb435b6db0d91"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/b679bc627f5a4ea6510af95adfb7476b07eba890"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/eaafd28296c54d983e28a47953c1f5cb2c334f48"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat/"
     },
     {
       "type": "WEB",
@@ -31,7 +67,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20220629-0002"
+      "url": "https://security.netapp.com/advisory/ntap-20220629-0002/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
Add source code location and patch links related to CVE-2022-29885 which fixed in multi-branches.
https://tomcat.apache.org/security-10.html shows patch in 10.X branch.