### PR TITLE
[GHSA-p22x-g9px-3945] Apache Tomcat may reject request containing invalid Content-Length header

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-p22x-g9px-3945/GHSA-p22x-g9px-3945.json
+++ b/advisories/github-reviewed/2022/11/GHSA-p22x-g9px-3945/GHSA-p22x-g9px-3945.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p22x-g9px-3945",
-  "modified": "2022-12-20T15:48:56Z",
+  "modified": "2023-05-30T06:45:24Z",
   "published": "2022-11-01T12:00:30Z",
   "aliases": [
     "CVE-2022-42252"
@@ -15,25 +15,6 @@
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "8.5.0"
-            },
-            {
-              "fixed": "8.5.83"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "Maven",
@@ -90,12 +71,47 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat:tomcat"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.5.0"
+            },
+            {
+              "fixed": "8.5.83"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-42252"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/0d089a15047faf9cb3c82f80f4d28febd4798920"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/4c7f4fd09d2cc1692112ef70b8ee23a7a037ae77"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/a1c07906d8dcaf7957e5cc97f5cdbac7d18a205a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/c9fe754e5d17e262dfbd3eab2a03ca96ff372dc3"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch links related to CVE-2022-42252 which fixed in multi-branches.
In https://tomcat.apache.org/security-10.html shows patch in two branches.