### PR TITLE
[GHSA-hfrx-6qgj-fp6c] Apache Commons FileUpload denial of service vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-hfrx-6qgj-fp6c/GHSA-hfrx-6qgj-fp6c.json
+++ b/advisories/github-reviewed/2023/02/GHSA-hfrx-6qgj-fp6c/GHSA-hfrx-6qgj-fp6c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hfrx-6qgj-fp6c",
-  "modified": "2023-03-02T19:56:24Z",
+  "modified": "2023-10-13T19:45:09Z",
   "published": "2023-02-20T18:30:17Z",
   "aliases": [
     "CVE-2023-24998"
@@ -43,6 +43,22 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/commons-fileupload/commit/e20c04990f7420ca917e96a84cec58b13a1b3d17"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/063e2e81ede50c287f737cc8e2915ce7217e886e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/8a2285f13affa961cc65595aad999db5efae45ce"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/9ca96c8c1eba86c0aaa2e6be581ba2a7d4d4ae6e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/cf77cc545de0488fb89e24294151504a7432df74"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
The CVE-2023-24998 also affect Apache Tomcat shows in https://tomcat.apache.org/security-10.html.
So I add patch links in Tomcat about this vulnerability.