### PR TITLE
[GHSA-mppv-79ch-vw6q] Apache Tomcat vulnerable to information leak

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-mppv-79ch-vw6q/GHSA-mppv-79ch-vw6q.json
+++ b/advisories/github-reviewed/2023/06/GHSA-mppv-79ch-vw6q/GHSA-mppv-79ch-vw6q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mppv-79ch-vw6q",
-  "modified": "2023-06-30T19:56:21Z",
+  "modified": "2023-11-06T05:05:00Z",
   "published": "2023-06-21T12:30:19Z",
   "aliases": [
     "CVE-2023-34981"
@@ -111,6 +111,22 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/2214c8030522aa9b2a367dfa5d9acff1a03666ae"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/2f0ca2378415f4cf0748f4bc8fa955f41f803fa5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/739c7381aed22b7636351caf885ddc519ab6b442"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/f0742f47b98aca943097f7f88e0d1163f57527e3"
+    },
+    {
+      "type": "WEB",
       "url": "https://bz.apache.org/bugzilla/show_bug.cgi?id=66512"
     },
     {
@@ -127,7 +143,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20230714-0003"
+      "url": "https://security.netapp.com/advisory/ntap-20230714-0003/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch links related to CVE-2023-34981 which fixed in multi-branches.
https://tomcat.apache.org/security-10.html shows patch in two branches.