### PR TITLE
[GHSA-8r3f-844c-mc37] The protojson.Unmarshal function can enter an infinite...

### DIFF
--- a/advisories/unreviewed/2024/03/GHSA-8r3f-844c-mc37/GHSA-8r3f-844c-mc37.json
+++ b/advisories/unreviewed/2024/03/GHSA-8r3f-844c-mc37/GHSA-8r3f-844c-mc37.json
@@ -1,22 +1,45 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8r3f-844c-mc37",
-  "modified": "2024-03-06T00:31:27Z",
+  "modified": "2024-03-06T00:31:33Z",
   "published": "2024-03-06T00:31:27Z",
   "aliases": [
     "CVE-2024-24786"
   ],
+  "summary": "The protojson.Unmarshal function can enter an infinite loop when unmarshaling certain forms of invalid JSON",
   "details": "The protojson.Unmarshal function can enter an infinite loop when unmarshaling certain forms of invalid JSON. This condition can occur when unmarshaling into a message which contains a google.protobuf.Any value, or when the UnmarshalOptions.DiscardUnknown option is set.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "google.golang.org/protobuf"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.33.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-24786"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/protocolbuffers/protobuf-go"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
It would be great if this was detected in the Go module ecosystem so Dependabot and other tools can push updates for these immediately. There were some empty fields and pre-filled fields, so I tried my best to 'just' edit the "Affected products/ecosystem" section.