### PR TITLE
[GHSA-x3p3-929j-pq66] Improper Neutralization of Input During Web Page Generation in Jenkins

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-x3p3-929j-pq66/GHSA-x3p3-929j-pq66.json
+++ b/advisories/github-reviewed/2022/05/GHSA-x3p3-929j-pq66/GHSA-x3p3-929j-pq66.json
@@ -42,11 +42,39 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/jenkinsci/jenkins/commit/27c303417a226bf4c06a588570f28ac2e2507c6c"
+      "url": "https://github.com/jenkinsci/jenkins/commit/0ce2a1ae3a4abfa2ef43d1bd90c685dd27172562"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/jenkinsci/jenkins/commit/d3fb2c09f29007dce84a213ae8323df1105dcc30"
+      "url": "https://github.com/jenkinsci/jenkins/commit/1e967ccec104bbfdca0fd3069b224f5619b55990"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/307095b758bcf04c392abf7c78b50556393c86a1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/57a82505f4dc5de97c57ad1f340561ad9f0159c5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/84174a922cd299686a8e103bf4418c85afbc658e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/92556fd1a33b2c0311355290c2fc7e1083fa32de"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/a7264a96278ac87d310d8ddaaf506196d6a550af"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/eb2b62e1aad4fae582c4d0433e2a9ed0dce71efc"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/edffecea84a4af2641e5814a555c208d9c4f42eb"
     },
     {
       "type": "PACKAGE",

--- a/advisories/github-reviewed/2022/05/GHSA-x3p3-929j-pq66/GHSA-x3p3-929j-pq66.json
+++ b/advisories/github-reviewed/2022/05/GHSA-x3p3-929j-pq66/GHSA-x3p3-929j-pq66.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x3p3-929j-pq66",
-  "modified": "2022-07-06T20:10:02Z",
+  "modified": "2023-01-27T05:02:22Z",
   "published": "2022-05-17T03:53:41Z",
   "aliases": [
     "CVE-2015-7536"
@@ -39,6 +39,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-7536"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/27c303417a226bf4c06a588570f28ac2e2507c6c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/d3fb2c09f29007dce84a213ae8323df1105dcc30"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add patch links and source code location related to CVE-2015-7536.
In https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-12-09 shows CVE-2015-7536 is related to SECURITY-95.