### PR TITLE
[GHSA-qr42-82qj-mw65] Improper Limitation of a Pathname to a Restricted Directory in Jenkins

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-qr42-82qj-mw65/GHSA-qr42-82qj-mw65.json
+++ b/advisories/github-reviewed/2022/05/GHSA-qr42-82qj-mw65/GHSA-qr42-82qj-mw65.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qr42-82qj-mw65",
-  "modified": "2023-10-26T16:18:01Z",
+  "modified": "2023-12-13T10:01:52Z",
   "published": "2022-05-24T16:50:30Z",
   "aliases": [
     "CVE-2019-10352"
@@ -76,6 +76,10 @@
     {
       "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2019:2548"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
Add source code location related to CVE-2019-10401.