### PR TITLE
[GHSA-58xm-mxjf-254g] Multiple vulnerabilities allow bypassing path filtering of agent-to-controller access control in Jenkins

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-58xm-mxjf-254g/GHSA-58xm-mxjf-254g.json
+++ b/advisories/github-reviewed/2022/05/GHSA-58xm-mxjf-254g/GHSA-58xm-mxjf-254g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-58xm-mxjf-254g",
-  "modified": "2022-12-16T20:19:52Z",
+  "modified": "2023-12-22T14:13:08Z",
   "published": "2022-05-24T19:19:44Z",
   "aliases": [
     "CVE-2021-21685"
@@ -64,6 +64,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21685"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/104c751d907919dd53f5090f84d53c671a66457b"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch link related to CVE-2021-21685.