### PR TITLE
[GHSA-62wf-24c4-8r76] Cross-site Scripting vulnerability in Jenkins

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-62wf-24c4-8r76/GHSA-62wf-24c4-8r76.json
+++ b/advisories/github-reviewed/2022/06/GHSA-62wf-24c4-8r76/GHSA-62wf-24c4-8r76.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-62wf-24c4-8r76",
-  "modified": "2022-12-06T00:12:32Z",
+  "modified": "2023-01-31T05:02:17Z",
   "published": "2022-06-24T00:00:31Z",
   "aliases": [
     "CVE-2022-34170"
@@ -77,6 +77,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-34170"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/f71495a63f8b861e8ca3a5fcf5cc931fce55bc57"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add patch link and source code location related to CVE-2022-34170.