### PR TITLE
[GHSA-279f-qwgh-h5mp] Jenkins does not exclude sensitive build variables from search

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-279f-qwgh-h5mp/GHSA-279f-qwgh-h5mp.json
+++ b/advisories/github-reviewed/2023/09/GHSA-279f-qwgh-h5mp/GHSA-279f-qwgh-h5mp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-279f-qwgh-h5mp",
-  "modified": "2023-09-21T16:55:44Z",
+  "modified": "2023-11-12T05:02:22Z",
   "published": "2023-09-20T18:30:21Z",
   "aliases": [
     "CVE-2023-43494"
@@ -58,6 +58,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-43494"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/b8ac8cd4c51511b9f844846ba80a8aed054288c5"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add source code location and patch link related to CVE-2023-43494.
In https://www.jenkins.io/security/advisory/2023-09-20/#SECURITY-3261 shows it is related to SECURITY-3261.