### PR TITLE
[GHSA-53ph-2r2x-vqw8] Cross-site WebSocket hijacking vulnerability in the Jenkins CLI

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-53ph-2r2x-vqw8/GHSA-53ph-2r2x-vqw8.json
+++ b/advisories/github-reviewed/2024/01/GHSA-53ph-2r2x-vqw8/GHSA-53ph-2r2x-vqw8.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-53ph-2r2x-vqw8",
-  "modified": "2024-01-31T20:22:29Z",
+  "modified": "2024-01-31T20:22:31Z",
   "published": "2024-01-24T18:31:02Z",
   "aliases": [
     "CVE-2024-23898"
   ],
   "summary": "Cross-site WebSocket hijacking vulnerability in the Jenkins CLI",
-  "details": "\n\nJenkins has a built-in command line interface (CLI) to access Jenkins from a script or shell environment. Since Jenkins 2.217 and LTS 2.222.1, one of the ways to communicate with the CLI is through a WebSocket endpoint. This endpoint relies on the default Jenkins web request authentication functionality, like HTTP Basic authentication with API tokens, or session cookies. This endpoint is enabled when running on a version of Jetty for which Jenkins supports WebSockets. This is the case when using the provided native installers, packages, or the Docker containers, as well as when running Jenkins with the command java -jar jenkins.war.\n\nJenkins 2.217 through 2.441 (both inclusive), LTS 2.222.1 through 2.426.2 (both inclusive) does not perform origin validation of requests made through the CLI WebSocket endpoint, resulting in a cross-site WebSocket hijacking (CSWSH) vulnerability.\n",
+  "details": "\nJenkins has a built-in command line interface (CLI) to access Jenkins from a script or shell environment. Since Jenkins 2.217 and LTS 2.222.1, one of the ways to communicate with the CLI is through a WebSocket endpoint. This endpoint relies on the default Jenkins web request authentication functionality, like HTTP Basic authentication with API tokens, or session cookies. This endpoint is enabled when running on a version of Jetty for which Jenkins supports WebSockets. This is the case when using the provided native installers, packages, or the Docker containers, as well as when running Jenkins with the command java -jar jenkins.war.\n\nJenkins 2.217 through 2.441 (both inclusive), LTS 2.222.1 through 2.426.2 (both inclusive) does not perform origin validation of requests made through the CLI WebSocket endpoint, resulting in a cross-site WebSocket hijacking (CSWSH) vulnerability.\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -73,6 +73,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23898"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/de450967f38398169650b55c002f1229a3fcdb1b"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Source code location

**Comments**
Add source code link and patch link related to CVE-2024-23898.
In https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3315 shows it is related to SECURITY-3315.