### PR TITLE
[GHSA-6f9g-cxwr-q5jr] Arbitrary file read vulnerability through the Jenkins CLI can lead to RCE

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-6f9g-cxwr-q5jr/GHSA-6f9g-cxwr-q5jr.json
+++ b/advisories/github-reviewed/2024/01/GHSA-6f9g-cxwr-q5jr/GHSA-6f9g-cxwr-q5jr.json
@@ -7,7 +7,7 @@
     "CVE-2024-23897"
   ],
   "summary": "Arbitrary file read vulnerability through the Jenkins CLI can lead to RCE",
-  "details": "\n\nJenkins has a built-in command line interface (CLI) to access Jenkins from a script or shell environment.\n\nJenkins uses the args4j library to parse command arguments and options on the Jenkins controller when processing CLI commands. This command parser has a feature that replaces an @ character followed by a file path in an argument with the file’s contents (expandAtFiles). This feature is enabled by default and Jenkins 2.441 and earlier, LTS 2.426.2 and earlier does not disable it.\n\nThis allows attackers to read arbitrary files on the Jenkins controller file system using the default character encoding of the Jenkins controller process.\n\n* Attackers with Overall/Read permission can read entire files.\n\n* Attackers without Overall/Read permission can read the first few lines of files. The number of lines that can be read depends on available CLI commands. As of publication of this advisory, the Jenkins security team has found ways to read the first three lines of files in recent releases of Jenkins without having any plugins installed, and has not identified any plugins that would increase this line count.\n\nBinary files containing cryptographic keys used for various Jenkins features can also be read, with some limitations (see note on binary files below). As of publication, the Jenkins security team has confirmed the following possible attacks in addition to reading contents of all files with a known file path. All of them leverage attackers' ability to obtain cryptographic keys from binary files, and are therefore only applicable to instances where that is feasible.\n",
+  "details": "\nJenkins has a built-in command line interface (CLI) to access Jenkins from a script or shell environment.\n\nJenkins uses the args4j library to parse command arguments and options on the Jenkins controller when processing CLI commands. This command parser has a feature that replaces an @ character followed by a file path in an argument with the file’s contents (expandAtFiles). This feature is enabled by default and Jenkins 2.441 and earlier, LTS 2.426.2 and earlier does not disable it.\n\nThis allows attackers to read arbitrary files on the Jenkins controller file system using the default character encoding of the Jenkins controller process.\n\n* Attackers with Overall/Read permission can read entire files.\n\n* Attackers without Overall/Read permission can read the first few lines of files. The number of lines that can be read depends on available CLI commands. As of publication of this advisory, the Jenkins security team has found ways to read the first three lines of files in recent releases of Jenkins without having any plugins installed, and has not identified any plugins that would increase this line count.\n\nBinary files containing cryptographic keys used for various Jenkins features can also be read, with some limitations (see note on binary files below). As of publication, the Jenkins security team has confirmed the following possible attacks in addition to reading contents of all files with a known file path. All of them leverage attackers' ability to obtain cryptographic keys from binary files, and are therefore only applicable to instances where that is feasible.\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -47,13 +47,16 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.427"
+              "introduced": "2.441"
             },
             {
-              "fixed": "2.440.1"
+              "fixed": "2.442"
             }
           ]
         }
+      ],
+      "versions": [
+        "2.441"
       ]
     },
     {
@@ -66,16 +69,13 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.441"
+              "introduced": "2.427"
             },
             {
-              "fixed": "2.442"
+              "fixed": "2.440.1"
             }
           ]
         }
-      ],
-      "versions": [
-        "2.441"
       ]
     }
   ],
@@ -83,6 +83,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23897"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jenkinsci/jenkins/commit/554f03782057c499c49bbb06575f0d28b5200edb"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jenkinsci/jenkins"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Source code location

**Comments**
Add patch link and source code location related to CVE-2024-23897.
In https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3314 shows it is related to SECURITY-3314.