### PR TITLE
[GHSA-v94h-hvhg-mf9h] Spring Framework vulnerable to denial of service

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-v94h-hvhg-mf9h/GHSA-v94h-hvhg-mf9h.json
+++ b/advisories/github-reviewed/2023/11/GHSA-v94h-hvhg-mf9h/GHSA-v94h-hvhg-mf9h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v94h-hvhg-mf9h",
-  "modified": "2023-12-14T12:31:43Z",
+  "modified": "2023-12-23T05:04:39Z",
   "published": "2023-11-28T09:30:27Z",
   "aliases": [
     "CVE-2023-34053"
@@ -41,6 +41,10 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-34053"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/c18784678df489d06a70e54fcddb5e3821d4b00c"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/spring-projects/spring-framework"
     },
@@ -50,7 +54,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20231214-0007"
+      "url": "https://security.netapp.com/advisory/ntap-20231214-0007/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The patch is in https://github.com/spring-projects/spring-framework/compare/v6.0.13...v6.0.14.
https://spring.io/security/cve-2023-34053 shows the CVE is related to micrometer-core and Spring MVC or Spring WebFlux, it is a  denial-of-service (DoS). 
The patch I added is related to these and the https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-6091650 also shows that. 