### PR TITLE
[GHSA-wxqc-pxw9-g2p8] Spring Framework vulnerable to denial of service

### DIFF
--- a/advisories/github-reviewed/2023/04/GHSA-wxqc-pxw9-g2p8/GHSA-wxqc-pxw9-g2p8.json
+++ b/advisories/github-reviewed/2023/04/GHSA-wxqc-pxw9-g2p8/GHSA-wxqc-pxw9-g2p8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wxqc-pxw9-g2p8",
-  "modified": "2023-04-17T17:34:37Z",
+  "modified": "2024-02-02T20:34:05Z",
   "published": "2023-04-13T21:30:27Z",
   "aliases": [
     "CVE-2023-20863"
@@ -80,7 +80,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/965a6392757d20f9db19241126fcc719a51eac15"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/spring-projects/spring-framework/commit/b73f5fcac22555f844cf27a7eeb876cb9d7f7f7e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/ebc82654282bda547fbc20a9749ab1bda886a46f"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add two more patch related to CVE-2023-20863 which fixed in multi-branches.