### PR TITLE
[GHSA-564r-hj7v-mcr5] Spring Framework vulnerable to denial of service via specially crafted SpEL expression

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-564r-hj7v-mcr5/GHSA-564r-hj7v-mcr5.json
+++ b/advisories/github-reviewed/2023/03/GHSA-564r-hj7v-mcr5/GHSA-564r-hj7v-mcr5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-564r-hj7v-mcr5",
-  "modified": "2023-03-28T18:04:53Z",
+  "modified": "2024-02-02T20:23:19Z",
   "published": "2023-03-23T21:30:19Z",
   "aliases": [
     "CVE-2023-20861"
@@ -83,12 +83,20 @@
       "url": "https://github.com/spring-projects/spring-framework/commit/430fc25acad2e85cbdddcd52b64481691f03ebd1"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/52c93b1c4b24d70de233a958e60e7c5822bd274f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/935c29e3ddba5b19951e54f6685c70ed45d9cbe5"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/spring-projects/spring-framework"
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20230420-0007"
+      "url": "https://security.netapp.com/advisory/ntap-20230420-0007/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add two more patches related to CVE-2023-20861 which fixed in multi-branches.