### PR TITLE
[GHSA-7phw-cxx7-q9vq] Spring Framework is vulnerable to security bypass via mvcRequestMatcher pattern mismatch

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-7phw-cxx7-q9vq/GHSA-7phw-cxx7-q9vq.json
+++ b/advisories/github-reviewed/2023/03/GHSA-7phw-cxx7-q9vq/GHSA-7phw-cxx7-q9vq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7phw-cxx7-q9vq",
-  "modified": "2023-03-28T13:39:35Z",
+  "modified": "2023-05-05T21:40:18Z",
   "published": "2023-03-28T00:34:28Z",
   "aliases": [
     "CVE-2023-20860"
@@ -60,12 +60,16 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-20860"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/202fa5cdb3a3d0cfe6967e85fa167d978244f28a"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/spring-projects/spring-framework"
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20230505-0006"
+      "url": "https://security.netapp.com/advisory/ntap-20230505-0006/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch link related to CVE-2023-20860.