### PR TITLE
[GHSA-53v4-42fg-g287] Apache ActiveMQ Deserialization of Untrusted Data vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-53v4-42fg-g287/GHSA-53v4-42fg-g287.json
+++ b/advisories/github-reviewed/2023/11/GHSA-53v4-42fg-g287/GHSA-53v4-42fg-g287.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-53v4-42fg-g287",
-  "modified": "2024-02-16T15:30:26Z",
+  "modified": "2024-02-25T05:08:29Z",
   "published": "2023-11-28T18:30:23Z",
   "aliases": [
     "CVE-2022-41678"
@@ -65,7 +65,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/5c8d457d9"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/activemq/commit/6120169e563b55323352431dfe9ac67a8b4de6c2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/bf65929fd"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/d8ce1d9ff"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The https://issues.apache.org/jira/browse/AMQ-9201 shows it fixed in four branches.
So I add three other branch patches link.