### PR TITLE
[GHSA-9mgm-gcq8-86wq] Improper Authentication in Apache ActiveMQ and Apache Artemis

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-9mgm-gcq8-86wq/GHSA-9mgm-gcq8-86wq.json
+++ b/advisories/github-reviewed/2021/06/GHSA-9mgm-gcq8-86wq/GHSA-9mgm-gcq8-86wq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9mgm-gcq8-86wq",
-  "modified": "2021-04-05T22:53:40Z",
+  "modified": "2023-11-21T00:32:34Z",
   "published": "2021-06-16T17:39:35Z",
   "aliases": [
     "CVE-2021-26117"
@@ -80,6 +80,98 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/46a774c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/73e291693d59a96c0054fc7e7e09c2c67b192911"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/c9f68f4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/raea451de09baed76950d6a60cc4bb1b74476c505e03205a3c68c9808@%3Cissues.activemq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rd05b1c9d61dbd220664d559aa0e2b55e5830f006a09e82057f3f7863%40%3Cissues.activemq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rd05b1c9d61dbd220664d559aa0e2b55e5830f006a09e82057f3f7863@%3Cissues.activemq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rd75600cee29cb248d548edcf6338fe296466d63a69e2ed0afc439ec7%40%3Cissues.activemq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rd75600cee29cb248d548edcf6338fe296466d63a69e2ed0afc439ec7@%3Cissues.activemq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/re1b98da90a5f2e1c2e2d50e31c12e2578d61fe01c0737f9d0bd8de99%40%3Cannounce.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/re1b98da90a5f2e1c2e2d50e31c12e2578d61fe01c0737f9d0bd8de99@%3Cannounce.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rec93794f8aeddf8a5f1a643d264b4e66b933f06fd72a38f31448f0ac%40%3Cgitbox.activemq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rec93794f8aeddf8a5f1a643d264b4e66b933f06fd72a38f31448f0ac@%3Cgitbox.activemq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rffa5cd05d01c4c9853b17f3004d80ea6eb8856c422a8545c5f79b1a6%40%3Ccommits.activemq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/rffa5cd05d01c4c9853b17f3004d80ea6eb8856c422a8545c5f79b1a6@%3Ccommits.activemq.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2021/03/msg00005.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2023/11/msg00013.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://mail-archives.apache.org/mod_mbox/activemq-users/202101.mbox/%3cCAH+vQmMeUEiKN4wYX9nLBbqmFZFPXqajNvBKmzb2V8QZANcSTA%40mail.gmail.com%3e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://mail-archives.apache.org/mod_mbox/activemq-users/202101.mbox/%3cCAH+vQmMeUEiKN4wYX9nLBbqmFZFPXqajNvBKmzb2V8QZANcSTA@mail.gmail.com%3e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.netapp.com/advisory/ntap-20210304-0008/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpuApr2021.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
+    },
+    {
+      "type": "WEB",
       "url": "https://issues.apache.org/jira/browse/AMQ-8035"
     },
     {
@@ -153,82 +245,6 @@
     {
       "type": "WEB",
       "url": "https://lists.apache.org/thread.html/raea451de09baed76950d6a60cc4bb1b74476c505e03205a3c68c9808%40%3Cissues.activemq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/raea451de09baed76950d6a60cc4bb1b74476c505e03205a3c68c9808@%3Cissues.activemq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rd05b1c9d61dbd220664d559aa0e2b55e5830f006a09e82057f3f7863%40%3Cissues.activemq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rd05b1c9d61dbd220664d559aa0e2b55e5830f006a09e82057f3f7863@%3Cissues.activemq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rd75600cee29cb248d548edcf6338fe296466d63a69e2ed0afc439ec7%40%3Cissues.activemq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rd75600cee29cb248d548edcf6338fe296466d63a69e2ed0afc439ec7@%3Cissues.activemq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/re1b98da90a5f2e1c2e2d50e31c12e2578d61fe01c0737f9d0bd8de99%40%3Cannounce.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/re1b98da90a5f2e1c2e2d50e31c12e2578d61fe01c0737f9d0bd8de99@%3Cannounce.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rec93794f8aeddf8a5f1a643d264b4e66b933f06fd72a38f31448f0ac%40%3Cgitbox.activemq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rec93794f8aeddf8a5f1a643d264b4e66b933f06fd72a38f31448f0ac@%3Cgitbox.activemq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rffa5cd05d01c4c9853b17f3004d80ea6eb8856c422a8545c5f79b1a6%40%3Ccommits.activemq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/rffa5cd05d01c4c9853b17f3004d80ea6eb8856c422a8545c5f79b1a6@%3Ccommits.activemq.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2021/03/msg00005.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2023/11/msg00013.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://mail-archives.apache.org/mod_mbox/activemq-users/202101.mbox/%3cCAH+vQmMeUEiKN4wYX9nLBbqmFZFPXqajNvBKmzb2V8QZANcSTA%40mail.gmail.com%3e"
-    },
-    {
-      "type": "WEB",
-      "url": "https://mail-archives.apache.org/mod_mbox/activemq-users/202101.mbox/%3cCAH+vQmMeUEiKN4wYX9nLBbqmFZFPXqajNvBKmzb2V8QZANcSTA@mail.gmail.com%3e"
-    },
-    {
-      "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20210304-0008"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpuApr2021.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
The https://activemq.apache.org/security-advisories.data/CVE-2021-26117-announcement.txt shows it is related to AMQ-8035.
And https://issues.apache.org/jira/browse/AMQ-8035 shows it is fixed in three branches.
So I add three patches and source code location.