### PR TITLE
[GHSA-cc94-3v9c-7rm8] Apache ActiveMQ webconsole admin GUI is open to XSS

### DIFF
--- a/advisories/github-reviewed/2020/05/GHSA-cc94-3v9c-7rm8/GHSA-cc94-3v9c-7rm8.json
+++ b/advisories/github-reviewed/2020/05/GHSA-cc94-3v9c-7rm8/GHSA-cc94-3v9c-7rm8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cc94-3v9c-7rm8",
-  "modified": "2021-06-15T17:57:09Z",
+  "modified": "2023-01-27T05:04:39Z",
   "published": "2020-05-21T21:08:56Z",
   "aliases": [
     "CVE-2020-1941"
@@ -39,6 +39,26 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-1941"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/7793a95"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/81bd743eaa243f0cc5dfbb1342cee1fef1fc5df2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/c0e17a3"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/AMQ-7231"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
The https://issues.apache.org/jira/browse/AMQ-7231 shows this CVE is related to AMQ-7231 and it is fixed in three branches.
So I add these patch links related to CVE-2020-1941.