### PR TITLE
[GHSA-66gw-ch5v-74v8] Cross-site scripting (XSS) in Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-66gw-ch5v-74v8/GHSA-66gw-ch5v-74v8.json
+++ b/advisories/github-reviewed/2022/02/GHSA-66gw-ch5v-74v8/GHSA-66gw-ch5v-74v8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-66gw-ch5v-74v8",
-  "modified": "2021-04-05T20:50:26Z",
+  "modified": "2023-02-01T05:05:13Z",
   "published": "2022-02-09T22:01:32Z",
   "aliases": [
     "CVE-2020-13947"
@@ -58,6 +58,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-13947"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
The CVE is fixed in 5.16.1, so I get https://github.com/apache/activemq/compare/activemq-5.16.0...activemq-5.16.1. All these commits only https://github.com/apache/activemq/commit/177eb71c52069712bcc9fe14c70e079cc2671a80 fixed message.jsp.