### PR TITLE
[GHSA-xgrx-xpv2-6vp4] Improper Authentication in Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-xgrx-xpv2-6vp4/GHSA-xgrx-xpv2-6vp4.json
+++ b/advisories/github-reviewed/2022/02/GHSA-xgrx-xpv2-6vp4/GHSA-xgrx-xpv2-6vp4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xgrx-xpv2-6vp4",
-  "modified": "2021-04-05T23:04:50Z",
+  "modified": "2023-11-21T00:30:27Z",
   "published": "2022-02-09T22:15:00Z",
   "aliases": [
     "CVE-2020-13920"
@@ -39,6 +39,26 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-13920"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/359ae4b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/48cd61d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/58382283330f7c7b110c7afd8ef4ca2648786532"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/b7dca5e"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
The NVD shows this CVE is related to LocateRegistry.createRegistry(). 
https://github.com/apache/activemq/commit/58382283330f7c7b110c7afd8ef4ca2648786532 fixed this CVE.
