### PR TITLE
[GHSA-jpv3-g4cc-6vfx] Improper Control of Generation of Code ('Code Injection') in org.apache.activemq:activemq-client

### DIFF
--- a/advisories/github-reviewed/2019/04/GHSA-jpv3-g4cc-6vfx/GHSA-jpv3-g4cc-6vfx.json
+++ b/advisories/github-reviewed/2019/04/GHSA-jpv3-g4cc-6vfx/GHSA-jpv3-g4cc-6vfx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jpv3-g4cc-6vfx",
-  "modified": "2022-09-17T00:22:23Z",
+  "modified": "2023-02-03T05:04:48Z",
   "published": "2019-04-02T15:46:42Z",
   "aliases": [
     "CVE-2019-0222"
@@ -42,6 +42,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/98b9f2e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/f78c0962ffb46fae3397eed6b7ec1e6e15045031"
+    },
+    {
+      "type": "WEB",
       "url": "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
     },
     {
@@ -54,7 +62,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20190502-0006"
+      "url": "https://security.netapp.com/advisory/ntap-20190502-0006/"
     },
     {
       "type": "WEB",
@@ -103,6 +111,10 @@
     {
       "type": "WEB",
       "url": "https://lists.apache.org/thread.html/03f91b1fb85686a848cee6b90112cf6059bd1b21b23bacaa11a962e1@%3Cdev.activemq.apache.org%3E"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
This CVE's patch is to update the version of MQTT.
