### PR TITLE
[GHSA-hvwm-2624-rp9x] Apache ActiveMQ web console vulnerable to Cross-site Scripting

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-hvwm-2624-rp9x/GHSA-hvwm-2624-rp9x.json
+++ b/advisories/github-reviewed/2018/10/GHSA-hvwm-2624-rp9x/GHSA-hvwm-2624-rp9x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hvwm-2624-rp9x",
-  "modified": "2022-11-17T18:56:52Z",
+  "modified": "2023-01-28T05:00:59Z",
   "published": "2018-10-30T20:48:58Z",
   "aliases": [
     "CVE-2018-8006"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-8006"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/2373aa1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/d8c80a98212ee5d73a281483a2f8b3f517465f62"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- References

**Comments**
The CVE is related to https://issues.apache.org/jira/browse/AMQ-6954.
Add fixed in three branches.