### PR TITLE
[GHSA-5jg4-p78r-p5j3] Improper Neutralization of Input During Web Page Generation Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-5jg4-p78r-p5j3/GHSA-5jg4-p78r-p5j3.json
+++ b/advisories/github-reviewed/2022/05/GHSA-5jg4-p78r-p5j3/GHSA-5jg4-p78r-p5j3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5jg4-p78r-p5j3",
-  "modified": "2022-07-06T19:45:41Z",
+  "modified": "2023-01-27T05:02:12Z",
   "published": "2022-05-14T01:06:24Z",
   "aliases": [
     "CVE-2016-6810"
@@ -42,6 +42,26 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-6810"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/77b827f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/c1157fe1f007ee2344a7f0badefa0794c98817cd"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/e16ed24"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/AMQ-6468"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add patch links related to CVE-2016-6810.