### PR TITLE
[GHSA-8rcq-p4gh-vmj8] Improper Neutralization of Input During Web Page Generation in Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-8rcq-p4gh-vmj8/GHSA-8rcq-p4gh-vmj8.json
+++ b/advisories/github-reviewed/2022/05/GHSA-8rcq-p4gh-vmj8/GHSA-8rcq-p4gh-vmj8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8rcq-p4gh-vmj8",
-  "modified": "2022-07-06T20:05:48Z",
+  "modified": "2023-01-27T05:02:24Z",
   "published": "2022-05-14T01:14:51Z",
   "aliases": [
     "CVE-2016-0782"
@@ -89,11 +89,27 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/0c9fdb5b4180c1ae800bbc8bae7a2c0620f6749b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/2061186a0a2486aebf26c4ceb8126933ed01826e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/7828069637acb2f1ca1710523f6a2b216c12c7f8"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2016:1424"
     },
     {
       "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1317516"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
The https://activemq.apache.org/security-advisories.data/CVE-2016-0782-announcement.txt shows the CVE is related to configured on Jolokia.
In commits https://github.com/apache/activemq/compare/activemq-5.13.1...activemq-5.13.2, these three all related to Jolokia and I think these are related to the patch.