### PR TITLE
[GHSA-w525-w93j-rxgm] Improper Neutralization of Input During Web Page Generation in Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-w525-w93j-rxgm/GHSA-w525-w93j-rxgm.json
+++ b/advisories/github-reviewed/2022/05/GHSA-w525-w93j-rxgm/GHSA-w525-w93j-rxgm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w525-w93j-rxgm",
-  "modified": "2022-07-06T20:07:08Z",
+  "modified": "2023-01-27T05:02:20Z",
   "published": "2022-05-14T01:14:51Z",
   "aliases": [
     "CVE-2016-0734"
@@ -45,7 +45,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/028a33ea7d73fabe6161defffdbfc85578328a68"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/24ad36778534c5ac888f880837075449169578ad"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2016:1424"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add patch links related to CVE-2016-0734 which is fixed in multi-branches.
The NVD shows this CVE is related to X-Frame-Options HTTP.

