### PR TITLE
[GHSA-9cvr-8xq4-2m73] Improper Neutralization of Input During Web Page Generation in Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9cvr-8xq4-2m73/GHSA-9cvr-8xq4-2m73.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9cvr-8xq4-2m73/GHSA-9cvr-8xq4-2m73.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9cvr-8xq4-2m73",
-  "modified": "2022-07-06T21:04:31Z",
+  "modified": "2023-02-13T20:29:17Z",
   "published": "2022-05-14T01:14:52Z",
   "aliases": [
     "CVE-2014-8110"
@@ -39,7 +39,23 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/994d9b26"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/f8b3de86d8154db5680433e46734b2bd9ced852b"
+    },
+    {
+      "type": "WEB",
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/100724"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/AMQ-5033"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
The https://issues.apache.org/jira/browse/AMQ-5033 shows it is related to CVE-2014-8110.
So I add these two patch links related to CVE-2014-8110.