### PR TITLE
[GHSA-p358-58jj-hp65] Improper Authentication in Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-p358-58jj-hp65/GHSA-p358-58jj-hp65.json
+++ b/advisories/github-reviewed/2022/05/GHSA-p358-58jj-hp65/GHSA-p358-58jj-hp65.json
@@ -39,11 +39,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/apache/activemq/commit/0fffe2172005f337412d5ec172cd92822395e239"
+      "url": "https://github.com/apache/activemq/commit/437ea2f6e58d18837ae0e68dcd2fdadc1fff3723"
     },
     {
       "type": "WEB",
       "url": "https://github.com/apache/activemq/commit/76153ff24574fb91b474cca2f879b25395230786"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/ced33d2551a040813cb40bd6d36fdd322034fa73"
     },
     {
       "type": "WEB",

--- a/advisories/github-reviewed/2022/05/GHSA-p358-58jj-hp65/GHSA-p358-58jj-hp65.json
+++ b/advisories/github-reviewed/2022/05/GHSA-p358-58jj-hp65/GHSA-p358-58jj-hp65.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p358-58jj-hp65",
-  "modified": "2022-07-08T19:14:28Z",
+  "modified": "2023-01-27T05:02:22Z",
   "published": "2022-05-17T03:46:28Z",
   "aliases": [
     "CVE-2013-3060"
@@ -39,7 +39,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/0fffe2172005f337412d5ec172cd92822395e239"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/76153ff24574fb91b474cca2f879b25395230786"
+    },
+    {
+      "type": "WEB",
       "url": "https://fisheye6.atlassian.com/changelog/activemq?cs=1404998"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/activemq/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Hello, I have found that there may be two possible fixes for the current vulnerability. I collected the commits between versions activemq-5.7.0 and activemq-5.8.0 at https://github.com/apache/activemq/compare/activemq-5.7.0...activemq-5.8.0 and found that only two commits are related to the fix mentioned in NVD, which is "The web console in Apache ActiveMQ before 5.8.0 does not require authentication." One of them is https://github.com/apache/activemq/commit/0fffe2172005f337412d5ec172cd92822395e239, which is mentioned in https://issues.apache.org/jira/browse/AMQ-3996 and addresses the validation issues with nio and ssl. The other one is https://github.com/apache/activemq/commit/76153ff24574fb91b474cca2f879b25395230786, which fixes the issue mentioned in https://issues.apache.org/jira/browse/AMQ-4110, where the web console can't send messages to the secured broker. I am inclined towards the second one.