### PR TITLE
[GHSA-v2c9-9m8v-8jjm] Apache ActiveMQ Sensitive Information Disclosure via the Jetty ResourceHandler

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-v2c9-9m8v-8jjm/GHSA-v2c9-9m8v-8jjm.json
+++ b/advisories/github-reviewed/2022/05/GHSA-v2c9-9m8v-8jjm/GHSA-v2c9-9m8v-8jjm.json
@@ -38,6 +38,30 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2010-1587"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/25f476624f021213342c38e294c9cfa1e64464f9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/2b019ea6277fd5af0767a83d648f8cb6b0acdb7f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/47b09a2a8995280fdda93f5c106abd2189617113"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/5a7ceacce9a3ce55643895c26a9cc5e8c71e3cd1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/5dd95eaa09554ee7c8720ce179c9bc36f7c70bf7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/activemq/commit/e8a06c43bbe640569b7f2d641ccb934908112d2b"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/apache/activemq"
     },

--- a/advisories/github-reviewed/2022/05/GHSA-v2c9-9m8v-8jjm/GHSA-v2c9-9m8v-8jjm.json
+++ b/advisories/github-reviewed/2022/05/GHSA-v2c9-9m8v-8jjm/GHSA-v2c9-9m8v-8jjm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v2c9-9m8v-8jjm",
-  "modified": "2024-02-07T23:08:48Z",
+  "modified": "2024-02-07T23:08:49Z",
   "published": "2022-05-14T02:45:01Z",
   "aliases": [
     "CVE-2010-1587"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
In https://issues.apache.org/activemq/browse/AMQ-2700 says it can be fixed when update Jetty to 7.
And the https://issues.apache.org/jira/browse/AMQ-2600 is related to update Jetty to 7.