### PR TITLE
[GHSA-jqwc-c49r-4w2x] Miscompilation of `i8x16.swizzle` and `select` with v128 inputs

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-jqwc-c49r-4w2x/GHSA-jqwc-c49r-4w2x.json
+++ b/advisories/github-reviewed/2022/06/GHSA-jqwc-c49r-4w2x/GHSA-jqwc-c49r-4w2x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jqwc-c49r-4w2x",
-  "modified": "2022-06-29T22:08:25Z",
+  "modified": "2023-01-27T05:05:25Z",
   "published": "2022-06-29T22:08:25Z",
   "aliases": [
     "CVE-2022-31104"
@@ -51,10 +51,7 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 0.85.0"
-      }
+      ]
     }
   ],
   "references": [
@@ -88,7 +85,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://webassembly.github.io/spec"
+      "url": "https://webassembly.github.io/spec/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
> We have released Wasmtime 0.38.1 and cranelift-codegen (and other associated cranelift crates) 0.85.1 which contain the corrected implementations of these two instructions in Cranelift.

Reading the quoted part, I think that anything less than 0.85.1 is an affected version, but is the current version less than 0.85.0 correct?