### PR TITLE
[GHSA-rgv9-q543-rqg4] Uncontrolled Resource Consumption in FasterXML jackson-databind

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-rgv9-q543-rqg4/GHSA-rgv9-q543-rqg4.json
+++ b/advisories/github-reviewed/2022/10/GHSA-rgv9-q543-rqg4/GHSA-rgv9-q543-rqg4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rgv9-q543-rqg4",
-  "modified": "2022-11-15T22:14:42Z",
+  "modified": "2023-02-02T05:07:35Z",
   "published": "2022-10-03T00:00:31Z",
   "aliases": [
     "CVE-2022-42004"
@@ -69,6 +69,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/35de19e7144c4df8ab178b800ba86e80c3d84252"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/cd090979b7ea78c75e4de8a4aed04f7e9fa8deea"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50490"
     },
     {
@@ -85,7 +93,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20221118-0008"
+      "url": "https://security.netapp.com/advisory/ntap-20221118-0008/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch links related to CVE-2022-42004 which fixed in multi-branches.