### PR TITLE
[GHSA-jjjh-jjxp-wpff] Uncontrolled Resource Consumption in Jackson-databind

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-jjjh-jjxp-wpff/GHSA-jjjh-jjxp-wpff.json
+++ b/advisories/github-reviewed/2022/10/GHSA-jjjh-jjxp-wpff/GHSA-jjjh-jjxp-wpff.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jjjh-jjxp-wpff",
-  "modified": "2023-03-31T14:46:13Z",
+  "modified": "2023-03-31T14:46:14Z",
   "published": "2022-10-03T00:00:31Z",
   "aliases": [
     "CVE-2022-42003"
@@ -73,6 +73,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/2c4a601c626f7790cad9d3c322d244e182838288"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/FasterXML/jackson-databind/commit/7ba9ac5b87a9d6ac0d2815158ecbeb315ad4dcdc"
     },
     {
@@ -93,7 +97,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20221124-0004"
+      "url": "https://security.netapp.com/advisory/ntap-20221124-0004/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Hi I only found three patch is related to CVE-2022-42003. 
https://github.com/FasterXML/jackson-databind/commit/2c4a601c626f7790cad9d3c322d244e182838288 https://github.com/FasterXML/jackson-databind/commit/cd090979b7ea78c75e4de8a4aed04f7e9fa8deea https://github.com/FasterXML/jackson-databind/commit/d78d00ee7b5245b93103fef3187f70543d67ca33
the other commit I do not think they are patches for this CVE.