### PR TITLE
[GHSA-5949-rw7g-wx7w] Deserialization of untrusted data in jackson-databind

### DIFF
--- a/advisories/github-reviewed/2021/01/GHSA-5949-rw7g-wx7w/GHSA-5949-rw7g-wx7w.json
+++ b/advisories/github-reviewed/2021/01/GHSA-5949-rw7g-wx7w/GHSA-5949-rw7g-wx7w.json
@@ -65,6 +65,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/08fbfacf89a4a4c026a6227a1b470ab7a13e2e88"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/FasterXML/jackson-databind/commit/7dbf51bf78d157098074a20bd9da39bd48c18e4a"
     },
     {
@@ -85,7 +89,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20210219-0008"
+      "url": "https://security.netapp.com/advisory/ntap-20210219-0008/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch link related to CVE-2021-20190.