### PR TITLE
[GHSA-mc6h-4qgp-37qh] Deserialization of untrusted data in Jackson Databind

### DIFF
--- a/advisories/github-reviewed/2020/06/GHSA-mc6h-4qgp-37qh/GHSA-mc6h-4qgp-37qh.json
+++ b/advisories/github-reviewed/2020/06/GHSA-mc6h-4qgp-37qh/GHSA-mc6h-4qgp-37qh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mc6h-4qgp-37qh",
-  "modified": "2021-10-21T21:05:45Z",
+  "modified": "2023-02-01T05:04:14Z",
   "published": "2020-06-18T14:44:43Z",
   "aliases": [
     "CVE-2020-14195"
@@ -49,6 +49,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/08fbfacf89a4a4c026a6227a1b470ab7a13e2e88"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/FasterXML/jackson-databind/commit/f6d9c664f6d481703138319f6a0f1fdbddb3a259"
     },
     {
@@ -61,7 +65,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20200702-0003"
+      "url": "https://security.netapp.com/advisory/ntap-20200702-0003/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch link related to CVE-2020-14195.