### PR TITLE
[GHSA-j823-4qch-3rgm] Deserialization of untrusted data in Jackson Databind

### DIFF
--- a/advisories/github-reviewed/2020/06/GHSA-j823-4qch-3rgm/GHSA-j823-4qch-3rgm.json
+++ b/advisories/github-reviewed/2020/06/GHSA-j823-4qch-3rgm/GHSA-j823-4qch-3rgm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j823-4qch-3rgm",
-  "modified": "2021-10-21T21:08:16Z",
+  "modified": "2023-02-01T05:04:07Z",
   "published": "2020-06-18T14:44:46Z",
   "aliases": [
     "CVE-2020-14060"
@@ -49,6 +49,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/08fbfacf89a4a4c026a6227a1b470ab7a13e2e88"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/ac7232e3f9004bdb4f11dcb5bc6c1fadf074f5f7"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/FasterXML/jackson-databind/commit/d1c67a0396e84c08d0558fbb843b5bd1f26e1921"
     },
     {
@@ -65,7 +73,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20200702-0003"
+      "url": "https://security.netapp.com/advisory/ntap-20200702-0003/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch links related to CVE-2020-14060.