### PR TITLE
[GHSA-h4rc-386g-6m85] jackson-databind mishandles the interaction between serialization gadgets and typing

### DIFF
--- a/advisories/github-reviewed/2020/04/GHSA-h4rc-386g-6m85/GHSA-h4rc-386g-6m85.json
+++ b/advisories/github-reviewed/2020/04/GHSA-h4rc-386g-6m85/GHSA-h4rc-386g-6m85.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h4rc-386g-6m85",
-  "modified": "2021-08-23T15:31:59Z",
+  "modified": "2023-02-01T05:02:58Z",
   "published": "2020-04-23T20:19:02Z",
   "aliases": [
     "CVE-2020-11620"
@@ -49,6 +49,18 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/08fbfacf89a4a4c026a6227a1b470ab7a13e2e88"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/77040d85e3eb6710508e6445640ae1a3d5e60c22"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/FasterXML/jackson-databind"
+    },
+    {
+      "type": "WEB",
       "url": "https://lists.apache.org/thread.html/rf1bbc0ea4a9f014cf94df9a12a6477d24a27f52741dbc87f2fd52ff2@%3Cissues.geode.apache.org%3E"
     },
     {
@@ -61,7 +73,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20200511-0004"
+      "url": "https://security.netapp.com/advisory/ntap-20200511-0004/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add patch links related to CVE-2020-11620.