### PR TITLE
[GHSA-9vvp-fxw6-jcxr] jackson-databind mishandles the interaction between serialization gadgets and typing

### DIFF
--- a/advisories/github-reviewed/2020/05/GHSA-9vvp-fxw6-jcxr/GHSA-9vvp-fxw6-jcxr.json
+++ b/advisories/github-reviewed/2020/05/GHSA-9vvp-fxw6-jcxr/GHSA-9vvp-fxw6-jcxr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9vvp-fxw6-jcxr",
-  "modified": "2021-08-25T21:00:41Z",
+  "modified": "2023-02-01T05:02:58Z",
   "published": "2020-05-15T18:58:47Z",
   "aliases": [
     "CVE-2020-11113"
@@ -48,6 +48,14 @@
       "url": "https://github.com/FasterXML/jackson-databind/issues/2670"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/08fbfacf89a4a4c026a6227a1b470ab7a13e2e88"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/e2ba12d5d60715d95105e3e790fc234cfb59893d"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/FasterXML/jackson-databind"
     },
@@ -61,7 +69,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20200403-0002"
+      "url": "https://security.netapp.com/advisory/ntap-20200403-0002/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch link related to CVE-2020-11113.