### PR TITLE
[GHSA-rf6r-2c4q-2vwg] jackson-databind mishandles the interaction between serialization gadgets and typing

### DIFF
--- a/advisories/github-reviewed/2020/05/GHSA-rf6r-2c4q-2vwg/GHSA-rf6r-2c4q-2vwg.json
+++ b/advisories/github-reviewed/2020/05/GHSA-rf6r-2c4q-2vwg/GHSA-rf6r-2c4q-2vwg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rf6r-2c4q-2vwg",
-  "modified": "2021-08-25T20:58:41Z",
+  "modified": "2023-02-01T05:03:05Z",
   "published": "2020-05-15T18:58:54Z",
   "aliases": [
     "CVE-2020-10968"
@@ -49,7 +49,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/FasterXML/jackson-databind"
+      "url": "https://github.com/FasterXML/jackson-databind/commit/05d7e0e13f43e12db6a51726df12c8b4d8040676"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/08fbfacf89a4a4c026a6227a1b470ab7a13e2e88"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/FasterXML/jackson-databind/"
     },
     {
       "type": "WEB",
@@ -61,7 +69,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20200403-0002"
+      "url": "https://security.netapp.com/advisory/ntap-20200403-0002/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch links related to CVE-2020-10968.