### PR TITLE
[GHSA-95cm-88f5-f2c7] jackson-databind mishandles the interaction between serialization gadgets and typing

### DIFF
--- a/advisories/github-reviewed/2020/04/GHSA-95cm-88f5-f2c7/GHSA-95cm-88f5-f2c7.json
+++ b/advisories/github-reviewed/2020/04/GHSA-95cm-88f5-f2c7/GHSA-95cm-88f5-f2c7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-95cm-88f5-f2c7",
-  "modified": "2021-10-21T21:13:58Z",
+  "modified": "2023-02-01T05:03:01Z",
   "published": "2020-04-23T16:32:59Z",
   "aliases": [
     "CVE-2020-10672"
@@ -48,6 +48,14 @@
       "url": "https://github.com/FasterXML/jackson-databind/issues/2659"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/08fbfacf89a4a4c026a6227a1b470ab7a13e2e88"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/592872f4235c7f2a3280725278da55544032f72d"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/FasterXML/jackson-databind"
     },
@@ -61,7 +69,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20200403-0002"
+      "url": "https://security.netapp.com/advisory/ntap-20200403-0002/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch links related to CVE-2020-10672.