### PR TITLE
[GHSA-cggj-fvv3-cqwv] FasterXML jackson-databind allows unauthenticated remote code execution 

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-cggj-fvv3-cqwv/GHSA-cggj-fvv3-cqwv.json
+++ b/advisories/github-reviewed/2018/10/GHSA-cggj-fvv3-cqwv/GHSA-cggj-fvv3-cqwv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cggj-fvv3-cqwv",
-  "modified": "2024-03-01T21:52:06Z",
+  "modified": "2024-03-01T21:52:07Z",
   "published": "2018-10-16T17:45:18Z",
   "aliases": [
     "CVE-2018-7489"
@@ -25,17 +25,14 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.8.0"
+              "introduced": "2.9.0"
             },
             {
-              "fixed": "2.8.11.1"
+              "fixed": "2.9.5"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 2.8.11.0"
-      }
+      ]
     },
     {
       "package": {
@@ -47,14 +44,17 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.9.0"
+              "introduced": "2.8.0"
             },
             {
-              "fixed": "2.9.5"
+              "fixed": "2.8.11.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.8.11.0"
+      }
     },
     {
       "package": {
@@ -119,6 +119,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FasterXML/jackson-databind/commit/bc22f90eb7f896ace9567598a99cb1ff6e0f9d9d"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add more patch links related to CVE-2018-7489.