### PR TITLE
[GHSA-5fxj-whcv-crrc] Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-5fxj-whcv-crrc/GHSA-5fxj-whcv-crrc.json
+++ b/advisories/github-reviewed/2024/03/GHSA-5fxj-whcv-crrc/GHSA-5fxj-whcv-crrc.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5fxj-whcv-crrc",
-  "modified": "2024-03-12T20:07:59Z",
+  "modified": "2024-03-12T20:08:00Z",
   "published": "2024-03-12T20:07:59Z",
   "aliases": [
     "CVE-2024-21392"
   ],
   "summary": "Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability",
-  "details": "# Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability\n\n## <a name=\"executive-summary\"></a>Executive summary\n\nMicrosoft is releasing this security advisory to provide information about a vulnerability in .NET 7.0 and .NET 8.0 . This advisory also provides guidance on what developers can do to update their applications to address this vulnerability.\n\nA vulnerability exists in .NET where specially crafted requests may cause a resource leak, leading to a Denial of Service\n\n## Announcement\n\nAnnouncement for this issue can be found at  https://github.com/dotnet/announcements/issues/299\n\n### <a name=\"mitigation-factors\"></a>Mitigation factors\n\nMicrosoft has not identified any mitigating factors for this vulnerability.\n\n## <a name=\"affected-software\"></a>Affected software\n\n* Any .NET 7.0 application running on .NET 7.0.16 or earlier.\n* Any .NET 8.0 application running on .NET 8.0.2 or earlier.\n\n## <a name=\"affected-packages\"></a>Affected Packages\nThe vulnerability affects any Microsoft .NET Core project if it uses any of affected packages versions listed below\n\n### <a name=\".NET 7\"></a>.NET 7.0\n\nPackage name | Affected version | Patched version\n------------ | ---------------- | -------------------------\n[Microsoft.NETCore.App.Runtime.Runtime.linux-arm](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.linux-arm)               |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.Runtime.linux-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.linux-arm64)           |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.Runtime.linux-musl-arm](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.linux-musl-arm)     |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.Runtime.linux-musl-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.linux-musl-arm64) |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.Runtime.linux-musl-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.linux-musl-x64)     |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.Runtime.linux-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.linux-x64)               |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.Runtime.osx-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.osx-arm64)               |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.Runtime.osx-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.osx-x64)                   |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.Runtime.win-arm](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.win-arm)                   |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.Runtime.win-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.win-arm64)               |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.Runtime.win-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.win-x64)                   |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.Runtime.win-x86](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.win-x86)                   |  <= 7.0.16 | 7.0.17\n\n### <a name=\".NET 7\"></a>.NET 8.0\nPackage name | Affected version | Patched version\n------------ | ---------------- | -------------------------\n[Microsoft.NETCore.App.Runtime.Runtime.linux-arm](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.linux-arm)               |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.Runtime.linux-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.linux-arm64)           |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.Runtime.linux-musl-arm](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.linux-musl-arm)     |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.Runtime.linux-musl-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.linux-musl-arm64) |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.Runtime.linux-musl-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.linux-musl-x64)     |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.Runtime.linux-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.linux-x64)               |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.Runtime.osx-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.osx-arm64)               |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.Runtime.osx-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.osx-x64)                   |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.Runtime.win-arm](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.win-arm)                   |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.Runtime.win-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.win-arm64)               |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.Runtime.win-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.win-x64)                   |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.Runtime.win-x86](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.Runtime.win-x86)                   |  <= 8.0.2 | 8.0.3\n\n\n## Advisory FAQ\n\n### <a name=\"how-affected\"></a>How do I know if I am affected?\n\nIf you have a runtime or SDK with a version listed, or an affected package listed in [affected software](#affected-software), you're exposed to the vulnerability.\n\n### <a name=\"how-fix\"></a>How do I fix the issue?\n\n* To fix the issue please install the latest version of .NET 8.0 or .NET 7.0 or .NET 6.0. If you have installed one or more .NET SDKs through Visual Studio, Visual Studio will prompt you to update Visual Studio, which will also update your .NET  SDKs.\n* If you have .NET 6.0 or greater installed, you can list the versions you have installed by running the `dotnet --info` command. You will see output like the following;\n\n```\n.NET Core SDK (reflecting any global.json):\n\n Version:   8.0.200\n Commit:    8473146e7d\n\nRuntime Environment:\n\n OS Name:     Windows\n OS Version:  10.0.18363\n OS Platform: Windows\n RID:         win10-x64\n Base Path:   C:\\Program Files\\dotnet\\sdk\\6.0.300\\\n\nHost (useful for support):\n\n  Version: 8.0.3\n  Commit:  8473146e7d\n\n.NET Core SDKs installed:\n\n  8.0.200 [C:\\Program Files\\dotnet\\sdk]\n\n.NET Core runtimes installed:\n\n  Microsoft.AspNetCore.App 8.0.3 [C:\\Program Files\\dotnet\\shared\\Microsoft.AspNetCore.App]\n  Microsoft.NETCore.App 8.0.3 [C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App]\n  Microsoft.WindowsDesktop.App 8.0.3 [C:\\Program Files\\dotnet\\shared\\Microsoft.WindowsDesktop.App]\n\nTo install additional .NET Core runtimes or SDKs:\n  https://aka.ms/dotnet-download\n```\n\n* If you're using .NET 8.0, you should download and install .NET 8.0.3  Runtime or .NET 8.0.202 SDK (for Visual Studio 2022 v17.8) from https://dotnet.microsoft.com/download/dotnet-core/8.0.\n* If you're using .NET 7.0, you should download and install Runtime 7.0.17 or SDK 7.0.117 (for Visual Studio 2022 v17.4) from https://dotnet.microsoft.com/download/dotnet-core/7.0.\n\n.NET 7.0 and, .NET 8.0 updates are also available from Microsoft Update. To access this either type \"Check for updates\" in your Windows search, or open Settings, choose Update & Security and then click Check for Updates.\n\nOnce you have installed the updated runtime or SDK, restart your apps for the update to take effect.\n\nAdditionally, if you've deployed [self-contained applications](https://docs.microsoft.com/dotnet/core/deploying/#self-contained-deployments-scd) targeting any of the impacted versions, these applications are also vulnerable and must be recompiled and redeployed.\n\n## Other Information\n\n### Reporting Security Issues\n\nIf you have found a potential security issue in .NET 8.0 or .NET 7.0 or .NET 6.0, please email details to secure@microsoft.com. Reports may qualify for the Microsoft .NET Core & .NET 5 Bounty. Details of the Microsoft .NET Bounty Program including terms and conditions are at <https://aka.ms/corebounty>.\n\n### Support\n\nYou can ask questions about this issue on GitHub in the .NET GitHub organization. The main repos are located at https://github.com/dotnet/runtime and https://github.com/dotnet/aspnet/. The Announcements repo (https://github.com/dotnet/Announcements) will contain this bulletin as an issue and will include a link to a discussion issue. You can ask questions in the linked discussion issue.\n\n### Disclaimer\n\nThe information provided in this advisory is provided \"as is\" without warranty of any kind. Microsoft disclaims all warranties, either express or implied, including the warranties of merchantability and fitness for a particular purpose. In no event shall Microsoft Corporation or its suppliers be liable for any damages whatsoever including direct, indirect, incidental, consequential, loss of business profits or special damages, even if Microsoft Corporation or its suppliers have been advised of the possibility of such damages. Some states do not allow the exclusion or limitation of liability for consequential or incidental damages so the foregoing limitation may not apply.\n\n### External Links\n\n[CVE-2024-21392]( https://www.cve.org/CVERecord?id=CVE-2024-21392)\n\n### Revisions\n\nV1.0 (March 12, 2024): Advisory published.\n\n_Version 1.0_\n\n_Last Updated 2024-03-12_",
+  "details": "# Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability\n\n## <a name=\"executive-summary\"></a>Executive summary\n\nMicrosoft is releasing this security advisory to provide information about a vulnerability in .NET 7.0 and .NET 8.0 . This advisory also provides guidance on what developers can do to update their applications to address this vulnerability.\n\nA vulnerability exists in .NET where specially crafted requests may cause a resource leak, leading to a Denial of Service\n\n## Announcement\n\nAnnouncement for this issue can be found at  https://github.com/dotnet/announcements/issues/299\n\n### <a name=\"mitigation-factors\"></a>Mitigation factors\n\nMicrosoft has not identified any mitigating factors for this vulnerability.\n\n## <a name=\"affected-software\"></a>Affected software\n\n* Any .NET 7.0 application running on .NET 7.0.16 or earlier.\n* Any .NET 8.0 application running on .NET 8.0.2 or earlier.\n\n## <a name=\"affected-packages\"></a>Affected Packages\nThe vulnerability affects any Microsoft .NET Core project if it uses any of affected packages versions listed below\n\n### <a name=\".NET 7\"></a>.NET 7.0\n\nPackage name | Affected version | Patched version\n------------ | ---------------- | -------------------------\n[Microsoft.NETCore.App.Runtime.linux-arm](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.linux-arm)               |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.linux-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.linux-arm64)           |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.linux-musl-arm](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.linux-musl-arm)     |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.linux-musl-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.linux-musl-arm64) |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.linux-musl-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.linux-musl-x64)     |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.linux-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.linux-x64)               |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.osx-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.osx-arm64)               |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.osx-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.osx-x64)                   |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.win-arm](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.win-arm)                   |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.win-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.win-arm64)               |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.win-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.win-x64)                   |  <= 7.0.16 | 7.0.17\n[Microsoft.NETCore.App.Runtime.win-x86](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.win-x86)                   |  <= 7.0.16 | 7.0.17\n\n### <a name=\".NET 7\"></a>.NET 8.0\nPackage name | Affected version | Patched version\n------------ | ---------------- | -------------------------\n[Microsoft.NETCore.App.Runtime.linux-arm](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.linux-arm)               |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.linux-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.linux-arm64)           |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.linux-musl-arm](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.linux-musl-arm)     |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.linux-musl-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.linux-musl-arm64) |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.linux-musl-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.linux-musl-x64)     |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.linux-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.linux-x64)               |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.osx-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.osx-arm64)               |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.osx-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.osx-x64)                   |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.win-arm](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.win-arm)                   |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.win-arm64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.win-arm64)               |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.win-x64](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.win-x64)                   |  <= 8.0.2 | 8.0.3\n[Microsoft.NETCore.App.Runtime.win-x86](https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.win-x86)                   |  <= 8.0.2 | 8.0.3\n\n\n## Advisory FAQ\n\n### <a name=\"how-affected\"></a>How do I know if I am affected?\n\nIf you have a runtime or SDK with a version listed, or an affected package listed in [affected software](#affected-software), you're exposed to the vulnerability.\n\n### <a name=\"how-fix\"></a>How do I fix the issue?\n\n* To fix the issue please install the latest version of .NET 8.0 or .NET 7.0 or .NET 6.0. If you have installed one or more .NET SDKs through Visual Studio, Visual Studio will prompt you to update Visual Studio, which will also update your .NET  SDKs.\n* If you have .NET 6.0 or greater installed, you can list the versions you have installed by running the `dotnet --info` command. You will see output like the following;\n\n```\n.NET Core SDK (reflecting any global.json):\n\n Version:   8.0.200\n Commit:    8473146e7d\n\nRuntime Environment:\n\n OS Name:     Windows\n OS Version:  10.0.18363\n OS Platform: Windows\n RID:         win10-x64\n Base Path:   C:\\Program Files\\dotnet\\sdk\\6.0.300\\\n\nHost (useful for support):\n\n  Version: 8.0.3\n  Commit:  8473146e7d\n\n.NET Core SDKs installed:\n\n  8.0.200 [C:\\Program Files\\dotnet\\sdk]\n\n.NET Core runtimes installed:\n\n  Microsoft.AspNetCore.App 8.0.3 [C:\\Program Files\\dotnet\\shared\\Microsoft.AspNetCore.App]\n  Microsoft.NETCore.App 8.0.3 [C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App]\n  Microsoft.WindowsDesktop.App 8.0.3 [C:\\Program Files\\dotnet\\shared\\Microsoft.WindowsDesktop.App]\n\nTo install additional .NET Core runtimes or SDKs:\n  https://aka.ms/dotnet-download\n```\n\n* If you're using .NET 8.0, you should download and install .NET 8.0.3  Runtime or .NET 8.0.202 SDK (for Visual Studio 2022 v17.8) from https://dotnet.microsoft.com/download/dotnet-core/8.0.\n* If you're using .NET 7.0, you should download and install Runtime 7.0.17 or SDK 7.0.117 (for Visual Studio 2022 v17.4) from https://dotnet.microsoft.com/download/dotnet-core/7.0.\n\n.NET 7.0 and, .NET 8.0 updates are also available from Microsoft Update. To access this either type \"Check for updates\" in your Windows search, or open Settings, choose Update & Security and then click Check for Updates.\n\nOnce you have installed the updated runtime or SDK, restart your apps for the update to take effect.\n\nAdditionally, if you've deployed [self-contained applications](https://docs.microsoft.com/dotnet/core/deploying/#self-contained-deployments-scd) targeting any of the impacted versions, these applications are also vulnerable and must be recompiled and redeployed.\n\n## Other Information\n\n### Reporting Security Issues\n\nIf you have found a potential security issue in .NET 8.0 or .NET 7.0 or .NET 6.0, please email details to secure@microsoft.com. Reports may qualify for the Microsoft .NET Core & .NET 5 Bounty. Details of the Microsoft .NET Bounty Program including terms and conditions are at <https://aka.ms/corebounty>.\n\n### Support\n\nYou can ask questions about this issue on GitHub in the .NET GitHub organization. The main repos are located at https://github.com/dotnet/runtime and https://github.com/dotnet/aspnet/. The Announcements repo (https://github.com/dotnet/Announcements) will contain this bulletin as an issue and will include a link to a discussion issue. You can ask questions in the linked discussion issue.\n\n### Disclaimer\n\nThe information provided in this advisory is provided \"as is\" without warranty of any kind. Microsoft disclaims all warranties, either express or implied, including the warranties of merchantability and fitness for a particular purpose. In no event shall Microsoft Corporation or its suppliers be liable for any damages whatsoever including direct, indirect, incidental, consequential, loss of business profits or special damages, even if Microsoft Corporation or its suppliers have been advised of the possibility of such damages. Some states do not allow the exclusion or limitation of liability for consequential or incidental damages so the foregoing limitation may not apply.\n\n### External Links\n\n[CVE-2024-21392]( https://www.cve.org/CVERecord?id=CVE-2024-21392)\n\n### Revisions\n\nV1.0 (March 12, 2024): Advisory published.\n\n_Version 1.0_\n\n_Last Updated 2024-03-12_",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.linux-arm"
+        "name": "Microsoft.NETCore.App.Runtime.linux-arm"
       },
       "ranges": [
         {
@@ -40,7 +40,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.linux-arm"
+        "name": "Microsoft.NETCore.App.Runtime.linux-arm"
       },
       "ranges": [
         {
@@ -57,6 +57,28 @@
       ],
       "database_specific": {
         "last_known_affected_version_range": "<= 8.0.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Microsoft.NETCore.App.Runtime.linux-arm64"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.0.17"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 7.0.16"
       }
     },
     {
@@ -69,28 +91,6 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
-            },
-            {
-              "fixed": "7.0.17"
-            }
-          ]
-        }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 7.0.16"
-      }
-    },
-    {
-      "package": {
-        "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.linux-arm64"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
               "introduced": "8.0.0"
             },
             {
@@ -106,7 +106,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.linux-musl-arm"
+        "name": "Microsoft.NETCore.App.Runtime.linux-musl-arm"
       },
       "ranges": [
         {
@@ -128,7 +128,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.linux-musl-arm"
+        "name": "Microsoft.NETCore.App.Runtime.linux-musl-arm"
       },
       "ranges": [
         {
@@ -150,7 +150,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.linux-musl-arm64"
+        "name": "Microsoft.NETCore.App.Runtime.linux-musl-arm64"
       },
       "ranges": [
         {
@@ -172,7 +172,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.linux-musl-arm64"
+        "name": "Microsoft.NETCore.App.Runtime.linux-musl-arm64"
       },
       "ranges": [
         {
@@ -194,7 +194,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.linux-musl-x64"
+        "name": "Microsoft.NETCore.App.Runtime.linux-musl-x64"
       },
       "ranges": [
         {
@@ -216,7 +216,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.linux-musl-x64"
+        "name": "Microsoft.NETCore.App.Runtime.linux-musl-x64"
       },
       "ranges": [
         {
@@ -238,7 +238,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.linux-x64"
+        "name": "Microsoft.NETCore.App.Runtime.linux-x64"
       },
       "ranges": [
         {
@@ -260,7 +260,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.linux-x64"
+        "name": "Microsoft.NETCore.App.Runtime.linux-x64"
       },
       "ranges": [
         {
@@ -282,7 +282,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.osx-arm64"
+        "name": "Microsoft.NETCore.App.Runtime.osx-arm64"
       },
       "ranges": [
         {
@@ -304,7 +304,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.osx-arm64"
+        "name": "Microsoft.NETCore.App.Runtime.osx-arm64"
       },
       "ranges": [
         {
@@ -326,7 +326,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.osx-x64"
+        "name": "Microsoft.NETCore.App.Runtime.osx-x64"
       },
       "ranges": [
         {
@@ -348,7 +348,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.osx-x64"
+        "name": "Microsoft.NETCore.App.Runtime.osx-x64"
       },
       "ranges": [
         {
@@ -370,7 +370,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.win-arm"
+        "name": "Microsoft.NETCore.App.Runtime.win-arm"
       },
       "ranges": [
         {
@@ -392,7 +392,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.win-arm"
+        "name": "Microsoft.NETCore.App.Runtime.win-arm"
       },
       "ranges": [
         {
@@ -414,7 +414,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.win-arm64"
+        "name": "Microsoft.NETCore.App.Runtime.win-arm64"
       },
       "ranges": [
         {
@@ -436,7 +436,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.win-arm64"
+        "name": "Microsoft.NETCore.App.Runtime.win-arm64"
       },
       "ranges": [
         {
@@ -458,7 +458,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.win-x64"
+        "name": "Microsoft.NETCore.App.Runtime.win-x64"
       },
       "ranges": [
         {
@@ -480,7 +480,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.win-x86"
+        "name": "Microsoft.NETCore.App.Runtime.win-x86"
       },
       "ranges": [
         {
@@ -502,7 +502,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.win-x86"
+        "name": "Microsoft.NETCore.App.Runtime.win-x86"
       },
       "ranges": [
         {
@@ -524,7 +524,7 @@
     {
       "package": {
         "ecosystem": "NuGet",
-        "name": "Microsoft.NETCore.App.Runtime.Runtime.win-x64"
+        "name": "Microsoft.NETCore.App.Runtime.win-x64"
       },
       "ranges": [
         {
@@ -560,6 +560,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/dotnet/runtime/issues/99621"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/dotnet/runtime/commit/5a958edb63110d8090c92fd34e2ae6379b23f4db"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/dotnet/runtime/commit/e597140113b0bcfb47f80bc2a03c17a98fac14f3"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
typo cause an incorrect identifier which doesn't exist on package manager so updating correct identifier.
updated typo mistake in package name (Runtime.Runtime -> Runtime)  
updated typo mistake in references (Runtime.Runtime -> Runtime)
added fix commit for respective branches 7.x and 8.x.