### PR TITLE
[GHSA-383p-xqxx-rrmp] Improper Input Validation in Apache Struts

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-383p-xqxx-rrmp/GHSA-383p-xqxx-rrmp.json
+++ b/advisories/github-reviewed/2022/05/GHSA-383p-xqxx-rrmp/GHSA-383p-xqxx-rrmp.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-383p-xqxx-rrmp",
-  "modified": "2022-07-06T19:56:14Z",
+  "modified": "2023-02-13T17:43:48Z",
   "published": "2022-05-17T03:42:18Z",
   "aliases": [
     "CVE-2016-3093"
   ],
-  "summary": "Improper Input Validation in Apache Struts",
+  "summary": "Denial of Service in Apache Struts",
   "details": "Apache Struts 2.0.0 through 2.3.24.1 does not properly cache method references when used with OGNL before 3.0.12, which allows remote attackers to cause a denial of service (block access to a web site) via unspecified vectors.",
   "severity": [
     {
@@ -36,6 +36,25 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 2.3.24.1"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "ognl:ognl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.12"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Vulnerability requires a combination of ognl:ognl < 3.0.12 and Apache Struts >= 2.0.0 through <= 2.3.24.1.

As documented by the official security bulletin at https://cwiki.apache.org/confluence/display/WW/S2-034, the recommended fix is to upgrade ognl:ognl to 3.0.12 or newer. The GitHub advisory listing was missing the impact to the ognl:ognl dependency and recommended remediation.

I also suggest the title be changed from "Improper Input Validation" to "Denial of Service" which better represents the CVE and impact.