### PR TITLE
[GHSA-3832-9276-x7gf] Improper Certificate Validation in apache HttpClient

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-3832-9276-x7gf/GHSA-3832-9276-x7gf.json
+++ b/advisories/github-reviewed/2022/05/GHSA-3832-9276-x7gf/GHSA-3832-9276-x7gf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3832-9276-x7gf",
-  "modified": "2022-07-13T13:58:59Z",
+  "modified": "2023-01-27T05:02:30Z",
   "published": "2022-05-13T01:10:34Z",
   "aliases": [
     "CVE-2012-5783"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.httpcomponents:httpclient"
+        "name": "commons-httpclient:commons-httpclient"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This vulnerability was pointing to the wrong package name. Version 3.x of Apache HTTP Components HTTP Client used a Maven package name of "commons-httpclient:commons-httpclient". Version 4.x used "org.apache.httpcomponents:httpclient", which this advisory was incorrectly pointing at.