### PR TITLE
[GHSA-rmqp-9w4c-gc7w] Apache Axis 1.x (EOL) may allow RCE when untrusted input is passed to getService

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-rmqp-9w4c-gc7w/GHSA-rmqp-9w4c-gc7w.json
+++ b/advisories/github-reviewed/2023/09/GHSA-rmqp-9w4c-gc7w/GHSA-rmqp-9w4c-gc7w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rmqp-9w4c-gc7w",
-  "modified": "2023-10-18T22:22:36Z",
+  "modified": "2023-11-05T05:01:17Z",
   "published": "2023-09-05T15:30:25Z",
   "aliases": [
     "CVE-2023-40743"
@@ -19,6 +19,25 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.apache.axis:axis"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "axis:axis"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Apache Axis is published to Maven Central with both the "axis" and "org.apache.axis" group ids.