### PR TITLE
[GHSA-hr2c-p8rh-238h] Apache Axis Improper Input Validation vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-hr2c-p8rh-238h/GHSA-hr2c-p8rh-238h.json
+++ b/advisories/github-reviewed/2024/01/GHSA-hr2c-p8rh-238h/GHSA-hr2c-p8rh-238h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hr2c-p8rh-238h",
-  "modified": "2024-01-12T22:23:34Z",
+  "modified": "2024-01-12T22:23:35Z",
   "published": "2024-01-06T12:30:34Z",
   "aliases": [
     "CVE-2023-51441"
@@ -19,6 +19,25 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.apache.axis:axis"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "axis:axis"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Apache Axis is published with both the "org.apache.axis" and "axis" group ids in Maven Central.