### PR TITLE
[GHSA-h9gj-rqrw-x4fq] Server Side Request Forgery in Apache Axis

### DIFF
--- a/advisories/github-reviewed/2019/05/GHSA-h9gj-rqrw-x4fq/GHSA-h9gj-rqrw-x4fq.json
+++ b/advisories/github-reviewed/2019/05/GHSA-h9gj-rqrw-x4fq/GHSA-h9gj-rqrw-x4fq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h9gj-rqrw-x4fq",
-  "modified": "2021-06-15T17:07:00Z",
+  "modified": "2023-01-27T05:02:18Z",
   "published": "2019-05-14T04:02:24Z",
   "aliases": [
     "CVE-2019-0227"
@@ -33,6 +33,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "axis:axis"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.4"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
@@ -50,7 +69,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://rhinosecuritylabs.com/application-security/cve-2019-0227-expired-domain-rce-apache-axis"
+      "url": "https://rhinosecuritylabs.com/application-security/cve-2019-0227-expired-domain-rce-apache-axis/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Apache Axis is published with both the "org.apache.axis" and "axis" group ids in Maven Central.