### PR TITLE
[GHSA-wjxj-5m7g-mg7q] Bouncy Castle Denial of Service (DoS)

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-wjxj-5m7g-mg7q/GHSA-wjxj-5m7g-mg7q.json
+++ b/advisories/github-reviewed/2023/11/GHSA-wjxj-5m7g-mg7q/GHSA-wjxj-5m7g-mg7q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wjxj-5m7g-mg7q",
-  "modified": "2023-12-05T22:05:06Z",
+  "modified": "2024-01-25T15:31:52Z",
   "published": "2023-11-23T18:30:33Z",
   "aliases": [
     "CVE-2023-33202"
@@ -52,6 +52,139 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.bouncycastle:bcprov-jdk16"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.73"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.bouncycastle:bcprov-jdk15to18"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.73"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.bouncycastle:bcprov-jdk15on"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.73"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.bouncycastle:bcprov-jdk15"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.73"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.bouncycastle:bcprov-jdk14"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.73"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.bouncycastle:bcprov-ext-jdk16"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.73"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.bouncycastle:bcprov-ext-jdk15on"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.73"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
@@ -69,7 +202,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20240125-0001"
+      "url": "https://security.netapp.com/advisory/ntap-20240125-0001/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The official vendor CVE report at https://github.com/bcgit/bc-java/wiki/CVE-2023-33202 states all versions of Bouncy Castle Java versions 1.72 and earlier are affected, not just the JDK18 JAR files. Other relevant Bouncy Castle Maven packages (JARs) have been added.