### PR TITLE
[GHSA-gvpg-vgmx-xg6w] In Connect2id Nimbus JOSE+JWT before 9.37.2, an attacker...

### DIFF
--- a/advisories/unreviewed/2024/02/GHSA-gvpg-vgmx-xg6w/GHSA-gvpg-vgmx-xg6w.json
+++ b/advisories/unreviewed/2024/02/GHSA-gvpg-vgmx-xg6w/GHSA-gvpg-vgmx-xg6w.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gvpg-vgmx-xg6w",
-  "modified": "2024-02-11T06:30:27Z",
+  "modified": "2024-02-11T06:30:32Z",
   "published": "2024-02-11T06:30:27Z",
   "aliases": [
     "CVE-2023-52428"
   ],
+  "summary": "Denial of Service in Connect2id Nimbus JOSE+JWT ",
   "details": "In Connect2id Nimbus JOSE+JWT before 9.37.2, an attacker can cause a denial of service (resource consumption) via a large JWE p2c header value (aka iteration count) for the PasswordBasedDecrypter (PBKDF2) component.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.nimbusds:nimbus-jose-jwt"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "9.37.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -19,12 +38,16 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-52428"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://bitbucket.org/connect2id/nimbus-jose-jwt"
+    },
+    {
       "type": "WEB",
       "url": "https://bitbucket.org/connect2id/nimbus-jose-jwt/commits/3b3b77e"
     },
     {
       "type": "WEB",
-      "url": "https://bitbucket.org/connect2id/nimbus-jose-jwt/issues/526"
+      "url": "https://bitbucket.org/connect2id/nimbus-jose-jwt/issues/526/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
Adding title and affected Maven package version