### PR TITLE
[GHSA-h59x-p739-982c] LangChain directory traversal vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-h59x-p739-982c/GHSA-h59x-p739-982c.json
+++ b/advisories/github-reviewed/2024/03/GHSA-h59x-p739-982c/GHSA-h59x-p739-982c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h59x-p739-982c",
-  "modified": "2024-03-13T22:27:52Z",
+  "modified": "2024-03-13T22:27:53Z",
   "published": "2024-03-04T00:30:53Z",
   "aliases": [
     "CVE-2024-28088"
@@ -23,9 +23,28 @@
           "events": [
             {
               "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 0.0.339"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "langchain-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
             },
             {
-              "fixed": "0.1.11"
+              "fixed": "0.1.30"
             }
           ]
         }
@@ -66,7 +85,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "LOW",
+    "severity": "CRITICAL",
     "github_reviewed": true,
     "github_reviewed_at": "2024-03-06T16:13:39Z",
     "nvd_published_at": "2024-03-04T00:15:47Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity

**Comments**
`langchain` and `langchain-core` got separated on 0.0.340.
the vulnerable code was moved from langchain - https://github.com/langchain-ai/langchain/blob/v0.0.339/libs/langchain/langchain/utils/loading.py
to langchain-core - https://github.com/langchain-ai/langchain/blob/v0.0.340/libs/core/langchain_core/utils/loading.py
Hence, technically langchain is only affected up to 0.0.339.
In addition, langhcain-core is affected as well, up to version 0.1.30 where the code was fixed.