### PR TITLE
[GHSA-hww2-5g85-429m] URI gem has ReDoS vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-hww2-5g85-429m/GHSA-hww2-5g85-429m.json
+++ b/advisories/github-reviewed/2023/06/GHSA-hww2-5g85-429m/GHSA-hww2-5g85-429m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hww2-5g85-429m",
-  "modified": "2023-07-14T21:52:02Z",
+  "modified": "2023-11-04T05:02:23Z",
   "published": "2023-06-29T15:30:34Z",
   "aliases": [
     "CVE-2023-36617"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.10.1"
             },
             {
               "fixed": "0.10.3"
@@ -44,10 +44,48 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0.11.0"
+              "introduced": "0.12.0"
             },
             {
               "fixed": "0.12.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "uri"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.11.0"
+            },
+            {
+              "fixed": "0.11.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "uri"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.10.0.3"
             }
           ]
         }
@@ -61,6 +99,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/ruby/uri/commit/05b1e7d026b886e65a60ee35625229da9ec220bb"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ruby/uri/commit/38bf797c488bcb4a37fb322bfa84977981863ec6"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/ruby/uri/commit/3cd938df20db26c9439e9f681aadfb9bbeb6d1c0"
     },
     {
@@ -69,7 +115,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/ruby/uri/commit/70794abc162bb15bb934713b5669713d6700d35c"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/ruby/uri/commit/7e33934c91b7f8f3ea7b7a4258b468e19f636bc3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ruby/uri/commit/9a8e0cc03da964054c2a4ea26b59c53c3bae4921"
     },
     {
       "type": "WEB",
@@ -85,11 +139,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20230725-0002"
+      "url": "https://security.netapp.com/advisory/ntap-20230725-0002/"
     },
     {
       "type": "WEB",
-      "url": "https://www.ruby-lang.org/en/news/2023/06/29/redos-in-uri-CVE-2023-36617"
+      "url": "https://www.ruby-lang.org/en/news/2023/06/29/redos-in-uri-CVE-2023-36617/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
It appears that versions 0.10.0.3 and 0.11.2 of the `uri` Ruby library contain the same fix as 0.10.3 and 0.12.2, even though the only the latter two are mentioned in the Ruby advisory. I've suggested additions to the References section of this advisory to list the commits included in the 0.10.0.3 and 0.11.2 releases that correspond to the already listed commits for 0.10.3 and 0.12.2--they seem to match exactly. I've also suggested updates to the listed affected and patched versions.

Note: The maintainers of the Ruby Advisory Database repository seem to have independently concluded that 0.10.0.3 and 0.11.2 include the fix for this vulnerability. If you look at https://github.com/rubysec/ruby-advisory-db/blob/master/gems/uri/CVE-2023-36617.yml (which was already listed as a reference in this advisory), the `patched_versions` section contains `"~> 0.10.0.3"` and `"~> 0.11.2"`, which are equivalent to `">= 0.10.0.3, < 0.10.1"` and  `">= 0.11.2, < 0.12"` respectively. The pull request that added the advisory (https://github.com/rubysec/ruby-advisory-db/pull/665) shows that the initial commit included only 0.10.3 and 0.12.2, but then 0.10.0.3 and 0.11.2 were added in a follow-up commit.