### PR TITLE
[GHSA-c2cp-3xj9-97w9] Denial of service in Spring Security OAuth

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-c2cp-3xj9-97w9/GHSA-c2cp-3xj9-97w9.json
+++ b/advisories/github-reviewed/2022/04/GHSA-c2cp-3xj9-97w9/GHSA-c2cp-3xj9-97w9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c2cp-3xj9-97w9",
-  "modified": "2022-05-04T03:52:42Z",
+  "modified": "2023-01-27T05:02:52Z",
   "published": "2022-04-22T00:00:33Z",
   "aliases": [
     "CVE-2022-22969"
@@ -18,29 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.springframework.security.oauth:spring-security-oauth-parent"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.5.0"
-            },
-            {
-              "fixed": "2.5.2.RELEASE"
-            }
-          ]
-        }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 2.5.1.RELEASE"
-      }
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.springframework.security.oauth:spring-security-oauth"
+        "name": "org.springframework.security.oauth:spring-security-oauth2"
       },
       "ranges": [
         {
@@ -64,6 +42,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-22969"
+    },
+    {
+      "type": "WEB",
+      "url": "https://spring.io/security/cve-2022-22969"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The parent POM (org.springframework.security.oauth:spring-security-oauth-parent) does not contain any binaries and is unaffected. The official security vulnerability reported by Spring (https://spring.io/security/cve-2022-22969) states that their oauth2 library is affected, not their oauth1 library. This advisory was referring to the wrong library.