### PR TITLE
Add table of custom database_specific values to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ The syntax of GHSA IDs follows this format: `GHSA-xxxx-xxxx-xxxx` where
 You can validate a GHSA ID using a regular expression:
 `/GHSA(-[23456789cfghjmpqrvwx]{4}){3}/`
 
+## `database_specific` Values
+
+The OSV Schema supports several `database_specific` JSON object fields that are used to add context to various other parts of the OSV schema, namely an [affected package](https://ossf.github.io/osv-schema/#affecteddatabase_specific-field), a package's [affected ranges](https://ossf.github.io/osv-schema/#affectedrangesdatabase_specific-field), and the [vulnerability](https://ossf.github.io/osv-schema/#database_specific-field) as a whole. Per the spec, these fields are used for holding additional information about the package, range, or vulnerability "as defined by the database from which the record was obtained." It additionally stipulates that the meaning and format of these custom values "is entirely defined by the database [of record]" and outside of the scope of the OSV Schema itself.
+
+For its purposes, GitHub uses a number of `database_specific` values in its OSV files. They are used primarily in support of [Community Contributions](#contributions) and are intended for internal use only unless otherwise specified. These values and their format are subject to change without notice. Consuming systems should not rely on them for processing vulnerability information.
+
+| **Scope** | **Field** | **Purpose** |
+|---|---|---|
+| vulnerability | `severity` | The OSV schema supports quantitative severity scores such as CVSS. GitHub additionally assigns each vulnerability a non-quantitative human-readable severity value. |
+| vulnerability | `cwe_ids` | GitHub assigns each vulnerability at least one Common Weakness Enumeration (CWE) as part of its vulnerability curation process. These IDs map directly to CWE IDs tracked in the [CWE Database](https://cwe.mitre.org/). |
+| vulnerability | `github_reviewed` | Whether a vulnerability has been reviewed by one of GitHub's security researchers. |
+| vulnerability | `github_reviewed_at` | The timestamp of the last review by a GitHub security researcher. |
+| range | `last_known_affected_version_range` | The OSV schema does not have native support for all of the potential ways GitHub represents vulnerabile version ranges internally. It is used to track version range information that is not representable in OSV format, or that GitHub needs to be able to track separately from the OSV ranges. This field may appear in addition to or in place of OSV affected range events. See [this comment](https://github.com/github/advisory-database/issues/470#issuecomment-1998604377) a technical explanation. |
+
 ## FAQ
 
 ### Who reviews the pull requests? 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For its purposes, GitHub uses a number of `database_specific` values in its OSV 
 |---|---|---|
 | vulnerability | `severity` | The OSV schema supports quantitative severity scores such as CVSS. GitHub additionally assigns each vulnerability a non-quantitative human-readable severity value. |
 | vulnerability | `cwe_ids` | GitHub assigns each vulnerability at least one Common Weakness Enumeration (CWE) as part of its vulnerability curation process. These IDs map directly to CWE IDs tracked in the [CWE Database](https://cwe.mitre.org/). |
-| vulnerability | `github_reviewed` | Whether a vulnerability has been reviewed by one of GitHub's security researchers. |
+| vulnerability | `github_reviewed` | Whether a vulnerability has been reviewed by one of GitHub's Security Curators. |
 | vulnerability | `github_reviewed_at` | The timestamp of the last review by a GitHub security researcher. |
 | range | `last_known_affected_version_range` | The OSV schema does not have native support for all of the potential ways GitHub represents vulnerabile version ranges internally. It is used to track version range information that is not representable in OSV format, or that GitHub needs to be able to track separately from the OSV ranges. This field may appear in addition to or in place of OSV affected range events. See [this comment](https://github.com/github/advisory-database/issues/470#issuecomment-1998604377) a technical explanation. |
 


### PR DESCRIPTION
This PR updates the README in the root of the project to include information about OSV's `database_specific` fields and how GitHub uses them in its OSV files.

[Rendered preview](https://github.com/github/advisory-database/blob/chrisbloom7/database-specific-values-readme/README.md#database_specific-values)