### PR TITLE
[GHSA-xc9x-jj77-9p9j] Nokogiri update packaged libxml2 to v2.12.5 to resolve CVE-2024-25062

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-xc9x-jj77-9p9j/GHSA-xc9x-jj77-9p9j.json
+++ b/advisories/github-reviewed/2024/02/GHSA-xc9x-jj77-9p9j/GHSA-xc9x-jj77-9p9j.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xc9x-jj77-9p9j",
-  "modified": "2024-02-05T20:22:56Z",
+  "modified": "2024-02-05T20:22:57Z",
   "published": "2024-02-05T20:22:56Z",
   "aliases": [
 
   ],
-  "summary": "Nokogiri update packaged libxml2 to v2.12.5 to resolve CVE-2024-25062",
+  "summary": "Nokogiri update packaged libxml2 to v2.12.5 and v2.11.7 to resolve CVE-2024-25062",
   "details": "## Summary\n\nNokogiri v1.16.2 upgrades the version of its dependency libxml2 to [v2.12.5](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.5).\n\nlibxml2 v2.12.5 addresses the following vulnerability:\n\n- CVE-2024-25062 / https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-25062\n  - described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/604\n  - patched by https://gitlab.gnome.org/GNOME/libxml2/-/commit/92721970\n\nPlease note that this advisory only applies to the CRuby implementation of Nokogiri `< 1.16.2`, and only if the _packaged_ libraries are being used. If you've overridden defaults at installation time to use _system_ libraries instead of packaged libraries, you should instead pay attention to your distro's `libxml2` release announcements.\n\n## Mitigation\n\nUpgrade to Nokogiri `>= 1.16.2`.\n\nUsers who are unable to upgrade Nokogiri may also choose a more complicated mitigation: compile and link Nokogiri against external libraries libxml2 `>= 2.12.5` which will also address these same issues.\n\n## Impact\n\nFrom the CVE description, this issue applies to the `xmlTextReader` module (which underlies `Nokogiri::XML::Reader`):\n\n> When using the XML Reader interface with DTD validation and XInclude expansion enabled, processing crafted XML documents can lead to an xmlValidatePopElement use-after-free.\n\n## Timeline\n\n- 2024-02-04 10:35 EST - this GHSA is drafted without complete details about when the upstream issue was introduced; a request is made of libxml2 maintainers for more detailed information\n- 2024-02-04 10:48 EST - updated GHSA to reflect libxml2 maintainers' confirmation of affected versions\n- 2024-02-04 11:54 EST - v1.16.2 published, this GHSA made public\n- 2024-02-05 10:18 EST - updated with MITRE link to the CVE information, and updated \"Impact\" section",
   "severity": [
 
@@ -22,10 +22,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.16.0.rc1"
             },
             {
               "fixed": "1.16.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "nokogiri"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.15.6"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
> This security release is a backport to the unsupported v1.15.x branch. Current stable is v1.16.x, which addressed the referenced CVE in v1.16.2 on 2024-02-04.

https://github.com/sparklemotion/nokogiri/releases/tag/v1.15.6
https://groups.google.com/g/ruby-security-ann/c/hh2jc5ef3aI/m/ZNuHuhVoAAAJ?utm_medium=email&utm_source=footer&pli=1