### PR TITLE
[GHSA-5fxj-whcv-crrc] Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-5fxj-whcv-crrc/GHSA-5fxj-whcv-crrc.json
+++ b/advisories/github-reviewed/2024/03/GHSA-5fxj-whcv-crrc/GHSA-5fxj-whcv-crrc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5fxj-whcv-crrc",
-  "modified": "2024-03-14T21:48:56Z",
+  "modified": "2024-03-14T21:48:59Z",
   "published": "2024-03-12T20:07:59Z",
   "aliases": [
     "CVE-2024-21392"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.0"
             },
             {
               "fixed": "7.0.17"
@@ -69,7 +69,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.0"
             },
             {
               "fixed": "7.0.17"
@@ -113,7 +113,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.0"
             },
             {
               "fixed": "7.0.17"
@@ -157,7 +157,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.0"
             },
             {
               "fixed": "7.0.17"
@@ -201,7 +201,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.0"
             },
             {
               "fixed": "7.0.17"
@@ -267,7 +267,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.0"
             },
             {
               "fixed": "7.0.17"
@@ -289,7 +289,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.0"
             },
             {
               "fixed": "7.0.17"
@@ -355,7 +355,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.0"
             },
             {
               "fixed": "7.0.17"
@@ -377,7 +377,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.0"
             },
             {
               "fixed": "7.0.17"
@@ -421,7 +421,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.0"
             },
             {
               "fixed": "7.0.17"
@@ -509,7 +509,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.0"
             },
             {
               "fixed": "7.0.17"
@@ -531,7 +531,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.0"
             },
             {
               "fixed": "7.0.17"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
We have had confirmation from Microsoft that this CVE does not affect .NET 6 therefore the affected versions should only be limited to 7.0.0 to 7.0.16 for .NET 7 instead of the open ended <=7.0.16.  This CVE is currently showing as a High vulnerability on .NET 6 images using Docker Scout and Trivy.