### PR TITLE
[GHSA-3gv7-3h64-78cm] Exposure of Sensitive Information to an Unauthorized Actor in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-3gv7-3h64-78cm/GHSA-3gv7-3h64-78cm.json
+++ b/advisories/github-reviewed/2022/05/GHSA-3gv7-3h64-78cm/GHSA-3gv7-3h64-78cm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3gv7-3h64-78cm",
-  "modified": "2024-02-22T21:49:53Z",
+  "modified": "2024-02-22T21:49:55Z",
   "published": "2022-05-14T01:10:16Z",
   "aliases": [
     "CVE-2017-5647"
@@ -72,13 +72,13 @@
               "introduced": "8.0.0"
             },
             {
-              "fixed": "8.0.42"
+              "fixed": "8.0.43"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 8.0.41"
+        "last_known_affected_version_range": "<= 8.0.42"
       }
     },
     {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
as per refernce issue is fixed in  8.0.43 which is deviating from the advisory. the commit provided for 8.x also matches the same data
https://tomcat.apache.org/security-8.html#Fixed_in_Apache_Tomcat_8.0.43