### PR TITLE
[GHSA-5gg7-5wv8-4gcj] Undertow Request Smuggling vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-5gg7-5wv8-4gcj/GHSA-5gg7-5wv8-4gcj.json
+++ b/advisories/github-reviewed/2022/05/GHSA-5gg7-5wv8-4gcj/GHSA-5gg7-5wv8-4gcj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5gg7-5wv8-4gcj",
-  "modified": "2022-11-08T12:39:25Z",
+  "modified": "2023-01-29T05:03:44Z",
   "published": "2022-05-13T01:38:14Z",
   "aliases": [
     "CVE-2017-12165"
@@ -83,7 +83,23 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/undertow-io/undertow/commit/1e72647818c9fb31b693a953b1ae595a6c82eb7f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/undertow-io/undertow/commit/5b008b7ac312c6cdb76679ff58c43620bb79d44f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/undertow-io/undertow/commit/691440ee58259fba76711b60d56dde6679808bdc"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2017-12165"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/undertow-io/undertow"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
added fix commits for respective versions.
1.3.31 https://github.com/undertow-io/undertow/commit/691440ee58259fba76711b60d56dde6679808bdc,
1.4.17 https://github.com/undertow-io/undertow/commit/5b008b7ac312c6cdb76679ff58c43620bb79d44f
2.0.0.Beta1 -https://github.com/undertow-io/undertow/commit/1e72647818c9fb31b693a953b1ae595a6c82eb7f

added Source Code Location