### PR TITLE
[GHSA-78hx-gp6g-7mj6] Memory leaks in code encrypting and verifying RSA payloads

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-78hx-gp6g-7mj6/GHSA-78hx-gp6g-7mj6.json
+++ b/advisories/github-reviewed/2024/03/GHSA-78hx-gp6g-7mj6/GHSA-78hx-gp6g-7mj6.json
@@ -66,11 +66,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.0.0"
+              "fixed": "2.0.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.0.0"
+      }
     },
     {
       "package": {
@@ -85,11 +88,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.2.8"
+              "fixed": "0.2.9"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.2.8"
+      }
     }
   ],
   "references": [
@@ -102,8 +108,20 @@
       "url": "https://github.com/golang-fips/openssl/commit/85d31d0d257ce842c8a1e63c4d230ae850348136"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/microsoft/go-crypto-openssl/commit/104fe7f6912788d2ad44602f77a0a0a62f1f259f"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/golang-fips/openssl"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/golang-fips/openssl/releases/tag/v2.0.1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/microsoft/go-crypto-openssl/releases/tag/v0.2.9"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
added fix commit for github.com/microsoft/go-crypto-openssl
release note
updated fix versions