### PR TITLE
[GHSA-wjxj-5m7g-mg7q] Bouncy Castle Denial of Service (DoS)

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-wjxj-5m7g-mg7q/GHSA-wjxj-5m7g-mg7q.json
+++ b/advisories/github-reviewed/2023/11/GHSA-wjxj-5m7g-mg7q/GHSA-wjxj-5m7g-mg7q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wjxj-5m7g-mg7q",
-  "modified": "2024-03-14T22:03:16Z",
+  "modified": "2024-03-14T22:03:17Z",
   "published": "2023-11-23T18:30:33Z",
   "aliases": [
     "CVE-2023-33202"
@@ -64,13 +64,13 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "1.73"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.70"
+      }
     },
     {
       "package": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The maximum version for that dependency (bcprov-jdk15on) is 1.70; there is no 1.73
https://central.sonatype.com/artifact/org.bouncycastle/bcprov-jdk15on/versions