### PR TITLE
[GHSA-hvpq-7vcc-5hj5] Froala Editor Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-hvpq-7vcc-5hj5/GHSA-hvpq-7vcc-5hj5.json
+++ b/advisories/github-reviewed/2023/09/GHSA-hvpq-7vcc-5hj5/GHSA-hvpq-7vcc-5hj5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hvpq-7vcc-5hj5",
-  "modified": "2023-09-20T21:32:13Z",
+  "modified": "2023-11-08T05:04:40Z",
   "published": "2023-09-15T00:30:29Z",
   "aliases": [
     "CVE-2023-41592"
@@ -28,13 +28,35 @@
               "introduced": "4.0.1"
             },
             {
-              "fixed": "4.1.2"
+              "fixed": "4.1.4"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 4.1.1"
+        "last_known_affected_version_range": "<= 4.1.3"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "froala-editor"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.0.1"
+            },
+            {
+              "fixed": "4.1.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.1.3"
       }
     }
   ],
@@ -53,15 +75,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://hacker.soarescorp.com/cve/2023-41592"
+      "url": "https://hacker.soarescorp.com/cve/2023-41592/"
     },
     {
       "type": "WEB",
-      "url": "https://owasp.org/Top10/A03_2021-Injection"
+      "url": "https://owasp.org/Top10/A03_2021-Injection/"
     },
     {
       "type": "WEB",
-      "url": "https://owasp.org/www-project-top-ten"
+      "url": "https://owasp.org/www-project-top-ten/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The changelog page for the package says it was fixed in 4.1.4: https://froala.com/wysiwyg-editor/changelog/#4.1.4
froala-editor is also available as an npm package, but this was missing from the advisory: https://www.npmjs.com/package/froala-editor