### PR TITLE
[GHSA-99cv-8cvv-666c] Apache Airflow vulnerable to Stored XSS

### DIFF
--- a/advisories/github-reviewed/2019/03/GHSA-99cv-8cvv-666c/GHSA-99cv-8cvv-666c.json
+++ b/advisories/github-reviewed/2019/03/GHSA-99cv-8cvv-666c/GHSA-99cv-8cvv-666c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-99cv-8cvv-666c",
-  "modified": "2023-08-30T23:03:48Z",
+  "modified": "2023-08-30T23:03:49Z",
   "published": "2019-03-06T17:35:58Z",
   "aliases": [
     "CVE-2018-20244"
@@ -41,8 +41,20 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-20244"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/27a4a888e946728d9bb33b78ec604e08d4a93f89"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/3ff94c7da60fbb24bf99eb6192c7386e8ab4c4c9"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-99cv-8cvv-666c"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/airflow"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add patch links related to CVE-2018-20244.