### PR TITLE
[GHSA-77rc-x84q-pv4f] Improper Certificate Validation in Apache Airflow

### DIFF
--- a/advisories/github-reviewed/2019/01/GHSA-77rc-x84q-pv4f/GHSA-77rc-x84q-pv4f.json
+++ b/advisories/github-reviewed/2019/01/GHSA-77rc-x84q-pv4f/GHSA-77rc-x84q-pv4f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-77rc-x84q-pv4f",
-  "modified": "2022-09-14T22:41:33Z",
+  "modified": "2023-01-09T05:03:57Z",
   "published": "2019-01-25T16:19:19Z",
   "aliases": [
     "CVE-2018-20245"
@@ -41,8 +41,24 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-20245"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/28abf87bd173cc4cedc57f553118470e5745a968"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/66d0d05ea0802aec407e0ef5435a962080db0926"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/d8d0e8c59203f793f81d47d5adb1362df0b5d8d1"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-77rc-x84q-pv4f"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/airflow"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add patch links related to CVE-2018-20245 which fixed in multi-branches.