### PR TITLE
[GHSA-w6j4-3gh2-9f5j] Apache Airflow vulnerable to CSRF Attacks

### DIFF
--- a/advisories/github-reviewed/2019/04/GHSA-w6j4-3gh2-9f5j/GHSA-w6j4-3gh2-9f5j.json
+++ b/advisories/github-reviewed/2019/04/GHSA-w6j4-3gh2-9f5j/GHSA-w6j4-3gh2-9f5j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w6j4-3gh2-9f5j",
-  "modified": "2023-08-30T23:11:45Z",
+  "modified": "2023-08-30T23:11:46Z",
   "published": "2019-04-18T14:27:40Z",
   "aliases": [
     "CVE-2019-0229"
@@ -39,6 +39,22 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-0229"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/267e363c1a8c2f8a437bf6c2b8f736a2aa0eaa76"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/63abfe09372fb02316a77e59e79ba831a12a33f0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/6c4b2ba9bab6b11cd2a2b91afebd6d9886c71ad0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/fa4eb04ad35dd257f7e41f7e8a9bca361cb2004c"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch links related to CVE-2019-0229 which fixed in multi-branches.