### PR TITLE
[GHSA-q3p4-gw7r-wqjc] Apache Airflow vulnerable to XSS and local file disclosure

### DIFF
--- a/advisories/github-reviewed/2019/11/GHSA-q3p4-gw7r-wqjc/GHSA-q3p4-gw7r-wqjc.json
+++ b/advisories/github-reviewed/2019/11/GHSA-q3p4-gw7r-wqjc/GHSA-q3p4-gw7r-wqjc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q3p4-gw7r-wqjc",
-  "modified": "2023-08-30T22:38:05Z",
+  "modified": "2023-08-30T22:38:06Z",
   "published": "2019-11-22T13:45:22Z",
   "aliases": [
     "CVE-2019-12417"
@@ -39,6 +39,26 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-12417"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/c082065f3be07e1c5f39bb86e2b4a06413238631"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/caf1f264b845153b9a61b00b1a57acb7c320e743"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/edbb4d90edebddd2168b7186216692bae59f8c84"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/fed0d0ee10275c5b0fccdb44a077dfa1f364acb6"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/airflow"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add patch links related to CVE-2019-12417 which fixed in multi-branches.