### PR TITLE
[GHSA-976r-qfjj-c24w] Command injection via Celery broker in Apache Airflow

### DIFF
--- a/advisories/github-reviewed/2020/07/GHSA-976r-qfjj-c24w/GHSA-976r-qfjj-c24w.json
+++ b/advisories/github-reviewed/2020/07/GHSA-976r-qfjj-c24w/GHSA-976r-qfjj-c24w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-976r-qfjj-c24w",
-  "modified": "2021-09-22T21:16:56Z",
+  "modified": "2023-08-30T21:44:46Z",
   "published": "2020-07-27T16:57:33Z",
   "aliases": [
     "CVE-2020-11981"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "apache-airflow"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "airflow.www_rbac.views.Airflow.index"
-        ]
       },
       "ranges": [
         {
@@ -47,7 +42,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/1dda6fdde7c6bcaf0d6534786beeeba868006dd2"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/airflow/commit/afa4b11fddfdbadb048f742cf66d5c21c675a5c8"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/airflow"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add patch link related to CVE-2020-11981.