### PR TITLE
[GHSA-9g2w-5f3v-mfmm] Insecure default config of Celery worker in Apache Airflow

### DIFF
--- a/advisories/github-reviewed/2020/07/GHSA-9g2w-5f3v-mfmm/GHSA-9g2w-5f3v-mfmm.json
+++ b/advisories/github-reviewed/2020/07/GHSA-9g2w-5f3v-mfmm/GHSA-9g2w-5f3v-mfmm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9g2w-5f3v-mfmm",
-  "modified": "2021-09-22T21:19:02Z",
+  "modified": "2023-01-09T05:03:46Z",
   "published": "2020-07-27T16:57:33Z",
   "aliases": [
     "CVE-2020-11982"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-11982"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/e91ecbea1b2daa0e243e1a2cfb30f1448d623aab"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/airflow"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add patch link related to CVE-2020-11982.