### PR TITLE
[GHSA-fh37-cx83-q542] Improper Authentication in Apache Airflow

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-fh37-cx83-q542/GHSA-fh37-cx83-q542.json
+++ b/advisories/github-reviewed/2021/06/GHSA-fh37-cx83-q542/GHSA-fh37-cx83-q542.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fh37-cx83-q542",
-  "modified": "2021-05-07T21:48:45Z",
+  "modified": "2023-01-27T05:02:46Z",
   "published": "2021-06-18T18:30:11Z",
   "aliases": [
     "CVE-2021-26697"
@@ -46,6 +46,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/commit/21cedff205e7d62675949fda2aa4616d77232b76"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/24a54242d56058846c7978130b3f37ca045d5142"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/93957e917ff4cfb0be11aef088bd9527cf728a04"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/airflow"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add patch links related to CVE-2021-26697 which fixed in multi-branches.