### PR TITLE
[GHSA-m6h2-jx9v-58w6] Missing Authorization in Apache Airflow

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-m6h2-jx9v-58w6/GHSA-m6h2-jx9v-58w6.json
+++ b/advisories/github-reviewed/2021/08/GHSA-m6h2-jx9v-58w6/GHSA-m6h2-jx9v-58w6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m6h2-jx9v-58w6",
-  "modified": "2021-08-26T15:44:06Z",
+  "modified": "2023-01-31T05:05:33Z",
   "published": "2021-08-30T16:25:57Z",
   "aliases": [
     "CVE-2021-35936"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-35936"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/27265516d2b897585f5019ecd820cfe5471fd351"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/d772f38f843b9add5319a01cf51a844145b01f63"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch links related to CVE-2021-35936.