### PR TITLE
[GHSA-q8h9-pqcx-59hw] Apache Airflow exposes arbitrary file content

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-q8h9-pqcx-59hw/GHSA-q8h9-pqcx-59hw.json
+++ b/advisories/github-reviewed/2022/09/GHSA-q8h9-pqcx-59hw/GHSA-q8h9-pqcx-59hw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q8h9-pqcx-59hw",
-  "modified": "2022-09-16T17:13:45Z",
+  "modified": "2023-01-31T05:03:54Z",
   "published": "2022-09-03T00:00:25Z",
   "aliases": [
     "CVE-2022-38170"
@@ -39,6 +39,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-38170"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/bf01d10cd348e679916034de1befb79ec6e46ff8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/c14ea8f0f34944d2ecfa9021d167602e8b2b8b90"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch links related to CVE-2022-38170.