### PR TITLE
[GHSA-6pw3-8h9w-32gc] Apache Airflow vulnerable to OS Command Injection via example DAGs

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-6pw3-8h9w-32gc/GHSA-6pw3-8h9w-32gc.json
+++ b/advisories/github-reviewed/2022/11/GHSA-6pw3-8h9w-32gc/GHSA-6pw3-8h9w-32gc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6pw3-8h9w-32gc",
-  "modified": "2022-11-16T21:51:08Z",
+  "modified": "2023-08-31T00:35:10Z",
   "published": "2022-11-14T12:00:15Z",
   "aliases": [
     "CVE-2022-40127"
@@ -46,7 +46,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/2bbb94897b0998c75192f97fda7f778ff709b65b"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/airflow/commit/372e699c2d1e11f7087b5340454d0a0a6a56fbf5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/b7e8d3ad3bd22e57529d82e1a9033b6d9f843b75"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch links related to CVE-2022-40127.