### PR TITLE
[GHSA-4fg5-j4mm-wfpg] Apache Airflow contains open redirect

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-4fg5-j4mm-wfpg/GHSA-4fg5-j4mm-wfpg.json
+++ b/advisories/github-reviewed/2022/09/GHSA-4fg5-j4mm-wfpg/GHSA-4fg5-j4mm-wfpg.json
@@ -46,7 +46,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/471ff463be8812efcebcba4e430631f255f74f26"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/apache/airflow/commit/56e7555c42f013f789a4b718676ff09b4a9d5135"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/airflow"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add more patch links related to CVE-2022-40754 which fixed in multi-branches.