### PR TITLE
[GHSA-6xwf-xvf3-v459] Apache Airflow: Incorrect Default Permissions in audit logs for Ops and Viewers users

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-6xwf-xvf3-v459/GHSA-6xwf-xvf3-v459.json
+++ b/advisories/github-reviewed/2024/03/GHSA-6xwf-xvf3-v459/GHSA-6xwf-xvf3-v459.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6xwf-xvf3-v459",
-  "modified": "2024-03-01T21:40:55Z",
+  "modified": "2024-03-01T21:40:56Z",
   "published": "2024-03-01T12:30:53Z",
   "aliases": [
     "CVE-2024-26280"
@@ -40,6 +40,34 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/pull/37501"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/1a96407cd2d76616c1137de288f092d4f3b097fa"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/7f10998c17ab9d725bc8671deb4c12d672bfba99"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/8324c87e05741e5a673c43b315619a3788bacc2e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/8463ee4f25114a6c5fb2408d6026afe94bdf106d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/e29e833e976cb250fad2968ba41b6f9b0ad4a87a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/f2ea8a3e1753012bfe0d529c9c8be66cf55ca28f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/f4b9cc74976b7df1acbc3c63471b5751b3e2c40c"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch links related to CVE-2024-26280 which fixed in multi-branches.