### PR TITLE
[GHSA-6v6w-h8m6-7mv2] Apache Airflow: DAG Code and Import Error Permissions Ignored

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-6v6w-h8m6-7mv2/GHSA-6v6w-h8m6-7mv2.json
+++ b/advisories/github-reviewed/2024/02/GHSA-6v6w-h8m6-7mv2/GHSA-6v6w-h8m6-7mv2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6v6w-h8m6-7mv2",
-  "modified": "2024-02-29T23:27:11Z",
+  "modified": "2024-02-29T23:27:12Z",
   "published": "2024-02-29T12:31:06Z",
   "aliases": [
     "CVE-2024-27906"
@@ -47,6 +47,42 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/pull/37468"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/08d25607abe8593ecb90a84e338896bb79692d7b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/0a95299691e2d6a9b874adfae94d246a7f681ec9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/2adbe882e68df0e2b1084bc869616bb01e416aa7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/2cb6027280bcf5e2b561f3ee7f55980f6ec4cc3a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/90255d9d44a649025f588497f6c82177dad48326"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/9c4defa08268322b9db80123a22d7b56b2063446"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/a7fa258ba1c69a18e0f620499625f6026768dc24"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/bc2646be043f71b4d1ab7eefd2af65a60bf919f2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/d944eb0de216d9e1d125fae5ce4af7440154deb4"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch links related to CVE-2024-27906 which fixed in multi-branches.