### PR TITLE
[GHSA-h574-6646-vfxx] Apache Airflow: Ignored Airflow Permission

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-h574-6646-vfxx/GHSA-h574-6646-vfxx.json
+++ b/advisories/github-reviewed/2024/03/GHSA-h574-6646-vfxx/GHSA-h574-6646-vfxx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h574-6646-vfxx",
-  "modified": "2024-03-15T14:19:23Z",
+  "modified": "2024-03-15T14:19:24Z",
   "published": "2024-03-14T09:31:05Z",
   "aliases": [
     "CVE-2024-28746"
@@ -44,6 +44,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/airflow/commit/89e7f3e7bdf2126bbbcd959dc10d65ef92773cca"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/a233ffba4d30746c1c9cc82ab525c56f0f1d16fc"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/a7b888240ace445b7c963ece75e847343ed9ffe0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/airflow/commit/bea6ff58e17e0f57293c7628a4e7430bf81e9dfd"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch links related to CVE-2024-28746 which fixed in multi-branches.