### PR TITLE
[GHSA-6mx3-3vqg-hpp2] Django allows unprivileged users to read the password hashes of arbitrary accounts

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-6mx3-3vqg-hpp2/GHSA-6mx3-3vqg-hpp2.json
+++ b/advisories/github-reviewed/2018/10/GHSA-6mx3-3vqg-hpp2/GHSA-6mx3-3vqg-hpp2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6mx3-3vqg-hpp2",
-  "modified": "2023-09-05T18:37:43Z",
+  "modified": "2023-09-05T18:37:45Z",
   "published": "2018-10-03T20:07:39Z",
   "aliases": [
     "CVE-2018-16984"
@@ -41,12 +41,20 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-16984"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/bf39978a53f117ca02e9a0c78b76664a41a54745"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-6mx3-3vqg-hpp2"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/django/django"
+    },
+    {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20190502-0009"
+      "url": "https://security.netapp.com/advisory/ntap-20190502-0009/"
     },
     {
       "type": "WEB",
@@ -54,7 +62,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.djangoproject.com/weblog/2018/oct/01/security-release"
+      "url": "https://www.djangoproject.com/weblog/2018/oct/01/security-release/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add patch link related to CVE-2018-16984.