### PR TITLE
[GHSA-8x94-hmjh-97hq] Django vulnerable to Reflected File Download attack 

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-8x94-hmjh-97hq/GHSA-8x94-hmjh-97hq.json
+++ b/advisories/github-reviewed/2022/08/GHSA-8x94-hmjh-97hq/GHSA-8x94-hmjh-97hq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8x94-hmjh-97hq",
-  "modified": "2022-09-16T21:38:06Z",
+  "modified": "2023-04-28T20:08:09Z",
   "published": "2022-08-11T14:49:12Z",
   "aliases": [
     "CVE-2022-36359"
@@ -52,44 +52,6 @@
           ]
         }
       ]
-    },
-    {
-      "package": {
-        "ecosystem": "PyPI",
-        "name": "django"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.2"
-            },
-            {
-              "fixed": "3.2.15"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "PyPI",
-        "name": "django"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "4.0"
-            },
-            {
-              "fixed": "4.0.7"
-            }
-          ]
-        }
-      ]
     }
   ],
   "references": [
@@ -99,7 +61,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://docs.djangoproject.com/en/4.0/releases/security"
+      "url": "https://github.com/django/django/commit/bd062445cffd3f6cc6dcd20d13e2abed818fa173"
+    },
+    {
+      "type": "WEB",
+      "url": "https://docs.djangoproject.com/en/4.0/releases/security/"
     },
     {
       "type": "ADVISORY",
@@ -119,15 +85,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HWY6DQWRVBALV73BPUVBXC3QIYUM24IK"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HWY6DQWRVBALV73BPUVBXC3QIYUM24IK/"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LTZVAKU5ALQWOKFTPISE257VCVIYGFQI"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LTZVAKU5ALQWOKFTPISE257VCVIYGFQI/"
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20220915-0008"
+      "url": "https://security.netapp.com/advisory/ntap-20220915-0008/"
     },
     {
       "type": "WEB",
@@ -135,7 +101,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.djangoproject.com/weblog/2022/aug/03/security-releases"
+      "url": "https://www.djangoproject.com/weblog/2022/aug/03/security-releases/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch link related to CVE-2022-36359.