### PR TITLE
[GHSA-qrw5-5h28-6cmg] Django denial-of-service vulnerability in internationalized URLs

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-qrw5-5h28-6cmg/GHSA-qrw5-5h28-6cmg.json
+++ b/advisories/github-reviewed/2022/10/GHSA-qrw5-5h28-6cmg/GHSA-qrw5-5h28-6cmg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qrw5-5h28-6cmg",
-  "modified": "2023-09-05T20:17:54Z",
+  "modified": "2023-09-05T20:17:57Z",
   "published": "2022-10-16T12:00:23Z",
   "aliases": [
     "CVE-2022-41323"
@@ -84,7 +84,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://docs.djangoproject.com/en/4.0/releases/security"
+      "url": "https://github.com/django/django/commit/e5ea2842941967f06cefa10865f303b39c95279f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://docs.djangoproject.com/en/4.0/releases/security/"
     },
     {
       "type": "PACKAGE",
@@ -100,31 +104,31 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/FKYVMMR7RPM6AHJ2SBVM2LO6D3NGFY7B"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/FKYVMMR7RPM6AHJ2SBVM2LO6D3NGFY7B/"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HWY6DQWRVBALV73BPUVBXC3QIYUM24IK"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HWY6DQWRVBALV73BPUVBXC3QIYUM24IK/"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LTZVAKU5ALQWOKFTPISE257VCVIYGFQI"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LTZVAKU5ALQWOKFTPISE257VCVIYGFQI/"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VZS4G6NSZWPTVXMMZHJOJVQEPL3QTO77"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VZS4G6NSZWPTVXMMZHJOJVQEPL3QTO77/"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/YJB6FUBBLVKKG655UMTLQNN6UQ6EDLSP"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/YJB6FUBBLVKKG655UMTLQNN6UQ6EDLSP/"
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20221124-0001"
+      "url": "https://security.netapp.com/advisory/ntap-20221124-0001/"
     },
     {
       "type": "WEB",
-      "url": "https://www.djangoproject.com/weblog/2022/oct/04/security-releases"
+      "url": "https://www.djangoproject.com/weblog/2022/oct/04/security-releases/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch link related to CVE-2022-41323 which fixed in multi-branches.