### PR TITLE
[GHSA-7h4p-27mh-hmrw] Django Denial of service vulnerability in django.utils.encoding.uri_to_iri

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-7h4p-27mh-hmrw/GHSA-7h4p-27mh-hmrw.json
+++ b/advisories/github-reviewed/2023/11/GHSA-7h4p-27mh-hmrw/GHSA-7h4p-27mh-hmrw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7h4p-27mh-hmrw",
-  "modified": "2023-11-06T16:30:44Z",
+  "modified": "2023-12-23T05:04:32Z",
   "published": "2023-11-03T06:36:29Z",
   "aliases": [
     "CVE-2023-41164"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "django"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "django.utils.encoding.uri_to_iri"
-        ]
       },
       "ranges": [
         {
@@ -44,11 +39,6 @@
         "ecosystem": "PyPI",
         "name": "django"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "django.utils.encoding.uri_to_iri"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -67,11 +57,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "django"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "django.utils.encoding.uri_to_iri"
-        ]
       },
       "ranges": [
         {
@@ -95,6 +80,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/django/django/commit/3f41d6d62929dfe53eda8109b3b836f26645bdce"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/django/django/commit/6f030b1149bd8fa4ba90452e77cb3edc095ce54e"
     },
     {
@@ -107,7 +96,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://docs.djangoproject.com/en/4.2/releases/security"
+      "url": "https://docs.djangoproject.com/en/4.2/releases/security/"
     },
     {
       "type": "PACKAGE",
@@ -127,19 +116,19 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/HJFRPUHDYJHBH3KYHSPGULQM4JN7BMSU"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/HJFRPUHDYJHBH3KYHSPGULQM4JN7BMSU/"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HJFRPUHDYJHBH3KYHSPGULQM4JN7BMSU"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HJFRPUHDYJHBH3KYHSPGULQM4JN7BMSU/"
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20231214-0002"
+      "url": "https://security.netapp.com/advisory/ntap-20231214-0002/"
     },
     {
       "type": "WEB",
-      "url": "https://www.djangoproject.com/weblog/2023/sep/04/security-releases"
+      "url": "https://www.djangoproject.com/weblog/2023/sep/04/security-releases/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch related to CVE-2023-41164 which fixed in multi-branches.