### PR TITLE
[GHSA-jg32-8h6w-x7vg] Metabase open source before 0.46.6.1 and Metabase...

### DIFF
--- a/advisories/unreviewed/2023/07/GHSA-jg32-8h6w-x7vg/GHSA-jg32-8h6w-x7vg.json
+++ b/advisories/unreviewed/2023/07/GHSA-jg32-8h6w-x7vg/GHSA-jg32-8h6w-x7vg.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jg32-8h6w-x7vg",
-  "modified": "2024-02-15T18:30:39Z",
+  "modified": "2024-02-15T18:30:40Z",
   "published": "2023-07-21T15:30:32Z",
   "aliases": [
     "CVE-2023-38646"
   ],
+  "summary": "CVE-2023-38646 not listed on GHSA",
   "details": "Metabase open source before 0.46.6.1 and Metabase Enterprise before 1.46.6.1 allow attackers to execute arbitrary commands on the server, at the server's privilege level. Authentication is not required for exploitation. The other fixed versions are 0.45.4.1, 1.45.4.1, 0.44.7.1, 1.44.7.1, 0.43.7.2, and 1.43.7.2.",
   "severity": [
     {
@@ -14,7 +15,50 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "metabase.jar"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.45.4.1, 1.45.4.1, 0.44.7.1, 0.43.7.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 0.46.6.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "metabase.jar"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.44.7.1, 1.43.7.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.46.6.1"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Trivy is not detecting this vulnerability on vulnerable images. This is a very critical issue, allowing unauthenticated RCE on the Metabase host server.