### PR TITLE
[GHSA-cxjh-pqwp-8mfp] follow-redirects' Proxy-Authorization header kept across hosts

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-cxjh-pqwp-8mfp/GHSA-cxjh-pqwp-8mfp.json
+++ b/advisories/github-reviewed/2024/03/GHSA-cxjh-pqwp-8mfp/GHSA-cxjh-pqwp-8mfp.json
@@ -7,7 +7,7 @@
     "CVE-2024-28849"
   ],
   "summary": "follow-redirects' Proxy-Authorization header kept across hosts",
-  "details": "When using axios, its dependency library follow-redirects only clears authorization header during cross-domain redirect, but allows the proxy-authentication header which contains credentials too.\n\nSteps To Reproduce & PoC\n\naxios Test Code\n\nconst axios = require('axios');\n\naxios.get('http://127.0.0.1:10081/',{\n    headers: {\n        'AuThorization': 'Rear Test',\n        'ProXy-AuthoriZation': 'Rear Test',\n        'coOkie': 't=1'\n    }\n    }).then(function (response) {\n        console.log(response);\n})\nWhen I meet the cross-domain redirect, the sensitive headers like authorization and cookie are cleared, but proxy-authentication header is kept.\n\nRequest sent by axios\n\nimage-20240314130755052.png\nRequest sent by follow-redirects after redirectimage-20240314130809838.png\n\nImpact\n\nThis vulnerability may lead to credentials leak.\n\nRecommendations\n\nRemove proxy-authentication header during cross-domain redirect\nRecommended Patch\n\nfollow-redirects/index.js:464\n\nremoveMatchingHeaders(/^(?:authorization|cookie)$/i, this._options.headers);\nchange to\n\nremoveMatchingHeaders(/^(?:authorization|proxy-authorization|cookie)$/i, this._options.headers);\nRef\n\nhttps://fetch.spec.whatwg.org/#authentication-entries\nhttps://hackerone.com/reports/2390009",
+  "details": "When using [axios](https://github.com/axios/axios), its dependency follow-redirects only clears authorization header during cross-domain redirect, but allows the proxy-authentication header which contains credentials too.\n\n## Steps To Reproduce & PoC\n\nTest code:\n\n```js\nconst axios = require('axios');\n\naxios.get('http://127.0.0.1:10081/', {\n    headers: {\n        'AuThorization': 'Rear Test',\n        'ProXy-AuthoriZation': 'Rear Test',\n        'coOkie': 't=1'\n    }\n})\n    .then((response) => {\n        console.log(response);\n    })\n```\n\nWhen I meet the cross-domain redirect, the sensitive headers like authorization and cookie are cleared, but proxy-authentication header is kept.\n\n## Impact\n\nThis vulnerability may lead to credentials leak.\n\n## Recommendations\n\nRemove proxy-authentication header during cross-domain redirect\n\n### Recommended Patch\n\n[follow-redirects/index.js:464](https://github.com/follow-redirects/follow-redirects/commit/c4f847f85176991f95ab9c88af63b1294de8649b)\n\n```diff\n- removeMatchingHeaders(/^(?:authorization|cookie)$/i, this._options.headers);\n+ removeMatchingHeaders(/^(?:authorization|proxy-authorization|cookie)$/i, this._options.headers);\n```",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -66,10 +66,6 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/follow-redirects/follow-redirects"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VOIF4EPQUCKDBEVTGRQDZ3CGTYQHPO7Z"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Reformatted the advisory to be much more human readable, including hyperlinks and using code blocks where needed. Also, removed duplicated links and wording which are already specified in the references section.