### PR TITLE
[GHSA-q4mp-jvh2-76fj] Pillow subject to DoS via SAMPLESPERPIXEL tag

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-q4mp-jvh2-76fj/GHSA-q4mp-jvh2-76fj.json
+++ b/advisories/github-reviewed/2022/11/GHSA-q4mp-jvh2-76fj/GHSA-q4mp-jvh2-76fj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q4mp-jvh2-76fj",
-  "modified": "2022-11-16T21:52:35Z",
+  "modified": "2023-09-02T05:03:04Z",
   "published": "2022-11-14T12:00:15Z",
   "aliases": [
     "CVE-2022-45199"
@@ -19,12 +19,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "pillow"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "PIL.TiffImagePlugin.MAX_SAMPLESPERPIXEL",
-          "PIL.TiffImagePlugin.TiffImageFile._setup"
-        ]
       },
       "ranges": [
         {
@@ -52,7 +46,27 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/commit/00b25fd3ac3648bc28eff5d4c4d816e605e3f05f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/commit/05b175ef88c22f5c416bc9b8d5b897dea1abbf2c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/commit/0846bfae48513f2f51ca8547ed3b8954fa501fda"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/commit/13f2c5ae14901c89c38f898496102afd9daeaf6d"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/python-pillow/Pillow/commit/2444cddab2f83f28687c7c20871574acbb6dbcf3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/commit/799a6a01052cea3f417a571d7c64cd14acc18c64"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch link related to CVE-2022-45199 which fixed in multi-branches.