### PR TITLE
[GHSA-hr8g-f6r6-mr22] Buffer over-flow in Pillow

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-hr8g-f6r6-mr22/GHSA-hr8g-f6r6-mr22.json
+++ b/advisories/github-reviewed/2022/05/GHSA-hr8g-f6r6-mr22/GHSA-hr8g-f6r6-mr22.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hr8g-f6r6-mr22",
-  "modified": "2022-06-01T21:22:06Z",
+  "modified": "2023-01-27T05:01:57Z",
   "published": "2022-05-26T00:01:27Z",
   "aliases": [
     "CVE-2022-30595"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-30595"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/commit/c846cc881ebe34e3518412c2e3636433d9947280"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch link related to CVE-2022-30595.