### PR TITLE
[GHSA-xrcv-f9gm-v42c] Out-of-bounds Read in Pillow

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-xrcv-f9gm-v42c/GHSA-xrcv-f9gm-v42c.json
+++ b/advisories/github-reviewed/2022/01/GHSA-xrcv-f9gm-v42c/GHSA-xrcv-f9gm-v42c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xrcv-f9gm-v42c",
-  "modified": "2022-02-17T23:26:14Z",
+  "modified": "2023-09-04T16:45:20Z",
   "published": "2022-01-12T20:07:41Z",
   "aliases": [
     "CVE-2022-22816"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "Pillow"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "PIL.ImagePath.Path"
-        ]
       },
       "ranges": [
         {
@@ -52,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/python-pillow/Pillow/commit/5543e4e2d409cd9e409bc64cdc77be0af007a31f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/commit/c48271ab354db49cdbd740bc45e13be4f0f7993c"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch link related to CVE-2022-22816 which fixed in multi-branches.