### PR TITLE
[GHSA-q5hq-fp76-qmrc] Uncontrolled Resource Consumption in Pillow

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-q5hq-fp76-qmrc/GHSA-q5hq-fp76-qmrc.json
+++ b/advisories/github-reviewed/2021/06/GHSA-q5hq-fp76-qmrc/GHSA-q5hq-fp76-qmrc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q5hq-fp76-qmrc",
-  "modified": "2021-09-15T18:31:36Z",
+  "modified": "2023-02-01T05:05:50Z",
   "published": "2021-06-08T18:49:36Z",
   "aliases": [
     "CVE-2021-28677"
@@ -45,6 +45,10 @@
       "url": "https://github.com/python-pillow/Pillow/pull/5377"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/commit/5a5e6db0abf4e7a638fb1b3408c4e495a096cb92"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/python-pillow/Pillow"
     },
@@ -54,7 +58,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/MQHA5HAIBOYI3R6HDWCLAGFTIQP767FL"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/MQHA5HAIBOYI3R6HDWCLAGFTIQP767FL/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch link related to CVE-2021-28677.