### PR TITLE
[GHSA-mvg9-xffr-p774] Out of bounds read in Pillow

### DIFF
--- a/advisories/github-reviewed/2021/03/GHSA-mvg9-xffr-p774/GHSA-mvg9-xffr-p774.json
+++ b/advisories/github-reviewed/2021/03/GHSA-mvg9-xffr-p774/GHSA-mvg9-xffr-p774.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mvg9-xffr-p774",
-  "modified": "2023-09-04T16:29:59Z",
+  "modified": "2023-09-04T16:30:00Z",
   "published": "2021-03-29T16:35:57Z",
   "aliases": [
     "CVE-2021-25291"
@@ -39,6 +39,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-25291"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/commit/8b8076bdcb3815be0ef0d279651d8d1342b8ea61"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch link related to CVE-2021-25291 which fixed in multi-branches.