### PR TITLE
[GHSA-8xjq-8fcg-g5hw] Out-of-bounds Write in Pillow

### DIFF
--- a/advisories/github-reviewed/2021/03/GHSA-8xjq-8fcg-g5hw/GHSA-8xjq-8fcg-g5hw.json
+++ b/advisories/github-reviewed/2021/03/GHSA-8xjq-8fcg-g5hw/GHSA-8xjq-8fcg-g5hw.json
@@ -45,6 +45,10 @@
       "url": "https://github.com/python-pillow/Pillow/commit/86f02f7c70862a0954bfe8133736d352db978eaa"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/python-pillow/Pillow/commit/e25be1e33dc526bfd1094bc778a54d8e29bf66c9"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/python-pillow/Pillow"
     },


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add patch link related to CVE-2021-25290 which fixed in multi-branches.