### PR TITLE
[GHSA-57h3-9rgr-c24m] Out of bounds write in Pillow

### DIFF
--- a/advisories/github-reviewed/2021/03/GHSA-57h3-9rgr-c24m/GHSA-57h3-9rgr-c24m.json
+++ b/advisories/github-reviewed/2021/03/GHSA-57h3-9rgr-c24m/GHSA-57h3-9rgr-c24m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-57h3-9rgr-c24m",
-  "modified": "2021-12-02T17:48:12Z",
+  "modified": "2023-02-01T05:05:15Z",
   "published": "2021-03-29T16:35:16Z",
   "aliases": [
     "CVE-2021-25289"
@@ -49,7 +49,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/python-pillow/Pillow"
+      "url": "https://github.com/python-pillow/Pillow/commit/cbfdde7b1f2295059a20a539ee9960f0bec7b299"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/python-pillow/Pillow/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add patch link related to CVE-2021-25289  which fixed in multi-branches.