### PR TITLE
[GHSA-vp35-85q5-9f25] Container build can leak any path on the host into the container

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-vp35-85q5-9f25/GHSA-vp35-85q5-9f25.json
+++ b/advisories/github-reviewed/2022/11/GHSA-vp35-85q5-9f25/GHSA-vp35-85q5-9f25.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vp35-85q5-9f25",
-  "modified": "2022-11-11T00:03:31Z",
+  "modified": "2023-01-07T05:06:55Z",
   "published": "2022-11-11T00:03:31Z",
   "aliases": [
 
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/moby/moby"
+        "name": "github.com/docker/docker"
       },
       "ranges": [
         {
@@ -42,7 +42,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.blog/2022-10-17-git-security-vulnerabilities-announced"
+      "url": "https://github.blog/2022-10-17-git-security-vulnerabilities-announced/"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
github.com/moby/moby is not a valid Go package; github.com/docker/docker is still the canonical name.