### PR TITLE
[GHSA-8fvr-5rqf-3wwh] Information Exposure in Docker Engine

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-8fvr-5rqf-3wwh/GHSA-8fvr-5rqf-3wwh.json
+++ b/advisories/github-reviewed/2022/02/GHSA-8fvr-5rqf-3wwh/GHSA-8fvr-5rqf-3wwh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8fvr-5rqf-3wwh",
-  "modified": "2021-05-19T22:47:32Z",
+  "modified": "2023-01-09T05:05:16Z",
   "published": "2022-02-15T01:57:18Z",
   "aliases": [
     "CVE-2015-3630"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/moby/moby"
+        "name": "github.com/docker/docker"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
github.com/moby/moby is not a valid Go package; github.com/docker/docker is still the canonical name.