### PR TITLE
[GHSA-v4h8-794j-g8mm] Arbitrary File Override in Docker Engine

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-v4h8-794j-g8mm/GHSA-v4h8-794j-g8mm.json
+++ b/advisories/github-reviewed/2022/02/GHSA-v4h8-794j-g8mm/GHSA-v4h8-794j-g8mm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v4h8-794j-g8mm",
-  "modified": "2021-05-19T22:04:37Z",
+  "modified": "2023-01-09T05:04:57Z",
   "published": "2022-02-15T01:57:18Z",
   "aliases": [
     "CVE-2015-3631"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/moby/moby"
+        "name": "github.com/docker/docker"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
github.com/moby/moby is not a valid Go package; github.com/docker/docker is still the canonical name.