### PR TITLE
[GHSA-qrqr-3x5j-2xw9] Docker Moby Authentication Bypass

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-qrqr-3x5j-2xw9/GHSA-qrqr-3x5j-2xw9.json
+++ b/advisories/github-reviewed/2024/01/GHSA-qrqr-3x5j-2xw9/GHSA-qrqr-3x5j-2xw9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qrqr-3x5j-2xw9",
-  "modified": "2024-01-31T23:28:22Z",
+  "modified": "2024-01-31T23:28:25Z",
   "published": "2024-01-31T23:28:22Z",
   "aliases": [
     "CVE-2018-12608"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/moby/moby"
+        "name": "github.com/docker/docker"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
github.com/moby/moby is not a valid Go package; github.com/docker/docker is still the canonical name.