### PR TITLE
[GHSA-v2cv-wwxq-qq97] Moby Docker cp broken with debian containers

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-v2cv-wwxq-qq97/GHSA-v2cv-wwxq-qq97.json
+++ b/advisories/github-reviewed/2022/05/GHSA-v2cv-wwxq-qq97/GHSA-v2cv-wwxq-qq97.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v2cv-wwxq-qq97",
-  "modified": "2024-02-01T21:22:37Z",
+  "modified": "2024-02-02T13:26:25Z",
   "published": "2022-05-24T16:51:39Z",
   "aliases": [
     "CVE-2019-14271"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/moby/moby"
+        "name": "github.com/docker/docker"
       },
       "ranges": [
         {
@@ -58,7 +58,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://docs.docker.com/engine/release-notes"
+      "url": "https://docs.docker.com/engine/release-notes/"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moby/moby"
     },
     {
       "type": "WEB",
@@ -66,7 +70,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20190828-0003"
+      "url": "https://security.netapp.com/advisory/ntap-20190828-0003/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
github.com/moby/moby is not a valid Go package; github.com/docker/docker is still the canonical name.