### PR TITLE
[GHSA-vj3f-3286-r4pf] Path Traversal in Docker

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-vj3f-3286-r4pf/GHSA-vj3f-3286-r4pf.json
+++ b/advisories/github-reviewed/2021/05/GHSA-vj3f-3286-r4pf/GHSA-vj3f-3286-r4pf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vj3f-3286-r4pf",
-  "modified": "2021-05-17T21:28:16Z",
+  "modified": "2023-01-09T05:04:29Z",
   "published": "2021-05-18T21:09:17Z",
   "aliases": [
     "CVE-2014-9356"
@@ -33,25 +33,6 @@
           ]
         }
       ]
-    },
-    {
-      "package": {
-        "ecosystem": "Go",
-        "name": "github.com/moby/moby"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.3.3"
-            }
-          ]
-        }
-      ]
     }
   ],
   "references": [
@@ -66,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1172761"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/moby/moby"
     },
     {
       "type": "WEB",
@@ -84,7 +69,7 @@
     "cwe_ids": [
       "CWE-22"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2021-05-17T21:28:16Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Source code location

**Comments**
github.com/moby/moby is not a valid Go package; github.com/docker/docker is still the canonical name.