### PR TITLE
[GHSA-6hwg-w5jg-9c6x] Path Traversal in Moby builder

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-6hwg-w5jg-9c6x/GHSA-6hwg-w5jg-9c6x.json
+++ b/advisories/github-reviewed/2024/01/GHSA-6hwg-w5jg-9c6x/GHSA-6hwg-w5jg-9c6x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6hwg-w5jg-9c6x",
-  "modified": "2024-01-31T23:13:10Z",
+  "modified": "2024-01-31T23:13:12Z",
   "published": "2024-01-31T23:13:10Z",
   "aliases": [
     "CVE-2020-27534"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/moby/moby"
+        "name": "github.com/docker/docker"
       },
       "ranges": [
         {
@@ -53,8 +53,12 @@
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1921154"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/moby/moby"
+    },
+    {
       "type": "WEB",
-      "url": "http://web.archive.org/web/20200530054359/https://docs.docker.com/engine/release-notes"
+      "url": "http://web.archive.org/web/20200530054359/https://docs.docker.com/engine/release-notes/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
github.com/moby/moby is not a valid Go package; github.com/docker/docker is still the canonical name.