### PR TITLE
[GHSA-7452-xqpj-6rpc] moby Access to remapped root allows privilege escalation to real root

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-7452-xqpj-6rpc/GHSA-7452-xqpj-6rpc.json
+++ b/advisories/github-reviewed/2024/01/GHSA-7452-xqpj-6rpc/GHSA-7452-xqpj-6rpc.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7452-xqpj-6rpc",
-  "modified": "2024-01-31T23:14:25Z",
+  "modified": "2024-01-31T23:14:27Z",
   "published": "2024-01-31T23:14:25Z",
   "aliases": [
     "CVE-2021-21284"
   ],
-  "summary": "moby Access to remapped root allows privilege escalation to real root",
+  "summary": "Docker Access to remapped root allows privilege escalation to real root",
   "details": "### Impact\n\nWhen using `--userns-remap`, if the root user in the remapped namespace has access to the host filesystem they can modify files under `/var/lib/docker/<remapping>` that cause writing files with extended privileges.\n\n### Patches\n\nVersions 20.10.3 and 19.03.15 contain patches that prevent privilege escalation from remapped user.\n\n### Credits\n\nMaintainers would like to thank Alex Chapman for discovering the vulnerability; @awprice, @nathanburrell, @raulgomis, @chris-walz, @erin-jensby, @bassmatt, @mark-adams, @dbaxa for working on it and Zac Ellis for responsibly disclosing it to security@docker.com",
   "severity": [
     {
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/moby/moby"
+        "name": "github.com/docker/docker"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/moby/moby"
+        "name": "github.com/docker/docker"
       },
       "ranges": [
         {
@@ -85,7 +85,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20210226-0005"
+      "url": "https://security.netapp.com/advisory/ntap-20210226-0005/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
github.com/moby/moby is not a valid Go package; github.com/docker/docker is still the canonical name.