### PR TITLE
[GHSA-6fj5-m822-rqx8] moby docker daemon crash during image pull of malicious image

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-6fj5-m822-rqx8/GHSA-6fj5-m822-rqx8.json
+++ b/advisories/github-reviewed/2024/01/GHSA-6fj5-m822-rqx8/GHSA-6fj5-m822-rqx8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6fj5-m822-rqx8",
-  "modified": "2024-01-31T23:16:46Z",
+  "modified": "2024-01-31T23:16:48Z",
   "published": "2024-01-31T23:16:46Z",
   "aliases": [
     "CVE-2021-21285"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/moby/moby"
+        "name": "github.com/docker/docker"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/moby/moby"
+        "name": "github.com/docker/docker"
       },
       "ranges": [
         {
@@ -72,6 +72,10 @@
       "url": "https://docs.docker.com/engine/release-notes/#20103"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/moby/moby"
+    },
+    {
       "type": "WEB",
       "url": "https://github.com/moby/moby/releases/tag/v19.03.15"
     },
@@ -85,7 +89,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20210226-0005"
+      "url": "https://security.netapp.com/advisory/ntap-20210226-0005/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
github.com/moby/moby is not a valid Go package; github.com/docker/docker is still the canonical name.