### PR TITLE
[GHSA-3fwx-pjgw-3558] Moby (Docker Engine) Insufficiently restricted permissions on data directory

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-3fwx-pjgw-3558/GHSA-3fwx-pjgw-3558.json
+++ b/advisories/github-reviewed/2024/01/GHSA-3fwx-pjgw-3558/GHSA-3fwx-pjgw-3558.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3fwx-pjgw-3558",
-  "modified": "2024-01-31T23:28:58Z",
+  "modified": "2024-01-31T23:29:01Z",
   "published": "2024-01-31T23:28:58Z",
   "aliases": [
     "CVE-2021-41091"
   ],
-  "summary": "Moby (Docker Engine) Insufficiently restricted permissions on data directory",
+  "summary": "Docker Engine Insufficiently restricted permissions on data directory",
   "details": "## Impact\n\nA bug was found in Moby (Docker Engine) where the data directory (typically `/var/lib/docker`) contained subdirectories with insufficiently restricted permissions, allowing otherwise unprivileged Linux users to traverse directory contents and execute programs.  When containers included executable programs with extended permission bits (such as `setuid`), unprivileged Linux users could discover and execute those programs.  When the UID of an unprivileged Linux user on the host collided with the file owner or group inside a container, the unprivileged Linux user on the host could discover, read, and modify those files.\n\n## Patches\n\nThis bug has been fixed in Moby (Docker Engine) 20.10.9.  Users should update to this version as soon as possible.  Running containers should be stopped and restarted for the permissions to be fixed.\n\n## Workarounds\n\nLimit access to the host to trusted users.  Limit access to host volumes to trusted containers.\n\n## Credits\n\nThe Moby project would like to thank Joan Bruguera for responsibly disclosing this issue in accordance with the [Moby security policy](https://github.com/moby/moby/blob/master/SECURITY.md).\n\n## For more information\n\nIf you have any questions or comments about this advisory:\n\n* [Open an issue](https://github.com/moby/moby/issues/new)\n* Email us at security@docker.com if you think you’ve found a security bug",
   "severity": [
     {
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/moby/moby"
+        "name": "github.com/docker/docker"
       },
       "ranges": [
         {
@@ -53,12 +53,16 @@
       "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-222547.pdf"
     },
     {
-      "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/B5Q6G6I4W5COQE25QMC7FJY3I3PAYFBB"
+      "type": "PACKAGE",
+      "url": "https://github.com/moby/moby"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZNFADTCHHYWVM6W4NJ6CB4FNFM2VMBIB"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/B5Q6G6I4W5COQE25QMC7FJY3I3PAYFBB/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZNFADTCHHYWVM6W4NJ6CB4FNFM2VMBIB/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
github.com/moby/moby is not a valid Go package; github.com/docker/docker is still the canonical name.