### PR TITLE
[GHSA-x9w5-v3q2-3rhw] browserify-sign upper bound check issue in `dsaVerify` leads to a signature forgery attack

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-x9w5-v3q2-3rhw/GHSA-x9w5-v3q2-3rhw.json
+++ b/advisories/github-reviewed/2023/10/GHSA-x9w5-v3q2-3rhw/GHSA-x9w5-v3q2-3rhw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x9w5-v3q2-3rhw",
-  "modified": "2024-02-28T03:30:30Z",
+  "modified": "2024-03-07T05:09:25Z",
   "published": "2023-10-26T20:53:21Z",
   "aliases": [
     "CVE-2023-46234"
@@ -19,11 +19,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "browserify-sign"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(browserify-sign).Verify"
-        ]
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
fix bug