### PR TITLE
[GHSA-47g3-mf24-6559] Vulnerability in the Oracle Java SE, Oracle GraalVM...

### DIFF
--- a/advisories/unreviewed/2024/02/GHSA-47g3-mf24-6559/GHSA-47g3-mf24-6559.json
+++ b/advisories/unreviewed/2024/02/GHSA-47g3-mf24-6559/GHSA-47g3-mf24-6559.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-47g3-mf24-6559",
-  "modified": "2024-02-17T03:30:29Z",
+  "modified": "2024-02-17T03:30:37Z",
   "published": "2024-02-17T03:30:29Z",
   "aliases": [
     "CVE-2024-20925"
   ],
+  "summary": "Vulnerability affecting the org.openjfx:javafx-media maven component of the OpenJFX project",
   "details": "Vulnerability in the Oracle Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: JavaFX).  Supported versions that are affected are Oracle Java SE: 8u391; Oracle GraalVM Enterprise Edition: 20.3.12 and  21.3.8. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Oracle Java SE, Oracle GraalVM Enterprise Edition.  Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in  unauthorized update, insert or delete access to some of Oracle Java SE, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability does not apply to Java deployments, typically in servers, that load and run only trusted code (e.g., code installed by an administrator). CVSS 3.1 Base Score 3.1 (Integrity impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N).",
   "severity": [
     {
@@ -14,12 +15,92 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.openjfx:javafx-media"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "17.0.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.openjfx:javafx-media"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "18-ea"
+            },
+            {
+              "fixed": "21.0.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.openjfx:javafx-media"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "22-ea"
+            },
+            {
+              "fixed": "22-ea+27"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-20925"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/openjdk/jfx/commit/0a52a4cf1d1226e7a3c6d73313fde02e7f36fb11"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/openjdk/jfx17u/commit/18206453163dec04f36f8787ce73624bb9ba6a7d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/openjdk/jfx21u/commit/0c00753da13ed696b1a5025ce01ff478ee7ebd0a"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/openjdk/jfx"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/openjdk/jfx/blob/4beeb89f864ccf1424db36c9739a7f6999adeecc/doc-files/release-notes-22.md?plain=1#L122"
+    },
+    {
+      "type": "WEB",
+      "url": "https://openjdk.org/groups/vulnerability/advisories/2024-01-16"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
It seems that one method of installing OpenJFX is via maven artifact per https://gluonhq.com/products/javafx/.  From some sleuthing of changelogs (see https://github.com/openjdk/jfx/blob/4beeb89f864ccf1424db36c9739a7f6999adeecc/doc-files/release-notes-22.md?plain=1#L122) it seems CVE-2024-20925 corresponds to JDK-8313105 which was patched in the following commits:
- https://github.com/openjdk/jfx17u/commit/18206453163dec04f36f8787ce73624bb9ba6a7d
- https://github.com/openjdk/jfx21u/commit/0c00753da13ed696b1a5025ce01ff478ee7ebd0a
- https://github.com/openjdk/jfx/commit/0a52a4cf1d1226e7a3c6d73313fde02e7f36fb11

I downloaded the jars from maven central and found via inspection of the contents where the `SetPlaneCount` function was added to determine which precise releases of org.openjfx:javafx-media got the patch for each supported series

I have more notes available at https://raw.githubusercontent.com/anchore/vulnerability-data-tools/main/annotation_format_examples/CVE-2024-20925.toml if anyone is interested in delving further into it.  I'll get around to CVE-2024-20923 and CVE-2024-20922 when I have more time, but they should follow a similar process.
