### PR TITLE
[GHSA-9fc5-q25c-r2wr] Jasig Java CAS Client, .NET CAS Client, and phpCAS contain URL parameter injection vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9fc5-q25c-r2wr/GHSA-9fc5-q25c-r2wr.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9fc5-q25c-r2wr/GHSA-9fc5-q25c-r2wr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9fc5-q25c-r2wr",
-  "modified": "2022-11-22T19:02:31Z",
+  "modified": "2023-02-02T05:03:46Z",
   "published": "2022-05-17T19:57:18Z",
   "aliases": [
     "CVE-2014-4172"
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.jasig.cas:cas-client"
+        "name": "org.jasig.cas.client:cas-client-core"
       },
       "ranges": [
         {
@@ -67,6 +67,25 @@
             },
             {
               "fixed": "1.3.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.jasig.cas:cas-client-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.1.10"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
updated identifier as per pom.xml as org.jasig.cas.client:cas-client-core

identifier in commit:https://github.com/apereo/java-cas-client/blob/ae37092100c8eaec610dab6d83e5e05a8ee58814/cas-client-core/pom.xml#L8C4-L9C45

Relocation in vulnerable identifier:https://github.com/apereo/java-cas-client/commit/de2ab6a3ad6a08de0e2981857b7b4ede33217c77#diff-8a0149a2a0939a2c277b86a176448f8e0cd342b16b94450580032bc09d4b7314
