### PR TITLE
[GHSA-q84m-rmw3-4382] LangChain's XMLOutputParser vulnerable to XML Entity Expansion

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-q84m-rmw3-4382/GHSA-q84m-rmw3-4382.json
+++ b/advisories/github-reviewed/2024/03/GHSA-q84m-rmw3-4382/GHSA-q84m-rmw3-4382.json
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.1.34"
+              "fixed": "0.1.35"
             }
           ]
         }
@@ -42,11 +42,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/langchain-ai/langchain/pull/17250"
+      "url": "https://github.com/langchain-ai/langchain/pull/19653"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/langchain-ai/langchain/commit/727d5023ce88e18e3074ef620a98137d26ff92a3"
+      "url": "https://github.com/langchain-ai/langchain/pull/19660"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/langchain-ai/langchain/commit/e8339b1d831199b6c67182e54623999c96fc3b13"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Original patch was reverted, and a new patch made and released as part of 0.1.35