### PR TITLE
[GHSA-56gj-927p-mfph] Jenkins Aqua Security Serverless Scanner Plugin showed plain text password in job configuration form fields 

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-56gj-927p-mfph/GHSA-56gj-927p-mfph.json
+++ b/advisories/github-reviewed/2022/05/GHSA-56gj-927p-mfph/GHSA-56gj-927p-mfph.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-56gj-927p-mfph",
-  "modified": "2024-01-30T21:19:12Z",
+  "modified": "2024-01-30T21:19:13Z",
   "published": "2022-05-24T16:55:59Z",
   "aliases": [
     "CVE-2019-10397"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Packagist",
-        "name": "org.jenkins-ci.plugins:aqua-serverless"
+        "name": "org.jenkins-ci.plugins/aqua-serverless"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It was brought to our attention via https://github.com/google/osv.dev/issues/2075 that the separator character should a slash and not a colon