### PR TITLE
[GHSA-4cm9-63x5-55wm] ** DISPUTED ** TensorFlow through 2.5.0 allows attackers...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-4cm9-63x5-55wm/GHSA-4cm9-63x5-55wm.json
+++ b/advisories/unreviewed/2022/05/GHSA-4cm9-63x5-55wm/GHSA-4cm9-63x5-55wm.json
@@ -6,6 +6,7 @@
   "aliases": [
     "CVE-2021-35958"
   ],
+  "summary": "CVE-2021-35958",
   "details": "** DISPUTED ** TensorFlow through 2.5.0 allows attackers to overwrite arbitrary files via a crafted archive when tf.keras.utils.get_file is used with extract=True. NOTE: the vendor's position is that tf.keras.utils.get_file is not intended for untrusted archives.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "tensorflow"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.5.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.5.0"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
It directly mentions the affected API is tf.keras.utils.get_file, so the affected package is tensorflow