### PR TITLE
[GHSA-8q87-cc79-vwjj] Cross Site Scripting (XSS) vulnerability in the...

### DIFF
--- a/advisories/unreviewed/2023/03/GHSA-8q87-cc79-vwjj/GHSA-8q87-cc79-vwjj.json
+++ b/advisories/unreviewed/2023/03/GHSA-8q87-cc79-vwjj/GHSA-8q87-cc79-vwjj.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8q87-cc79-vwjj",
-  "modified": "2023-03-13T18:30:43Z",
+  "modified": "2023-04-06T15:30:19Z",
   "published": "2023-03-07T00:30:25Z",
   "aliases": [
     "CVE-2021-36713"
   ],
+  "summary": "CVE-2021-36713",
   "details": "Cross Site Scripting (XSS) vulnerability in the DataTables plug-in 1.9.2 for jQuery allows attackers to run arbitrary code via the sBaseName parameter to function _fnCreateCookie. NOTE: 1.9.2 is a version from 2012.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "datatables"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.10.9"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.9.2"
+      }
+    }
   ],
   "references": [
     {
@@ -31,7 +53,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20230406-0003"
+      "url": "https://security.netapp.com/advisory/ntap-20230406-0003/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The affected package is the datatables. 

The poc is included in `https://gist.github.com/walhajri/711af9b62f6fb25e66a5d9a490deab98` and mentions the affected package's URL `https://github.com/DataTables/DataTables`, which is also listed in the npm page of datatables: `https://www.npmjs.com/package/datatables.net?activeTab=code`.

1.10.9 is the oldest version that can be found in npm `https://www.npmjs.com/package/datatables.net?activeTab=versions`