### PR TITLE
[GHSA-v63q-hgqc-qvpg] MooTools is a collection of JavaScript utilities for...

### DIFF
--- a/advisories/unreviewed/2023/01/GHSA-v63q-hgqc-qvpg/GHSA-v63q-hgqc-qvpg.json
+++ b/advisories/unreviewed/2023/01/GHSA-v63q-hgqc-qvpg/GHSA-v63q-hgqc-qvpg.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v63q-hgqc-qvpg",
-  "modified": "2023-01-10T15:30:25Z",
+  "modified": "2023-02-03T05:01:33Z",
   "published": "2023-01-03T18:30:25Z",
   "aliases": [
     "CVE-2021-32821"
   ],
+  "summary": "CVE-2021-32821",
   "details": "MooTools is a collection of JavaScript utilities for JavaScript developers. All known versions include a CSS selector parser that is vulnerable to Regular Expression Denial of Service (ReDoS). An attack requires that an attacker can inject a string into a CSS selector at runtime, which is quite common with e.g. jQuery CSS selectors. No patches are available for this issue.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "mootools"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.5.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,7 +42,7 @@
     },
     {
       "type": "ADVISORY",
-      "url": "https://securitylab.github.com/advisories/GHSL-2020-345-redos-mootools"
+      "url": "https://securitylab.github.com/advisories/GHSL-2020-345-redos-mootools/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
As mentioned in description, the vulnerable package is MooTools, and this package has not been updated since 9 years ago `https://www.npmjs.com/package/mootools?activeTab=versions`