### PR TITLE
[GHSA-9p4g-cjcf-q3x2] The jQuery deserialize library in Fisheye and Crucible...

### DIFF
--- a/advisories/unreviewed/2022/03/GHSA-9p4g-cjcf-q3x2/GHSA-9p4g-cjcf-q3x2.json
+++ b/advisories/unreviewed/2022/03/GHSA-9p4g-cjcf-q3x2/GHSA-9p4g-cjcf-q3x2.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9p4g-cjcf-q3x2",
-  "modified": "2022-03-23T00:00:35Z",
+  "modified": "2023-01-27T05:00:46Z",
   "published": "2022-03-17T00:00:51Z",
   "aliases": [
     "CVE-2021-43956"
   ],
+  "summary": "CVE-2021-43956",
   "details": "The jQuery deserialize library in Fisheye and Crucible before version 4.8.9 allowed remote attackers to to inject arbitrary HTML and/or JavaScript via a prototype pollution vulnerability.",
   "severity": [
     {
@@ -14,7 +15,44 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "crucible"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.8.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "fisheye"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.8.9"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
the affected packages and their versions are pointed outed in the reference:
~~~
https://jira.atlassian.com/browse/CRUC-8531
https://jira.atlassian.com/browse/FE-7395
~~~