### PR TITLE
[GHSA-43x9-7hfv-mxrf] A cross-site scripting (XSS) vulnerability in the...

### DIFF
--- a/advisories/unreviewed/2022/02/GHSA-43x9-7hfv-mxrf/GHSA-43x9-7hfv-mxrf.json
+++ b/advisories/unreviewed/2022/02/GHSA-43x9-7hfv-mxrf/GHSA-43x9-7hfv-mxrf.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-43x9-7hfv-mxrf",
-  "modified": "2022-03-17T00:05:11Z",
+  "modified": "2023-02-03T05:06:24Z",
   "published": "2022-02-26T00:00:39Z",
   "aliases": [
     "CVE-2021-37504"
   ],
+  "summary": "CVE-2021-37504",
   "details": "A cross-site scripting (XSS) vulnerability in the fileNameStr parameter of jQuery-Upload-File v4.0.11 allows attackers to execute arbitrary web scripts or HTML via a crafted file with a Javascript payload in the file name.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "jquery-file-upload"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "4.0.11"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
In reference `https://github.com/hayageek/jquery-upload-file/blob/master/js/jquery.uploadfile.js#L469`, it directly mentions the affected package `hayageek/jquery-upload-file`, which corresponds to the npm URL `https://www.npmjs.com/package/jquery-file-upload`.

Additionally, this is the latest version of `jquery-upload-file`, so it is still not patched.