### PR TITLE
[GHSA-mjh3-g7qw-vgfv] Cross-site scripting (XSS) vulnerability in the jQuery...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-mjh3-g7qw-vgfv/GHSA-mjh3-g7qw-vgfv.json
+++ b/advisories/unreviewed/2022/05/GHSA-mjh3-g7qw-vgfv/GHSA-mjh3-g7qw-vgfv.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mjh3-g7qw-vgfv",
-  "modified": "2022-05-17T04:53:39Z",
+  "modified": "2023-01-28T05:02:43Z",
   "published": "2022-05-17T04:53:39Z",
   "aliases": [
     "CVE-2013-4383"
   ],
+  "summary": "CVE-2013-4383",
   "details": "Cross-site scripting (XSS) vulnerability in the jQuery Countdown module 7.x-1.x before 7.x-1.1 for Drupal allows remote authenticated users with the \"access administration pages\" permission to inject arbitrary web script or HTML via unspecified vectors.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "jquery-countdown"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.x-1.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
In reference `https://www.drupal.org/node/2087089`, it directly mentions the affected package is `https://www.drupal.org/node/2087089`, which corresponds to the URL `https://www.npmjs.com/package/jquery-countdown` in npm