### PR TITLE
[GHSA-pfm2-mqwj-ggm5] In MediaWiki before 1.34.1, users can add various...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-pfm2-mqwj-ggm5/GHSA-pfm2-mqwj-ggm5.json
+++ b/advisories/unreviewed/2022/05/GHSA-pfm2-mqwj-ggm5/GHSA-pfm2-mqwj-ggm5.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pfm2-mqwj-ggm5",
-  "modified": "2022-05-24T17:13:21Z",
+  "modified": "2023-01-29T05:02:18Z",
   "published": "2022-05-24T17:13:21Z",
   "aliases": [
     "CVE-2020-10960"
   ],
+  "summary": "CVE-2020-10960",
   "details": "In MediaWiki before 1.34.1, users can add various Cascading Style Sheets (CSS) classes (which can affect what content is shown or hidden in the user interface) to arbitrary DOM nodes via HTML content within a MediaWiki page. This occurs because jquery.makeCollapsible allows applying an event handler to any Cascading Style Sheets (CSS) selector. There is no known way to exploit this for cross-site scripting (XSS).",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "mediawiki"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.34.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The vulnerability description directly mentions the affected package `mediawiki`, which is included in npm, `https://www.npmjs.com/package/mediawiki`