### PR TITLE
[GHSA-76x8-gg39-5jjg] Directory traversal vulnerability in the _get_file_path...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-76x8-gg39-5jjg/GHSA-76x8-gg39-5jjg.json
+++ b/advisories/unreviewed/2022/05/GHSA-76x8-gg39-5jjg/GHSA-76x8-gg39-5jjg.json
@@ -1,17 +1,39 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-76x8-gg39-5jjg",
-  "modified": "2022-05-01T23:28:42Z",
+  "modified": "2023-01-31T05:05:37Z",
   "published": "2022-05-01T23:28:42Z",
   "aliases": [
     "CVE-2008-0252"
   ],
+  "summary": "CVE-2008-0252",
   "details": "Directory traversal vulnerability in the _get_file_path function in (1) lib/sessions.py in CherryPy 3.0.x up to 3.0.2, (2) filter/sessionfilter.py in CherryPy 2.1, and (3) filter/sessionfilter.py in CherryPy 2.x allows remote attackers to create or delete arbitrary files, and possibly read and write portions of arbitrary files, via a crafted session id in a cookie.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "CherryPy"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.0.2"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The vulnerability directly mentions the targeted package, CherryPy