### PR TITLE
[GHSA-c3qv-mf8h-434r] Multiple unspecified vulnerabilities in Roundup before 1...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-c3qv-mf8h-434r/GHSA-c3qv-mf8h-434r.json
+++ b/advisories/unreviewed/2022/05/GHSA-c3qv-mf8h-434r/GHSA-c3qv-mf8h-434r.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c3qv-mf8h-434r",
-  "modified": "2022-05-01T23:40:33Z",
+  "modified": "2023-01-31T05:05:29Z",
   "published": "2022-05-01T23:40:33Z",
   "aliases": [
     "CVE-2008-1474"
   ],
+  "summary": "CVE-2008-1474",
   "details": "Multiple unspecified vulnerabilities in Roundup before 1.4.4 have unknown impact and attack vectors, some of which may be related to cross-site scripting (XSS).",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "roundup"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.4.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Both the vulnerability description and the reference URL `https://lists.debian.org/debian-security-announce/2008/msg00125.html` mentions the affected package, roundup