### PR TITLE
[GHSA-j59j-h3g7-cpmf] The xml-rpc server in Roundup 1.4.4 does not check...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-j59j-h3g7-cpmf/GHSA-j59j-h3g7-cpmf.json
+++ b/advisories/unreviewed/2022/05/GHSA-j59j-h3g7-cpmf/GHSA-j59j-h3g7-cpmf.json
@@ -1,17 +1,39 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j59j-h3g7-cpmf",
-  "modified": "2022-05-01T23:40:33Z",
+  "modified": "2023-01-31T05:05:45Z",
   "published": "2022-05-01T23:40:33Z",
   "aliases": [
     "CVE-2008-1475"
   ],
+  "summary": "CVE-2008-1475",
   "details": "The xml-rpc server in Roundup 1.4.4 does not check property permissions, which allows attackers to bypass restrictions and edit or read restricted properties via the (1) list, (2) display, and (3) set methods.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "roundup"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.4.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.4.4"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The vulnerability description directly mentions the affected package `roundup`