### PR TITLE
[GHSA-5432-c996-hvhj] Zope Object Database (ZODB) before 3.8.2, when certain...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-5432-c996-hvhj/GHSA-5432-c996-hvhj.json
+++ b/advisories/unreviewed/2022/05/GHSA-5432-c996-hvhj/GHSA-5432-c996-hvhj.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5432-c996-hvhj",
-  "modified": "2022-05-02T03:17:24Z",
+  "modified": "2023-01-31T05:06:52Z",
   "published": "2022-05-02T03:17:24Z",
   "aliases": [
     "CVE-2009-0669"
   ],
+  "summary": "CVE-2009-0669",
   "details": "Zope Object Database (ZODB) before 3.8.2, when certain Zope Enterprise Objects (ZEO) database sharing is enabled, allows remote attackers to bypass authentication via vectors involving the ZEO network protocol.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "ZODB3"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.8.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The reference `https://pypi.org/project/ZODB3/3.8.2/#whats-new-in-zodb-3-8-2` mentions that in the pypi package `ZODB3` version 3.8.2, it fixes this vulnerability.