### PR TITLE
[GHSA-4849-cfqq-r8pq] Multiple directory traversal vulnerabilities in FCKeditor...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-4849-cfqq-r8pq/GHSA-4849-cfqq-r8pq.json
+++ b/advisories/unreviewed/2022/05/GHSA-4849-cfqq-r8pq/GHSA-4849-cfqq-r8pq.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4849-cfqq-r8pq",
-  "modified": "2022-05-02T03:33:25Z",
+  "modified": "2023-01-31T05:08:39Z",
   "published": "2022-05-02T03:33:25Z",
   "aliases": [
     "CVE-2009-2265"
   ],
+  "summary": "CVE-2009-2265",
   "details": "Multiple directory traversal vulnerabilities in FCKeditor before 2.6.4.1 allow remote attackers to create executable files in arbitrary directories via directory traversal sequences in the input to unspecified connector modules, as exploited in the wild for remote code execution in July 2009, related to the file browser and the editor/filemanager/connectors/ directory.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "Products.FCKeditor"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.6.4.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The vulnerability directly mentions the affected python package `FCKeditor`, and the affected folder is `https://github.com/treadmillian/fckeditor/tree/master/editor/filemanager/browser/default/connectors` now, corresponding to the package `Products.FCKeditor` (the full name of `FCKeditor`).