### PR TITLE
[GHSA-9rj9-5wcv-xgf2] The EditCSVAction function in cgi/actions.py in Roundup 1...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-9rj9-5wcv-xgf2/GHSA-9rj9-5wcv-xgf2.json
+++ b/advisories/unreviewed/2022/05/GHSA-9rj9-5wcv-xgf2/GHSA-9rj9-5wcv-xgf2.json
@@ -1,17 +1,61 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9rj9-5wcv-xgf2",
-  "modified": "2022-05-02T03:38:04Z",
+  "modified": "2023-01-31T05:07:36Z",
   "published": "2022-05-02T03:38:04Z",
   "aliases": [
     "CVE-2009-2737"
   ],
+  "summary": "CVE-2009-2737",
   "details": "The EditCSVAction function in cgi/actions.py in Roundup 1.2 before 1.2.1, 1.4 through 1.4.6, and possibly other versions does not properly check permissions, which allows remote authenticated users with edit or create privileges for a class to modify arbitrary items within that class, as demonstrated by editing all queries, modifying settings, and adding roles to users.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "Roundup"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.2"
+            },
+            {
+              "fixed": "1.2.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.2"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "Roundup"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.4"
+            },
+            {
+              "fixed": "1.4.7"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.4.6"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The vulnerability description directly mentions that the affected package is `Roundup` with the vulnerable file `cgi/actions.py`.