### PR TITLE
[GHSA-jqqh-999x-w26w] Cross-site scripting (XSS) vulnerability in the waterfall...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-jqqh-999x-w26w/GHSA-jqqh-999x-w26w.json
+++ b/advisories/unreviewed/2022/05/GHSA-jqqh-999x-w26w/GHSA-jqqh-999x-w26w.json
@@ -1,17 +1,39 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jqqh-999x-w26w",
-  "modified": "2022-05-02T03:40:27Z",
+  "modified": "2023-01-31T05:08:56Z",
   "published": "2022-05-02T03:40:27Z",
   "aliases": [
     "CVE-2009-2959"
   ],
+  "summary": "CVE-2009-2959",
   "details": "Cross-site scripting (XSS) vulnerability in the waterfall web status view (status/web/waterfall.py) in Buildbot 0.7.6 through 0.7.11p1 allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "Buildbot"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.7.6"
+            },
+            {
+              "fixed": "0.7.11p2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.7.11p1"
+      }
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The vulnerability description directly mentions that the affected package is a pypi package, `Buildbot`. 

From pypi, we find that the patched version (after 0.7.11p1) is 0.7.11p2 (`https://pypi.org/project/buildbot/#history`)