### PR TITLE
[GHSA-mj3x-wprp-mvj9] Multiple cross-site scripting (XSS) vulnerabilities in...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-mj3x-wprp-mvj9/GHSA-mj3x-wprp-mvj9.json
+++ b/advisories/unreviewed/2022/05/GHSA-mj3x-wprp-mvj9/GHSA-mj3x-wprp-mvj9.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mj3x-wprp-mvj9",
-  "modified": "2022-05-02T03:40:28Z",
+  "modified": "2023-01-31T05:08:57Z",
   "published": "2022-05-02T03:40:28Z",
   "aliases": [
     "CVE-2009-2967"
   ],
+  "summary": "CVE-2009-2967",
   "details": "Multiple cross-site scripting (XSS) vulnerabilities in Buildbot 0.7.6 through 0.7.11p2 allow remote attackers to inject arbitrary web script or HTML via unspecified vectors, different vulnerabilities than CVE-2009-2959.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "Buildbot"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.7.6"
+            },
+            {
+              "fixed": "0.7.11p2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Updates

Affected products
Summary
Comments
The vulnerability description directly mentions that the affected package is a pypi package, Buildbot.

From pypi, we find that the patched version (after 0.7.11p2) is 0.7.11p3 (https://pypi.org/project/buildbot/#history)