### PR TITLE
[GHSA-vvf9-jwf6-834q] common/snapshots.py in Back In Time (aka backintime) 0.9...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-vvf9-jwf6-834q/GHSA-vvf9-jwf6-834q.json
+++ b/advisories/unreviewed/2022/05/GHSA-vvf9-jwf6-834q/GHSA-vvf9-jwf6-834q.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vvf9-jwf6-834q",
-  "modified": "2024-01-26T00:30:24Z",
+  "modified": "2024-02-03T05:07:13Z",
   "published": "2022-05-02T03:46:53Z",
   "aliases": [
     "CVE-2009-3611"
   ],
+  "summary": "CVE-2009-3611",
   "details": "common/snapshots.py in Back In Time (aka backintime) 0.9.26 changes certain permissions to 0777 before deleting the files in an old backup snapshot, which allows local users to obtain sensitive information by reading these files, or interfere with backup integrity by modifying files that are shared across snapshots.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "backintime"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.9.26"
+            },
+            {
+              "fixed": "0.9.26-3"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -62,7 +81,7 @@
     "cwe_ids": [
       "CWE-732"
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2009-10-26T16:30:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Summary

**Comments**
The vulnerability description directly mentions that the affected package is backintime (a pypi package).

The reference `https://bugs.launchpad.net/ubuntu/+source/backintime/+bug/434256` indicates that in version `0.9.26-3`, this vulnerability is fixed.