### PR TITLE
[GHSA-876c-qmcf-cxv6] MoinMoin 1.9 before 1.9.1 does not perform the expected...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-876c-qmcf-cxv6/GHSA-876c-qmcf-cxv6.json
+++ b/advisories/unreviewed/2022/05/GHSA-876c-qmcf-cxv6/GHSA-876c-qmcf-cxv6.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-876c-qmcf-cxv6",
-  "modified": "2022-05-02T06:14:38Z",
+  "modified": "2023-02-01T05:00:36Z",
   "published": "2022-05-02T06:14:38Z",
   "aliases": [
     "CVE-2010-0667"
   ],
+  "summary": "CVE-2010-0667",
   "details": "MoinMoin 1.9 before 1.9.1 does not perform the expected clearing of the sys.argv array in situations where the GATEWAY_INTERFACE environment variable is set, which allows remote attackers to obtain sensitive information via unspecified vectors.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "moin"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.9.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
In reference `https://moinmo.in/SecurityFixes`, it directly mentions that `1.9.1 fixes CVE-2010-0667. (moin 1.9.1)`

So, the patched version is `moin 1.9.1`