### PR TITLE
[GHSA-v5fm-hr72-27hx] HashiCorp Nomad and Nomad Enterprise 0.11.0 up to 1.5.6...

### DIFF
--- a/advisories/unreviewed/2023/07/GHSA-v5fm-hr72-27hx/GHSA-v5fm-hr72-27hx.json
+++ b/advisories/unreviewed/2023/07/GHSA-v5fm-hr72-27hx/GHSA-v5fm-hr72-27hx.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v5fm-hr72-27hx",
-  "modified": "2023-07-20T00:30:25Z",
+  "modified": "2023-11-06T05:05:00Z",
   "published": "2023-07-20T00:30:25Z",
   "aliases": [
     "CVE-2023-3300"
   ],
+  "summary": "CVE-2023-3300",
   "details": "HashiCorp Nomad and Nomad Enterprise 0.11.0 up to 1.5.6 and 1.4.1 HTTP search API can reveal names of available CSI plugins to unauthenticated users or users without the plugin:read policy. Fixed in 1.6.0, 1.5.7, and 1.4.1.",
   "severity": [
     {
@@ -14,7 +15,63 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/nomad"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.6.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/nomad"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.5.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/nomad"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.4.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -30,7 +87,7 @@
     "cwe_ids": [
       "CWE-862"
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-07-20T00:15:10Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Summary

**Comments**
In reference `https://discuss.hashicorp.com/t/hcsec-2023-22-nomad-search-api-leaks-information-about-csi-plugins/56272`, it corresponds to the go developer 'HashiCorp' and affects the package `Nomad `