### PR TITLE
[GHSA-33j2-92xf-fwm3] HashiCorp Vault Enterprise 1.13.0 up to 1.13.1 is...

### DIFF
--- a/advisories/unreviewed/2023/07/GHSA-33j2-92xf-fwm3/GHSA-33j2-92xf-fwm3.json
+++ b/advisories/unreviewed/2023/07/GHSA-33j2-92xf-fwm3/GHSA-33j2-92xf-fwm3.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-33j2-92xf-fwm3",
-  "modified": "2023-07-06T19:24:19Z",
+  "modified": "2023-11-10T05:02:22Z",
   "published": "2023-07-06T19:24:19Z",
   "aliases": [
     "CVE-2023-2197"
   ],
+  "summary": "CVE-2023-2197",
   "details": "HashiCorp Vault Enterprise 1.13.0 up to 1.13.1 is vulnerable to a padding oracle attack when using an HSM in conjunction with the CKM_AES_CBC_PAD or CKM_AES_CBC encryption mechanisms. An attacker with privileges to modify storage and restart Vault may be able to intercept or modify cipher text in order to derive Vault’s root key. Fixed in 1.13.2",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/vault"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.13.0"
+            },
+            {
+              "fixed": "1.13.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -30,7 +49,7 @@
     "cwe_ids": [
       "CWE-326"
     ],
-    "severity": null,
+    "severity": "LOW",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-05-01T20:15:14Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Summary

**Comments**
In reference `https://discuss.hashicorp.com/t/hcsec-2023-14-vault-enterprise-vulnerable-to-padding-oracle-attacks-when-using-a-cbc-based-encryption-mechanism-with-a-hsm/53322`, it corresponds to the go developer 'HashiCorp' and affects the package`Vault`.