### PR TITLE
[GHSA-9jfx-84v9-2rr2] 


HashiCorp Nomad Enterprise 1.2.11 up to 1.5.6, and 1.4...

### DIFF
--- a/advisories/unreviewed/2023/07/GHSA-9jfx-84v9-2rr2/GHSA-9jfx-84v9-2rr2.json
+++ b/advisories/unreviewed/2023/07/GHSA-9jfx-84v9-2rr2/GHSA-9jfx-84v9-2rr2.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9jfx-84v9-2rr2",
-  "modified": "2023-07-20T00:30:24Z",
+  "modified": "2023-11-06T05:05:00Z",
   "published": "2023-07-20T00:30:24Z",
   "aliases": [
     "CVE-2023-3299"
   ],
-  "details": "\n\n\nHashiCorp Nomad Enterprise 1.2.11 up to 1.5.6, and 1.4.10 ACL policies using a block without a label generates unexpected results. Fixed in 1.6.0, 1.5.7, and 1.4.11.\n\n\n",
+  "summary": "CVE-2023-3299",
+  "details": "\n\nHashiCorp Nomad Enterprise 1.2.11 up to 1.5.6, and 1.4.10 ACL policies using a block without a label generates unexpected results. Fixed in 1.6.0, 1.5.7, and 1.4.11.\n\n\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,7 +15,63 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/nomad"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.6.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/nomad"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.5.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/nomad"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.4.11"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -30,7 +87,7 @@
     "cwe_ids": [
       "CWE-668"
     ],
-    "severity": null,
+    "severity": "LOW",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-07-20T00:15:10Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Severity
- Summary

**Comments**
In reference `https://discuss.hashicorp.com/t/hcsec-2023-21-nomad-caller-acl-tokens-secret-id-is-exposed-to-sentinel/56271`, it corresponds to the go developer 'HashiCorp' and affects the package `Nomad`.