### PR TITLE
[GHSA-9rhf-q362-77mx] HashiCorp Consul and Consul Enterprise 1.16.0 when using...

### DIFF
--- a/advisories/unreviewed/2023/08/GHSA-9rhf-q362-77mx/GHSA-9rhf-q362-77mx.json
+++ b/advisories/unreviewed/2023/08/GHSA-9rhf-q362-77mx/GHSA-9rhf-q362-77mx.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9rhf-q362-77mx",
-  "modified": "2023-08-09T18:30:52Z",
+  "modified": "2023-11-09T05:06:19Z",
   "published": "2023-08-09T18:30:52Z",
   "aliases": [
     "CVE-2023-3518"
   ],
+  "summary": "CVE-2023-3518",
   "details": "HashiCorp Consul and Consul Enterprise 1.16.0 when using JWT Auth for service mesh incorrectly allows/denies access regardless of service identities. Fixed in 1.16.1.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/consul"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.16.0"
+            },
+            {
+              "fixed": "1.16.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.16.0"
+      ]
+    }
   ],
   "references": [
     {
@@ -30,7 +52,7 @@
     "cwe_ids": [
       "CWE-285"
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-08-09T16:15:09Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Summary

**Comments**
In reference `https://discuss.hashicorp.com/t/hcsec-2023-25-consul-jwt-auth-in-l7-intentions-allow-for-mismatched-service-identity-and-jwt-providers/57004`, it corresponds to the go developer 'HashiCorp' and affects the package `Consul`.