### PR TITLE
[GHSA-rpvr-38xv-xvxq] HashiCorp Nomad and Nomad Enterprise 0.7.0 up to 1.5.6...

### DIFF
--- a/advisories/unreviewed/2023/07/GHSA-rpvr-38xv-xvxq/GHSA-rpvr-38xv-xvxq.json
+++ b/advisories/unreviewed/2023/07/GHSA-rpvr-38xv-xvxq/GHSA-rpvr-38xv-xvxq.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rpvr-38xv-xvxq",
-  "modified": "2023-07-20T00:30:24Z",
+  "modified": "2023-11-06T05:05:41Z",
   "published": "2023-07-20T00:30:24Z",
   "aliases": [
     "CVE-2023-3072"
   ],
+  "summary": "CVE-2023-3072",
   "details": "HashiCorp Nomad and Nomad Enterprise 0.7.0 up to 1.5.6 and 1.4.10 ACL policies using a block without a label generates unexpected results. Fixed in 1.6.0, 1.5.7, and 1.4.11.",
   "severity": [
     {
@@ -14,7 +15,63 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/nomad"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.6.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/nomad"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.5.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/nomad"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.4.11"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -30,7 +87,7 @@
     "cwe_ids": [
       "CWE-862"
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-07-20T00:15:10Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Summary

**Comments**
In reference `https://discuss.hashicorp.com/t/hcsec-2023-20-nomad-acl-policies-without-label-are-applied-to-unexpected-resources/56270`, it corresponds to the go developer 'HashiCorp' and affects the package `Nomad`.