### PR TITLE
[GHSA-fhmj-jv7w-vvg2] Terraform Enterprise since v202207-1 did not properly...

### DIFF
--- a/advisories/unreviewed/2023/06/GHSA-fhmj-jv7w-vvg2/GHSA-fhmj-jv7w-vvg2.json
+++ b/advisories/unreviewed/2023/06/GHSA-fhmj-jv7w-vvg2/GHSA-fhmj-jv7w-vvg2.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fhmj-jv7w-vvg2",
-  "modified": "2023-06-23T00:30:20Z",
+  "modified": "2023-11-07T05:01:25Z",
   "published": "2023-06-23T00:30:20Z",
   "aliases": [
     "CVE-2023-3114"
   ],
+  "summary": "CVE-2023-3114",
   "details": "Terraform Enterprise since v202207-1 did not properly implement authorization rules for agent pools, allowing the workspace to be targeted by unauthorized agents. This authorization flaw could potentially allow a workspace to access resources from a separate, higher-privileged workspace in the same organization that targeted an agent pool. This vulnerability, CVE-2023-3114, is fixed in Terraform Enterprise v202306-1.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/terraform"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "202207-1"
+            },
+            {
+              "fixed": "v202306.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 202306-1"
+      }
+    }
   ],
   "references": [
     {
@@ -30,7 +52,7 @@
     "cwe_ids": [
       "CWE-863"
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-06-22T22:15:09Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Summary

**Comments**
In reference `https://discuss.hashicorp.com/t/hcsec-2023-18-terraform-enterprise-agent-pool-controls-allowed-unauthorized-workspaces-to-target-an-agent-pool/55329`, it corresponds to the go developer 'HashiCorp' and affects the package `terraform`.