### PR TITLE
[GHSA-5r79-3284-v2f8] Nullsoft Scriptable Install System (NSIS) before 3.09...

### DIFF
--- a/advisories/unreviewed/2023/07/GHSA-5r79-3284-v2f8/GHSA-5r79-3284-v2f8.json
+++ b/advisories/unreviewed/2023/07/GHSA-5r79-3284-v2f8/GHSA-5r79-3284-v2f8.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5r79-3284-v2f8",
-  "modified": "2023-07-11T18:31:20Z",
+  "modified": "2023-11-09T05:00:42Z",
   "published": "2023-07-03T21:30:57Z",
   "aliases": [
     "CVE-2023-37378"
   ],
+  "summary": "CVE-2023-1296",
   "details": "Nullsoft Scriptable Install System (NSIS) before 3.09 mishandles access control for an uninstaller directory.",
   "severity": [
     {
@@ -14,7 +15,44 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/nomad"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.4.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/nomad"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.5.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -39,11 +77,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/A65FBUMHLZ7GBV3VDKUB5EK3A7X2UUWK"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/A65FBUMHLZ7GBV3VDKUB5EK3A7X2UUWK/"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OZPAAU57IA3NP6UOUXNBUQBAYK3JB2IM"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OZPAAU57IA3NP6UOUXNBUQBAYK3JB2IM/"
     },
     {
       "type": "WEB",
@@ -51,7 +89,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://sourceforge.net/p/nsis/news/2023/07/nsis-309-released"
+      "url": "https://sourceforge.net/p/nsis/news/2023/07/nsis-309-released/"
     },
     {
       "type": "WEB",
@@ -62,7 +100,7 @@
     "cwe_ids": [
 
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-07-03T20:15:09Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Summary

**Comments**
In reference `https://discuss.hashicorp.com/t/hcsec-2023-09-nomad-acls-can-not-deny-access-to-workloads-own-variables/51390`, it corresponds to the go developer 'HashiCorp' and affects the package `Nomad`.