### PR TITLE
[GHSA-hr3v-8cp3-68rf] HashiCorp Consul 1.8.1 up to 1.11.8, 1.12.4, and 1.13.1...

### DIFF
--- a/advisories/unreviewed/2022/09/GHSA-hr3v-8cp3-68rf/GHSA-hr3v-8cp3-68rf.json
+++ b/advisories/unreviewed/2022/09/GHSA-hr3v-8cp3-68rf/GHSA-hr3v-8cp3-68rf.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hr3v-8cp3-68rf",
-  "modified": "2022-09-25T00:00:15Z",
+  "modified": "2023-09-05T03:30:16Z",
   "published": "2022-09-25T00:00:15Z",
   "aliases": [
     "CVE-2021-41803"
   ],
+  "summary": "CVE-2021-41803",
   "details": "HashiCorp Consul 1.8.1 up to 1.11.8, 1.12.4, and 1.13.1 do not properly validate the node or segment names prior to interpolation and usage in JWT claim assertions with the auto config RPC. Fixed in 1.11.9, 1.12.5, and 1.13.2.\"",
   "severity": [
     {
@@ -14,7 +15,63 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/consul"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.11.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/consul"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.12.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/hashicorp/consul"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.13.2"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -27,11 +84,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LYZOKMMVX4SIEHPJW3SJUQGMO5YZCPHC"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LYZOKMMVX4SIEHPJW3SJUQGMO5YZCPHC/"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZTE4ITXXPIWZEQ4HYQCB6N6GZIMWXDAI"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZTE4ITXXPIWZEQ4HYQCB6N6GZIMWXDAI/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
In reference `https://discuss.hashicorp.com/t/hcsec-2022-19-consul-auto-config-jwt-authorization-missing-input-validation/44627`, it corresponds to the go developer 'HashiCorp' and affects the package `consul`.