### PR TITLE
[GHSA-rxwq-x6h5-x525] Malicious code distributed via tarball archive of xz >= 5.6.0

### DIFF
--- a/advisories/unreviewed/2024/03/GHSA-rxwq-x6h5-x525/GHSA-rxwq-x6h5-x525.json
+++ b/advisories/unreviewed/2024/03/GHSA-rxwq-x6h5-x525/GHSA-rxwq-x6h5-x525.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rxwq-x6h5-x525",
-  "modified": "2024-03-30T18:40:35Z",
+  "modified": "2024-03-31T17:38:50Z",
   "published": "2024-03-29T18:30:43Z",
   "aliases": [
     "CVE-2024-3094"
@@ -17,7 +17,7 @@
   "affected": [
     {
       "package": {
-        "ecosystem": "Debian",
+        "ecosystem": "Debian:13",
         "name": "xz"
       },
       "ranges": [

--- a/advisories/unreviewed/2024/03/GHSA-rxwq-x6h5-x525/GHSA-rxwq-x6h5-x525.json
+++ b/advisories/unreviewed/2024/03/GHSA-rxwq-x6h5-x525/GHSA-rxwq-x6h5-x525.json
@@ -6,7 +6,7 @@
   "aliases": [
     "CVE-2024-3094"
   ],
-  "summary": "Malicious code distributed via tarball archives of xz >= 5.6.0"
+  "summary": "Malicious code distributed via tarball archives of xz >= 5.6.0",
   "details": "Malicious code was discovered in the upstream tarballs of xz, starting with version 5.6.0. The tarballs included extra .m4 files, which contained instructions for building with automake that did not exist in the repository. These instructions, through a series of complex obfuscations, extract a prebuilt object file from one of the test archives, which is then used to modify specific functions in the code while building the liblzma package. This issue results in liblzma being used by additional software, like sshd, to provide functionality that will be interpreted by the modified functions.",
   "severity": [
     {

--- a/advisories/unreviewed/2024/03/GHSA-rxwq-x6h5-x525/GHSA-rxwq-x6h5-x525.json
+++ b/advisories/unreviewed/2024/03/GHSA-rxwq-x6h5-x525/GHSA-rxwq-x6h5-x525.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rxwq-x6h5-x525",
-  "modified": "2024-03-29T18:30:43Z",
+  "modified": "2024-03-30T18:40:35Z",
   "published": "2024-03-29T18:30:43Z",
   "aliases": [
     "CVE-2024-3094"
   ],
+  "summary": "Malicious code distributed via tarball archives of xz >= 5.6.0"
   "details": "Malicious code was discovered in the upstream tarballs of xz, starting with version 5.6.0. The tarballs included extra .m4 files, which contained instructions for building with automake that did not exist in the repository. These instructions, through a series of complex obfuscations, extract a prebuilt object file from one of the test archives, which is then used to modify specific functions in the code while building the liblzma package. This issue results in liblzma being used by additional software, like sshd, to provide functionality that will be interpreted by the modified functions.",
   "severity": [
     {
@@ -14,6 +15,25 @@
     }
   ],
   "affected": [
+    {
+      "package": {
+        "ecosystem": "",
+        "name": "xz"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.6.0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "5.6.0"
+      ]
+    }
 
   ],
   "references": [

--- a/advisories/unreviewed/2024/03/GHSA-rxwq-x6h5-x525/GHSA-rxwq-x6h5-x525.json
+++ b/advisories/unreviewed/2024/03/GHSA-rxwq-x6h5-x525/GHSA-rxwq-x6h5-x525.json
@@ -17,7 +17,7 @@
   "affected": [
     {
       "package": {
-        "ecosystem": "",
+        "ecosystem": "Debian",
         "name": "xz"
       },
       "ranges": [


### PR DESCRIPTION
Adding some info that may help in refining this advisory. Today, there's no supported ecosystem info. But other info can be added which could possibly be helpful.