### PR TITLE
[GHSA-qppj-fm5r-hxr3] HTTP/2 Stream Cancellation Attack

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-qppj-fm5r-hxr3/GHSA-qppj-fm5r-hxr3.json
+++ b/advisories/github-reviewed/2023/10/GHSA-qppj-fm5r-hxr3/GHSA-qppj-fm5r-hxr3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qppj-fm5r-hxr3",
-  "modified": "2024-03-05T21:48:12Z",
+  "modified": "2024-03-05T21:48:15Z",
   "published": "2023-10-10T21:28:24Z",
   "aliases": [
     "CVE-2023-44487"
@@ -15,25 +15,6 @@
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "SwiftURL",
-        "name": "github.com/apple/swift-nio-http2"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.28.0"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "Go",
@@ -264,6 +245,25 @@
     },
     {
       "package": {
+        "ecosystem": "SwiftURL",
+        "name": "github.com/apple/swift-nio-http2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.28.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
         "ecosystem": "Maven",
         "name": "org.eclipse.jetty.http2:http2-common"
       },
@@ -413,6 +413,82 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.typesafe.akka:akka-http-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "10.5.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.typesafe.akka:akka-http-core_2.13"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "10.5.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.typesafe.akka:akka-http-core_2.12"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "10.5.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.typesafe.akka:akka-http-core_2.11"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 10.5.3"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Akka HTTP prior to 10.5.3 is also vulnerable to CVE-2023-44487: https://akka.io/security/akka-http-cve-2023-44487.html

PR https://github.com/akka/akka-http/pull/4324/files shows the fix being made to the `akka-http-core` library.
Backport PR https://github.com/akka/akka-http/pull/4325 was merged into the release branch for 10.5.X.

Certain versions of com.typesafe.akka:akka-http-core are published under alternate names that include the version number. The stable versions of these (`com.typesafe.akka:akka-http-core_2.11`, `com.typesafe.akka:akka-http-core_2.12`, `com.typesafe.akka:akka-http-core_2.13`) that are published in Maven Central have been included. However, Akka publishes many different package names for each version - experimental, milestone, and every version branch. Due to the vast number of these they have been omitted (at this time) to avoid cluttering the affected products list. 

`com.typesafe.akka:akka-http-core_2.11` only goes to `10.1.15` in Maven Central, so no patched version is listed in the affected products list to avoid confusing dependency analysis/fix tools. A fix would require switching to a different package name.