### PR TITLE
[GHSA-f62v-xpxf-3v68] Code injection in Apache Ant

### DIFF
--- a/advisories/github-reviewed/2021/02/GHSA-f62v-xpxf-3v68/GHSA-f62v-xpxf-3v68.json
+++ b/advisories/github-reviewed/2021/02/GHSA-f62v-xpxf-3v68/GHSA-f62v-xpxf-3v68.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f62v-xpxf-3v68",
-  "modified": "2022-02-08T22:04:08Z",
+  "modified": "2023-02-01T05:05:08Z",
   "published": "2021-02-03T19:16:35Z",
   "aliases": [
     "CVE-2020-11979"
@@ -25,13 +25,16 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.10.8"
             },
             {
               "fixed": "1.10.9"
             }
           ]
         }
+      ],
+      "versions": [
+        "1.10.8"
       ]
     }
   ],
@@ -78,15 +81,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/U3NRQQ7ECII4ZNGW7GBC225LVYMPQEKB"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/U3NRQQ7ECII4ZNGW7GBC225LVYMPQEKB/"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DYBRN5C2RW7JRY75IB7Q7ZVKZCHWAQWS"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DYBRN5C2RW7JRY75IB7Q7ZVKZCHWAQWS/"
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/AALW42FWNQ35F7KB3JVRC6NBVV7AAYYI"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/AALW42FWNQ35F7KB3JVRC6NBVV7AAYYI/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
NVD indicates that this vulnerability was first introduced as a mitigation for CVE-2020-1945 in Apache Ant 1.10.8. As such, the current impacted version range of < 1.10.9 is overly broad. This change more narrowly scopes the affected versions to the impacted version only.