### PR TITLE
[GHSA-r65j-6h5f-4f92] JJWT improperly generates signing keys

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-r65j-6h5f-4f92/GHSA-r65j-6h5f-4f92.json
+++ b/advisories/github-reviewed/2024/03/GHSA-r65j-6h5f-4f92/GHSA-r65j-6h5f-4f92.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-r65j-6h5f-4f92",
+  "modified": "2024-04-01T16:28:50Z",
+  "published": "2024-04-01T03:30:38Z",
+  "aliases": [
+    "CVE-2024-31033"
+  ],
+  "summary": "JJWT improperly generates signing keys",
+  "details": "JJWT (aka Java JWT) through 0.12.5 ignores certain characters and thus a user might falsely conclude that they have a strong key. The impacted code is the setSigningKey() method within the DefaultJwtParser class and the signWith() method within the DefaultJwtBuilder class.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.jsonwebtoken:jwt-impl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "0.12.5"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-31033"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/2308652512/JJWT_BUG"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/jwtk/jjwt"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.viralpatel.net/java-create-validate-jwt-token"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-327"
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true,
+    "github_reviewed_at": "2024-04-01T16:28:49Z",
+    "nvd_published_at": "2024-04-01T02:15:07Z"
+  }
+}


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
`io.jsonwebtoken:jjwt-root` is a Maven base project ('pom') and doesn't contain any binaries or implementation (https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-root/0.12.5/jjwt-root-0.12.5.pom shows `<packaging>pom</packaging>`). 

The CVE lists the `signWith` and `setSigningKey` methods as affected. The implementation of these methods are distributed in `io.jsonwebtoken:jjwt-impl` (e.g. https://github.com/jwtk/jjwt/blob/26948610fbef81eba867cbaad54b516d1874c70a/impl/src/main/java/io/jsonwebtoken/impl/DefaultJwtParserBuilder.java#L242)