### PR TITLE
[GHSA-jm46-725r-hh9v] An issue was found in the CPython `zipfile` module...

### DIFF
--- a/advisories/unreviewed/2024/03/GHSA-jm46-725r-hh9v/GHSA-jm46-725r-hh9v.json
+++ b/advisories/unreviewed/2024/03/GHSA-jm46-725r-hh9v/GHSA-jm46-725r-hh9v.json
@@ -6,7 +6,8 @@
   "aliases": [
     "CVE-2024-0450"
   ],
-  "details": "An issue was found in the CPython `zipfile` module affecting versions 3.12.2, 3.11.8, 3.10.13, 3.9.18, and 3.8.18 and prior.\n\nThe zipfile module is vulnerable to “quoted-overlap” zip-bombs which exploit the zip format to create a zip-bomb with a high compression ratio. The fixed versions of CPython makes the zipfile module reject zip archives which overlap entries in the archive.\n\n",
+  "summary": "CPython zipfile module vulnerable to \"quoted-overlap\" zip-bombs",
+  "details": "An issue was found in the CPython `zipfile` module affecting versions 3.12.1, 3.11.7, 3.10.13, 3.9.18, and 3.8.18 and prior.\n\nFixed in 3.12.2, 3.11.8.\n\nThe zipfile module is vulnerable to “quoted-overlap” zip-bombs which exploit the zip format to create a zip-bomb with a high compression ratio. The fixed versions of CPython makes the zipfile module reject zip archives which overlap entries in the archive.\n\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,7 +15,22 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Summary

**Comments**
This PR makes a correcttion to the list of python versions which https://github.com/advisories/GHSA-jm46-725r-hh9v states are affected by CVE-2024-0450, for example:
- CPython 3.11.8 is _not_ vulnerable to this as the fix was backported to 3.11 by https://github.com/python/cpython/pull/113913 and `gh-109858` is listed as fixed in the python 3.11.8 release notes at https://docs.python.org/3.11/whatsnew/changelog.html#python-3-11-8-final
- CPython 3.12.2 is _not_ vulnerable to this either, see `gh-109858` on https://docs.python.org/3.12/whatsnew/changelog.html#python-3-12-2-final

(I'm unsure for earlier python versions, for example although it appears to have been backported to the 3.10 branch by https://github.com/python/cpython/pull/113914 it is not yet shown on https://docs.python.org/3.10/whatsnew/changelog.html so I'm unclear on whether there is yet a released version of 3.10 with the patch or not.)