### PR TITLE
[GHSA-hfg5-xpvw-c9x4] Improper Input Validation in Apache Camel

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-hfg5-xpvw-c9x4/GHSA-hfg5-xpvw-c9x4.json
+++ b/advisories/github-reviewed/2021/05/GHSA-hfg5-xpvw-c9x4/GHSA-hfg5-xpvw-c9x4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hfg5-xpvw-c9x4",
-  "modified": "2021-09-01T19:36:12Z",
+  "modified": "2023-04-14T19:27:10Z",
   "published": "2021-05-21T19:20:30Z",
   "aliases": [
     "CVE-2020-11971"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.22.0"
             },
             {
               "fixed": "3.2.0"
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.22.0"
             },
             {
               "fixed": "3.2.0"
@@ -63,7 +63,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.22.0"
             },
             {
               "fixed": "3.2.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
NVD indicates this CVE was introduced in Apache Camel starting at 2.22.0. Current impact range of < 3.2.0 is therefore overly broad as it includes version below 2.22.0. 

This change is aimed at indicating all versions >= 2.22.0 (until patched version) are impacted to avoid versions lower than the first impacted version being flagged.

reference: https://nvd.nist.gov/vuln/detail/CVE-2020-11971#range-9880510