### PR TITLE
[GHSA-67hx-6x53-jw92] Babel vulnerable to arbitrary code execution when compiling specifically crafted malicious code

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-67hx-6x53-jw92/GHSA-67hx-6x53-jw92.json
+++ b/advisories/github-reviewed/2023/10/GHSA-67hx-6x53-jw92/GHSA-67hx-6x53-jw92.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-67hx-6x53-jw92",
-  "modified": "2023-10-16T13:55:36Z",
+  "modified": "2023-12-08T19:11:42Z",
   "published": "2023-10-16T13:55:36Z",
   "aliases": [
     "CVE-2023-45133"
@@ -52,6 +52,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "babel-traverse"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 7.23.2"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
CVE lists "babel-traverse" as affected but it was missing in the affected product lists. All versions of babel-traverse are affected and there's no fix for that package name as they moved into a scope with a new name. I've listed < 7.23.2 as the affected version even though there's no fix; this is to align with the versioning scheme that was carried over to @babel/traverse.