### PR TITLE
[GHSA-jhv5-cxf2-r67v] UVDesk Community Skeleton v1.1.1 allows unauthenticated...

### DIFF
--- a/advisories/unreviewed/2023/10/GHSA-jhv5-cxf2-r67v/GHSA-jhv5-cxf2-r67v.json
+++ b/advisories/unreviewed/2023/10/GHSA-jhv5-cxf2-r67v/GHSA-jhv5-cxf2-r67v.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jhv5-cxf2-r67v",
-  "modified": "2023-10-30T21:33:39Z",
+  "modified": "2023-11-08T05:03:57Z",
   "published": "2023-10-23T21:30:58Z",
   "aliases": [
     "CVE-2023-37635"
   ],
+  "summary": "CVE-2023-37635",
   "details": "UVDesk Community Skeleton v1.1.1 allows unauthenticated attackers to perform brute force attacks on the login page to gain access to the application.",
   "severity": [
     {
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "uvdesk/community-skeletom"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.1.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.1.1"
+      }
+    }
   ],
   "references": [
     {
@@ -22,15 +44,19 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-37635"
     },
     {
+      "type": "PACKAGE",
+      "url": "https://github.com/uvdesk/community-skeleton/"
+    },
+    {
       "type": "WEB",
-      "url": "https://www.esecforte.com/cve-2023-37635-login-bruteforce"
+      "url": "https://www.esecforte.com/cve-2023-37635-login-bruteforce/"
     }
   ],
   "database_specific": {
     "cwe_ids": [
       "CWE-307"
     ],
-    "severity": null,
+    "severity": "CRITICAL",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-10-23T21:15:08Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity
- Source code location
- Summary

**Comments**
I submitted this vulnerability with my organisation eSecForte Technologies, so I know what package and version were affected. If a detailed Video Poc is required I'll share that as well.