### PR TITLE
 [GHSA-pjqh-2jcc-5j84] Update pkg name from spring-amqp to spring-ldap-core

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-pjqh-2jcc-5j84/GHSA-pjqh-2jcc-5j84.json
+++ b/advisories/github-reviewed/2022/05/GHSA-pjqh-2jcc-5j84/GHSA-pjqh-2jcc-5j84.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pjqh-2jcc-5j84",
-  "modified": "2022-06-30T21:14:06Z",
+  "modified": "2024-04-05T15:30:00Z",
   "published": "2022-05-13T01:12:09Z",
   "aliases": [
     "CVE-2017-8028"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.springframework.amqp:spring-amqp"
+        "name": "org.springframework.ldap:spring-ldap-core"
       },
       "ranges": [
         {
@@ -34,7 +34,7 @@
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 2.3.1"
+        "last_known_affected_version_range": "< 2.3.2"
       }
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to the Spring advisory https://spring.io/security/cve-2017-8028 this vulnerability affects Spring-LDAP and not spring-amqp. The linked PR https://github.com/spring-projects/spring-ldap/pull/432/files fixes a package in ldap core, hence the affected package seems to be org.springframework.ldap:spring-ldap-core