### PR TITLE
[GHSA-f5x3-32g6-xq36] Denial of service while parsing a tar file due to lack of folders count validation

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-f5x3-32g6-xq36/GHSA-f5x3-32g6-xq36.json
+++ b/advisories/github-reviewed/2024/03/GHSA-f5x3-32g6-xq36/GHSA-f5x3-32g6-xq36.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f5x3-32g6-xq36",
-  "modified": "2024-03-22T16:57:05Z",
+  "modified": "2024-03-22T16:57:07Z",
   "published": "2024-03-22T16:57:05Z",
   "aliases": [
     "CVE-2024-28863"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "npm",
-        "name": "node-tar"
+        "name": "tar"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
node-tar is a deprecated package, the vulnerability is for tar
https://www.npmjs.com/package/node-tar
https://www.npmjs.com/package/tar