### PR TITLE
[GHSA-59j7-ghrg-fj52] Microsoft Security Advisory CVE-2024-21319: .NET Denial of Service Vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-59j7-ghrg-fj52/GHSA-59j7-ghrg-fj52.json
+++ b/advisories/github-reviewed/2024/01/GHSA-59j7-ghrg-fj52/GHSA-59j7-ghrg-fj52.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-59j7-ghrg-fj52",
-  "modified": "2024-01-09T19:35:02Z",
+  "modified": "2024-01-09T19:35:04Z",
   "published": "2024-01-09T19:35:02Z",
   "aliases": [
 


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Is this not a duplicate of https://github.com/advisories/GHSA-8g9c-28fc-mcx2? If it isn't I believe CVE-2024-21319 would still be the CVE-ID to refer to here, but I couldn't find a form field to add it.