### PR TITLE
[GHSA-f8h5-v2vg-46rr] quarkus-core leaks local environment variables from Quarkus namespace during application's build

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-f8h5-v2vg-46rr/GHSA-f8h5-v2vg-46rr.json
+++ b/advisories/github-reviewed/2024/04/GHSA-f8h5-v2vg-46rr/GHSA-f8h5-v2vg-46rr.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-f8h5-v2vg-46rr",
+  "modified": "2024-04-04T17:01:46Z",
+  "published": "2024-04-04T15:30:34Z",
+  "aliases": [
+    "CVE-2024-2700"
+  ],
+  "summary": "quarkus-core leaks local environment variables from Quarkus namespace during application's build",
+  "details": "A vulnerability was found in the quarkus-core component. Quarkus captures the local environment variables from the Quarkus namespace during the application's build. Thus, running the resulting application inherits the values captured at build time. \n\nHowever, some local environment variables may have been set by the developer / CI environment for testing purposes, such as dropping the database during the application startup or trusting all TLS certificates to accept self-signed certificates. If these properties are configured using environment variables or the .env facility, they are captured into the built application. It leads to dangerous behavior if the application does not override these values.\n\nThis behavior only happens for configuration properties from the `quarkus.*` namespace. So, application-specific properties are not captured.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.quarkus:quarkus-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.9.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.9.1"
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-2700"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/security/cve/CVE-2024-2700"
+    },
+    {
+      "type": "WEB",
+      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2273281"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/quarkusio/quarkus"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-526"
+    ],
+    "severity": "HIGH",
+    "github_reviewed": true,
+    "github_reviewed_at": "2024-04-04T17:01:45Z",
+    "nvd_published_at": "2024-04-04T14:15:09Z"
+  }
+}


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
See https://github.com/quarkusio/quarkus/issues/39927#issuecomment-2041376909 - there might be a reason though why the team hasn't updated their internal tickets. Maybe even the link to Guillaume's comment would be of help for people coming to this advisory.