### PR TITLE
[GHSA-f5x3-32g6-xq36] Denial of service while parsing a tar file due to lack of folders count validation

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-f5x3-32g6-xq36/GHSA-f5x3-32g6-xq36.json
+++ b/advisories/github-reviewed/2024/03/GHSA-f5x3-32g6-xq36/GHSA-f5x3-32g6-xq36.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f5x3-32g6-xq36",
-  "modified": "2024-03-22T16:57:05Z",
+  "modified": "2024-03-22T16:57:07Z",
   "published": "2024-03-22T16:57:05Z",
   "aliases": [
     "CVE-2024-28863"
@@ -19,6 +19,25 @@
       "package": {
         "ecosystem": "npm",
         "name": "node-tar"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 6.2.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "tar"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Published NPM package name is 'tar', which is different than the README and GitHub repository ('node-tar'). A single deprecated version was released under the node-tar name (v1.0.0) so that's been left in the affected package list without a listed patched version.