### PR TITLE
[GHSA-35jh-r3h4-6jhm] Command Injection in lodash

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-35jh-r3h4-6jhm/GHSA-35jh-r3h4-6jhm.json
+++ b/advisories/github-reviewed/2021/05/GHSA-35jh-r3h4-6jhm/GHSA-35jh-r3h4-6jhm.json
@@ -20,11 +20,6 @@
         "ecosystem": "npm",
         "name": "lodash"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash).template"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -44,11 +39,6 @@
         "ecosystem": "npm",
         "name": "lodash-es"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(lodash-es).template"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -62,6 +52,44 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "lodash.template"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.17.21"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "lodash-template"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 4.17.21"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
'lodash.template' and 'lodash-template' were modularized versions of the Lodash template function, published to NPM by third parties. They contain the vulnerable code. 'lodash.template' has relatively high usage (>1000 dependents) and is not marked as deprecated. Since neither of these packages appear to be maintained any longer, I have left the 'patched version' field blank. The fix is to switch to the officially maintained lodash packages instead.