### PR TITLE
[GHSA-9mg4-v392-8j68] erlang-jose (aka JOSE for Erlang and Elixir) through 1.11...

### DIFF
--- a/advisories/unreviewed/2024/03/GHSA-9mg4-v392-8j68/GHSA-9mg4-v392-8j68.json
+++ b/advisories/unreviewed/2024/03/GHSA-9mg4-v392-8j68/GHSA-9mg4-v392-8j68.json
@@ -1,22 +1,48 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9mg4-v392-8j68",
-  "modified": "2024-03-19T15:30:34Z",
+  "modified": "2024-04-08T16:46:04Z",
   "published": "2024-03-19T15:30:34Z",
   "aliases": [
     "CVE-2023-50966"
   ],
+  "summary": "DoS via a large p2c value in a JOSE header",
   "details": "erlang-jose (aka JOSE for Erlang and Elixir) through 1.11.6 allow attackers to cause a denial of service (CPU consumption) via a large p2c (aka PBES2 Count) value in a JOSE header.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Hex",
+        "name": "jose"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.0.0"
+            },
+            {
+              "fixed": "1.1.19"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-50966"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/potatosalad/erlang-jose/commit/718d213f07b08056737923f8063d5df56dcb66ae"
     },
     {
       "type": "WEB",
@@ -33,9 +59,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-400"
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2024-03-19T15:15:07Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Summary

**Comments**
Add affected package & versions as well as CVSS