### PR TITLE
[GHSA-p8f7-22gq-m7j9] Phoenix before 1.6.14 mishandles check_origin wildcarding

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-p8f7-22gq-m7j9/GHSA-p8f7-22gq-m7j9.json
+++ b/advisories/github-reviewed/2022/10/GHSA-p8f7-22gq-m7j9/GHSA-p8f7-22gq-m7j9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p8f7-22gq-m7j9",
-  "modified": "2022-10-20T20:12:38Z",
+  "modified": "2023-02-01T05:08:43Z",
   "published": "2022-10-17T12:00:27Z",
   "aliases": [
     "CVE-2022-42975"
@@ -55,7 +55,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-346"
     ],
     "severity": "HIGH",
     "github_reviewed": true,


### PR DESCRIPTION
**Updates**
- CWEs

**Comments**
Add CWE