### PR TITLE
[GHSA-h755-8qp9-cq85] protobufjs Prototype Pollution vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-h755-8qp9-cq85/GHSA-h755-8qp9-cq85.json
+++ b/advisories/github-reviewed/2023/07/GHSA-h755-8qp9-cq85/GHSA-h755-8qp9-cq85.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h755-8qp9-cq85",
-  "modified": "2023-08-15T21:16:36Z",
+  "modified": "2023-11-29T22:15:04Z",
   "published": "2023-07-05T15:30:24Z",
   "aliases": [
     "CVE-2023-36665"
   ],
   "summary": "protobufjs Prototype Pollution vulnerability",
-  "details": "protobuf.js (aka protobufjs) 6.10.0 until 6.11.4 and 7.0.0 until 7.2.4 allows Prototype Pollution, a different vulnerability than CVE-2022-25878. A user-controlled protobuf message can be used by an attacker to pollute the prototype of Object.prototype by adding and overwriting its data and functions. Exploitation can involve: (1) using the function parse to parse protobuf messages on the fly, (2) loading .proto files by using load/loadSync functions, or (3) providing untrusted input to the functions ReflectionObject.setParsedOption and util.setProperty. NOTE: this CVE Record is about `Object.constructor.prototype.<new-property> = ...;` whereas CVE-2022-25878 was about `Object.__proto__.<new-property> = ...;` instead.",
+  "details": "protobuf.js (aka protobufjs) 6.10.0 until 6.11.4 and 7.0.0 until 7.2.5 allows Prototype Pollution, a different vulnerability than CVE-2022-25878. A user-controlled protobuf message can be used by an attacker to pollute the prototype of Object.prototype by adding and overwriting its data and functions. Exploitation can involve: (1) using the function parse to parse protobuf messages on the fly, (2) loading .proto files by using load/loadSync functions, or (3) providing untrusted input to the functions ReflectionObject.setParsedOption and util.setProperty. NOTE: this CVE Record is about `Object.constructor.prototype.<new-property> = ...;` whereas CVE-2022-25878 was about `Object.__proto__.<new-property> = ...;` instead.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -20,11 +20,6 @@
         "ecosystem": "npm",
         "name": "protobufjs"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(protobufjs).util.setProperty"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -33,7 +28,7 @@
               "introduced": "7.0.0"
             },
             {
-              "fixed": "7.2.4"
+              "fixed": "7.2.5"
             }
           ]
         }
@@ -43,11 +38,6 @@
       "package": {
         "ecosystem": "npm",
         "name": "protobufjs"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(protobufjs).util.setProperty"
-        ]
       },
       "ranges": [
         {
@@ -68,6 +58,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-36665"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/protobufjs/protobuf.js/issues/1918"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
The 7.2.4 release still contains vulnerabilities, the original CVE was updated to include the 7.2.4 version as affected but the change was not mirrored into Github

https://github.com/protobufjs/protobuf.js/issues/1918#issuecomment-1723500294