### PR TITLE
[GHSA-5xv2-q475-rwrh] Katello uses hard coded credential

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-5xv2-q475-rwrh/GHSA-5xv2-q475-rwrh.json
+++ b/advisories/github-reviewed/2022/05/GHSA-5xv2-q475-rwrh/GHSA-5xv2-q475-rwrh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5xv2-q475-rwrh",
-  "modified": "2024-04-09T14:24:53Z",
+  "modified": "2024-04-09T14:24:54Z",
   "published": "2022-05-17T05:13:13Z",
   "aliases": [
     "CVE-2012-3503"
@@ -25,11 +25,36 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.0"
+              "fixed": ">= 1.0.6"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.0.6"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "katello"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.1.0"
+            },
+            {
+              "fixed": ">= 1.1.7"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.1.7"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The [patch commit](https://github.com/Katello/katello/commit/7c256fef9d75029d0ffff58ff1dcda915056d3a3) appears in the [katello-1.0.6-1](https://github.com/Katello/katello/commits/katello-1.0.6-1/) and [katello-1.1.7-1](https://github.com/Katello/katello/commits/katello-1.1.7-1/) tags.