### PR TITLE
[GHSA-46cm-pfwv-cgf8] LiteLLM has Server-Side Template Injection vulnerability in /completions endpoint

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-46cm-pfwv-cgf8/GHSA-46cm-pfwv-cgf8.json
+++ b/advisories/github-reviewed/2024/04/GHSA-46cm-pfwv-cgf8/GHSA-46cm-pfwv-cgf8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-46cm-pfwv-cgf8",
-  "modified": "2024-04-10T22:18:53Z",
+  "modified": "2024-04-10T22:18:55Z",
   "published": "2024-04-10T18:30:48Z",
   "aliases": [
     "CVE-2024-2952"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.34.1"
+              "fixed": "1.34.42"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.34.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Hi, I'm the maintainer of LiteLLM and we fixed this issue - please can you help us mark this as resolved 

Issue: https://github.com/BerriAI/litellm/issues/2949
PR with fix: https://github.com/BerriAI/litellm/pull/2941