### PR TITLE
[GHSA-46cm-pfwv-cgf8] LiteLLM has Server-Side Template Injection vulnerability in /completions endpoint

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-46cm-pfwv-cgf8/GHSA-46cm-pfwv-cgf8.json
+++ b/advisories/github-reviewed/2024/04/GHSA-46cm-pfwv-cgf8/GHSA-46cm-pfwv-cgf8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-46cm-pfwv-cgf8",
-  "modified": "2024-04-10T22:18:53Z",
+  "modified": "2024-04-10T22:18:55Z",
   "published": "2024-04-10T18:30:48Z",
   "aliases": [
     "CVE-2024-2952"
@@ -28,10 +28,35 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.34.1"
+              "fixed": "1.34.42"
             }
           ]
         }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.34.41"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "litellm"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.35.0.dev1"
+            },
+            {
+              "fixed": "1.35.0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.35.0.dev1"
       ]
     }
   ],
@@ -41,12 +66,24 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-2952"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/BerriAI/litellm/pull/2941"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/BerriAI/litellm/commit/8a1cdc901708b07b7ff4eca20f9cb0f1f0e8d0b3"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/BerriAI/litellm"
     },
     {
       "type": "WEB",
       "url": "https://github.com/BerriAI/litellm/blob/0d803e13798db40aa7463e64a6bafaee386424f5/litellm/proxy/proxy_server.py#L2087"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/BerriAI/litellm/releases/tag/v1.34.42"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
identified fix commit from hunter.dev conversation and update fix /vulnerable versions as per it.