### PR TITLE
[GHSA-7w75-32cg-r6g2] Apache Tomcat Denial of Service due to improper input validation vulnerability for HTTP/2 requests

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-7w75-32cg-r6g2/GHSA-7w75-32cg-r6g2.json
+++ b/advisories/github-reviewed/2024/03/GHSA-7w75-32cg-r6g2/GHSA-7w75-32cg-r6g2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7w75-32cg-r6g2",
-  "modified": "2024-04-06T06:31:08Z",
+  "modified": "2024-04-06T06:31:09Z",
   "published": "2024-03-13T18:31:34Z",
   "aliases": [
     "CVE-2024-24549"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -59,7 +59,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -81,7 +81,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It appears that the patch applies specifically to org.apache.coyote.http2 which per https://github.com/search?q=repo%3Aapache%2Ftomcat+org.apache.coyote+path%3Ares%2Fbnd&type=code is bundled into the specific artifact`org.apache.tomcat:tomcat-coyote` (as well as `org.apache.tomcat.embed:tomcat-embed-core`)