### PR TITLE
[GHSA-3p86-9955-h393] Arbitrary File Overwrite in Eclipse JGit 

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-3p86-9955-h393/GHSA-3p86-9955-h393.json
+++ b/advisories/github-reviewed/2023/09/GHSA-3p86-9955-h393/GHSA-3p86-9955-h393.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3p86-9955-h393",
-  "modified": "2024-01-12T20:44:52Z",
+  "modified": "2023-11-09T05:01:46Z",
   "published": "2023-09-18T15:30:18Z",
   "aliases": [
     "CVE-2023-4759"
   ],
   "summary": "Arbitrary File Overwrite in Eclipse JGit ",
-  "details": "Arbitrary File Overwrite in Eclipse JGit <= 6.6.0\n\nIn Eclipse JGit, all versions <= 6.6.0.202305301015-r, a symbolic link present in a specially crafted git repository can be used to write a file to locations outside the working tree when this repository is cloned with JGit to a case-insensitive filesystem, or when a checkout from a clone of such a repository is performed on a case-insensitive filesystem.\n\nThis can happen on checkout (DirCacheCheckout), merge (ResolveMerger via its WorkingTreeUpdater), pull (PullCommand using merge), and when applying a patch (PatchApplier). This can be exploited for remote code execution (RCE), for instance if the file written outside the working tree is a git filter that gets executed on a subsequent git command.\n\nThe issue occurs only on case-insensitive filesystems, like the default filesystems on Windows and macOS. The user performing the clone or checkout must have the rights to create symbolic links for the problem to occur, and symbolic links must be enabled in the git configuration.\n\nSetting git configuration option core.symlinks = false before checking out avoids the problem.\n\nThe issue was fixed in Eclipse JGit version 6.6.1.202309021850-r and 6.7.0.202309050840-r, available via  Maven Central https://repo1.maven.org/maven2/org/eclipse/jgit/  and  repo.eclipse.org https://repo.eclipse.org/content/repositories/jgit-releases/ .\n\n\nThe JGit maintainers would like to thank RyotaK for finding and reporting this issue.\n\n\n\n",
+  "details": "Arbitrary File Overwrite in Eclipse JGit <= 6.6.0\n\nIn Eclipse JGit, all versions <= 6.6.0.202305301015-r except 5.13.3.202401111512-r, a symbolic link present in a specially crafted git repository can be used to write a file to locations outside the working tree when this repository is cloned with JGit to a case-insensitive filesystem, or when a checkout from a clone of such a repository is performed on a case-insensitive filesystem.\n\nThis can happen on checkout (DirCacheCheckout), merge (ResolveMerger via its WorkingTreeUpdater), pull (PullCommand using merge), and when applying a patch (PatchApplier). This can be exploited for remote code execution (RCE), for instance if the file written outside the working tree is a git filter that gets executed on a subsequent git command.\n\nThe issue occurs only on case-insensitive filesystems, like the default filesystems on Windows and macOS. The user performing the clone or checkout must have the rights to create symbolic links for the problem to occur, and symbolic links must be enabled in the git configuration.\n\nSetting git configuration option core.symlinks = false before checking out avoids the problem.\n\nThe issue was fixed in Eclipse JGit version 6.6.1.202309021850-r and 6.7.0.202309050840-r and backported to 5.13.3.202401111512-r, available via  Maven Central https://repo1.maven.org/maven2/org/eclipse/jgit/  and  repo.eclipse.org https://repo.eclipse.org/content/repositories/jgit-releases/ .\n\n\nThe JGit maintainers would like to thank RyotaK for finding and reporting this issue.\n\n\n\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -36,12 +36,35 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 6.6.0.202305301015-r"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.jgit:org.eclipse.jgit"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.13.3.202401111512-r"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-4759"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/eclipse-jgit/jgit/issues/30"
     },
     {
       "type": "PACKAGE",
@@ -54,6 +77,10 @@
     {
       "type": "WEB",
       "url": "https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/11"
+    },
+    {
+      "type": "WEB",
+      "url": "https://projects.eclipse.org/projects/technology.jgit/releases/5.13.3"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
Updated Affected Products since the fix was backported to 5.13.3.202401111512-r per project release notes.