### PR TITLE
[GHSA-37q5-v5qm-c9v8] Transformers Deserialization of Untrusted Data vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-37q5-v5qm-c9v8/GHSA-37q5-v5qm-c9v8.json
+++ b/advisories/github-reviewed/2024/04/GHSA-37q5-v5qm-c9v8/GHSA-37q5-v5qm-c9v8.json
@@ -1,18 +1,15 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-37q5-v5qm-c9v8",
-  "modified": "2024-04-10T22:20:56Z",
+  "modified": "2024-04-10T22:20:57Z",
   "published": "2024-04-10T18:30:48Z",
   "aliases": [
     "CVE-2024-3568"
   ],
   "summary": "Transformers Deserialization of Untrusted Data vulnerability",
-  "details": "The huggingface/transformers library is vulnerable to arbitrary code execution through deserialization of untrusted data within the `load_repo_checkpoint()` function of the `TFPreTrainedModel()` class. Attackers can execute arbitrary code and commands by crafting a malicious serialized payload, exploiting the use of `pickle.load()` on data from potentially untrusted sources. This vulnerability allows for remote code execution (RCE) by deceiving victims into loading a seemingly harmless checkpoint during a normal training process, thereby enabling attackers to execute arbitrary code on the targeted machine.",
+  "details": "The huggingface/transformers library is vulnerable to arbitrary code execution through the deserialization of untrusted data within the `load_repo_checkpoint()` function of the `TFPreTrainedModel()` class. Attackers can execute arbitrary code and commands by crafting a malicious serialized payload, exploiting the use of `pickle.load()` on data from potentially untrusted sources. This vulnerability allows for remote code execution (RCE) by deceiving victims into loading a seemingly harmless checkpoint during a normal training process, thereby enabling attackers to execute arbitrary code on the targeted machine.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:C/C:N/I:N/A:L"
-    }
+
   ],
   "affected": [
     {
@@ -43,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/huggingface/transformers/commit/693667b8ac8138b83f8adb6522ddaf42fa07c125"
+    },
+    {
+      "type": "WEB",
+      "url": "https://gist.github.com/retr0reg/1804fd680a620223747173d0775e2f3a"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- References

**Comments**
I am the author of this report on huntr.com. I fixed a few grammatic mistakes and updated the `poc.py`.
Additionally, The reason for changing the Severity to Low is that the CVSS cannot directly show the severity of this vulnerability. Maintainers in huntr.com cannot rate a vulnerability directly into 'Low' since they can only adjust the CVSS scoring into the Low category.