### PR TITLE
[GHSA-xm2m-2q6h-22jw] Apache NiFi vulnerable to Code Injection

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-xm2m-2q6h-22jw/GHSA-xm2m-2q6h-22jw.json
+++ b/advisories/github-reviewed/2023/06/GHSA-xm2m-2q6h-22jw/GHSA-xm2m-2q6h-22jw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xm2m-2q6h-22jw",
-  "modified": "2023-06-21T13:48:41Z",
+  "modified": "2023-11-11T05:05:10Z",
   "published": "2023-06-12T18:30:18Z",
   "aliases": [
     "CVE-2023-34468"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -52,6 +52,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.nifi:nifi-dbcp-service-nar"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.0.2"
+            },
+            {
+              "fixed": "1.22.0"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
@@ -66,6 +85,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/nifi/commit/4faf3ea59895e7e153db3f8f61147ff70a254361"
+    },
+    {
+      "type": "WEB",
+      "url": "https://exceptionfactory.com/posts/2023/10/07/firsthand-analysis-of-apache-nifi-vulnerability-cve-2023-34468/"
     },
     {
       "type": "PACKAGE",
@@ -85,7 +108,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.cyfirma.com/outofband/apache-nifi-cve-2023-34468-rce-vulnerability-analysis-and-exploitation"
+      "url": "https://www.cyfirma.com/outofband/apache-nifi-cve-2023-34468-rce-vulnerability-analysis-and-exploitation/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- References

**Comments**
Added blog post to References, which provides additional background on the vulnerable components. Based on that analysis, the attack complexity should be considered high because an attacker must authenticate to Apache NiFi and must have permissions that authorize the configuration of the vulnerable components. Also added `nifi-dbcp-service-nar` to affected products as it contains the JAR artifacts with the vulnerable components.