### PR TITLE
[GHSA-prjv-jj26-wf8h] ClassLoader manipulation in Apache Struts

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-prjv-jj26-wf8h/GHSA-prjv-jj26-wf8h.json
+++ b/advisories/github-reviewed/2022/05/GHSA-prjv-jj26-wf8h/GHSA-prjv-jj26-wf8h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-prjv-jj26-wf8h",
-  "modified": "2023-12-28T19:02:21Z",
+  "modified": "2023-12-28T19:02:22Z",
   "published": "2022-05-14T00:54:16Z",
   "aliases": [
     "CVE-2014-0112"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0112"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/74e26830d2849a84729b33497f729e0f033dc147"
     },
     {
       "type": "WEB",
@@ -80,7 +84,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-284"
     ],
     "severity": "HIGH",
     "github_reviewed": true,


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- References

**Comments**
Add a patch https://github.com/apache/struts/commit/74e26830d2849a84729b33497f729e0f033dc147, of which the commit message claims `Adds additional pattern to prevent access to getClass method`. This shows its correlation with the root cause of this cve `The Struts 2 ParametersInterceptor was updated to block access to the 'class' parameter, but not all forms in which this parameter can be specified were blocked` as claimed by Redhat: https://bugzilla.redhat.com/show_bug.cgi?id=1091939.
