### PR TITLE
[GHSA-3c5c-xrq4-qhr8] ClassLoader manipulation in Apache Struts

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-3c5c-xrq4-qhr8/GHSA-3c5c-xrq4-qhr8.json
+++ b/advisories/github-reviewed/2022/05/GHSA-3c5c-xrq4-qhr8/GHSA-3c5c-xrq4-qhr8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3c5c-xrq4-qhr8",
-  "modified": "2022-11-03T22:53:53Z",
+  "modified": "2023-02-01T05:04:17Z",
   "published": "2022-05-14T00:54:15Z",
   "aliases": [
     "CVE-2014-0113"
@@ -36,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0113"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/74e26830d2849a84729b33497f729e0f033dc147"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apache/struts/commit/74e26830d2849a84729b33497f729e0f033dc147, of which the commit message claims `Adds additional pattern to prevent access to getClass method`. This patch is also for CVE-2014-0112, since the two cves are caused by the same root cause: ` an incomplete fix related to ParametersInterceptor and the failure to restrict access to the class parameter`.
