### PR TITLE
[GHSA-hmhq-382q-mp56] ClassLoader manipulation in Apache Struts

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-hmhq-382q-mp56/GHSA-hmhq-382q-mp56.json
+++ b/advisories/github-reviewed/2022/05/GHSA-hmhq-382q-mp56/GHSA-hmhq-382q-mp56.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hmhq-382q-mp56",
-  "modified": "2022-11-03T22:53:33Z",
+  "modified": "2023-12-28T19:12:48Z",
   "published": "2022-05-14T00:54:14Z",
   "aliases": [
     "CVE-2014-0116"
   ],
   "summary": "ClassLoader manipulation in Apache Struts",
-  "details": "CookieInterceptor in Apache Struts 2.x before 2.3.20, when a wildcard cookiesName value is used, does not properly restrict access to the getClass method, which allows remote attackers to \"manipulate\" the ClassLoader and modify session state via a crafted request. NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-0113.",
+  "details": "<html xmlns:v=\"urn:schemas-microsoft-com:vml\"\nxmlns:o=\"urn:schemas-microsoft-com:office:office\"\nxmlns:x=\"urn:schemas-microsoft-com:office:excel\"\nxmlns=\"http://www.w3.org/TR/REC-html40\">\n\n<head>\n\n<meta name=ProgId content=Excel.Sheet>\n<meta name=Generator content=\"Microsoft Excel 15\">\n<link id=Main-File rel=Main-File\nhref=\"file:///C:/Users/kaixuan/AppData/Local/Temp/msohtmlclip1/01/clip.htm\">\n<link rel=File-List\nhref=\"file:///C:/Users/kaixuan/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml\">\n<style>\n<!--table\n\t{mso-displayed-decimal-separator:\"\\.\";\n\tmso-displayed-thousand-separator:\"\\,\";}\n@page\n\t{margin:.75in .7in .75in .7in;\n\tmso-header-margin:.3in;\n\tmso-footer-margin:.3in;}\ntr\n\t{mso-height-source:auto;}\ncol\n\t{mso-width-source:auto;}\nbr\n\t{mso-data-placement:same-cell;}\ntd\n\t{padding-top:1px;\n\tpadding-right:1px;\n\tpadding-left:1px;\n\tmso-ignore:padding;\n\tcolor:black;\n\tfont-size:11.0pt;\n\tfont-weight:400;\n\tfont-style:normal;\n\ttext-decoration:none;\n\tfont-family:Calibri, sans-serif;\n\tmso-font-charset:134;\n\tmso-number-format:General;\n\ttext-align:general;\n\tvertical-align:bottom;\n\tborder:none;\n\tmso-background-source:auto;\n\tmso-pattern:auto;\n\tmso-protection:locked visible;\n\twhite-space:nowrap;\n\tmso-rotate:0;}\n-->\n</style>\n</head>\n\n<body link=\"#0563C1\" vlink=\"#954F72\">\n\n\nAdd a patch   https://github.com/apache/struts/commit/74e26830d2849a84729b33497f729e0f033dc147,   of which the commit message claims `Adds additional pattern to prevent access   to getClass method`\n--\n\n\n\n\n</body>\n\n</html>\nCookieInterceptor in Apache Struts 2.x before 2.3.20, when a wildcard cookiesName value is used, does not properly restrict access to the getClass method, which allows remote attackers to \"manipulate\" the ClassLoader and modify session state via a crafted request. NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-0113.",
   "severity": [
 
   ],
@@ -40,6 +40,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/struts/commit/1a668af7f1ffccea4a3b46d8d8c1fe1c7331ff02"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/struts/commit/74e26830d2849a84729b33497f729e0f033dc147"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
Add a ""potential patch" commit https://github.com/apache/struts/commit/74e26830d2849a84729b33497f729e0f033dc147, of which the commit message claims `Adds additional pattern to prevent access to getClass method`, this commit tried to fix CVE-2014-0112 and CVE-2014-0113, as the previous pr I opened. As described in the CVE desc of CVE-2014-0116, this commit would provide some insights for this vuln, even though it may be not a valid patch commit for this cve. 
