### PR TITLE
[GHSA-7vpq-g998-qpv7] Netty denial of service vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-7vpq-g998-qpv7/GHSA-7vpq-g998-qpv7.json
+++ b/advisories/github-reviewed/2022/05/GHSA-7vpq-g998-qpv7/GHSA-7vpq-g998-qpv7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7vpq-g998-qpv7",
-  "modified": "2023-08-07T20:25:36Z",
+  "modified": "2023-08-16T05:02:25Z",
   "published": "2022-05-13T01:54:02Z",
   "aliases": [
     "CVE-2014-0193"
@@ -116,6 +116,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/netty/netty/issues/2441"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/netty/netty/commit/8599ab5bdb761bb99d41a975d689f74c12e4892b"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/netty/netty"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add a patch https://github.com/netty/netty/commit/8599ab5bdb761bb99d41a975d689f74c12e4892b, of which the commit message reflects the motivation for fixing this cve, consistent with the issue (https://github.com/netty/netty/issues/2441) this cve referred to: `Remove ContinuationWebSocketFrame.aggregatedText()...`
