### PR TITLE
[GHSA-42j3-498q-m6vp] Improper Input Validation in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-42j3-498q-m6vp/GHSA-42j3-498q-m6vp.json
+++ b/advisories/github-reviewed/2022/05/GHSA-42j3-498q-m6vp/GHSA-42j3-498q-m6vp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-42j3-498q-m6vp",
-  "modified": "2022-07-07T22:52:25Z",
+  "modified": "2023-01-27T05:02:12Z",
   "published": "2022-05-14T01:10:18Z",
   "aliases": [
     "CVE-2014-0227"
@@ -77,7 +77,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/593a2447e6ebe465585cfa07e93b5635dffa1c70"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1109196"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tomcat"
     },
     {
       "type": "WEB",
@@ -110,6 +118,10 @@
     {
       "type": "WEB",
       "url": "https://source.jboss.org/changelog/JBossWeb?cs=2455"
+    },
+    {
+      "type": "WEB",
+      "url": "https://svn.apache.org/viewvc?view=revision&revision=1600984"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/apache/tomcat/commit/593a2447e6ebe465585cfa07e93b5635dffa1c70, of which the commit message claims `i18n for ChunkedInputFilter error message Add error flag to allow subsequent attempts at reading after an error to fail fast`, which coincides with the cve description. 
