### PR TITLE
[GHSA-c438-8cvq-pxxx] Apache Tapestry Unsafe Object Storage

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-c438-8cvq-pxxx/GHSA-c438-8cvq-pxxx.json
+++ b/advisories/github-reviewed/2022/05/GHSA-c438-8cvq-pxxx/GHSA-c438-8cvq-pxxx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c438-8cvq-pxxx",
-  "modified": "2023-08-07T20:22:29Z",
+  "modified": "2023-08-16T05:02:13Z",
   "published": "2022-05-13T01:26:11Z",
   "aliases": [
     "CVE-2014-1972"
@@ -43,7 +43,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/apache/tapestry-5"
+      "url": "https://github.com/apache/tapestry-5/commit/95846b173d83c2eb42db75dae3e7d5e13a633946"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tapestry-5/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add a patch https://github.com/apache/tapestry-5/commit/95846b173d83c2eb42db75dae3e7d5e13a633946, of which the commit message claims `TAP5-2008: Implement HMAC signatures on object streams stored on the client`, which use the same commit msg with the existing patch commit in the current ref links.
