### PR TITLE
[GHSA-wmv4-5w76-vp9g] Authorization Bypass in Spring Security

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-wmv4-5w76-vp9g/GHSA-wmv4-5w76-vp9g.json
+++ b/advisories/github-reviewed/2020/09/GHSA-wmv4-5w76-vp9g/GHSA-wmv4-5w76-vp9g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wmv4-5w76-vp9g",
-  "modified": "2021-10-04T21:18:23Z",
+  "modified": "2023-02-01T05:04:58Z",
   "published": "2020-09-15T20:16:22Z",
   "aliases": [
     "CVE-2014-3527"
@@ -65,7 +65,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/spring-projects/spring-security"
+      "url": "https://github.com/spring-projects/spring-security/commit/934937d9c1dc20c396b96c08310b72cfa627acb"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/spring-projects/spring-security/"
     },
     {
       "type": "WEB",

--- a/advisories/github-reviewed/2020/09/GHSA-wmv4-5w76-vp9g/GHSA-wmv4-5w76-vp9g.json
+++ b/advisories/github-reviewed/2020/09/GHSA-wmv4-5w76-vp9g/GHSA-wmv4-5w76-vp9g.json
@@ -65,6 +65,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-security/commit/2cb99f079152ac05cee5c90457c7feb3bb2de55"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/spring-projects/spring-security/commit/934937d9c1dc20c396b96c08310b72cfa627acb"
     },
     {


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/spring-projects/spring-security/commit/934937d9c1dc20c396b96c08310b72cfa627acb, of which the commit message claims `SEC-2688: CAS Proxy Ticket Authentication uses Service for host & port`, coinciding with the CVE desc and the issue id SEC-2688
was also mentioned in the github issue link: https://github.com/spring-projects/spring-security/issues/2907.