### PR TITLE
[GHSA-q56h-jjj6-52mf] Improper Restriction of XML External Entity Reference in Apache POI

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-q56h-jjj6-52mf/GHSA-q56h-jjj6-52mf.json
+++ b/advisories/github-reviewed/2022/05/GHSA-q56h-jjj6-52mf/GHSA-q56h-jjj6-52mf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q56h-jjj6-52mf",
-  "modified": "2022-07-07T22:42:15Z",
+  "modified": "2023-01-27T05:02:30Z",
   "published": "2022-05-17T01:24:40Z",
   "aliases": [
     "CVE-2014-3529"
@@ -39,7 +39,31 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/poi/commit/103b45073c7b504236588b3acc146530205af53c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/poi/commit/236c3c52a9b90688b2e57ec503559409e29f33ed"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/poi/commit/6050a68d5adfb4ffef1edb778add09bcee32d1c3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/poi/commit/d72bd78c19dfb7b57395a66ae8d9269d59a87bd2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/poi/commit/eabb6a924be24abb879372d0bc967e0d316b2cf8"
+    },
+    {
+      "type": "WEB",
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/95770"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/poi"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add 5 patch commits: 

- `https://github.com/apache/poi/commit/d72bd78c19dfb7b57395a66ae8d9269d59a87bd2`
  - explanation: This commit tidies up the OPC SAX setup code, which is directly related to mitigating the XXE vulnerabilities identified in this cve.

- `https://github.com/apache/poi/commit/103b45073c7b504236588b3acc146530205af53c`
  - explanation: This commit applies multiple security enhancements, including secure XML defaults and parser updates, to address the XXE vulnerabilities outlined in this cve. It merges critical security suggestions for robust defense mechanisms against XML entity attacks.

- `https://github.com/apache/poi/commit/6050a68d5adfb4ffef1edb778add09bcee32d1c3`
  - explanation: Addition of test files and unit tests to verify the mitigation of XXE issues associated with this cve. These tests are crucial for ensuring that the security patches effectively prevent the type of attacks detailed in the CVE.

- `https://github.com/apache/poi/commit/eabb6a924be24abb879372d0bc967e0d316b2cf8`
  - explanation: This commit addresses additional external entity leaks that contribute to the vulnerabilities in this cve, ensuring tighter security and compliance with recommended XML handling practices.

- `https://github.com/apache/poi/commit/236c3c52a9b90688b2e57ec503559409e29f33ed`
  - explanation: Implements advanced XML parser settings as suggested by security experts, specifically targeting the prevention of XXE vulnerabilities as noted in this cve. This patch enhances the security framework necessary to protect against XML entity attacks.