### PR TITLE
[GHSA-845h-985r-jrqh] Improper Authentication in Hibernate Validator

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-845h-985r-jrqh/GHSA-845h-985r-jrqh.json
+++ b/advisories/github-reviewed/2022/05/GHSA-845h-985r-jrqh/GHSA-845h-985r-jrqh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-845h-985r-jrqh",
-  "modified": "2022-07-07T22:41:16Z",
+  "modified": "2023-01-27T05:02:13Z",
   "published": "2022-05-14T01:18:38Z",
   "aliases": [
     "CVE-2014-3558"
@@ -74,6 +74,42 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-3558"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hibernate/hibernate-validator/commit/2c95d4ea0ef20977be249e31a4a4f4f4f71c945d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hibernate/hibernate-validator/commit/67fdff14831c035c25e098fe14bd86523d17f726"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hibernate/hibernate-validator/commit/7e7131939a4361a7cad3e77ab89a8462132c561c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hibernate/hibernate-validator/commit/c489416f699a46859c134796b3ccfea41ef3ce52"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hibernate/hibernate-validator/commit/c9525ca544b1281e2b7c7347e86e87c86dc1dc6e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hibernate/hibernate-validator/commit/e8c42b689df8c6752d635d02c6518da3fece3870"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hibernate/hibernate-validator/commit/f97c2021a03c825abdeca1692f5be51e77e76a8f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hibernate/hibernate-validator/commit/fd4eaed7fb930db6a5e4c03742b4b3adcfecc90e"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/hibernate/hibernate-validator"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
add 8 patch commits, the commit msgs show their role to fix the issue `HV-912`, as referred in the current reference links:

https://github.com/hibernate/hibernate-validator/commit/c489416f699a46859c134796b3ccfea41ef3ce52
https://github.com/hibernate/hibernate-validator/commit/c9525ca544b1281e2b7c7347e86e87c86dc1dc6e
https://github.com/hibernate/hibernate-validator/commit/7e7131939a4361a7cad3e77ab89a8462132c561c
https://github.com/hibernate/hibernate-validator/commit/fd4eaed7fb930db6a5e4c03742b4b3adcfecc90e
https://github.com/hibernate/hibernate-validator/commit/f97c2021a03c825abdeca1692f5be51e77e76a8f
https://github.com/hibernate/hibernate-validator/commit/e8c42b689df8c6752d635d02c6518da3fece3870
https://github.com/hibernate/hibernate-validator/commit/2c95d4ea0ef20977be249e31a4a4f4f4f71c945d
https://github.com/hibernate/hibernate-validator/commit/67fdff14831c035c25e098fe14bd86523d17f726
