### PR TITLE
[GHSA-4vhf-2hv7-8mrx] Improper Restriction of XML External Entity Reference in Apache ActiveMQ

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4vhf-2hv7-8mrx/GHSA-4vhf-2hv7-8mrx.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4vhf-2hv7-8mrx/GHSA-4vhf-2hv7-8mrx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4vhf-2hv7-8mrx",
-  "modified": "2023-12-20T19:11:17Z",
+  "modified": "2023-12-20T19:11:57Z",
   "published": "2022-05-14T01:14:52Z",
   "aliases": [
     "CVE-2014-3600"
@@ -65,10 +65,14 @@
     },
     {
       "type": "WEB",
-      "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/100722"
+      "url": "https://github.com/apache/activemq/commit/b9696ac80bb496b52d05c3884f81b0746d9af9e2"
     },
     {
       "type": "WEB",
+      "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/100722"
+    },
+    {
+      "type": "PACKAGE",
       "url": "https://github.com/apache/activemq"
     },
     {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Add a patch https://github.com/apache/activemq/commit/b9696ac80bb496b52d05c3884f81b0746d9af9e2, of which the commit message claims `https://issues.apache.org/jira/browse/AMQ-5333 - make xpath parser features configurable`, same with the msg of current patch commit.
