### PR TITLE
[GHSA-9fc5-q25c-r2wr] Jasig Java CAS Client, .NET CAS Client, and phpCAS contain URL parameter injection vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9fc5-q25c-r2wr/GHSA-9fc5-q25c-r2wr.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9fc5-q25c-r2wr/GHSA-9fc5-q25c-r2wr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9fc5-q25c-r2wr",
-  "modified": "2022-11-22T19:02:31Z",
+  "modified": "2023-02-02T05:03:46Z",
   "published": "2022-05-17T19:57:18Z",
   "aliases": [
     "CVE-2014-4172"
@@ -89,6 +89,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/Jasig/java-cas-client/commit/ae37092100c8eaec610dab6d83e5e05a8ee58814"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apereo/java-cas-client/commit/ab6cbdc3daa451b4fef89c0bd0f4e6568f3aa9ef"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
Add a patch https://github.com/apereo/java-cas-client/commit/ab6cbdc3daa451b4fef89c0bd0f4e6568f3aa9ef, of which the commit message claims `Merge pull request #73 from battags/CASC-228
CASC-228 URL Encode Paramaters Passed to Server via Validate`, the bug id coincides with the one in reference links.
