### PR TITLE
[GHSA-w7cq-j9p9-hm3m] Improper Input Validation in Apache Santuario XML Security

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-w7cq-j9p9-hm3m/GHSA-w7cq-j9p9-hm3m.json
+++ b/advisories/github-reviewed/2022/05/GHSA-w7cq-j9p9-hm3m/GHSA-w7cq-j9p9-hm3m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w7cq-j9p9-hm3m",
-  "modified": "2022-07-06T21:02:07Z",
+  "modified": "2023-01-27T05:02:12Z",
   "published": "2022-05-13T01:05:55Z",
   "aliases": [
     "CVE-2014-8152"
@@ -39,7 +39,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/santuario-java/commit/55857fd4cdfdb1af4069170ecdac448c078f544e"
+    },
+    {
+      "type": "WEB",
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/99993"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/santuario-java"
     },
     {
       "type": "WEB",
@@ -48,6 +56,10 @@
     {
       "type": "WEB",
       "url": "https://lists.apache.org/thread.html/r1c07a561426ec5579073046ad7f4207cdcef452bb3100abaf908e0cd@%3Ccommits.santuario.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://svn.apache.org/viewvc?view=revision&revision=1634334"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
"Add a patch https://github.com/apache/santuario-java/commit/55857fd4cdfdb1af4069170ecdac448c078f544e, of which the commit message claims `more signature verification tests
git-svn-id: https://svn.apache.org/repos/asf/santuario/xml-security-java/trunk@1634334 13f79535-47bb-0310-9956-ffa450edef68`" and the git svn link's msg claims `CVE-2014-8152 - more signature verification tests`
