### PR TITLE
[GHSA-9284-j4c9-779q] Improper Input Validation in Apache Jackrabbit

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9284-j4c9-779q/GHSA-9284-j4c9-779q.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9284-j4c9-779q/GHSA-9284-j4c9-779q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9284-j4c9-779q",
-  "modified": "2022-07-06T20:22:18Z",
+  "modified": "2023-01-27T05:02:25Z",
   "published": "2022-05-14T02:49:30Z",
   "aliases": [
     "CVE-2015-1833"
@@ -152,11 +152,47 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/17e9f68f5a3f05ded20569777a7b07422680612d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/26e601934d0f439f0a61d62265f52936d79df40d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/3903739363b79deb7579802fbc27b9b7448218b2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/6191b366c607e65325a0116097aca8a359b36486"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/89c5c4ed6ab250ad609829517f167d2dbe0abdd0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/b7fa1ae39641936872617ff95363353b0345b777"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/ddf9a3cd408397d0805917299c4114b09449373d"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/jackrabbit"
+    },
+    {
+      "type": "WEB",
       "url": "https://issues.apache.org/jira/browse/JCR-3883"
     },
     {
       "type": "WEB",
-      "url": "https://www.exploit-db.com/exploits/37110"
+      "url": "https://svn.apache.org/repos/asf/jackrabbit/branches/2.2@1680800"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.exploit-db.com/exploits/37110/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
add 8 patch commits from github and git-svn for various version:
https://github.com/apache/jackrabbit/commit/26e601934d0f439f0a61d62265f52936d79df40d
https://github.com/apache/jackrabbit/commit/3903739363b79deb7579802fbc27b9b7448218b2
https://github.com/apache/jackrabbit/commit/ddf9a3cd408397d0805917299c4114b09449373d
https://github.com/apache/jackrabbit/commit/17e9f68f5a3f05ded20569777a7b07422680612d
https://github.com/apache/jackrabbit/commit/b7fa1ae39641936872617ff95363353b0345b777
https://github.com/apache/jackrabbit/commit/89c5c4ed6ab250ad609829517f167d2dbe0abdd0
https://github.com/apache/jackrabbit/commit/6191b366c607e65325a0116097aca8a359b36486
and a git-svn link: https://svn.apache.org/repos/asf/jackrabbit/branches/2.2@1680800

The commit msg explicitly claim to fix this cve and refer to the bug id: `jcr: 3883`.