### PR TITLE
[GHSA-9fc7-rhq3-wm7x] Apache Jackrabbit Authentication Hijacking Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9fc7-rhq3-wm7x/GHSA-9fc7-rhq3-wm7x.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9fc7-rhq3-wm7x/GHSA-9fc7-rhq3-wm7x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9fc7-rhq3-wm7x",
-  "modified": "2023-11-07T21:16:23Z",
+  "modified": "2023-11-07T21:16:24Z",
   "published": "2022-05-17T03:48:02Z",
   "aliases": [
     "CVE-2016-6801"
@@ -137,7 +137,15 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/apache/jackrabbit/commit/16f2f02fcaef6202a2bf24c449d4fd10eb98f08d"
+      "url": "https://github.com/apache/jackrabbit/commit/f0bd17956647cf09cc898d30e7d58221ef409bca"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/f05620fb3f4c72429c9856ab7f63a9ac8ca90acf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/eae001a54aae9c243ac06b5c8f711b2cb2038700"
     },
     {
       "type": "WEB",
@@ -145,19 +153,63 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/apache/jackrabbit/commit/eae001a54aae9c243ac06b5c8f711b2cb2038700"
+      "url": "https://github.com/apache/jackrabbit/commit/db26ade17d791bbb4e4771ed9650ec1159a541ff"
     },
     {
-      "type": "PACKAGE",
-      "url": "https://github.com/apache/jackrabbit"
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/d6e86e4350989af3eb3eb0429d6e4d4d6bd40e5c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/cab86cdfb7829b66c89196dfb6095f0faa5aa3c3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/987168c04327fd4fbbb4fb9d13ae92d5ca888386"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/8dde23b63151417769eaca112fbbae9a52c47ff3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/884ede7db1c6ca490fcbb8238762b000a25f82c3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/4908cb64317122cdd3e096ebe8c32bd98d2ed8b7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/43accb855897b0d82393d47420e25a1e4a569211"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/30318d5aef7bf494e579a86f45c79b18b204a997"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/283df6f101676579086400e30e8dd42eacd5ef33"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/16f2f02fcaef6202a2bf24c449d4fd10eb98f08d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/jackrabbit/commit/09393f93862923e4c8a2f8c7d1236e1a5d3373b5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://web.archive.org/web/20210123170657/http://www.securityfocus.com/bid/92966"
     },
     {
       "type": "WEB",
       "url": "https://issues.apache.org/jira/browse/JCR-4009"
     },
     {
-      "type": "WEB",
-      "url": "https://web.archive.org/web/20210123170657/http://www.securityfocus.com/bid/92966"
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/jackrabbit"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add 13 patch commits for this cve: 

https://github.com/apache/jackrabbit/commit/283df6f101676579086400e30e8dd42eacd5ef33
https://github.com/apache/jackrabbit/commit/db26ade17d791bbb4e4771ed9650ec1159a541ff
https://github.com/apache/jackrabbit/commit/d6e86e4350989af3eb3eb0429d6e4d4d6bd40e5c
https://github.com/apache/jackrabbit/commit/987168c04327fd4fbbb4fb9d13ae92d5ca888386
https://github.com/apache/jackrabbit/commit/4908cb64317122cdd3e096ebe8c32bd98d2ed8b7
https://github.com/apache/jackrabbit/commit/30318d5aef7bf494e579a86f45c79b18b204a997
https://github.com/apache/jackrabbit/commit/43accb855897b0d82393d47420e25a1e4a569211
https://github.com/apache/jackrabbit/commit/f0bd17956647cf09cc898d30e7d58221ef409bca
https://github.com/apache/jackrabbit/commit/09393f93862923e4c8a2f8c7d1236e1a5d3373b5
https://github.com/apache/jackrabbit/commit/8dde23b63151417769eaca112fbbae9a52c47ff3
https://github.com/apache/jackrabbit/commit/884ede7db1c6ca490fcbb8238762b000a25f82c3
https://github.com/apache/jackrabbit/commit/cab86cdfb7829b66c89196dfb6095f0faa5aa3c3
https://github.com/apache/jackrabbit/commit/f05620fb3f4c72429c9856ab7f63a9ac8ca90acf

Their commit msgs explicitly show they fix the bug `jcr-4009` and the git-svn links within the msg explicitly claim they are fixing this cve.
