### PR TITLE
[GHSA-j8g6-2wh7-6439] Apache Tika allows Java code execution for serialized objects embedded in MATLAB files

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-j8g6-2wh7-6439/GHSA-j8g6-2wh7-6439.json
+++ b/advisories/github-reviewed/2018/10/GHSA-j8g6-2wh7-6439/GHSA-j8g6-2wh7-6439.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j8g6-2wh7-6439",
-  "modified": "2022-04-26T21:47:39Z",
+  "modified": "2023-01-09T05:02:56Z",
   "published": "2018-10-17T15:44:36Z",
   "aliases": [
     "CVE-2016-6809"
@@ -42,11 +42,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/tika/commit/8a68b5d474205cc91cbbb610d4a1c05af57f0610"
+    },
+    {
+      "type": "WEB",
       "url": "https://dist.apache.org/repos/dist/release/tika/CHANGES-1.14.txt"
     },
     {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-j8g6-2wh7-6439"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/tika"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/apache/tika/commit/8a68b5d474205cc91cbbb610d4a1c05af57f0610, of which the commit message claims `clean up MatParser`, coinciding with the CVE desc and the code diff shows that it indeed tried to resolve the deserialization issue.
