### PR TITLE
[GHSA-m9jm-rhrm-gcxj] Path traversal in org.springframework.integration:spring-integration-zip

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-m9jm-rhrm-gcxj/GHSA-m9jm-rhrm-gcxj.json
+++ b/advisories/github-reviewed/2018/10/GHSA-m9jm-rhrm-gcxj/GHSA-m9jm-rhrm-gcxj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m9jm-rhrm-gcxj",
-  "modified": "2021-08-30T23:12:53Z",
+  "modified": "2023-02-01T05:03:52Z",
   "published": "2018-10-18T18:05:46Z",
   "aliases": [
     "CVE-2018-1261"
@@ -41,8 +41,16 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-1261"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-integration-extensions/commit/a5573eb232ff85199ff9bb28993df715d9a19a25"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-m9jm-rhrm-gcxj"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/spring-projects/spring-integration-extensions"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/spring-projects/spring-integration-extensions/commit/a5573eb232ff85199ff9bb28993df715d9a19a25, of which the commit message claims `Disallow traversal entity in zip
When the file name holds path traversal file names it gets
concatenated to the target extraction directory,
the final path ends up outside of the target folder.`