### PR TITLE
[GHSA-rvgg-f8qm-6h7j] High severity vulnerability that affects io.vertx:vertx-web

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-rvgg-f8qm-6h7j/GHSA-rvgg-f8qm-6h7j.json
+++ b/advisories/github-reviewed/2018/10/GHSA-rvgg-f8qm-6h7j/GHSA-rvgg-f8qm-6h7j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rvgg-f8qm-6h7j",
-  "modified": "2020-06-16T21:55:57Z",
+  "modified": "2023-01-09T05:03:25Z",
   "published": "2018-10-17T16:19:43Z",
   "aliases": [
     "CVE-2018-12540"
@@ -39,6 +39,18 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/vert-x3/vertx-web/issues/970"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vert-x3/vertx-web/commit/98891b1d9e022b467a3e4674aca4d1889849b1d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/vert-x3/vertx-web/commit/f42b193b15a29b772fc576b2d0f2497e7474a7e"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2018:2371"
     },
     {
@@ -48,6 +60,10 @@
     {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-rvgg-f8qm-6h7j"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/vert-x3/vertx-web"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
Add a patch https://github.com/vert-x3/vertx-web/commit/f42b193b15a29b772fc576b2d0f2497e7474a7e, of which the commit message claims `Validate that X-XSRF-Token and X-XSRF-Token cookie are the same - fixes #970
(cherry picked from commit 482bc72)`

Add a patch https://github.com/vert-x3/vertx-web/commit/98891b1d9e022b467a3e4674aca4d1889849b1d, of which the commit message claims `Validate that X-XSRF-Token and X-XSRF-Token cookie are the same - fixes #970
(cherry picked from commit f42b193)`

And update the bug issue link: https://github.com/vert-x3/vertx-web/issues/970, which shows the tracing for this cve.
