### PR TITLE
[GHSA-jmg4-x4vp-6c6x] Apache Geode vulnerable to Incorrect Authorization

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-jmg4-x4vp-6c6x/GHSA-jmg4-x4vp-6c6x.json
+++ b/advisories/github-reviewed/2022/05/GHSA-jmg4-x4vp-6c6x/GHSA-jmg4-x4vp-6c6x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jmg4-x4vp-6c6x",
-  "modified": "2022-11-08T14:16:18Z",
+  "modified": "2023-01-29T05:03:44Z",
   "published": "2022-05-13T01:18:20Z",
   "aliases": [
     "CVE-2017-15695"
@@ -46,7 +46,39 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/apache/geode/commit/00be4f9774e1adf8e7ccc2664da8005fc30bb11d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/geode/commit/49d28f93fd2ef069693ce15d124ef3a29f22fb7d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/geode/commit/6df14c8b1e3c644f9f810149e80bba0c2f073dab"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/geode/commit/740289c61d60256c6270756bc84b9e24b76e4913"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/geode/commit/90f8f6242927c5e16da64f38bba9abf3d450a305"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/geode/commit/954ccb545d24a9c9a35cbd84023a4d7e07032de0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/geode/commit/aa469239860778eb46e09dd7b390aee08f152480"
+    },
+    {
+      "type": "WEB",
       "url": "https://cwiki.apache.org/confluence/display/GEODE/Release+Notes#ReleaseNotes-SecurityVulnerabilities"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/geode"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
ADD 7 patch commits:
https://github.com/apache/geode/commit/90f8f6242927c5e16da64f38bba9abf3d450a305
https://github.com/apache/geode/commit/aa469239860778eb46e09dd7b390aee08f152480
https://github.com/apache/geode/commit/6df14c8b1e3c644f9f810149e80bba0c2f073dab
https://github.com/apache/geode/commit/740289c61d60256c6270756bc84b9e24b76e4913
https://github.com/apache/geode/commit/49d28f93fd2ef069693ce15d124ef3a29f22fb7d
https://github.com/apache/geode/commit/00be4f9774e1adf8e7ccc2664da8005fc30bb11d
https://github.com/apache/geode/commit/954ccb545d24a9c9a35cbd84023a4d7e07032de0

the commit msg explicitly show they fixed the `GEODE-3974` issue of the pr: https://github.com/apache/geode/pull/1258
