### PR TITLE
[GHSA-mh7g-99w9-xpjm] Remote code execution occurs in Apache Solr

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-mh7g-99w9-xpjm/GHSA-mh7g-99w9-xpjm.json
+++ b/advisories/github-reviewed/2018/10/GHSA-mh7g-99w9-xpjm/GHSA-mh7g-99w9-xpjm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mh7g-99w9-xpjm",
-  "modified": "2022-04-27T15:06:43Z",
+  "modified": "2023-02-01T05:03:51Z",
   "published": "2018-10-17T19:56:17Z",
   "aliases": [
     "CVE-2017-12629"
@@ -80,43 +80,27 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.exploit-db.com/exploits/43009"
+      "url": "https://github.com/apache/lucene-solr/commit/f9fd6e9e26224f26f1542224ce187e04c27b268"
     },
     {
       "type": "WEB",
-      "url": "https://www.debian.org/security/2018/dsa-4124"
+      "url": "https://github.com/apache/lucene-solr/commit/d8000beebfb13ba0b6e754f84c760e11592d8d1"
     },
     {
       "type": "WEB",
-      "url": "https://usn.ubuntu.com/4259-1"
+      "url": "https://github.com/apache/lucene-solr/commit/d28baa3fc5566b47f1ca7cc2ba1aba658dc634a"
     },
     {
       "type": "WEB",
-      "url": "https://twitter.com/searchtools_avi/status/918904813613543424"
+      "url": "https://github.com/apache/lucene-solr/commit/926cc4d65b6d2cc40ff07f76d50ddeda947e3cc"
     },
     {
       "type": "WEB",
-      "url": "https://twitter.com/joshbressers/status/919258716297420802"
+      "url": "https://github.com/apache/lucene-solr/commit/3bba91131b5257e64b9d0a2193e1e32a145b2a2"
     },
     {
       "type": "WEB",
-      "url": "https://twitter.com/ApacheSolr/status/918731485611401216"
-    },
-    {
-      "type": "WEB",
-      "url": "https://s.apache.org/FJDl"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.debian.org/debian-lts-announce/2018/01/msg00028.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r95df34bb158375948da82b4dfe9a1b5d528572d586584162f8f5aeef@%3Cusers.solr.apache.org%3E"
-    },
-    {
-      "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r3da74965aba2b5f5744b7289ad447306eeb2940c872801819faa9314@%3Cusers.solr.apache.org%3E"
+      "url": "https://lists.apache.org/thread.html/r140128dc6bb4f4e0b6a39e962c7ca25a8cbc8e48ed766176c931fccc@%3Cusers.solr.apache.org%3E"
     },
     {
       "type": "WEB",
@@ -124,7 +108,47 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.apache.org/thread.html/r140128dc6bb4f4e0b6a39e962c7ca25a8cbc8e48ed766176c931fccc@%3Cusers.solr.apache.org%3E"
+      "url": "https://lists.apache.org/thread.html/r3da74965aba2b5f5744b7289ad447306eeb2940c872801819faa9314@%3Cusers.solr.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.apache.org/thread.html/r95df34bb158375948da82b4dfe9a1b5d528572d586584162f8f5aeef@%3Cusers.solr.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2018/01/msg00028.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://s.apache.org/FJDl"
+    },
+    {
+      "type": "WEB",
+      "url": "https://twitter.com/ApacheSolr/status/918731485611401216"
+    },
+    {
+      "type": "WEB",
+      "url": "https://twitter.com/joshbressers/status/919258716297420802"
+    },
+    {
+      "type": "WEB",
+      "url": "https://twitter.com/searchtools_avi/status/918904813613543424"
+    },
+    {
+      "type": "WEB",
+      "url": "https://usn.ubuntu.com/4259-1/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.debian.org/security/2018/dsa-4124"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.exploit-db.com/exploits/43009/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/SOLR-11477"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
add 5 patch commits:
https://github.com/apache/lucene-solr/commit/f9fd6e9e26224f26f1542224ce187e04c27b268
https://github.com/apache/lucene-solr/commit/3bba91131b5257e64b9d0a2193e1e32a145b2a2
https://github.com/apache/lucene-solr/commit/d8000beebfb13ba0b6e754f84c760e11592d8d1
https://github.com/apache/lucene-solr/commit/d28baa3fc5566b47f1ca7cc2ba1aba658dc634a
https://github.com/apache/lucene-solr/commit/926cc4d65b6d2cc40ff07f76d50ddeda947e3cc

The commit msg show the intention: `SOLR-11477: Disallow resolving of external entities in Lucene queryparser/xml/CoreParser and SolrCoreParser (defType=xmlparser or {!xmlparser ...}) by default.`

and add the corresponding but track link: https://issues.apache.org/jira/browse/SOLR-11477.