### PR TITLE
[GHSA-fv7x-4hpc-hf9f] Moderate severity vulnerability that affects org.apache.cxf.fediz:fediz-spring, org.apache.cxf.fediz:fediz-spring2, and org.apache.cxf.fediz:fediz-spring3

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-fv7x-4hpc-hf9f/GHSA-fv7x-4hpc-hf9f.json
+++ b/advisories/github-reviewed/2018/10/GHSA-fv7x-4hpc-hf9f/GHSA-fv7x-4hpc-hf9f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fv7x-4hpc-hf9f",
-  "modified": "2020-06-16T21:35:15Z",
+  "modified": "2023-02-01T05:03:42Z",
   "published": "2018-10-18T16:57:21Z",
   "aliases": [
     "CVE-2017-12631"
@@ -133,8 +133,24 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-12631"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf-fediz/commit/48dd9b68d67c6b729376c1ce8886f52a57df6c4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf-fediz/commit/ccdb12b26ff89e0a998a333e84dd84bd713ac76"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/cxf-fediz/commit/e7127129dbc0f4ee83985052085e185e750cebbf"
+    },
+    {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-fv7x-4hpc-hf9f"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/cxf-fediz"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References
- Source code location

**Comments**
ADD 3 patch commits:

https://github.com/apache/cxf-fediz/commit/e7127129dbc0f4ee83985052085e185e750cebbf
https://github.com/apache/cxf-fediz/commit/48dd9b68d67c6b729376c1ce8886f52a57df6c4
https://github.com/apache/cxf-fediz/commit/ccdb12b26ff89e0a998a333e84dd84bd713ac76

the commit diff on plugins/spring/src/main/java/org/apache/cxf/fediz/spring/web/FederationAuthenticationFilter.java show they tried to enhance the security to prevent the security context that is set up using a malicious client's roles for the given enduser.