### PR TITLE
[GHSA-264p-99wq-f4j6] Ion Java StackOverflow vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-264p-99wq-f4j6/GHSA-264p-99wq-f4j6.json
+++ b/advisories/github-reviewed/2024/01/GHSA-264p-99wq-f4j6/GHSA-264p-99wq-f4j6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-264p-99wq-f4j6",
-  "modified": "2024-01-04T16:07:16Z",
+  "modified": "2024-01-04T16:07:17Z",
   "published": "2024-01-03T22:04:08Z",
   "aliases": [
     "CVE-2024-21634"
@@ -33,6 +33,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "software.amazon.ion:ion-java"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.10.5"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Older versions of Amazon Ion Java were published with the scope "software.amazon.ion:ion-java". In 2020 Amazon migrated to the new group id "com.amazon.ion": https://amazon-ion.github.io/ion-docs/news/2020/01/15/software.amazon.ion-deprecated.html

The affected versions (< 1.10.5) also cover the versions published under the deprecated group id (1.0.0 through 1.5.1), so I'm proposing it be included in this advisory. As there is no fix for the old scope, I didn't list any patched version for that new affected 'product' entry.