### PR TITLE
[GHSA-frc2-w2cc-x794] Eclipse Kura LogServlet vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-frc2-w2cc-x794/GHSA-frc2-w2cc-x794.json
+++ b/advisories/github-reviewed/2024/04/GHSA-frc2-w2cc-x794/GHSA-frc2-w2cc-x794.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-frc2-w2cc-x794",
-  "modified": "2024-04-09T18:53:17Z",
+  "modified": "2024-04-09T18:53:18Z",
   "published": "2024-04-09T12:30:47Z",
   "aliases": [
     "CVE-2024-3046"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS

**Comments**
Error in CVSS vector: 
- https://nvd.nist.gov/vuln/detail/CVE-2024-3046
- https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/188