### PR TITLE
[GHSA-5x7m-6737-26cr] SixLabors.ImageSharp vulnerable to Use After Free

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-5x7m-6737-26cr/GHSA-5x7m-6737-26cr.json
+++ b/advisories/github-reviewed/2024/04/GHSA-5x7m-6737-26cr/GHSA-5x7m-6737-26cr.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5x7m-6737-26cr",
-  "modified": "2024-04-15T21:37:26Z",
+  "modified": "2024-04-15T21:37:28Z",
   "published": "2024-04-15T20:24:06Z",
   "aliases": [
     "CVE-2024-32036"
   ],
-  "summary": "SixLabors.ImageSharp vulnerable to Use After Free",
+  "summary": "Buffers not cleared before reuse in SixLabors.ImageSharp",
   "details": "### Impact\nA data leakage flaw was found in ImageSharp's JPEG and TGA decoders. This vulnerability is triggered when an attacker passes a specially crafted JPEG or TGA image file to a software using ImageSharp, potentially disclosing sensitive information from other parts of the software in the resulting image buffer.\n\n### Patches\nThe problem has been patched. All users are advised to upgrade to v3.1.4 or v2.1.8.\n\n### Workarounds\nNone\n\n### References\nNone\n",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:H"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N"
     }
   ],
   "affected": [
@@ -78,10 +78,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-226",
-      "CWE-416"
+      "CWE-226"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-04-15T20:24:06Z",
     "nvd_published_at": "2024-04-15T20:15:11Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity
- Summary

**Comments**
We internally discussed https://github.com/SixLabors/ImageSharp/security/advisories/GHSA-5x7m-6737-26cr with @JimBobSquarePants and came to an agreement that the original assesment of the vulnerability being a case of CWE-416 is incorrect: the attack does not have a Use After Free aspect and potential to corrupt memory so it doesn't impact Availability. Moreover, we determined that the Attack Complexity is High, and server-side software using ImageSharp might be exposed to Network attacks, therefore it's a better choice for Attack Vector.

https://github.com/SixLabors/ImageSharp/security/advisories/GHSA-5x7m-6737-26cr has been edited to reflect these decisions, but the CVE went out with incorrect content, so it must be updated, including the title.