### PR TITLE
[GHSA-6p4c-r453-8743] In PuTTY 0.68 through 0.80 before 0.81, biased ECDSA...

### DIFF
--- a/advisories/unreviewed/2024/04/GHSA-6p4c-r453-8743/GHSA-6p4c-r453-8743.json
+++ b/advisories/unreviewed/2024/04/GHSA-6p4c-r453-8743/GHSA-6p4c-r453-8743.json
@@ -1,22 +1,45 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6p4c-r453-8743",
-  "modified": "2024-04-17T00:30:53Z",
+  "modified": "2024-04-17T00:31:29Z",
   "published": "2024-04-15T21:30:46Z",
   "aliases": [
     "CVE-2024-31497"
   ],
+  "summary": "Vulnerability in popular SSH and Telnet client",
   "details": "In PuTTY 0.68 through 0.80 before 0.81, biased ECDSA nonce generation allows an attacker to recover a user's NIST P-521 secret key via a quick attack in approximately 60 signatures. This is especially important in a scenario where an adversary is able to read messages signed by PuTTY or Pageant. One scenario is that the adversary is an operator of an SSH server to which the victim authenticates (for remote login or file copy), even though this server is not fully trusted by the victim, and the victim uses the same private key for SSH connections to other services operated by other entities. Here, the rogue server operator (who would otherwise have no way to determine the victim's private key) can derive the victim's private key, and then use it for unauthorized access to those other services. Because SSH is sometimes used to authenticate to Git services, it is possible that this vulnerability could be leveraged for supply-chain attacks on software maintained in Git. It is also conceivable that signed messages from PuTTY or Pageant are readable by adversaries more easily in other scenarios, but none have yet been disclosed.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+    }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-31497"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.tenable.com/cve/CVE-2024-31497"
     },
     {
       "type": "WEB",
@@ -103,7 +126,7 @@
     "cwe_ids": [
 
     ],
-    "severity": null,
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2024-04-15T20:15:11Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- References
- Severity
- Summary

**Comments**
Not sure if this is helpful, but Tenable has released a CVE score. Hope this helps. Have a nice day :)