### PR TITLE
[GHSA-85fq-56wq-gmcf] mariadb is malware

### DIFF
--- a/advisories/github-reviewed/2018/07/GHSA-85fq-56wq-gmcf/GHSA-85fq-56wq-gmcf.json
+++ b/advisories/github-reviewed/2018/07/GHSA-85fq-56wq-gmcf/GHSA-85fq-56wq-gmcf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-85fq-56wq-gmcf",
-  "modified": "2023-09-07T18:17:13Z",
+  "modified": "2023-09-07T18:17:14Z",
   "published": "2018-07-18T18:28:17Z",
   "aliases": [
     "CVE-2017-16046"
@@ -28,10 +28,35 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.0.2"
+              "fixed": ">= 2.0.0-alpha, < 2.13.0"
             }
           ]
         }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.0.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "mariadb"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.13.0"
+            },
+            {
+              "fixed": "3.0.0-beta"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "2.13.0"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It is a bit tricky to follow the version history of the npm component [mariadb](https://www.npmjs.com/package/mariadb/v/1.0.1?activeTab=versions), but I think the only versions ever being malicious are the ones <= 1.0.2 and 2.13.0.

- 0.0.1-security and 0.0.2-security are npm holding packages
- 1.0.1 and 1.0.2 may have been malicious but their content has been unpublished
- 2.13.0 is highlighted by the [NVD](https://nvd.nist.gov/vuln/detail/CVE-2017-16046), and also available in malware datasets like the [Backstabber's Knife Collection](https://github.com/cybertier/Backstabbers-Knife-Collection), clearly showing the exfiltration of environment information.

References:
- https://security.snyk.io/vuln/npm:mariadb:20170802 (inconsistent: console output points to 2.13.0, but the header says <0.7.0 >=1.0.1 <2.0.0-alpha)
- https://gitlab.com/gitlab-org/security-products/gemnasium-db/-/blob/master/npm/mariadb/CVE-2017-16046.yml (<= 1.0.2 affected)
- https://github.com/mariadb-corporation/mariadb-connector-nodejs/issues/121