### PR TITLE
[GHSA-cw54-59pw-4g8c] Apache Tomcat Improper Access Control vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-cw54-59pw-4g8c/GHSA-cw54-59pw-4g8c.json
+++ b/advisories/github-reviewed/2022/05/GHSA-cw54-59pw-4g8c/GHSA-cw54-59pw-4g8c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cw54-59pw-4g8c",
-  "modified": "2024-02-22T20:36:17Z",
+  "modified": "2024-03-02T05:06:36Z",
   "published": "2022-05-13T01:14:52Z",
   "aliases": [
     "CVE-2016-8735"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-catalina"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-catalina"
       },
       "ranges": [
         {
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-catalina"
       },
       "ranges": [
         {
@@ -75,7 +75,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-catalina"
       },
       "ranges": [
         {
@@ -94,7 +94,102 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-catalina"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.0.M1"
+            },
+            {
+              "fixed": "9.0.0.M12"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "6.0.48"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "7.0.0"
+            },
+            {
+              "fixed": "7.0.73"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.0.0"
+            },
+            {
+              "fixed": "8.0.39"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.5.0"
+            },
+            {
+              "fixed": "8.5.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Looking at the commits (such as https://github.com/apache/tomcat/commit/7e3a037055cca4a17e90b49399fb1bab4dd7c821), the affected component is `org.apache.catalina.mbeans` which is bundled into the maven artifacts `org.apache.tomcat:tomcat-catalina` and `org.apache.tomcat.embed:tomcat-embed-core` per https://github.com/search?q=repo%3Aapache%2Ftomcat+catalina.mbeans+path%3A%2F%5Eres%5C%2Fbnd%5C%2F%2F&type=code