### PR TITLE
[GHSA-8m45-2rjm-j347] Version ranges input into GHSA did not end up on published advisory

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-8m45-2rjm-j347/GHSA-8m45-2rjm-j347.json
+++ b/advisories/github-reviewed/2024/04/GHSA-8m45-2rjm-j347/GHSA-8m45-2rjm-j347.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8m45-2rjm-j347",
-  "modified": "2024-04-17T19:47:52Z",
+  "modified": "2024-04-17T19:47:53Z",
   "published": "2024-04-17T18:21:18Z",
   "aliases": [
     "CVE-2024-30253"
@@ -25,10 +25,2012 @@
           "type": "ECOSYSTEM",
           "events": [
             {
+              "introduced": "1.91"
+            },
+            {
+              "fixed": ">=1.91.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.91.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.90"
+            },
+            {
+              "fixed": "1.90.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.90.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.89"
+            },
+            {
+              "fixed": "1.89.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.89.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.88"
+            },
+            {
+              "fixed": "1.88.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.88"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.87"
+            },
+            {
+              "fixed": "1.87.7"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.87.6"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.86"
+            },
+            {
+              "fixed": "1.86.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.86"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.85"
+            },
+            {
+              "fixed": "1.85.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.85"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.84"
+            },
+            {
+              "fixed": "1.84.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.84"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.83"
+            },
+            {
+              "fixed": "1.83.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.83"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.82"
+            },
+            {
+              "fixed": "1.82.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.82"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.81"
+            },
+            {
+              "fixed": "1.81.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.81"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.80"
+            },
+            {
+              "fixed": "1.80.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.80"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.79"
+            },
+            {
+              "fixed": "1.79.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.79"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.78"
+            },
+            {
+              "fixed": "1.78.8"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.78.7"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.77"
+            },
+            {
+              "fixed": "1.77.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.77.3"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.76"
+            },
+            {
+              "fixed": "1.76.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.76"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.75"
+            },
+            {
+              "fixed": "1.75.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.75"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.74"
+            },
+            {
+              "fixed": "1.74.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.74"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.73"
+            },
+            {
+              "fixed": "1.73.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.73.4"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.72"
+            },
+            {
+              "fixed": "1.72.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.72"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.71"
+            },
+            {
+              "fixed": "1.71.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.71"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.70"
+            },
+            {
+              "fixed": "1.70.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.70.3"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.69"
+            },
+            {
+              "fixed": "1.69.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.69"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.68"
+            },
+            {
+              "fixed": "1.68.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.68.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.67"
+            },
+            {
+              "fixed": "1.67.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.67.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.66"
+            },
+            {
+              "fixed": "1.66.6"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.66.5"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.65"
+            },
+            {
+              "fixed": "1.65.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.65"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.64"
+            },
+            {
+              "fixed": "1.64.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.64"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.63"
+            },
+            {
+              "fixed": "1.63.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.63.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.62"
+            },
+            {
+              "fixed": "1.62.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.62.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.61"
+            },
+            {
+              "fixed": "1.61.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.61.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.60"
+            },
+            {
+              "fixed": "1.60.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.60"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.59"
+            },
+            {
+              "fixed": "1.59.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.59.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.58"
+            },
+            {
+              "fixed": "1.58.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.58"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.57"
+            },
+            {
+              "fixed": "1.57.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.57"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.56"
+            },
+            {
+              "fixed": "1.56.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.56.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.55"
+            },
+            {
+              "fixed": "1.55.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.55"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.54"
+            },
+            {
+              "fixed": "1.54.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.54.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.53"
+            },
+            {
+              "fixed": "1.53.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.53"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.52"
+            },
+            {
+              "fixed": "1.52.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.52"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.51"
+            },
+            {
+              "fixed": "1.51.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.51"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.50"
+            },
+            {
+              "fixed": "1.50.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.50.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.49"
+            },
+            {
+              "fixed": "1.49.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.49"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.48"
+            },
+            {
+              "fixed": "1.48.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.48"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.47"
+            },
+            {
+              "fixed": "1.47.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.47.4"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.46"
+            },
+            {
+              "fixed": "1.46.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.46"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.45"
+            },
+            {
+              "fixed": "1.45.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.45"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.44"
+            },
+            {
+              "fixed": "1.44.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.44.3"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.43"
+            },
+            {
+              "fixed": "1.43.7"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.43.6"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.42"
+            },
+            {
+              "fixed": "1.42.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.42"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.41"
+            },
+            {
+              "fixed": "1.41.11"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.41.10"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.40"
+            },
+            {
+              "fixed": "1.40.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.40.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.39"
+            },
+            {
+              "fixed": "1.39.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.39.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.38"
+            },
+            {
+              "fixed": "1.38.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.38"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.37"
+            },
+            {
+              "fixed": "1.37.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.37.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.36"
+            },
+            {
+              "fixed": "1.36.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.36"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.35"
+            },
+            {
+              "fixed": "1.35.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.35.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.34"
+            },
+            {
+              "fixed": "1.34.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.34"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.33"
+            },
+            {
+              "fixed": "1.33.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.33"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.32"
+            },
+            {
+              "fixed": "1.32.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.32.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.31"
+            },
+            {
+              "fixed": "1.31.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.31"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.30"
+            },
+            {
+              "fixed": "1.30.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.30.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.29"
+            },
+            {
+              "fixed": "1.29.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.29.3"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.28"
+            },
+            {
+              "fixed": "1.28.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.28"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.27"
+            },
+            {
+              "fixed": "1.27.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.27"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.26"
+            },
+            {
+              "fixed": "1.26.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.26"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.25"
+            },
+            {
+              "fixed": "1.25.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.25"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.24"
+            },
+            {
+              "fixed": "1.24.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.24.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.23"
+            },
+            {
+              "fixed": "1.23.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.23"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.22"
+            },
+            {
+              "fixed": "1.22.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.22"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.21"
+            },
+            {
+              "fixed": "1.21.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.21"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.20"
+            },
+            {
+              "fixed": "1.20.3"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.20.2"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.19"
+            },
+            {
+              "fixed": "1.19.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.19"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.18"
+            },
+            {
+              "fixed": "1.18.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.18"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.17"
+            },
+            {
+              "fixed": "1.17.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.17"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.16"
+            },
+            {
+              "fixed": "1.16.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.16.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.15"
+            },
+            {
+              "fixed": "1.15.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.15"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.14"
+            },
+            {
+              "fixed": "1.14.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.14"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.13"
+            },
+            {
+              "fixed": "1.13.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.13"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.12"
+            },
+            {
+              "fixed": "1.12.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.12"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.11"
+            },
+            {
+              "fixed": "1.11.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.11"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.10"
+            },
+            {
+              "fixed": "1.10.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.10.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.9"
+            },
+            {
+              "fixed": "1.9.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.9.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.8"
+            },
+            {
+              "fixed": "1.8.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.8"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.7"
+            },
+            {
+              "fixed": "1.7.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.7.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.6"
+            },
+            {
+              "fixed": "1.6.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.6"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.5"
+            },
+            {
+              "fixed": "1.5.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.5"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.4"
+            },
+            {
+              "fixed": "1.4.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.4"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.3"
+            },
+            {
+              "fixed": "1.3.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.3"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.2"
+            },
+            {
+              "fixed": "1.2.8"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.2.7"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.1"
+            },
+            {
+              "fixed": "1.1.2"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.1.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@solana/web3.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
               "introduced": "0"
             },
             {
-              "fixed": "1.91.3"
+              "last_affected": "1.0.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This advisory is missing the versions from the original GHSA. Without them, Dependabot advisories won't clear, even if someone is using a non-affected version.