### PR TITLE
[GHSA-4v3g-g84w-hv7r] Authentication Bypass Using an Alternate Path or Channel in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4v3g-g84w-hv7r/GHSA-4v3g-g84w-hv7r.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4v3g-g84w-hv7r/GHSA-4v3g-g84w-hv7r.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-jasper"
       },
       "ranges": [
         {
@@ -32,15 +32,12 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 9.0.0.M9"
-      }
+      ]
     },
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-jasper"
       },
       "ranges": [
         {
@@ -54,15 +51,12 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 8.5.4"
-      }
+      ]
     },
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-jasper"
       },
       "ranges": [
         {
@@ -76,15 +70,12 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 8.0.36"
-      }
+      ]
     },
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-jasper"
       },
       "ranges": [
         {
@@ -98,15 +89,12 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 7.0.70"
-      }
+      ]
     },
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-jasper"
       },
       "ranges": [
         {
@@ -120,10 +108,121 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 6.0.45"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat:jasper"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.0.47"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-jasper"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.0.M1"
+            },
+            {
+              "fixed": "9.0.0.M10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-jasper"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.5.0"
+            },
+            {
+              "fixed": "8.5.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-jasper"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.0.0RC1"
+            },
+            {
+              "fixed": "8.0.37"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-jasper"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "7.0.0"
+            },
+            {
+              "fixed": "7.0.72"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-jasper"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.0.47"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The commits (for instance https://github.com/apache/tomcat/commit/a6b1ebc246b91b854237e5aad3dfd2b5460ea282) indicate that the affected component is under jasper.runtime which per https://github.com/search?q=repo%3Aapache%2Ftomcat+jasper.runtime+path%3A%2F%5Eres%5C%2Fbnd%5C%2F%2F&type=code corresponds to the `org.apacher.tomcat.embed:tomcat-embed-jasper` and `org.apache.tomcat:tomcat-jasper` maven artifacts.  Also, the v6 release line artifacts were present at `org.apache.tomcat:jasper`