### PR TITLE
[GHSA-3vx3-xf6q-r5xp] Exposure of Resource to Wrong Sphere in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-3vx3-xf6q-r5xp/GHSA-3vx3-xf6q-r5xp.json
+++ b/advisories/github-reviewed/2022/05/GHSA-3vx3-xf6q-r5xp/GHSA-3vx3-xf6q-r5xp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3vx3-xf6q-r5xp",
-  "modified": "2024-02-22T21:53:02Z",
+  "modified": "2024-02-22T21:53:03Z",
   "published": "2022-05-13T01:25:13Z",
   "aliases": [
     "CVE-2017-5648"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-catalina"
       },
       "ranges": [
         {
@@ -32,15 +32,12 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 9.0.0.M17"
-      }
+      ]
     },
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-catalina"
       },
       "ranges": [
         {
@@ -54,15 +51,12 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 8.5.12"
-      }
+      ]
     },
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-catalina"
       },
       "ranges": [
         {
@@ -76,15 +70,12 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 8.0.41"
-      }
+      ]
     },
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-catalina"
       },
       "ranges": [
         {
@@ -98,10 +89,83 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 7.0.75"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.0.M1"
+            },
+            {
+              "fixed": "9.0.0.M18"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.5.0"
+            },
+            {
+              "fixed": "8.5.13"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.0.0"
+            },
+            {
+              "fixed": "8.0.42"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "7.0.0"
+            },
+            {
+              "fixed": "7.0.76"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Per the associated commits (such as https://github.com/apache/tomcat80/commit/6d73b079c55ee25dea1bbd0556bb568a4247dacd), the affected component is catalina which corresponds to the `org.apache.tomcat:tomcat-catalina` and `org.apache.tomcat.embed:tomcat-embed-core` maven artifacts