### PR TITLE
[GHSA-9hg2-395j-83rm] Expected Behavior Violation in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9hg2-395j-83rm/GHSA-9hg2-395j-83rm.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9hg2-395j-83rm/GHSA-9hg2-395j-83rm.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -32,15 +32,12 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 9.0.0.M18"
-      }
+      ]
     },
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -54,10 +51,45 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 8.5.12"
-      }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.0.M1"
+            },
+            {
+              "fixed": "9.0.0.M19"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.5.0"
+            },
+            {
+              "fixed": "8.5.13"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Per the associated commit https://github.com/apache/tomcat/commit/9233d9d6a018be4415d4d7d6cb4fe01176adf1a8 the affected component is coyote.http11 which per https://github.com/search?q=repo%3Aapache%2Ftomcat+apache.coyote+path%3A%2F%5Eres%5C%2Fbnd%5C%2F%2F&type=code is distributed as part of the `org.apache.tomcat:tomcat-coyote` and `org.apache.tomcat.embed:tomcat-embed-core` maven artifacts