### PR TITLE
[GHSA-f8h5-v2vg-46rr] quarkus-core leaks local environment variables from Quarkus namespace during application's build

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-f8h5-v2vg-46rr/GHSA-f8h5-v2vg-46rr.json
+++ b/advisories/github-reviewed/2024/04/GHSA-f8h5-v2vg-46rr/GHSA-f8h5-v2vg-46rr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f8h5-v2vg-46rr",
-  "modified": "2024-04-17T22:05:36Z",
+  "modified": "2024-04-17T22:05:37Z",
   "published": "2024-04-04T15:30:34Z",
   "aliases": [
     "CVE-2024-2700"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "3.9.2"
+              "fixed": "3.2.12.Final, 3.9.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
See https://quarkus.io/blog/quarkus-3-2-12-final-released/ - there's also a a release for 3.8 LTS, see https://quarkus.io/blog/quarkus-3-8-4-released/, but the post for 3.8.4 doesn't explicitly state that it contains all changes to fix CVE-2024-2700 like the post for 3.2.12.Final does - maybe they fixed the vulnerability even in an older version for both, and only _forgot_ to mention it's now also fixed for 3.8?