### PR TITLE
[GHSA-mppv-79ch-vw6q] Apache Tomcat vulnerable to information leak

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-mppv-79ch-vw6q/GHSA-mppv-79ch-vw6q.json
+++ b/advisories/github-reviewed/2023/06/GHSA-mppv-79ch-vw6q/GHSA-mppv-79ch-vw6q.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mppv-79ch-vw6q",
-  "modified": "2024-03-11T17:45:02Z",
+  "modified": "2024-03-11T17:45:03Z",
   "published": "2023-06-21T12:30:19Z",
   "aliases": [
     "CVE-2023-34981"
   ],
   "summary": "Apache Tomcat vulnerable to information leak",
-  "details": "A regression in the fix for bug 66512 in Apache Tomcat 11.0.0-M5, 10.1.8, 9.0.74 and 8.5.88 meant that, if a response did not include any HTTP headers no AJP SEND_HEADERS messare woudl be sent for the response which in turn meant that at least one AJP proxy (mod_proxy_ajp) would use the response headers from the previous request leading to an information leak.",
+  "details": "A regression in the fix for bug 66512 in Apache Tomcat 11.0.0-M5, 10.1.8, 9.0.74 and 8.5.88 meant that, if a response did not include any HTTP headers no AJP SEND_HEADERS messare would be sent for the response which in turn meant that at least one AJP proxy (mod_proxy_ajp) would use the response headers from the previous request leading to an information leak.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -40,7 +40,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -62,7 +62,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -84,7 +84,95 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.5.88"
+            },
+            {
+              "fixed": "8.5.89"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "8.5.88"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "11.0.0-M5"
+            },
+            {
+              "fixed": "11.0.0-M6"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "11.0.0-M5"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.1.8"
+            },
+            {
+              "fixed": "10.1.9"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "10.1.8"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.74"
+            },
+            {
+              "fixed": "9.0.75"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "9.0.74"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Per the commits such as https://github.com/apache/tomcat/commit/2214c8030522aa9b2a367dfa5d9acff1a03666ae the fix is to coyote/ajp which ends up distributed as the `org.apache.tomcat:tomcat-coyote` and `org.apache.tomcat.embed:tomcat-embed-core` maven artifacts per https://github.com/search?q=repo%3Aapache%2Ftomcat+coyote.ajp+path%3A%2F%5Eres%5C%2Fbnd%5C%2F%2F&type=code