### PR TITLE
[GHSA-cx6h-86xw-9x34] Apache Tomcat - Fix for CVE-2023-24998 was incomplete

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-cx6h-86xw-9x34/GHSA-cx6h-86xw-9x34.json
+++ b/advisories/github-reviewed/2023/07/GHSA-cx6h-86xw-9x34/GHSA-cx6h-86xw-9x34.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cx6h-86xw-9x34",
-  "modified": "2023-07-06T23:34:50Z",
+  "modified": "2023-11-08T05:04:39Z",
   "published": "2023-07-06T21:14:59Z",
   "aliases": [
     "CVE-2023-28709"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -75,7 +75,83 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.5.85"
+            },
+            {
+              "fixed": "8.5.88"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "11.0.0-M2"
+            },
+            {
+              "fixed": "11.0.0-M5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.1.5"
+            },
+            {
+              "fixed": "10.1.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.71"
+            },
+            {
+              "fixed": "9.0.74"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
       },
       "ranges": [
         {
@@ -98,6 +174,22 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28709"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/5badf94e79e5de206fc0ef3054fd536b1bb787cd"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/ba848da71c523d94950d3c53c19ea155189df9dc"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/d53d8e7f77042cc32a3b98f589496a1ef5088e38"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/fbd81421629afe8b8a3922d59020cde81caea861"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/apache/tomcat"
     },
@@ -111,7 +203,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20230616-0004"
+      "url": "https://security.netapp.com/advisory/ntap-20230616-0004/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adds the commits for each release line obtained from the security pages at:
- https://tomcat.apache.org/security-10.html
- https://tomcat.apache.org/security-11.html
- https://tomcat.apache.org/security-8.html
- https://tomcat.apache.org/security-9.html 

Looking at the commits (such as https://github.com/apache/tomcat/commit/d53d8e7f77042cc32a3b98f589496a1ef5088e38), the affected code was under util/http which ends up bundled into the `org.apache.tomcat:tomcat-coyote` and `org.apache.tomcat.embed:tomcat-embed-core` maven artifacts per https://github.com/search?q=repo%3Aapache%2Ftomcat+util.http+path%3A%2F%5Eres%5C%2Fbnd%5C%2F%2F&type=code