### PR TITLE
[GHSA-f4qf-m5gf-8jm8] Apache Tomcat vulnerable to Generation of Error Message Containing Sensitive Information

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-f4qf-m5gf-8jm8/GHSA-f4qf-m5gf-8jm8.json
+++ b/advisories/github-reviewed/2024/01/GHSA-f4qf-m5gf-8jm8/GHSA-f4qf-m5gf-8jm8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f4qf-m5gf-8jm8",
-  "modified": "2024-02-16T15:30:26Z",
+  "modified": "2024-02-25T05:07:43Z",
   "published": "2024-01-19T12:30:18Z",
   "aliases": [
     "CVE-2024-21733"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -37,7 +37,45 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.0-M11"
+            },
+            {
+              "fixed": "9.0.44"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.5.7"
+            },
+            {
+              "fixed": "8.5.64"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
       },
       "ranges": [
         {
@@ -60,6 +98,14 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-21733"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/86ccc43940861703c2be96a5f35384407522125a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/tomcat/commit/ce4b154e7b48f66bd98858626347747cd2514311"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/apache/tomcat"
     },
@@ -70,6 +116,14 @@
     {
       "type": "WEB",
       "url": "https://security.netapp.com/advisory/ntap-20240216-0005"
+    },
+    {
+      "type": "WEB",
+      "url": "https://tomcat.apache.org/security-8.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://tomcat.apache.org/security-9.html"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Adds the fixing commits obtained from the tomcat security logs
- https://tomcat.apache.org/security-8.html [commit](https://github.com/apache/tomcat/commit/ce4b154e7b48f66bd98858626347747cd2514311)
- https://tomcat.apache.org/security-9.html [commit](https://github.com/apache/tomcat/commit/86ccc43940861703c2be96a5f35384407522125a)

Per the commits the affected component is under coyote/http11 which is bundled into the `org.apache.tomcat:tomcat-coyote` and `org.apache.tomcat.embed:tomcat-embed-core` maven artifacts