### PR TITLE
[GHSA-rq2w-37h9-vg94] Apache Tomcat improperly escapes input from JsonErrorReportValve

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-rq2w-37h9-vg94/GHSA-rq2w-37h9-vg94.json
+++ b/advisories/github-reviewed/2023/01/GHSA-rq2w-37h9-vg94/GHSA-rq2w-37h9-vg94.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rq2w-37h9-vg94",
-  "modified": "2023-05-30T06:44:57Z",
+  "modified": "2023-06-27T20:23:10Z",
   "published": "2023-01-03T21:30:21Z",
   "aliases": [
     "CVE-2022-45143"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-catalina"
       },
       "ranges": [
         {
@@ -40,7 +40,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-catalina"
       },
       "ranges": [
         {
@@ -54,15 +54,12 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 9.0.68"
-      }
+      ]
     },
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-catalina"
       },
       "ranges": [
         {
@@ -76,10 +73,127 @@
             }
           ]
         }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat:tomcat-util"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.5.83"
+            },
+            {
+              "fixed": "8.5.84"
+            }
+          ]
+        }
       ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 10.1.1"
-      }
+      "versions": [
+        "8.5.83"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat:tomcat-util"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.40"
+            },
+            {
+              "fixed": "9.0.69"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat:tomcat-util"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.1.0"
+            },
+            {
+              "fixed": "10.1.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.5.83"
+            },
+            {
+              "fixed": "8.5.84"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "8.5.83"
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.0.40"
+            },
+            {
+              "fixed": "9.0.69"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.tomcat.embed:tomcat-embed-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.1.0"
+            },
+            {
+              "fixed": "10.1.2"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Per the commits (such as https://github.com/apache/tomcat/commit/b336f4e58893ea35114f1e4a415657f723b1298e), the specifically patched components get distributed as part of the following maven artifacts:
- org.apache.tomcat:tomcat-catalina
- org.apache.tomcat:tomcat-util
- org.apache.tomcat.embed:tomcat-embed-core