### PR TITLE
[GHSA-592j-995h-p23j] RDoc RCE vulnerability with .rdoc_options

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-592j-995h-p23j/GHSA-592j-995h-p23j.json
+++ b/advisories/github-reviewed/2024/03/GHSA-592j-995h-p23j/GHSA-592j-995h-p23j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-592j-995h-p23j",
-  "modified": "2024-03-25T19:37:00Z",
+  "modified": "2024-03-25T19:37:01Z",
   "published": "2024-03-25T19:36:59Z",
   "aliases": [
     "CVE-2024-27281"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The CVE number reported seems not to exist....