### PR TITLE
[GHSA-33c5-9fx5-fvjm] Privilege Escalation in Kubernetes

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-33c5-9fx5-fvjm/GHSA-33c5-9fx5-fvjm.json
+++ b/advisories/github-reviewed/2024/04/GHSA-33c5-9fx5-fvjm/GHSA-33c5-9fx5-fvjm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-33c5-9fx5-fvjm",
-  "modified": "2024-04-24T20:01:22Z",
+  "modified": "2024-04-24T20:01:23Z",
   "published": "2024-04-24T20:01:22Z",
   "aliases": [
     "CVE-2020-8559"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.6.0"
             },
             {
               "fixed": "1.16.13"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Change the minimum affected version. This otherwise falsely impacts latest go k8s sdk dependencies such as `k8s.io/apimachinery | v0.29.4`