### PR TITLE
[GHSA-33c5-9fx5-fvjm] Privilege Escalation in Kubernetes

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-33c5-9fx5-fvjm/GHSA-33c5-9fx5-fvjm.json
+++ b/advisories/github-reviewed/2024/04/GHSA-33c5-9fx5-fvjm/GHSA-33c5-9fx5-fvjm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-33c5-9fx5-fvjm",
-  "modified": "2024-04-24T20:01:22Z",
+  "modified": "2024-04-24T20:01:23Z",
   "published": "2024-04-24T20:01:22Z",
   "aliases": [
     "CVE-2020-8559"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.16.13"
+              "fixed": "0.16.13"
             }
           ]
         }
@@ -44,10 +44,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.17.0"
+              "introduced": "0.17.0"
             },
             {
-              "fixed": "1.17.9"
+              "fixed": "0.17.9"
             }
           ]
         }
@@ -63,10 +63,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.18.0"
+              "introduced": "0.18.0"
             },
             {
-              "fixed": "1.18.7"
+              "fixed": "0.18.7"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Even though kube-apiserver is versioned as Kubernetes, the vulnerable package (`k8s.io/apimachinery`) is not. The versions affected are tagged as v0 instead of v1. The versions mentioned in this GHSA cause all packages ever published to be falsely reported as vulnerable.