### PR TITLE
[GHSA-33c5-9fx5-fvjm] Privilege Escalation in Kubernetes

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-33c5-9fx5-fvjm/GHSA-33c5-9fx5-fvjm.json
+++ b/advisories/github-reviewed/2024/04/GHSA-33c5-9fx5-fvjm/GHSA-33c5-9fx5-fvjm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-33c5-9fx5-fvjm",
-  "modified": "2024-04-24T20:01:22Z",
+  "modified": "2024-04-24T20:01:23Z",
   "published": "2024-04-24T20:01:22Z",
   "aliases": [
     "CVE-2020-8559"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "k8s.io/apimachinery"
+        "name": "k8s.io/kubernetes"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "k8s.io/apimachinery"
+        "name": "k8s.io/kubernetes"
       },
       "ranges": [
         {
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "k8s.io/apimachinery"
+        "name": "k8s.io/kubernetes"
       },
       "ranges": [
         {
@@ -67,6 +67,25 @@
             },
             {
               "fixed": "1.18.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "k8s.io/apimachinery"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.20.0-alpha.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The actual k8s.io/apimachinery commit is https://github.com/kubernetes/apimachinery/commit/a76b7114b20a2e56fd698bba815b1e2c82ec4bff
k8s.io/apimachinery has not even had a 1.* release yet, these are kubernetes versions in https://github.com/kubernetes/kubernetes/issues/92914, not apimachinery.