### PR TITLE
[GHSA-8m45-2rjm-j347] Handling untrusted input can result in a crash, leading to loss of availability / denial of service

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-8m45-2rjm-j347/GHSA-8m45-2rjm-j347.json
+++ b/advisories/github-reviewed/2024/04/GHSA-8m45-2rjm-j347/GHSA-8m45-2rjm-j347.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8m45-2rjm-j347",
-  "modified": "2024-04-17T21:29:10Z",
+  "modified": "2024-04-17T21:29:14Z",
   "published": "2024-04-17T18:21:18Z",
   "aliases": [
     "CVE-2024-30253"
@@ -105,13 +105,13 @@
           "events": [
             {
               "introduced": "1.87.0"
-            },
-            {
-              "fixed": "1.87.7"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.87.7"
+      }
     },
     {
       "package": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
I cannot find a release tagged 1.87.7 in repo. Based on release notes v1.91.3 is the only release with the linked bounds check.

https://github.com/solana-labs/solana-web3.js/releases/tag/v1.91.3

