### PR TITLE
[GHSA-3xh5-5v5v-mfgm] Moodle: fixing affected version ranges

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-3xh5-5v5v-mfgm/GHSA-3xh5-5v5v-mfgm.json
+++ b/advisories/github-reviewed/2022/05/GHSA-3xh5-5v5v-mfgm/GHSA-3xh5-5v5v-mfgm.json
@@ -25,10 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.7"
+              "introduced": "3.5"
             },
             {
-              "fixed": "3.7.3"
+              "fixed": "3.5.9"
             }
           ]
         }
@@ -63,10 +63,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.5"
+              "introduced": "3.7"
             },
             {
-              "fixed": "3.6.73.5.9"
+              "fixed": "3.7.3"
             }
           ]
         }


### PR DESCRIPTION
The current affected version ranges overlap with a fixed version.  

The fix suggested is based on NVD data: https://nvd.nist.gov/vuln/detail/CVE-2019-14884