### PR TITLE
[GHSA-33c5-9fx5-fvjm] Privilege Escalation in Kubernetes

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-33c5-9fx5-fvjm/GHSA-33c5-9fx5-fvjm.json
+++ b/advisories/github-reviewed/2024/04/GHSA-33c5-9fx5-fvjm/GHSA-33c5-9fx5-fvjm.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-33c5-9fx5-fvjm",
-  "modified": "2024-04-24T20:01:22Z",
-  "published": "2024-04-24T20:01:22Z",
+  "modified": "2024-04-25T21:03:11Z",
+  "published": "2024-04-25T21:03:11Z",
   "aliases": [
     "CVE-2020-8559"
   ],
   "summary": "Privilege Escalation in Kubernetes",
-  "details": "The Kubernetes kube-apiserver in versions v1.6-v1.15, and versions prior to v1.16.13, v1.17.9 and v1.18.7 are vulnerable to an unvalidated redirect on proxied upgrade requests that could allow an attacker to escalate privileges from a node compromise to a full cluster compromise.",
+  "details": "The Kubernetes kube-apiserver in versions older than v1.15.0, and versions prior to v1.16.13, v1.17.9 and v1.18.7 are vulnerable to an unvalidated redirect on proxied upgrade requests that could allow an attacker to escalate privileges from a node compromise to a full cluster compromise.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "k8s.io/apimachinery"
+        "name": "k8s.io/kubernetes"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "k8s.io/apimachinery"
+        "name": "k8s.io/kubernetes"
       },
       "ranges": [
         {
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "k8s.io/apimachinery"
+        "name": "k8s.io/kubernetes"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**

- Affected products


**Comments**
Generally the package fixed versions are pointing to wrong values. These fixed versions belong to Kubernetes releases which ideally trigger an upgrade of the affected packages by this CVE. These affected dependencies are apiserver and apimachinery which would need a bump to their respective fixed versions v0.16.13, v0.17.9 and v0.18.7.

https://nvd.nist.gov/vuln/detail/CVE-2020-8559
https://github.com/kubernetes/kubernetes/issues/92914
https://groups.google.com/g/kubernetes-security-announce/c/JAIGG5yNROs