### PR TITLE
[GHSA-33c5-9fx5-fvjm] Privilege Escalation in Kubernetes 

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-33c5-9fx5-fvjm/GHSA-33c5-9fx5-fvjm.json
+++ b/advisories/github-reviewed/2024/04/GHSA-33c5-9fx5-fvjm/GHSA-33c5-9fx5-fvjm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-33c5-9fx5-fvjm",
-  "modified": "2024-04-25T21:29:39Z",
+  "modified": "2024-04-25T22:42:39Z",
   "published": "2024-04-24T20:01:22Z",
   "aliases": [
     "CVE-2020-8559"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.16.13"
+              "fixed": "1.16.13"
             }
           ]
         }
@@ -44,10 +44,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0.17.0"
+              "introduced": "1.17.0"
             },
             {
-              "fixed": "0.17.9"
+              "fixed": "1.17.9"
             }
           ]
         }
@@ -63,10 +63,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0.18.0"
+              "introduced": "1.18.0"
             },
             {
-              "fixed": "0.18.7"
+              "fixed": "1.18.7"
             }
           ]
         }


### PR DESCRIPTION
**Updates**

- Affected products

**Comments**

While merging two PRs modifying this CVE, the fixed versions for the kubernetes package are now wrong.

https://nvd.nist.gov/vuln/detail/CVE-2020-8559
https://github.com/kubernetes/kubernetes/issues/92914
https://groups.google.com/g/kubernetes-security-announce/c/JAIGG5yNROs