### PR TITLE
[GHSA-98p4-xjmm-8mfh] gix-transport indirect code execution via malicious username

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-98p4-xjmm-8mfh/GHSA-98p4-xjmm-8mfh.json
+++ b/advisories/github-reviewed/2024/04/GHSA-98p4-xjmm-8mfh/GHSA-98p4-xjmm-8mfh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-98p4-xjmm-8mfh",
-  "modified": "2024-04-15T19:33:03Z",
+  "modified": "2024-04-15T19:33:04Z",
   "published": "2024-04-15T19:33:03Z",
   "aliases": [
 
@@ -86,7 +86,8 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-77"
+      "CWE-77",
+      "CWE-88"
     ],
     "severity": "MODERATE",
     "github_reviewed": true,


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs

**Comments**
This adds the more specific weakness [CWE-88](https://cwe.mitre.org/data/definitions/88.html), as discussed in [the pull request that fixed this vulnerability](https://github.com/Byron/gitoxide/pull/1342), in comments https://github.com/Byron/gitoxide/pull/1342#issuecomment-2057647039 and below. I've already made this change at the corresponding repository-level advisory https://github.com/Byron/gitoxide/security/advisories/GHSA-98p4-xjmm-8mfh. Because [CWE-88](https://cwe.mitre.org/data/definitions/88.html) is a [child](https://cwe.mitre.org/data/definitions/88.html#Relationships) of [CWE-77](https://cwe.mitre.org/data/definitions/77.html), I wasn't sure if it was best to keep [CWE-77](https://cwe.mitre.org/data/definitions/77.html) as well, but [several other git-related advisories](https://github.com/advisories?query=cwe%3A77+cwe%3A88+git), some of which this resembles, do list both explicitly. If [CWE-88](https://cwe.mitre.org/data/definitions/88.html) ought instead to replace [CWE-77](https://cwe.mitre.org/data/definitions/77.html) here, then I have no objection to that.