### PR TITLE
[GHSA-r4ph-mx67-x58p] Shopware database password is leaked to an unauthenticated users

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-r4ph-mx67-x58p/GHSA-r4ph-mx67-x58p.json
+++ b/advisories/github-reviewed/2022/05/GHSA-r4ph-mx67-x58p/GHSA-r4ph-mx67-x58p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r4ph-mx67-x58p",
-  "modified": "2024-04-24T22:41:45Z",
+  "modified": "2024-04-24T22:41:48Z",
   "published": "2022-05-24T17:24:28Z",
   "aliases": [
     "CVE-2020-13997"
@@ -19,25 +19,6 @@
       "package": {
         "ecosystem": "Packagist",
         "name": "shopware/core"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "6.2.3"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Packagist",
-        "name": "shopware/shopware"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The composer package name `shopware/shopware` refers to `Shopware 5` and is a totally different system. See https://github.com/shopware5/shopware/blob/5.7/composer.json#L2
We just renamed the GitHub repository name from `shopware/platform` to `shopware/shopware`  a while ago. 

This urgently needs to be fixed, as it spreads misinformation about a wrong security issue on a project that is not affected