### PR TITLE
[GHSA-xjhv-p3fv-x24r] In Reactor Netty HTTP Server a malicious user can send a request using a specially crafted URL that can lead to a directory traversal attack

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-xjhv-p3fv-x24r/GHSA-xjhv-p3fv-x24r.json
+++ b/advisories/github-reviewed/2023/11/GHSA-xjhv-p3fv-x24r/GHSA-xjhv-p3fv-x24r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xjhv-p3fv-x24r",
-  "modified": "2023-11-15T18:36:00Z",
+  "modified": "2023-11-15T18:36:04Z",
   "published": "2023-11-15T12:30:30Z",
   "aliases": [
     "CVE-2023-34062"
@@ -58,6 +58,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-34062"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/reactor/reactor-netty/commit/b1dd46b9a424ca27f7f770be6561faa84d812e5b"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Added link to the fix commit. The commit message only references other changes, but the fix is also there in the 'validateScheme' method