### PR TITLE
[GHSA-3494-cfwf-56hw] phpecc, as used in paragonie/phpecc before 2.0.1, has a...

### DIFF
--- a/advisories/unreviewed/2024/04/GHSA-3494-cfwf-56hw/GHSA-3494-cfwf-56hw.json
+++ b/advisories/unreviewed/2024/04/GHSA-3494-cfwf-56hw/GHSA-3494-cfwf-56hw.json
@@ -1,17 +1,55 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3494-cfwf-56hw",
-  "modified": "2024-04-28T00:30:22Z",
+  "modified": "2024-04-28T00:30:23Z",
   "published": "2024-04-28T00:30:22Z",
   "aliases": [
     "CVE-2024-33851"
   ],
-  "details": "phpecc, as used in paragonie/phpecc before 2.0.1, has a branch-based timing leak in Point addition. (This is related to phpecc/phpecc on GitHub, and the Matyas Danter ECC library.)",
+  "summary": "Cryptographic timing vulnerability in mdanter/ecc",
+  "details": "phpecc, as used in **all versions** of mdanter/ecc, as well as paragonie/ecc before 2.0.1, has a branch-based timing leak in Point addition. (This is related to phpecc/phpecc on GitHub, and the Matyas Danter ECC library.)\n\nParagon Initiative Enterprises [hard-forked phpecc/phpecc](https://github.com/phpecc/phpecc/issues/289) and discovered the issue in the original code, then cut v2.0.1 which fixes the vulnerability. [The upstream code](https://github.com/phpecc/phpecc) is no longer maintained and remains vulnerable for all versions.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "mdanter/ecc"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.0.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "paragonie/ecc"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.0.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -21,13 +59,21 @@
     {
       "type": "WEB",
       "url": "https://github.com/paragonie/phpecc/releases/tag/v2.0.1"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/phpecc/phpecc/blob/34e2eec096bf3dcda814e8f66dd91ae87a2db7cd/src/Primitives/Point.php#L188-L194"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.openwall.com/lists/oss-security/2024/04/24/4"
     }
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-327"
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2024-04-27T22:15:08Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- Description
- References
- Severity
- Source code location
- Summary

**Comments**
More accurate information, more resources