### PR TITLE
[GHSA-9848-v244-962p] Apache Struts XSS

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9848-v244-962p/GHSA-9848-v244-962p.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9848-v244-962p/GHSA-9848-v244-962p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9848-v244-962p",
-  "modified": "2023-08-14T23:23:18Z",
+  "modified": "2023-08-14T23:23:20Z",
   "published": "2022-05-14T02:21:24Z",
   "aliases": [
     "CVE-2012-1007"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.struts:struts2-parent"
+        "name": "org.apache.struts:struts-parent"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
If the struts vulnerable version is <= 1.3.10, this must affect struts, not struts2.