### PR TITLE
[GHSA-c5pj-mqfh-rvc3] Runc allows an arbitrary systemd property to be injected

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-c5pj-mqfh-rvc3/GHSA-c5pj-mqfh-rvc3.json
+++ b/advisories/github-reviewed/2024/04/GHSA-c5pj-mqfh-rvc3/GHSA-c5pj-mqfh-rvc3.json
@@ -6,8 +6,8 @@
   "aliases": [
     "CVE-2024-3154"
   ],
-  "summary": "Runc allows an arbitrary systemd property to be injected",
-  "details": "A flaw was found in cri-o, where an arbitrary systemd property can be injected via a Pod annotation. Any user who can create a pod with an arbitrary annotation may perform an arbitrary action on the host system. This issue has its root in how runc handles Config Annotations lists.",
+  "summary": "cri-o allows an arbitrary systemd property to be injected",
+  "details": "A flaw was found in cri-o, where an arbitrary systemd property can be injected via a Pod annotation. Any user who can create a pod with an arbitrary annotation may perform an arbitrary action on the host system. \n\nThis issue was once misidentified as a vulnerability of runc (< 1.2.0-rc.1), but actually this is the matter of how cri-o generates and validates the config for runc.\nrunc is designed to accept an arbitrary systemd property specified in the config, and will continue to do so in >= 1.2.0-rc.1.\nUsers do NOT need to update runc.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/opencontainers/runc"
+        "name": "github.com/cri-o/cri-o"
       },
       "ranges": [
         {
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.2.0-rc.1"
+              "fixed": "1.30.0, 1.29.4, 1.28.6, 1.27.6"
             }
           ]
         }
@@ -43,6 +43,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-3154"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/opencontainers/runc/issues/4263"
     },
     {
       "type": "WEB",
@@ -62,7 +66,7 @@
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/opencontainers/runc"
+      "url": "https://github.com/cri-o/cri-o"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Source code location
- Summary

**Comments**
Because this is a vulnerability of cri-o, not runc. 
runc is working as designed, and it's cri-o's responsibility to validate the config.
Users do NOT need to update runc.
https://github.com/opencontainers/runc/issues/4263