### PR TITLE
[GHSA-j8g6-2wh7-6439] Apache Tika allows Java code execution for serialized objects embedded in MATLAB files

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-j8g6-2wh7-6439/GHSA-j8g6-2wh7-6439.json
+++ b/advisories/github-reviewed/2018/10/GHSA-j8g6-2wh7-6439/GHSA-j8g6-2wh7-6439.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tika:tika-core"
+        "name": "org.apache.tika:tika-parsers"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The vulnerable package is tika-parsers, not tika-core.
It can be seen in the fixing commit, which only changes code under tika-parsers: https://github.com/apache/tika/commit/8a68b5d474205cc91cbbb610d4a1c05af57f0610