### PR TITLE
[GHSA-w6g3-v46q-5p28] Moderate severity vulnerability that affects org.apache.tika:tika-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-w6g3-v46q-5p28/GHSA-w6g3-v46q-5p28.json
+++ b/advisories/github-reviewed/2018/10/GHSA-w6g3-v46q-5p28/GHSA-w6g3-v46q-5p28.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w6g3-v46q-5p28",
-  "modified": "2021-09-21T17:58:38Z",
+  "modified": "2023-01-09T05:03:16Z",
   "published": "2018-10-17T15:49:58Z",
   "aliases": [
     "CVE-2018-11762"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tika:tika-core"
+        "name": "org.apache.tika:tika-app"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This vulnerability does not effect tika-core, but tika-app, like the fixing commit shows: https://github.com/apache/tika/commit/a09d853dbed712f644e274b497cce254f3189d57