### PR TITLE
[GHSA-j53j-gmr9-h8g3] Comparison errorr in org.apache.tika:tika-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-j53j-gmr9-h8g3/GHSA-j53j-gmr9-h8g3.json
+++ b/advisories/github-reviewed/2018/10/GHSA-j53j-gmr9-h8g3/GHSA-j53j-gmr9-h8g3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j53j-gmr9-h8g3",
-  "modified": "2024-03-04T23:27:07Z",
+  "modified": "2024-03-04T23:27:08Z",
   "published": "2018-10-17T15:50:31Z",
   "aliases": [
     "CVE-2018-8017"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tika:tika-core"
+        "name": "org.apache.tika:tika-parsers"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The vulnerability does not effect tika-core, but tika-parsers, like the fixing commit shows: https://github.com/apache/tika/commit/8a6a9e1344f5b10ebfa1a189dc3c30d0da2b9d4