### PR TITLE
[GHSA-5mf7-26mw-3rqr] Moderate severity vulnerability that affects org.apache.tika:tika-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-5mf7-26mw-3rqr/GHSA-5mf7-26mw-3rqr.json
+++ b/advisories/github-reviewed/2018/10/GHSA-5mf7-26mw-3rqr/GHSA-5mf7-26mw-3rqr.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5mf7-26mw-3rqr",
-  "modified": "2021-09-01T22:17:57Z",
+  "modified": "2023-01-09T05:02:45Z",
   "published": "2018-10-17T15:50:45Z",
   "aliases": [
     "CVE-2018-1338"
   ],
-  "summary": "Moderate severity vulnerability that affects org.apache.tika:tika-core",
+  "summary": "Moderate severity vulnerability that affects org.apache.tika:tika-parsers",
   "details": "A carefully crafted (or fuzzed) file can trigger an infinite loop in Apache Tika's BPGParser in versions of Apache Tika before 1.18.",
   "severity": [
     {
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tika:tika-core"
+        "name": "org.apache.tika:tika-parsers"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The vulnerability does not effect tika-core, but tika-parsers. The vulnerable class `BPGParser` is under tika-parsers: https://github.com/search?q=repo%3Aapache%2Ftika%20BPGParser&type=code