### PR TITLE
[GHSA-cjwg-qfpm-7377] python-jose denial of service via compressed JWT tokens

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-cjwg-qfpm-7377/GHSA-cjwg-qfpm-7377.json
+++ b/advisories/github-reviewed/2024/04/GHSA-cjwg-qfpm-7377/GHSA-cjwg-qfpm-7377.json
@@ -6,7 +6,7 @@
   "aliases": [
     "CVE-2024-33664"
   ],
-  "summary": "python-jose denial of service via compressed JWT tokens",
+  "summary": "python-jose denial of service via compressed JWE content",
   "details": "python-jose through 3.3.0 allows attackers to cause a denial of service (resource consumption) during a decode via a crafted JSON Web Encryption (JWE) token with a high compression ratio, aka a \"JWT bomb.\" This is similar to CVE-2024-21319.",
   "severity": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The vulnerability does not affect JWT tokens but JWE messages. This is an important distinction because JWE is used less frequently.