### PR TITLE
[GHSA-rhxf-5pw9-q4gm] Hex package manager version 0.14.0 through 0.18.2...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-rhxf-5pw9-q4gm/GHSA-rhxf-5pw9-q4gm.json
+++ b/advisories/unreviewed/2022/05/GHSA-rhxf-5pw9-q4gm/GHSA-rhxf-5pw9-q4gm.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rhxf-5pw9-q4gm",
-  "modified": "2022-05-13T01:07:56Z",
+  "modified": "2023-02-01T05:03:12Z",
   "published": "2022-05-13T01:07:56Z",
   "aliases": [
     "CVE-2019-1000012"
   ],
+  "summary": "Hex authenticity of signed packages not validated ",
   "details": "Hex package manager version 0.14.0 through 0.18.2 contains a Signing oracle vulnerability in Package registry verification that can result in Package modifications not detected, allowing code execution. This attack appears to be exploitable via victim fetches packages from malicious/compromised mirror. This vulnerability appears to have been fixed in 0.19.",
   "severity": [
     {
@@ -14,7 +15,44 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Hex",
+        "name": "hex"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.14.0"
+            },
+            {
+              "fixed": "0.19.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Hex",
+        "name": "hex_core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.0.0"
+            },
+            {
+              "fixed": "0.4.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -28,6 +66,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/hexpm/hex/pull/651"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/hexpm/hex"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
Just linking the things already present in the CVE description.

The hex_core package was carved out of the hex client after this vulnerability was introduced and fixed with v0.4.0