### PR TITLE
[GHSA-7f88-5hhx-67m2] XNIO denial of service vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-7f88-5hhx-67m2/GHSA-7f88-5hhx-67m2.json
+++ b/advisories/github-reviewed/2024/03/GHSA-7f88-5hhx-67m2/GHSA-7f88-5hhx-67m2.json
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.8.13.Final"
+              "fixed": "3.8.14.Final"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.8.13.Final"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to SNYK and Maven Repo, version 3.8.14.Final is the latest version and patches vulnerability CVE-2023-5685:

https://mvnrepository.com/artifact/org.jboss.xnio/xnio-api/3.8.14.Final
https://security.snyk.io/vuln/SNYK-JAVA-ORGJBOSSXNIO-6403375
