### PR TITLE
[GHSA-vm8q-m57g-pff3] Regular expression denial-of-service in Django

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-vm8q-m57g-pff3/GHSA-vm8q-m57g-pff3.json
+++ b/advisories/github-reviewed/2024/03/GHSA-vm8q-m57g-pff3/GHSA-vm8q-m57g-pff3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vm8q-m57g-pff3",
-  "modified": "2024-05-02T18:48:10Z",
+  "modified": "2024-05-02T18:48:11Z",
   "published": "2024-03-15T21:30:43Z",
   "aliases": [
     "CVE-2024-27351"
@@ -16,11 +16,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "django"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "django.utils.text.Truncator.words"
-        ]
       },
       "ranges": [
         {
@@ -41,11 +36,6 @@
         "ecosystem": "PyPI",
         "name": "django"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "django.utils.text.Truncator.words"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
@@ -64,11 +54,6 @@
       "package": {
         "ecosystem": "PyPI",
         "name": "django"
-      },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "django.utils.text.Truncator.words"
-        ]
       },
       "ranges": [
         {
@@ -89,6 +74,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-27351"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/3394fc6132436eca89e997083bae9985fb7e761e"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add patch commit: https://github.com/django/django/commit/3394fc6132436eca89e997083bae9985fb7e761e, the commit msg shows it fixed this cve.