### PR TITLE
[GHSA-c5pj-mqfh-rvc3] Withdrawn: Runc allows an arbitrary systemd property to be injected

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-c5pj-mqfh-rvc3/GHSA-c5pj-mqfh-rvc3.json
+++ b/advisories/github-reviewed/2024/04/GHSA-c5pj-mqfh-rvc3/GHSA-c5pj-mqfh-rvc3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c5pj-mqfh-rvc3",
-  "modified": "2024-04-30T09:37:23Z",
+  "modified": "2024-04-30T09:37:24Z",
   "published": "2024-04-26T06:30:34Z",
   "withdrawn": "2024-04-30T09:37:23Z",
   "aliases": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
CVE-2024-3154 is missing from CVE alias 