### PR TITLE
[GHSA-pf59-j7c2-rh6x] Exposure of Sensitive Information to an Unauthorized Actor and Insertion of Sensitive Information Into Sent Data in Calico

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-pf59-j7c2-rh6x/GHSA-pf59-j7c2-rh6x.json
+++ b/advisories/github-reviewed/2022/02/GHSA-pf59-j7c2-rh6x/GHSA-pf59-j7c2-rh6x.json
@@ -25,10 +25,124 @@
           "type": "ECOSYSTEM",
           "events": [
             {
+              "introduced": "3.14.0"
+            },
+            {
+              "fixed": "3.14.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/projectcalico/calico"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.13.0"
+            },
+            {
+              "fixed": "3.13.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/projectcalico/calico"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.12.0"
+            },
+            {
+              "fixed": "3.12.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/projectcalico/calico"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.11.0"
+            },
+            {
+              "fixed": "3.11.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/projectcalico/calico"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.10.0"
+            },
+            {
+              "fixed": "3.10.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/projectcalico/calico"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.9.0"
+            },
+            {
+              "fixed": "3.9.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/projectcalico/calico"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
               "introduced": "0"
             },
             {
-              "fixed": "0.8.6"
+              "fixed": "3.8.9"
             }
           ]
         }
@@ -46,7 +160,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/containernetworking/plugins/pull/484"
+      "url": "https://github.com/containernetworking/plugins/pull/484/"
     },
     {
       "type": "WEB",
@@ -58,7 +172,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.projectcalico.org/security-bulletins"
+      "url": "https://www.projectcalico.org/security-bulletins/"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The previously mentioned version "0.8.6" didn't appear to exist for the calico project at all. I pulled the corrected affected and patched versions from https://www.tigera.io/security-bulletins-tta-2020-001/.