### PR TITLE
[GHSA-33c5-9fx5-fvjm] Privilege Escalation in Kubernetes kube-apiserver

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-33c5-9fx5-fvjm/GHSA-33c5-9fx5-fvjm.json
+++ b/advisories/github-reviewed/2024/04/GHSA-33c5-9fx5-fvjm/GHSA-33c5-9fx5-fvjm.json
@@ -7,7 +7,7 @@
     "CVE-2020-8559"
   ],
   "summary": "Privilege Escalation in Kubernetes",
-  "details": "The Kubernetes kube-apiserver in versions v1.6-v1.15, and versions prior to v1.16.13, v1.17.9 and v1.18.7 are vulnerable to an unvalidated redirect on proxied upgrade requests that could allow an attacker to escalate privileges from a node compromise to a full cluster compromise.",
+  "details": "The Kubernetes kube-apiserver in versions v1.6-v1.15, and versions prior to v1.16.13, v1.17.9 and v1.18.7 are vulnerable to an unvalidated redirect on proxied upgrade requests that could allow an attacker to escalate privileges from a node compromise to a full cluster compromise.\n\nThe underlying issue and fix are in k8s.io/apimachinery, which has a major version offset compared to k8s.io/kubernetes (i.e. v0.18.7 of k8s.io/apimachinery matches v1.18.7 of k8s.io/kubernetes).",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "k8s.io/kubernetes"
+        "name": "k8s.io/apimachinery"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "k8s.io/kubernetes"
+        "name": "k8s.io/apimachinery"
       },
       "ranges": [
         {
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "k8s.io/kubernetes"
+        "name": "k8s.io/apimachinery"
       },
       "ranges": [
         {
@@ -67,6 +67,63 @@
             },
             {
               "fixed": "0.18.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "k8s.io/kubernetes"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.16.13"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "k8s.io/kubernetes"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.17.0"
+            },
+            {
+              "fixed": "1.17.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "k8s.io/kubernetes"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.18.0"
+            },
+            {
+              "fixed": "1.18.7"
             }
           ]
         }


### PR DESCRIPTION
The original version of this advisory correctly used package k8s.io/apimachinery, but with the wrong versioning:
- The versioning used v1.x.y, instead of v0.x.y
- k8s.io/apimachinery has a major version offset compared to k8s.io/kubernetes
- For example, k8s.io/apimachinery v0.18.6, which is affected by the CVE, matches k8s.io/kubernetes v1.18.6 (see https://github.com/kubernetes/apimachinery/releases/tag/v0.18.6)

The updated version of this advisory over-corrected, changing both the package and the versions affected:
- As per the CVE issue, the k8s.io/kubernetes versions affected are v1.x.y, not v0.x.y (see https://github.com/kubernetes/kubernetes/issues/92914)
- The fix itself is in the apimachinery package (see https://github.com/kubernetes/kubernetes/pull/92941/commits/1f991f8a2f5a73d51683ce064b97324f83661621)

This fix corrects the package back to k8s.io/apimachinery, using the v0.x.y versions, and also adds k8s.io/kubernetes as an affected package, with the v1.x.y versions.

Additional context is added to the 'details' text to explain the versioning discrepancy.