### PR TITLE
[GHSA-j3j3-jrfh-cm2w] Django Denial-of-service possibility with strip_tags

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-j3j3-jrfh-cm2w/GHSA-j3j3-jrfh-cm2w.json
+++ b/advisories/github-reviewed/2022/05/GHSA-j3j3-jrfh-cm2w/GHSA-j3j3-jrfh-cm2w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j3j3-jrfh-cm2w",
-  "modified": "2024-04-29T11:21:09Z",
+  "modified": "2024-04-29T11:21:10Z",
   "published": "2022-05-14T02:06:52Z",
   "aliases": [
     "CVE-2015-2316"
@@ -74,6 +74,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-2316"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/5447709a571cd5d95971f1d5d21d4a7edcf85bbd"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/b6b3cb9899214a23ebb0f4ebf0e0b300b0ee524f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/e63363f8e075fa8d66326ad6a1cc3391cc95cd97"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add 3 patch commits:
Django 1.6: https://github.com/django/django/commit/b6b3cb9899214a23ebb0f4ebf0e0b300b0ee524f
Django 1.7: https://github.com/django/django/commit/e63363f8e075fa8d66326ad6a1cc3391cc95cd97
Django 1.8: https://github.com/django/django/commit/5447709a571cd5d95971f1d5d21d4a7edcf85bbd
