### PR TITLE
[GHSA-x38m-486c-2wr9] The (1) contrib.sessions.backends.base.SessionBase.flush...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-x38m-486c-2wr9/GHSA-x38m-486c-2wr9.json
+++ b/advisories/unreviewed/2022/05/GHSA-x38m-486c-2wr9/GHSA-x38m-486c-2wr9.json
@@ -1,0 +1,125 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-x38m-486c-2wr9",
+  "modified": "2023-01-27T05:01:27Z",
+  "published": "2022-05-17T03:16:12Z",
+  "aliases": [
+    "CVE-2015-5964"
+  ],
+  "summary": "denial of service (session store consumption) via unspecified vectors in Django",
+  "details": "The (1) contrib.sessions.backends.base.SessionBase.flush and (2) cache_db.SessionStore.flush functions in Django 1.7.x before 1.7.10, 1.4.x before 1.4.22, and possibly other versions create empty sessions in certain circumstances, which allows remote attackers to cause a denial of service (session store consumption) via unspecified vectors.",
+  "severity": [
+
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "django"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.7.0"
+            },
+            {
+              "fixed": "1.7.10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "django"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.4.0"
+            },
+            {
+              "fixed": "1.4.22"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5964"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/2f5485346ee6f84b4e52068c04e043092daf55f7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/575f59f9bc7c59a5e41a081d1f5f55fc859c5012"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/8cc41ce7a7a8f6bebfdd89d5ab276cd0109f4fc5"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/django/django"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.djangoproject.com/weblog/2015/aug/18/security-releases/"
+    },
+    {
+      "type": "WEB",
+      "url": "http://lists.fedoraproject.org/pipermail/package-announce/2015-November/172084.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://rhn.redhat.com/errata/RHSA-2015-1766.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://rhn.redhat.com/errata/RHSA-2015-1767.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://rhn.redhat.com/errata/RHSA-2015-1894.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.debian.org/security/2015/dsa-3338"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.oracle.com/technetwork/topics/security/bulletinoct2015-2511968.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.securityfocus.com/bid/76440"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.securitytracker.com/id/1033318"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.ubuntu.com/usn/USN-2720-1"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": false,
+    "github_reviewed_at": null,
+    "nvd_published_at": "2015-08-24T14:59:00Z"
+  }
+}


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
add patches:

https://github.com/django/django/commit/575f59f9bc7c59a5e41a081d1f5f55fc859c5012
https://github.com/django/django/commit/2f5485346ee6f84b4e52068c04e043092daf55f7
https://github.com/django/django/commit/8cc41ce7a7a8f6bebfdd89d5ab276cd0109f4fc5

and update the vvr according to the cve desc