### PR TITLE
[GHSA-92jh-gwch-jq38] PocketMine-MP server crash with certain invalid JSON payloads in `LoginPacket` due to dependency vulnerability (again)

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-92jh-gwch-jq38/GHSA-92jh-gwch-jq38.json
+++ b/advisories/github-reviewed/2023/09/GHSA-92jh-gwch-jq38/GHSA-92jh-gwch-jq38.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-92jh-gwch-jq38",
-  "modified": "2023-09-14T17:10:37Z",
+  "modified": "2023-09-14T17:10:38Z",
   "published": "2023-09-14T17:10:37Z",
   "aliases": [
 
   ],
   "summary": "PocketMine-MP server crash with certain invalid JSON payloads in `LoginPacket` due to dependency vulnerability (again)",
-  "details": "### Impact\nAn attacker could crash the server by sending malformed JWT JSON in `LoginPacket` due to a security vulnerability in [`netresearch/jsonmapper`](https://github.com/cweiske/JsonMapper), due to accepting `NULL` values in arrays whose types do not expect `NULL`.\n\n### Patches\nThis problem was fixed in 5.3.1 and 4.23.1 by updating JsonMapper to include the following commit: pmmp/netresearch-jsonmapper@4f90e8dab1c9df331fad7d3d89823404e882668c\n\n### Workarounds\nA plugin may handle `DataPacketReceiveEvent` for `LoginPacket` and check that none of the input arrays contain `NULL` where it's not expected, but this is rather cumbersome.",
+  "details": "### Impact\nAn attacker could crash the server by sending malformed JWT JSON in `LoginPacket` due to a security vulnerability in [`pocketmine/netresearch-jsonmapper`](https://github.com/pmmp/netresearch-jsonmapper), due to accepting `NULL` values in arrays whose types do not expect `NULL`.\n\n### Patches\nThis problem was fixed in 5.3.1 and 4.23.1 by updating JsonMapper to include the following commit: pmmp/netresearch-jsonmapper@4f90e8dab1c9df331fad7d3d89823404e882668c\n\n### Workarounds\nA plugin may handle `DataPacketReceiveEvent` for `LoginPacket` and check that none of the input arrays contain `NULL` where it's not expected, but this is rather cumbersome.",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
This report only is relevant to pocketmine/pocketmine-mp because that repo contains the class `LoginPacket` that does not properly validate the input values. The relevant package dealing with mapping JSON to PHP classes is a fork in https://github.com/pmmp/netresearch-jsonmapper

This report does not affect the original JsonMapper library, as having NULL entries in arrays is a defined and tested use case (admittedly an unexpected one). The original project has received several invalid vulnerability reports because of this incorrect attribution, as multiple "security report collector" companies spread this incorrect information through channels beyond the maintainers control.