### PR TITLE
[GHSA-c9h3-c6qj-hh7q] Apache Kafka vulnerability can lead to brokers hitting OutOfMemoryException, causing Denial of Service

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-c9h3-c6qj-hh7q/GHSA-c9h3-c6qj-hh7q.json
+++ b/advisories/github-reviewed/2022/09/GHSA-c9h3-c6qj-hh7q/GHSA-c9h3-c6qj-hh7q.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c9h3-c6qj-hh7q",
-  "modified": "2022-09-23T17:08:42Z",
+  "modified": "2023-01-31T05:03:54Z",
   "published": "2022-09-21T00:00:52Z",
   "aliases": [
     "CVE-2022-34917"
   ],
   "summary": "Apache Kafka vulnerability can lead to brokers hitting OutOfMemoryException, causing Denial of Service",
-  "details": "A security vulnerability has been identified in Apache Kafka. It affects all releases since 2.8.0. The vulnerability allows malicious unauthenticated clients to allocate large amounts of memory on brokers. This can lead to brokers hitting OutOfMemoryException and causing denial of service. Example scenarios: - Kafka cluster without authentication: Any clients able to establish a network connection to a broker can trigger the issue. - Kafka cluster with SASL authentication: Any clients able to establish a network connection to a broker, without the need for valid SASL credentials, can trigger the issue. - Kafka cluster with TLS authentication: Only clients able to successfully authenticate via TLS can trigger the issue. We advise the users to upgrade the Kafka installations to one of the 3.2.3, 3.1.2, 3.0.2, 2.8.2 versions.",
+  "details": "A security vulnerability has been identified in Apache Kafka. It affects all releases since 2.8.0. The vulnerability allows malicious unauthenticated clients to allocate large amounts of memory on brokers. This can lead to brokers hitting OutOfMemoryException and causing denial of service.\n\nExample scenarios:\n\n- Kafka cluster without authentication: Any clients able to establish a network connection to a broker can trigger the issue.\n- Kafka cluster with SASL authentication: Any clients able to establish a network connection to a broker, without the need for valid SASL credentials, can trigger the issue.\n- Kafka cluster with TLS authentication: Only clients able to successfully authenticate via TLS can trigger the issue.\n\nWe advise the users to upgrade the Kafka installations to one of the 3.2.3, 3.1.2, 3.0.2, 2.8.2 versions.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -99,7 +99,31 @@
     },
     {
       "type": "WEB",
-      "url": "https://kafka.apache.org/cve-list"
+      "url": "https://github.com/apache/kafka/commit/14951a83e3fdead212156e5532359500d72f68bc"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/kafka/commit/2bfa24b2bd416e7b8c4a0c566b984c43904fdecb"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/kafka/commit/aaceb6b79bfcb1d32874ccdbc8f3138d1c1c00fb"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/kafka/commit/c1295662768e64b4467e27c3d5158f95f2307657"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/kafka/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/KAFKA-14063"
+    },
+    {
+      "type": "WEB",
+      "url": "https://kafka.apache.org/cve-list#CVE-2022-34917"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Description
- References
- Source code location

**Comments**
Added patch commits and bug tracker entry that I found useful while triaging this vuln for a VDR analysis engagement, plus added back lost whitespace in the description