### PR TITLE
[GHSA-32h7-7j94-8fc2] Mattermost vulnerable to denial of service via large number of emoji reactions

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-32h7-7j94-8fc2/GHSA-32h7-7j94-8fc2.json
+++ b/advisories/github-reviewed/2024/02/GHSA-32h7-7j94-8fc2/GHSA-32h7-7j94-8fc2.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-32h7-7j94-8fc2",
-  "modified": "2024-02-09T21:35:00Z",
+  "modified": "2024-02-09T21:35:04Z",
   "published": "2024-02-09T18:31:07Z",
   "aliases": [
     "CVE-2024-1402"
   ],
   "summary": "Mattermost vulnerable to denial of service via large number of emoji reactions",
-  "details": "Mattermost fails to check if a custom emoji reaction exists when sending it to a post and to limit the amount of custom emojis allowed to be added in a post, allowing an attacker sending a huge amount of non-existent custom emojis in a post to crash the mobile app of a user seeing the post. \n\n",
+  "details": "Mattermost fails to check if a custom emoji reaction exists when sending it to a post and to limit the amount of custom emojis allowed to be added in a post, allowing an attacker sending a huge amount of non-existent custom emojis in a post to crash the mobile app of a user seeing the post. Fetching posts with huge amounts of reactions results in Uncontrolled Resource Consumption.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description

**Comments**
The DoS of the mobile app is just a side-effect. See https://github.com/c0rydoras/cves/tree/main/CVE-2024-1402