### PR TITLE
[GHSA-g7vv-2v7x-gj9p] tqdm CLI arguments injection attack

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-g7vv-2v7x-gj9p/GHSA-g7vv-2v7x-gj9p.json
+++ b/advisories/github-reviewed/2024/05/GHSA-g7vv-2v7x-gj9p/GHSA-g7vv-2v7x-gj9p.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g7vv-2v7x-gj9p",
-  "modified": "2024-05-03T19:33:28Z",
+  "modified": "2024-05-03T19:33:29Z",
   "published": "2024-05-03T19:33:28Z",
   "aliases": [
     "CVE-2024-34062"
   ],
   "summary": "tqdm CLI arguments injection attack",
-  "details": "### Impact\nAny optional non-boolean CLI arguments (e.g. `--delim`, `--buf-size`, `--manpath`) are passed through python's `eval`, allowing arbitrary code execution. Example:\n\n```sh\npython -m tqdm --manpath=\"\\\" + str(exec(\\\"import os\\nos.system('echo hi && killall python3')\\\")) + \\\"\"\n```\n\n### Patches\nhttps://github.com/tqdm/tqdm/commit/4e613f84ed2ae029559f539464df83fa91feb316 released in `tqdm>=4.66.3`\n\n### Workarounds\nNone\n\n### References\n- https://github.com/tqdm/tqdm/releases/tag/v4.66.3",
+  "details": "### Impact\nAny optional non-boolean CLI arguments (e.g. `--delim`, `--buf-size`, `--manpath`) are passed through python's `eval`, allowing arbitrary code execution. Example:\n\n```sh\npython -m tqdm --manpath=\"\\\" + str(exec(\\\"import os\\nos.system('echo hi && killall python3')\\\")) + \\\"\"\n```\n\n### Patches\nhttps://github.com/tqdm/tqdm/commit/4e613f84ed2ae029559f539464df83fa91feb316 released in `tqdm>=4.66.3`\n\n### Workarounds\nNone\n\n### References\n- https://github.com/tqdm/tqdm/releases/tag/v4.66.3\n\n### Credit\nThis issue was reported by [CopperEagle](https://github.com/CopperEagle).",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Hey there! I added credits in the description. I received credit and it shows in the repositories' security advisory (https://github.com/tqdm/tqdm/security/advisories/GHSA-g7vv-2v7x-gj9p) but it does not show up here, even the day after. 
Thank you!