### PR TITLE
[GHSA-vr64-r9qj-h27f] Reading specially crafted serializable objects from an untrusted source may cause an infinite loop and denial of service

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-vr64-r9qj-h27f/GHSA-vr64-r9qj-h27f.json
+++ b/advisories/github-reviewed/2024/02/GHSA-vr64-r9qj-h27f/GHSA-vr64-r9qj-h27f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vr64-r9qj-h27f",
-  "modified": "2024-03-24T03:30:43Z",
+  "modified": "2024-03-24T03:30:44Z",
   "published": "2024-02-29T03:33:18Z",
   "aliases": [
     "CVE-2024-22871"
@@ -25,11 +25,14 @@
               "introduced": "1.7.0"
             },
             {
-              "fixed": "1.11.2"
+              "fixed": ">= 1.11.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.11.2"
+      }
     },
     {
       "package": {
@@ -44,11 +47,14 @@
               "introduced": "1.12.0-alpha1"
             },
             {
-              "fixed": "1.12.0-alpha9"
+              "fixed": ">= 1.12.0-alpha9"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.12.0-alpha9"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Change patched versions to include all future versions after the patch