### PR TITLE
[GHSA-x9vc-6hfv-hg8c] Npgsql vulnerable to SQL Injection via Protocol Message Size Overflow

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-x9vc-6hfv-hg8c/GHSA-x9vc-6hfv-hg8c.json
+++ b/advisories/github-reviewed/2024/05/GHSA-x9vc-6hfv-hg8c/GHSA-x9vc-6hfv-hg8c.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x9vc-6hfv-hg8c",
-  "modified": "2024-05-09T15:12:49Z",
+  "modified": "2024-05-09T15:12:50Z",
   "published": "2024-05-09T15:12:49Z",
   "aliases": [
     "CVE-2024-32655"
   ],
   "summary": "Npgsql vulnerable to SQL Injection via Protocol Message Size Overflow",
-  "details": "### Summary\nThe `WriteBind()` method in `src/Npgsql/Internal/NpgsqlConnector.FrontendMessages.cs` uses `int` variables to store the message length and the sum of parameter lengths. Both variables overflow when the sum of parameter lengths becomes too large.\n\nThis causes Npgsql to write a message size that is too small when constructing a Postgres protocol message to send it over the network to the database. When parsing the message, the database will only read a small number of bytes and treat any following bytes as new messages while they belong to the old message.\n\nAttackers can abuse this to inject arbitrary Postgres protocol messages into the connection, leading to the execution of arbitrary SQL statements on the application's behalf.\n\n### Details\nPlease see [this attached PDF file](https://github.com/npgsql/npgsql/files/14309386/Npgsql.Security.Advisory.pdf) for a detailed description, including the suspected root cause, exploitation steps, impact, and recommendations on for fixing the issue.\n\n### PoC\nSee the steps in the \"Exploitation\" section of the attached PDF and this PoC project: [npgsql-protocol-overflow-poc.zip](https://github.com/npgsql/npgsql/files/14309397/npgsql-protocol-overflow-poc.zip)\n\n### Impact\nAttackers can issue arbitrary SQL statements to the database on behalf of the application. The final impact depends on the application that uses Npgsql, the data it stores in Postgres, etc.",
+  "details": "### Summary\nThe `WriteBind()` method in `src/Npgsql/Internal/NpgsqlConnector.FrontendMessages.cs` uses `int` variables to store the message length and the sum of parameter lengths. Both variables overflow when the sum of parameter lengths becomes too large.\n\nThis causes Npgsql to write a message size that is too small when constructing a Postgres protocol message to send it over the network to the database. When parsing the message, the database will only read a small number of bytes and treat any following bytes as new messages while they belong to the old message.\n\nAttackers can abuse this to inject arbitrary Postgres protocol messages into the connection, leading to the execution of arbitrary SQL statements on the application's behalf.\n\n### Impact\nAttackers can issue arbitrary SQL statements to the database on behalf of the application. The final impact depends on the application that uses Npgsql, the data it stores in Postgres, etc.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,14 +28,106 @@
               "introduced": "0"
             },
             {
+              "fixed": "4.0.14"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Npgsql"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.1.0"
+            },
+            {
+              "fixed": "4.1.13"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Npgsql"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.0.0"
+            },
+            {
+              "fixed": "5.0.18"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Npgsql"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.0.0"
+            },
+            {
+              "fixed": "6.0.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Npgsql"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "7.0.0"
+            },
+            {
+              "fixed": "7.0.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Npgsql"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.0.0"
+            },
+            {
               "fixed": "8.0.3"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 8.0.2"
-      }
+      ]
     }
   ],
   "references": [
@@ -53,11 +145,23 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/npgsql/npgsql/files/14309386/Npgsql.Security.Advisory.pdf"
+      "url": "https://github.com/npgsql/npgsql/releases/tag/v4.0.14"
     },
     {
       "type": "WEB",
-      "url": "https://github.com/npgsql/npgsql/files/14309397/npgsql-protocol-overflow-poc.zip"
+      "url": "https://github.com/npgsql/npgsql/releases/tag/v4.1.13"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/npgsql/npgsql/releases/tag/v5.0.18"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/npgsql/npgsql/releases/tag/v6.0.11"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/npgsql/npgsql/releases/tag/v7.0.7"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
I'm a maintainer for Npgsql. It was unclear to us the security vulnerability author provided the template for the advisory, and that we had to edit it. The suggested changes trim down the summary, remove the POCs links and provide the correct affected and patched versions.