### PR TITLE
[GHSA-x9vc-6hfv-hg8c] Npgsql vulnerable to SQL Injection via Protocol Message Size Overflow

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-x9vc-6hfv-hg8c/GHSA-x9vc-6hfv-hg8c.json
+++ b/advisories/github-reviewed/2024/05/GHSA-x9vc-6hfv-hg8c/GHSA-x9vc-6hfv-hg8c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x9vc-6hfv-hg8c",
-  "modified": "2024-05-09T15:12:49Z",
+  "modified": "2024-05-09T15:12:50Z",
   "published": "2024-05-09T15:12:49Z",
   "aliases": [
     "CVE-2024-32655"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
NPGSQL lists many more patched versions than this does, see https://github.com/npgsql/npgsql/security/advisories/GHSA-x9vc-6hfv-hg8c

I'm not sure how to update the "Affected products" to cover this appropriately.