### PR TITLE
[GHSA-x9vc-6hfv-hg8c] Npgsql vulnerable to SQL Injection via Protocol Message Size Overflow

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-x9vc-6hfv-hg8c/GHSA-x9vc-6hfv-hg8c.json
+++ b/advisories/github-reviewed/2024/05/GHSA-x9vc-6hfv-hg8c/GHSA-x9vc-6hfv-hg8c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x9vc-6hfv-hg8c",
-  "modified": "2024-05-09T15:12:49Z",
+  "modified": "2024-05-09T15:12:50Z",
   "published": "2024-05-09T15:12:49Z",
   "aliases": [
     "CVE-2024-32655"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
I didn't know how else to submit a "question" about the advisory - but it looks like there were patches applied to the major revs 6 and 7 to address this vulnerability. however since the advisory lists everything below 8.0.3 as vulnerable, analyzers are still flagging patched revs of 6.0.x with the patched vulnerability (as an example)

is there a means of providing vulnerable / patched versions on a per major rev basis for the security advisory?  Doing an upgrade from major rev 6 -> 8 is not necessarily feasible in the short term