### PR TITLE
[GHSA-x9vc-6hfv-hg8c] Npgsql vulnerable to SQL Injection via Protocol Message Size Overflow

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-x9vc-6hfv-hg8c/GHSA-x9vc-6hfv-hg8c.json
+++ b/advisories/github-reviewed/2024/05/GHSA-x9vc-6hfv-hg8c/GHSA-x9vc-6hfv-hg8c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x9vc-6hfv-hg8c",
-  "modified": "2024-05-09T15:12:49Z",
+  "modified": "2024-05-09T15:12:50Z",
   "published": "2024-05-09T15:12:49Z",
   "aliases": [
     "CVE-2024-32655"
@@ -36,6 +36,50 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 8.0.2"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Npgsql"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "6.0.11"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 6.0.10"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "NuGet",
+        "name": "Npgsql"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.0.7"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 7.0.6"
+      }
     }
   ],
   "references": [
@@ -58,6 +102,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/npgsql/npgsql/files/14309397/npgsql-protocol-overflow-poc.zip"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/npgsql/npgsql/releases/tag/v6.0.11"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/npgsql/npgsql/releases/tag/v7.0.7"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
This vulnerability looks to be addressed on multiple major versions (8, 7 and 6) by different minor releases on each of them