### PR TITLE
[GHSA-x9vc-6hfv-hg8c] Npgsql vulnerable to SQL Injection via Protocol Message Size Overflow

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-x9vc-6hfv-hg8c/GHSA-x9vc-6hfv-hg8c.json
+++ b/advisories/github-reviewed/2024/05/GHSA-x9vc-6hfv-hg8c/GHSA-x9vc-6hfv-hg8c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x9vc-6hfv-hg8c",
-  "modified": "2024-05-10T16:46:14Z",
+  "modified": "2024-05-10T16:46:17Z",
   "published": "2024-05-09T15:12:49Z",
   "aliases": [
     "CVE-2024-32655"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The nuget API feed does not match the data listed here, e.g. 7.0.7 is not considered a patched version

https://api.nuget.org/v3-vulnerabilities/2024.05.09.01.15.07/2024.05.10.13.15.11/vulnerability.update.json