### PR TITLE
[GHSA-rrvx-pwf8-p59p] In Bouncy Castle JCE Provider the DSA key pair generator generates a weak private key if used with default values

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-rrvx-pwf8-p59p/GHSA-rrvx-pwf8-p59p.json
+++ b/advisories/github-reviewed/2018/10/GHSA-rrvx-pwf8-p59p/GHSA-rrvx-pwf8-p59p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rrvx-pwf8-p59p",
-  "modified": "2022-04-27T13:29:11Z",
+  "modified": "2023-01-09T05:03:22Z",
   "published": "2018-10-17T16:24:22Z",
   "aliases": [
     "CVE-2016-1000343"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.38"
             },
             {
               "fixed": "1.56"
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.38"
             },
             {
               "fixed": "1.56"
@@ -89,11 +89,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20181127-0004"
+      "url": "https://security.netapp.com/advisory/ntap-20181127-0004/"
     },
     {
       "type": "WEB",
-      "url": "https://usn.ubuntu.com/3727-1"
+      "url": "https://usn.ubuntu.com/3727-1/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
https://sca.analysiscenter.veracode.com/vulnerability-database/security/partial-signature-validation/java/sid-3301/summary