### PR TITLE
[GHSA-r95h-9x8f-r3f7] Nokogiri updates packaged libxml2 to v2.12.7 to resolve CVE-2024-34459

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-r95h-9x8f-r3f7/GHSA-r95h-9x8f-r3f7.json
+++ b/advisories/github-reviewed/2024/05/GHSA-r95h-9x8f-r3f7/GHSA-r95h-9x8f-r3f7.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r95h-9x8f-r3f7",
-  "modified": "2024-05-13T16:05:42Z",
+  "modified": "2024-05-13T16:05:43Z",
   "published": "2024-05-13T16:05:42Z",
   "aliases": [
 
   ],
   "summary": "Nokogiri updates packaged libxml2 to v2.12.7 to resolve CVE-2024-34459",
-  "details": "## Summary\n\nNokogiri v1.16.5 upgrades its dependency libxml2 to [2.12.7](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.7) from 2.12.6.\n\nlibxml2 v2.12.7 addresses CVE-2024-34459:\n\n- described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/720\n- patched by https://gitlab.gnome.org/GNOME/libxml2/-/commit/2876ac53\n\n\n## Impact\n\nThere is no impact to Nokogiri users because the issue is present only in libxml2's `xmllint` tool which Nokogiri does not provide or expose.\n\n\n## Timeline\n\n- 2024-05-13 05:57 EDT, libxml2 2.12.7 release is announced\n- 2024-05-13 08:30 EDT, nokogiri maintainers begin triage\n- 2024-05-13 10:05 EDT, nokogiri [v1.16.5 is released](https://github.com/sparklemotion/nokogiri/releases/tag/v1.16.5) and this GHSA made public",
+  "details": "## Summary\n\nNokogiri v1.16.5 upgrades its dependency libxml2 from [`2.12.6`](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.6) to [`2.12.7`](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.7).\n\nlibxml2 v2.12.7 addresses CVE-2024-34459:\n\n- described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/720\n- patched by https://gitlab.gnome.org/GNOME/libxml2/-/commit/2876ac53\n\n\n## Impact\n\nThere is no impact to Nokogiri users because the issue is present only in libxml2's `xmllint` tool which Nokogiri does not provide or expose.\n\n\n## Timeline\n\n- 2024-05-13 05:57 EDT, libxml2 2.12.7 release is announced\n- 2024-05-13 08:30 EDT, nokogiri maintainers begin triage\n- 2024-05-13 10:05 EDT, nokogiri [v1.16.5 is released](https://github.com/sparklemotion/nokogiri/releases/tag/v1.16.5) and this GHSA made public",
   "severity": [
 
   ],


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
listing the dependencys that were bumped in the `to X from Y` syntax is harder to parse than nessesary and tripped me up
=> Changing this to `from Y to X` helps readability ^^