### PR TITLE
[GHSA-xphj-m9cc-8fmq] Deserialization of Untrusted Data in Groovy

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-xphj-m9cc-8fmq/GHSA-xphj-m9cc-8fmq.json
+++ b/advisories/github-reviewed/2022/05/GHSA-xphj-m9cc-8fmq/GHSA-xphj-m9cc-8fmq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xphj-m9cc-8fmq",
-  "modified": "2022-07-06T19:46:12Z",
+  "modified": "2023-01-27T05:02:10Z",
   "published": "2022-05-13T01:25:19Z",
   "aliases": [
     "CVE-2016-6814"
@@ -28,13 +28,13 @@
               "introduced": "1.7.0"
             },
             {
-              "fixed": "2.4.4"
+              "fixed": "2.4.8"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 2.4.3"
+        "last_known_affected_version_range": "<= 2.4.7"
       }
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to the [patch](https://github.com/apache/groovy/commit/4df8b652aa018a5d5d1cda8fba938bf3422db31c), I confirm that the patch location is between 2.4.7 and 2.4.8.