### PR TITLE
[GHSA-f26x-pr96-vw86] Moderate severity vulnerability that affects org.springframework:spring-core

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-f26x-pr96-vw86/GHSA-f26x-pr96-vw86.json
+++ b/advisories/github-reviewed/2018/10/GHSA-f26x-pr96-vw86/GHSA-f26x-pr96-vw86.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f26x-pr96-vw86",
-  "modified": "2024-03-05T17:44:22Z",
+  "modified": "2024-03-05T17:44:23Z",
   "published": "2018-10-16T17:43:45Z",
   "aliases": [
     "CVE-2018-11040"
@@ -25,10 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "5.0.0"
+              "introduced": "5.0.0.RELEASE"
             },
             {
-              "fixed": "5.0.7"
+              "fixed": "5.0.7.RELEASE"
             }
           ]
         }
@@ -44,10 +44,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.3.0"
+              "introduced": "4.3.0.RELEASE"
             },
             {
-              "fixed": "4.3.18"
+              "fixed": "4.3.18.RELEASE"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Add the .RELEASE suffix to describe the affected version more accurately.