### PR TITLE
[GHSA-qcgx-crrx-38v5] Denial of service in DataCommunicator class in Vaadin 8

### DIFF
--- a/advisories/github-reviewed/2021/10/GHSA-qcgx-crrx-38v5/GHSA-qcgx-crrx-38v5.json
+++ b/advisories/github-reviewed/2021/10/GHSA-qcgx-crrx-38v5/GHSA-qcgx-crrx-38v5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qcgx-crrx-38v5",
-  "modified": "2021-10-20T19:22:21Z",
+  "modified": "2023-09-25T16:13:34Z",
   "published": "2021-10-13T18:54:09Z",
   "aliases": [
     "CVE-2021-33609"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "8.0.0"
+              "introduced": "8.0.6"
             },
             {
               "fixed": "8.14.1"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to [Patch](https://github.com/vaadin/framework/commit/2fc98eaf9c0e2cd42cf4a66fb6d2cd2e9f0a08a9), vulnerability functions did not exist before 8.0.6, and I have verified that this vulnerability could not be triggered before 8.0.6.