### PR TITLE
[GHSA-m8p2-495h-ccmh] The SafeHtml annotation in Hibernate-Validator does not properly guard against XSS attacks

### DIFF
--- a/advisories/github-reviewed/2020/01/GHSA-m8p2-495h-ccmh/GHSA-m8p2-495h-ccmh.json
+++ b/advisories/github-reviewed/2020/01/GHSA-m8p2-495h-ccmh/GHSA-m8p2-495h-ccmh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m8p2-495h-ccmh",
-  "modified": "2022-02-08T22:07:14Z",
+  "modified": "2023-02-01T05:02:40Z",
   "published": "2020-01-08T17:01:52Z",
   "aliases": [
     "CVE-2019-10219"
@@ -33,6 +33,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.hibernate.validator:hibernate-validator"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.1.0.Alpha1"
+            },
+            {
+              "last_affected": "6.1.0.Alpha6"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
@@ -54,7 +73,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20220210-0024"
+      "url": "https://security.netapp.com/advisory/ntap-20220210-0024/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to the [patch](https://github.com/hibernate/hibernate-validator/commit/124b7dd6d9a4ad24d4d49f74701f05a13e56ceee), CVE-2019-10219 also affect [6.1.0.Alpha1,6.1.0.Alpha6].