### PR TITLE
[GHSA-pv7h-hx5h-mgfj] Unsafe deserialization in com.alibaba:fastjson

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-pv7h-hx5h-mgfj/GHSA-pv7h-hx5h-mgfj.json
+++ b/advisories/github-reviewed/2022/06/GHSA-pv7h-hx5h-mgfj/GHSA-pv7h-hx5h-mgfj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pv7h-hx5h-mgfj",
-  "modified": "2022-06-20T21:58:53Z",
+  "modified": "2023-01-27T05:04:27Z",
   "published": "2022-06-11T00:00:17Z",
   "aliases": [
     "CVE-2022-25845"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.2.25"
             },
             {
               "fixed": "1.2.83"
@@ -66,7 +66,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.ddosi.org/fastjson-poc"
+      "url": "https://www.ddosi.org/fastjson-poc/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to [Patch](https://github.com/alibaba/fastjson/commit/35db4adad70c32089542f23c272def1ad920a60d), vulnerability function did not exist before 1.2.25, and I have verified that this vulnerability could not be triggered before 1.2.25.