### PR TITLE
[GHSA-24r8-fm9r-cpj2] Low severity vulnerability that affects com.linecorp.armeria:armeria

### DIFF
--- a/advisories/github-reviewed/2019/12/GHSA-24r8-fm9r-cpj2/GHSA-24r8-fm9r-cpj2.json
+++ b/advisories/github-reviewed/2019/12/GHSA-24r8-fm9r-cpj2/GHSA-24r8-fm9r-cpj2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-24r8-fm9r-cpj2",
-  "modified": "2021-01-08T20:10:19Z",
+  "modified": "2023-01-09T05:02:37Z",
   "published": "2019-12-05T18:40:51Z",
   "aliases": [
     "CVE-2019-16771"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.50.0"
             },
             {
               "fixed": "0.97.0"
@@ -61,7 +61,7 @@
     "cwe_ids": [
       "CWE-113"
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2020-06-16T20:51:26Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- Severity

**Comments**
According to [Patch](https://github.com/line/armeria/commit/b597f7a865a527a84ee3d6937075cfbb4470ed20), vulnerability function did not exist before 0.50.0, and I have verified that this vulnerability could not be triggered before 0.50.0.