### PR TITLE
[GHSA-88cc-g835-76rp] Improper Restriction of XML External Entity Reference

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-88cc-g835-76rp/GHSA-88cc-g835-76rp.json
+++ b/advisories/github-reviewed/2022/02/GHSA-88cc-g835-76rp/GHSA-88cc-g835-76rp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-88cc-g835-76rp",
-  "modified": "2022-02-10T00:30:07Z",
+  "modified": "2023-01-27T05:02:50Z",
   "published": "2022-02-10T00:30:07Z",
   "aliases": [
     "CVE-2020-13692"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "9.4.1212.jre6"
             },
             {
               "fixed": "42.2.13"
@@ -86,11 +86,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DCCAPM6FSNOC272DLSNQ6YHXS3OMHGJC"
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DCCAPM6FSNOC272DLSNQ6YHXS3OMHGJC/"
     },
     {
       "type": "WEB",
-      "url": "https://security.netapp.com/advisory/ntap-20200619-0005"
+      "url": "https://security.netapp.com/advisory/ntap-20200619-0005/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to [Patch](https://github.com/spring-projects/spring-security/commit/a40f73521c0dd88b879ff6165d280e78bdf8154f), vulnerability function did not exist before 9.4.1212.jre6, and I have verified that this vulnerability could not be triggered before 9.4.1212.jre6.