### PR TITLE
[GHSA-p979-4mfw-53vg] HTTP Request Smuggling in Netty

### DIFF
--- a/advisories/github-reviewed/2019/10/GHSA-p979-4mfw-53vg/GHSA-p979-4mfw-53vg.json
+++ b/advisories/github-reviewed/2019/10/GHSA-p979-4mfw-53vg/GHSA-p979-4mfw-53vg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p979-4mfw-53vg",
-  "modified": "2022-04-01T18:11:58Z",
+  "modified": "2023-08-14T16:54:28Z",
   "published": "2019-10-11T18:41:23Z",
   "aliases": [
     "CVE-2019-16869"
@@ -15,25 +15,6 @@
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "io.netty:netty-all"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "4.1.42.Final"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "Maven",
@@ -52,6 +33,25 @@
       "database_specific": {
         "last_known_affected_version_range": "< 4.0.0"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.netty:netty-all"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.0.0.Alpha1"
+            },
+            {
+              "fixed": "4.1.42.Final"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
@@ -149,7 +149,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://usn.ubuntu.com/4532-1"
+      "url": "https://usn.ubuntu.com/4532-1/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to [Patch](https://github.com/netty/netty/commit/39cafcb05c99f2aa9fce7e6597664c9ed6a63a95), vulnerability function did not exist before 4.0.0.Alpha1, and I have verified that this vulnerability could not be triggered before 4.0.0.Alpha1.