### PR TITLE
[GHSA-5p52-j8pw-j7x5] Improper Restriction of XML External Entity Reference in bedework:bw-webdav

### DIFF
--- a/advisories/github-reviewed/2018/12/GHSA-5p52-j8pw-j7x5/GHSA-5p52-j8pw-j7x5.json
+++ b/advisories/github-reviewed/2018/12/GHSA-5p52-j8pw-j7x5/GHSA-5p52-j8pw-j7x5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5p52-j8pw-j7x5",
-  "modified": "2022-09-14T22:12:54Z",
+  "modified": "2023-01-09T05:03:56Z",
   "published": "2018-12-19T19:24:52Z",
   "aliases": [
     "CVE-2018-20000"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.0.1"
             },
             {
               "fixed": "4.0.3"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to [Patch](https://github.com/Bedework/bw-webdav/commit/ccb87c2757bab531c53faf0637ee342a378caa7f), vulnerability function did not exist before 4.0.1, and I have verified that this vulnerability could not be triggered before 4.0.1.