### PR TITLE
[GHSA-gw5j-77f9-v2g2] Loop with Unreachable Exit Condition in Apache CXF

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-gw5j-77f9-v2g2/GHSA-gw5j-77f9-v2g2.json
+++ b/advisories/github-reviewed/2022/05/GHSA-gw5j-77f9-v2g2/GHSA-gw5j-77f9-v2g2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gw5j-77f9-v2g2",
-  "modified": "2023-12-21T22:29:12Z",
+  "modified": "2023-12-21T22:29:13Z",
   "published": "2022-05-13T01:09:20Z",
   "aliases": [
     "CVE-2014-3584"
@@ -68,6 +68,28 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.cxf:cxf-rt-rs-security-xml"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.5.0"
+            },
+            {
+              "fixed": "2.6.11"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.6.10"
+      }
     }
   ],
   "references": [
@@ -88,8 +110,8 @@
       "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/97753"
     },
     {
-      "type": "WEB",
-      "url": "https://github.com/apache/cxf"
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/cxf/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to [patch](https://github.com/apache/cxf/commit/0b3894f57388b9955f2c33b2295223f2835cd7b3), This vulnerability also affect `org.apache.cxf:cxf-rt-rs-security-xml`.