### PR TITLE
[GHSA-9c8w-jrw3-q2c3] Cross-site Scripting in OWASP AntiSamy

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-9c8w-jrw3-q2c3/GHSA-9c8w-jrw3-q2c3.json
+++ b/advisories/github-reviewed/2021/08/GHSA-9c8w-jrw3-q2c3/GHSA-9c8w-jrw3-q2c3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9c8w-jrw3-q2c3",
-  "modified": "2022-02-08T21:02:36Z",
+  "modified": "2023-01-27T05:02:28Z",
   "published": "2021-08-02T16:58:43Z",
   "aliases": [
     "CVE-2021-35043"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.4.5"
             },
             {
               "fixed": "1.6.4"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to [Patch](https://github.com/nahsra/antisamy/commit/be6a42b2a3e2600c774d91f9fb830c44bfc217fc), vulnerability function did not exist before 1.4.5, and I have verified that this vulnerability could not be triggered before 1.4.5.