### PR TITLE
[GHSA-pfh2-hfmq-phg5] json-path Out-of-bounds Write vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-pfh2-hfmq-phg5/GHSA-pfh2-hfmq-phg5.json
+++ b/advisories/github-reviewed/2023/12/GHSA-pfh2-hfmq-phg5/GHSA-pfh2-hfmq-phg5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pfh2-hfmq-phg5",
-  "modified": "2024-01-22T17:12:12Z",
+  "modified": "2024-01-22T17:12:13Z",
   "published": "2023-12-27T21:31:01Z",
   "aliases": [
     "CVE-2023-51074"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.1.0"
             },
             {
               "fixed": "2.9.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to [Patch](https://github.com/json-path/JsonPath/commit/71a09c1193726c010917f1157ecbb069ad6c3e3b), vulnerability function did not exist before 2.1.0, and I have verified that this vulnerability could not be triggered before 2.1.0.