### PR TITLE
[GHSA-q7q2-qf2q-rw3w] Django Vulnerable to Cache Poisoning

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-q7q2-qf2q-rw3w/GHSA-q7q2-qf2q-rw3w.json
+++ b/advisories/github-reviewed/2022/05/GHSA-q7q2-qf2q-rw3w/GHSA-q7q2-qf2q-rw3w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q7q2-qf2q-rw3w",
-  "modified": "2024-03-07T22:22:46Z",
+  "modified": "2024-03-07T22:22:48Z",
   "published": "2022-05-17T03:07:00Z",
   "aliases": [
     "CVE-2014-1418"
@@ -86,6 +86,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/django/django/commit/4001ec8698f577b973c5a540801d8a0bbea1205b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/7fef18ba9e5a8b47bc24b5bb259c8bf3d3879f2a"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add a patch for v1.7: https://github.com/django/django/commit/7fef18ba9e5a8b47bc24b5bb259c8bf3d3879f2a