### PR TITLE
[GHSA-89hj-xfx5-7q66] Django Reuses Cached CSRF Token

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-89hj-xfx5-7q66/GHSA-89hj-xfx5-7q66.json
+++ b/advisories/github-reviewed/2022/05/GHSA-89hj-xfx5-7q66/GHSA-89hj-xfx5-7q66.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-89hj-xfx5-7q66",
-  "modified": "2023-09-05T13:57:57Z",
+  "modified": "2023-09-05T13:57:58Z",
   "published": "2022-05-17T03:07:04Z",
   "aliases": [
     "CVE-2014-0473"
@@ -76,12 +76,28 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-0473"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/1170f285ddd6a94a65f911a27788ba49ca08c0b0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/380545bf85cbf17fc698d136815b7691f8d023ca"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/6872f42757d7ef6a97e0b6ec5db4d2615d8a2bd8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/d63e20942f3024f24cb8cd85a49461ba8a9b6736"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/django/django"
     },
     {
       "type": "WEB",
-      "url": "https://www.djangoproject.com/weblog/2014/apr/21/security"
+      "url": "https://www.djangoproject.com/weblog/2014/apr/21/security/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add 4 patches:
https://github.com/django/django/commit/1170f285ddd6a94a65f911a27788ba49ca08c0b0
https://github.com/django/django/commit/6872f42757d7ef6a97e0b6ec5db4d2615d8a2bd8
https://github.com/django/django/commit/d63e20942f3024f24cb8cd85a49461ba8a9b6736
https://github.com/django/django/commit/380545bf85cbf17fc698d136815b7691f8d023ca
for v1.4, v1.5, v.16 and v1.7