### PR TITLE
[GHSA-4c42-4rxm-x6qf] Django Denial of Service Vulnerability in the authentication framework 

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4c42-4rxm-x6qf/GHSA-4c42-4rxm-x6qf.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4c42-4rxm-x6qf/GHSA-4c42-4rxm-x6qf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4c42-4rxm-x6qf",
-  "modified": "2023-08-17T23:30:35Z",
+  "modified": "2023-08-17T23:30:36Z",
   "published": "2022-05-17T04:53:45Z",
   "aliases": [
     "CVE-2013-1443"
@@ -65,12 +65,16 @@
       "url": "https://github.com/django/django/commit/3f3d887a6844ec2db743fee64c9e53e04d39a368"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/aae5a96d5754ad34e48b7f673ef2411a3bbc1015"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/django/django"
     },
     {
       "type": "WEB",
-      "url": "https://www.djangoproject.com/weblog/2013/sep/15/security"
+      "url": "https://www.djangoproject.com/weblog/2013/sep/15/security/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add a patch https://github.com/django/django/commit/aae5a96d5754ad34e48b7f673ef2411a3bbc1015, the patch for v1.4 shows it was backported from this patch.