### PR TITLE
[GHSA-x64m-686f-fmm3] The XML libraries for Python 3.4, 3.3, 3.2, 3.1, 2.7, and...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-x64m-686f-fmm3/GHSA-x64m-686f-fmm3.json
+++ b/advisories/unreviewed/2022/05/GHSA-x64m-686f-fmm3/GHSA-x64m-686f-fmm3.json
@@ -6,8 +6,8 @@
   "aliases": [
     "CVE-2013-1665"
   ],
-  "summary": "The XML libraries for Python 3.4, 3.3, 3.2, 3.1, 2.7, and 2.6, as used in OpenStack Keystone Essex and Folsom, Django, and possibly other products allow remote attackers to read arbitrary files via an XML external entity declaration in conjunction with an entity reference, aka an XML External Entity (XXE) attack.",
-  "details": "The XML libraries for Python 3.4, 3.3, 3.2, 3.1, 2.7, and 2.6, as used in OpenStack Keystone Essex and Folsom, Django, and possibly other products allow remote attackers to read arbitrary files via an XML external entity declaration in conjunction with an entity reference, aka an XML External Entity (XXE) attack.",
+  "summary": "The XML libraries for QPython 3.4, 3.3, 3.2, 3.1, 2.7, and 2.6, as used in OpenStack Keystone Essex and Folsom, Django, and possibly other products allow remote attackers to read arbitrary files via an XML external entity declaration in conjunction with an entity reference, aka an XML External Entity (XXE) attack.",
+  "details": "The XML libraries for QPython 3.4, 3.3, 3.2, 3.1, 2.7, and 2.6, as used in OpenStack Keystone Essex and Folsom, Django, and possibly other products allow remote attackers to read arbitrary files via an XML external entity declaration in conjunction with an entity reference, aka an XML External Entity (XXE) attack.",
   "severity": [
 
   ],
@@ -23,6 +23,9 @@
           "events": [
             {
               "introduced": "1.3.0"
+            },
+            {
+              "fixed": "1.3.6"
             }
           ]
         }
@@ -39,6 +42,28 @@
           "events": [
             {
               "introduced": "1.4.0"
+            },
+            {
+              "fixed": "1.4.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "django"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.6.0"
+            },
+            {
+              "fixed": "1.6a1"
             }
           ]
         }
@@ -52,7 +77,23 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/django/django/commit/1c60d07ba23e0350351c278ad28d0bd5aa410b40"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/c6d69c12ea7ee9ad35abc7dbf95e00d624d0df5d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/d19a27066b2247102e65412aa66917aff0091112"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugs.launchpad.net/keystone/+bug/1100279"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/django/django"
     },
     {
       "type": "WEB",

--- a/advisories/unreviewed/2022/05/GHSA-x64m-686f-fmm3/GHSA-x64m-686f-fmm3.json
+++ b/advisories/unreviewed/2022/05/GHSA-x64m-686f-fmm3/GHSA-x64m-686f-fmm3.json
@@ -1,17 +1,49 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x64m-686f-fmm3",
-  "modified": "2022-05-17T05:09:39Z",
+  "modified": "2023-01-28T05:03:27Z",
   "published": "2022-05-17T05:09:39Z",
   "aliases": [
     "CVE-2013-1665"
   ],
+  "summary": "The XML libraries for Python 3.4, 3.3, 3.2, 3.1, 2.7, and 2.6, as used in OpenStack Keystone Essex and Folsom, Django, and possibly other products allow remote attackers to read arbitrary files via an XML external entity declaration in conjunction with an entity reference, aka an XML External Entity (XXE) attack.",
   "details": "The XML libraries for Python 3.4, 3.3, 3.2, 3.1, 2.7, and 2.6, as used in OpenStack Keystone Essex and Folsom, Django, and possibly other products allow remote attackers to read arbitrary files via an XML external entity declaration in conjunction with an entity reference, aka an XML External Entity (XXE) attack.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "django"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.3.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "django"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.4.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
add 3 patches for django:

https://github.com/django/django/commit/d19a27066b2247102e65412aa66917aff0091112	v1.4
https://github.com/django/django/commit/1c60d07ba23e0350351c278ad28d0bd5aa410b40	v1.5
https://github.com/django/django/commit/c6d69c12ea7ee9ad35abc7dbf95e00d624d0df5d    v1.6a1

these patches are also for CVE-2013-1664, updated in this pr as well: https://github.com/github/advisory-database/pull/4427