### PR TITLE
[GHSA-x88j-93vc-wpmp] Moderate severity vulnerability that affects django

### DIFF
--- a/advisories/github-reviewed/2018/07/GHSA-x88j-93vc-wpmp/GHSA-x88j-93vc-wpmp.json
+++ b/advisories/github-reviewed/2018/07/GHSA-x88j-93vc-wpmp/GHSA-x88j-93vc-wpmp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x88j-93vc-wpmp",
-  "modified": "2021-09-21T22:24:47Z",
+  "modified": "2023-01-09T05:03:39Z",
   "published": "2018-07-23T19:52:39Z",
   "aliases": [
     "CVE-2011-4136"
@@ -58,6 +58,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/django/django/commit/ac7c3a110f906e4dfed3a17451bf7fd9fcb81296"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/fbe2eead2fa9d808658ca582241bcacb02618840"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=737366"
     },
     {
@@ -74,11 +82,11 @@
     },
     {
       "type": "WEB",
-      "url": "https://www.djangoproject.com/weblog/2011/sep/09"
+      "url": "https://www.djangoproject.com/weblog/2011/sep/09/"
     },
     {
       "type": "WEB",
-      "url": "https://www.djangoproject.com/weblog/2011/sep/10/127"
+      "url": "https://www.djangoproject.com/weblog/2011/sep/10/127/"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- References

**Comments**
add 2 patches:
https://github.com/django/django/commit/ac7c3a110f906e4dfed3a17451bf7fd9fcb81296	v1.2
https://github.com/django/django/commit/fbe2eead2fa9d808658ca582241bcacb02618840	v1.3