### PR TITLE
[GHSA-4gmj-3p3h-gm8h] es5-ext vulnerable to Regular Expression Denial of Service in `function#copy` and `function#toStringTokens`

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-4gmj-3p3h-gm8h/GHSA-4gmj-3p3h-gm8h.json
+++ b/advisories/github-reviewed/2024/02/GHSA-4gmj-3p3h-gm8h/GHSA-4gmj-3p3h-gm8h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4gmj-3p3h-gm8h",
-  "modified": "2024-02-26T20:01:28Z",
+  "modified": "2024-02-26T20:01:29Z",
   "published": "2024-02-26T20:01:28Z",
   "aliases": [
     "CVE-2024-27088"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
I'm not sure if there is an improvement. Since `0.10.53` some virus detectors have flagged this repository for doing illegal `postInstall` operations, related to posting anti-Russian news articles. 

There is a better place to share this information, and in the post install isn't it.