### PR TITLE
[GHSA-4724-7jwc-3fpw] Grafana Spoofing originalUrl of snapshots

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-4724-7jwc-3fpw/GHSA-4724-7jwc-3fpw.json
+++ b/advisories/github-reviewed/2024/05/GHSA-4724-7jwc-3fpw/GHSA-4724-7jwc-3fpw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4724-7jwc-3fpw",
-  "modified": "2024-05-14T22:29:26Z",
+  "modified": "2024-05-14T22:29:27Z",
   "published": "2024-05-14T22:29:26Z",
   "aliases": [
     "CVE-2022-39324"
@@ -17,7 +17,7 @@
   "affected": [
     {
       "package": {
-        "ecosystem": "PyPI",
+        "ecosystem": "Go",
         "name": "github.com/grafana/grafana"
       },
       "ranges": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
the vulnerable code is in go language and has identifier in go-language it seems to be an typo.