### PR TITLE
[GHSA-rc6h-qwj9-2c53] Apache DolphinScheduler vulnerable to arbitrary JavaScript execution as root for authenticated users

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-rc6h-qwj9-2c53/GHSA-rc6h-qwj9-2c53.json
+++ b/advisories/github-reviewed/2024/02/GHSA-rc6h-qwj9-2c53/GHSA-rc6h-qwj9-2c53.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rc6h-qwj9-2c53",
-  "modified": "2024-02-23T21:41:17Z",
+  "modified": "2024-02-23T21:41:20Z",
   "published": "2024-02-23T18:30:59Z",
   "aliases": [
     "CVE-2024-23320"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.dolphinscheduler:dolphinscheduler"
+        "name": "org.apache.dolphinscheduler:dolphinscheduler-master"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
From the fix commit https://github.com/apache/dolphinscheduler/commit/ef9ed3db55cb1647886b06c2b2c6a5cfcdccfb5c the change was to the dolphinscheduler-master component.

Apache also specify it specifically in the CVE json: https://github.com/CVEProject/cvelistV5/blob/1c8cd9a8eaea06fdc2108233b3c3d2144e097dd4/cves/2024/23xxx/CVE-2024-23320.json#L19 