### PR TITLE
[GHSA-9324-jv53-9cc8] dio vulnerable to CRLF injection with HTTP method string

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-9324-jv53-9cc8/GHSA-9324-jv53-9cc8.json
+++ b/advisories/github-reviewed/2023/03/GHSA-9324-jv53-9cc8/GHSA-9324-jv53-9cc8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9324-jv53-9cc8",
-  "modified": "2023-03-21T22:41:11Z",
+  "modified": "2023-10-05T14:01:00Z",
   "published": "2023-03-21T22:41:11Z",
   "aliases": [
     "CVE-2021-31402"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
الروابط المرجعية:
CVE-2021-31402: هو معرف الثغرة في قاعدة بيانات NVD.
OSV - Open Source Vulnerabilities: يوفر معلومات إضافية حول الثغرة والإصلاح.
Issue #1752: يحتوي على المناقشة والتحديثات المتعلقة بالثغرة وإصلاحها في مستودع GitHub للمشروع.
التزام التعليمات البرمجية:
الالتزام cfug/dio@927f79e: يوضح التغيير المحدد الذي تم إجراؤه لإصلاح الثغرة ويمكن استخدامه كمرجع للتفاصيل التقنية.
السياق الأوسع:
يمكنك البحث عن الرسائل والنقاشات الأخرى في مستودع GitHub للمشروع (مثل Issue #1130) للحصول على مزيد من السياق والمعلومات المتعلقة بالثغرة والإصلاح.