### PR TITLE
[GHSA-364c-vvqx-446c] Croc sender may place ANSI or CSI escape sequences in filename to attach receiver's terminal device

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-364c-vvqx-446c/GHSA-364c-vvqx-446c.json
+++ b/advisories/github-reviewed/2023/09/GHSA-364c-vvqx-446c/GHSA-364c-vvqx-446c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-364c-vvqx-446c",
-  "modified": "2023-09-22T19:43:27Z",
+  "modified": "2023-11-04T05:04:50Z",
   "published": "2023-09-20T06:30:50Z",
   "aliases": [
     "CVE-2023-43620"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "9.6.5"
+              "fixed": "9.6.16"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 9.6.15"
+      }
     }
   ],
   "references": [
@@ -43,6 +46,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/schollz/croc/issues/595"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/schollz/croc/pull/697"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
https://github.com/schollz/croc/pull/697