### PR TITLE
[GHSA-9v8h-57gv-qch6] Django vulnerable to Denial of Service via i18n middleware component

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9v8h-57gv-qch6/GHSA-9v8h-57gv-qch6.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9v8h-57gv-qch6/GHSA-9v8h-57gv-qch6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9v8h-57gv-qch6",
-  "modified": "2024-04-29T14:37:50Z",
+  "modified": "2024-04-29T14:37:52Z",
   "published": "2022-05-01T18:36:08Z",
   "aliases": [
     "CVE-2007-5712"
@@ -80,6 +80,18 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2007-5712"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/412ed22502e11c50dbfee854627594f0e7e2c234"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/7dd2dd08a79e388732ce00e2b5514f15bd6d0f6f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/8bc36e726c9e8c75c681d3ad232df8e882aaac81"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add 3 patches:
https://github.com/django/django/commit/8bc36e726c9e8c75c681d3ad232df8e882aaac81
https://github.com/django/django/commit/412ed22502e11c50dbfee854627594f0e7e2c234
https://github.com/django/django/commit/7dd2dd08a79e388732ce00e2b5514f15bd6d0f6f