### PR TITLE
[GHSA-jj54-5q2m-q7pj] NATS server TLS missing ciphersuite settings when CLI flags used

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-jj54-5q2m-q7pj/GHSA-jj54-5q2m-q7pj.json
+++ b/advisories/github-reviewed/2024/05/GHSA-jj54-5q2m-q7pj/GHSA-jj54-5q2m-q7pj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jj54-5q2m-q7pj",
-  "modified": "2024-05-14T22:03:51Z",
+  "modified": "2024-05-14T22:03:53Z",
   "published": "2024-05-14T22:03:51Z",
   "aliases": [
     "CVE-2021-32026"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "https://pkg.go.dev/github.com/nats-io/nats-server/v2"
+        "name": "github.com/nats-io/nats-server/v2"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Removed protocol information from package name as this is the usual procedure with other GHSAs. Moreover, having package names starting with "https://" leads to import warnings in OWASP Dependency-Track, e.g.:

`[GitHubAdvisoryMirrorTask] Unable to create purl from GitHub Vulnerability. Skipping GO : https://pkg.go.dev/github.com/nats-io/nats-server/v2 for: GHSA-jj54-5q2m-q7pj`