### PR TITLE
[GHSA-7jg2-jgv3-fmr4] The PDF viewer does not sufficiently sanitize PostScript...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-7jg2-jgv3-fmr4/GHSA-7jg2-jgv3-fmr4.json
+++ b/advisories/unreviewed/2022/05/GHSA-7jg2-jgv3-fmr4/GHSA-7jg2-jgv3-fmr4.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7jg2-jgv3-fmr4",
-  "modified": "2022-05-14T01:22:02Z",
+  "modified": "2023-02-02T05:03:34Z",
   "published": "2022-05-14T01:22:02Z",
   "aliases": [
     "CVE-2018-5158"
   ],
-  "details": "The PDF viewer does not sufficiently sanitize PostScript calculator functions, allowing malicious JavaScript to be injected through a crafted PDF file. This JavaScript can then be run with the permissions of the PDF viewer by its worker. This vulnerability affects Firefox ESR < 52.8 and Firefox < 60.",
+  "summary": "Malicious PDF can inject JavaScript into PDF Viewer",
+  "details": "The PDF viewer does not sufficiently sanitize PostScript calculator functions, allowing malicious JavaScript to be injected through a crafted PDF file. This JavaScript can then be run with the permissions of the PDF viewer by its worker. This vulnerability affects Firefox ESR < 52.8, Firefox < 60 and PDF.js < 2.0.943.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,12 +15,41 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "pdfjs-dist"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.0.943"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.10.100"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-5158"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mozilla/pdf.js/pull/9659"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mozilla/pdf.js/commit/2dc4af525d1612c98afcd1e6bee57d4788f78f97"
     },
     {
       "type": "WEB",
@@ -32,6 +62,10 @@
     {
       "type": "WEB",
       "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1452075"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/mozilla/pdf.js"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Source code location
- Summary

**Comments**
Added affected versions, projects, commit and PR. The PR is already referenced by the bugzilla.mozilla.org link associated with the CVE.