### PR TITLE
[GHSA-86jx-wr74-xr74] Add affected product org.apache.zeppelin:zeppel…

### DIFF
--- a/advisories/unreviewed/2024/04/GHSA-86jx-wr74-xr74/GHSA-86jx-wr74-xr74.json
+++ b/advisories/unreviewed/2024/04/GHSA-86jx-wr74-xr74/GHSA-86jx-wr74-xr74.json
@@ -11,7 +11,25 @@
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.zeppelin:zeppelin-interpreter"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.8.2"
+            },
+            {
+              "fixed": "0.11.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
…in-interpreter 0.8.2 < 0.11.1

This information was in the CVE metadata at https://www.cve.org/CVERecord?id=CVE-2024-31866