### PR TITLE
[GHSA-8pfj-w89w-m24x] Add affected product org.apache.zeppelin:zeppel…

### DIFF
--- a/advisories/unreviewed/2024/04/GHSA-8pfj-w89w-m24x/GHSA-8pfj-w89w-m24x.json
+++ b/advisories/unreviewed/2024/04/GHSA-8pfj-w89w-m24x/GHSA-8pfj-w89w-m24x.json
@@ -11,7 +11,25 @@
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.zeppelin:zeppelin-shell"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.10.1"
+            },
+            {
+              "fixed": "0.11.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
…in-shell 0.10.1 < 0.11.1

This information was in the CVE metadata at https://www.cve.org/CVERecord?id=CVE-2024-31861