### PR TITLE
[GHSA-3jvv-r7g7-63qp] Cross-site scripting (XSS) vulnerability in SourceBans...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-3jvv-r7g7-63qp/GHSA-3jvv-r7g7-63qp.json
+++ b/advisories/unreviewed/2022/05/GHSA-3jvv-r7g7-63qp/GHSA-3jvv-r7g7-63qp.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3jvv-r7g7-63qp",
-  "modified": "2022-05-14T02:47:25Z",
+  "modified": "2023-02-02T05:06:17Z",
   "published": "2022-05-14T02:47:25Z",
   "aliases": [
     "CVE-2015-8349"
   ],
-  "details": "Cross-site scripting (XSS) vulnerability in SourceBans before 2.0 pre-alpha allows remote attackers to inject arbitrary web script or HTML via the advSearch parameter to index.php.",
+  "summary": "XSS in SourceBans up to (including) 1.4.10",
+  "details": "Cross-site scripting (XSS) vulnerability in SourceBans before 1.4.10 (including) allows remote attackers to inject arbitrary web script or HTML via the advSearch parameter to index.php.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,12 +15,34 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "GitHub Actions",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.4.10"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-8349"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/sbpp/sourcebans-pp/commit/d14aeb64bced19144ed7c5a953366d4715bf2e24"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location
- Summary

**Comments**
The following fix seems to address CVE-2015-8349:  https://github.com/sbpp/sourcebans-pp/commit/d14aeb64bced19144ed7c5a953366d4715bf2e24
The version in the change log (1.4.10) is close to the one in the CPE: "Up to (including) 1.4.11".