### PR TITLE
[GHSA-3965-hpx2-q597] Pug allows JavaScript code execution if an application accepts untrusted input

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-3965-hpx2-q597/GHSA-3965-hpx2-q597.json
+++ b/advisories/github-reviewed/2024/05/GHSA-3965-hpx2-q597/GHSA-3965-hpx2-q597.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3965-hpx2-q597",
-  "modified": "2024-05-24T14:45:02Z",
+  "modified": "2024-05-24T14:45:05Z",
   "published": "2024-05-24T14:45:02Z",
   "aliases": [
     "CVE-2024-36361"
@@ -47,11 +47,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.0.2"
+              "fixed": "3.0.3"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.0.2"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Patched in this PR: https://github.com/pugjs/pug/pull/3438
which was released as `pug` 3.0.3 and `pug-code-gen` 3.0.3
as mentioned here https://github.com/pugjs/pug/releases/tag/pug%403.0.3
and as can be seen here https://diff.intrinsic.com/pug/3.0.2/3.0.3
and here https://diff.intrinsic.com/pug-code-gen/3.0.2/3.0.3