### PR TITLE
[GHSA-ph87-4x2g-6hp4] Jenkins NeuVector Vulnerability Scanner Plugin missing permission check

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-ph87-4x2g-6hp4/GHSA-ph87-4x2g-6hp4.json
+++ b/advisories/github-reviewed/2023/11/GHSA-ph87-4x2g-6hp4/GHSA-ph87-4x2g-6hp4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ph87-4x2g-6hp4",
-  "modified": "2023-11-29T21:31:50Z",
+  "modified": "2023-12-05T22:53:18Z",
   "published": "2023-11-29T15:30:21Z",
   "aliases": [
     "CVE-2023-49674"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "o.jenkins.plugins:neuvector-vulnerability-scanner"
+        "name": "io.jenkins.plugins:neuvector-vulnerability-scanner"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The Package name is incorrect. It is recommended to change it to "/io.jenkins.plugins/neuvector-vulnerability-scanner". Reference source: https://mvnrepository.com/artifact/io.jenkins.plugins/neuvector-vulnerability-scanner You can see the Maven coordinates here