### PR TITLE
[GHSA-fvcf-wgxj-h7ch] CSRF vulnerability in Jenkins Nomad Plugin allow SSRF

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-fvcf-wgxj-h7ch/GHSA-fvcf-wgxj-h7ch.json
+++ b/advisories/github-reviewed/2022/05/GHSA-fvcf-wgxj-h7ch/GHSA-fvcf-wgxj-h7ch.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "rg.jenkins-ci.plugins:kmap-jenkins"
+        "name": "org.jenkins-ci.plugins:kmap-jenkins"
       },
       "versions": [
         "1.6"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The Package name is incorrect. It is recommended to change it to "org.jenkins-ci.plugins:kmap-jenkins". Reference source: https://mvnrepository.com/artifact/org.jenkins-ci.plugins/kmap-jenkins You can see the Maven coordinates here