### PR TITLE
[GHSA-q5wm-qgxj-h9ph] Missing permission check in Jenkins Kmap Plugin allow SSRF

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-q5wm-qgxj-h9ph/GHSA-q5wm-qgxj-h9ph.json
+++ b/advisories/github-reviewed/2022/05/GHSA-q5wm-qgxj-h9ph/GHSA-q5wm-qgxj-h9ph.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q5wm-qgxj-h9ph",
-  "modified": "2024-01-30T22:04:47Z",
+  "modified": "2024-01-30T22:04:48Z",
   "published": "2022-05-13T01:15:05Z",
   "aliases": [
     "CVE-2019-10293"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "rg.jenkins-ci.plugins:kmap-jenkins"
+        "name": "org.jenkins-ci.plugins:kmap-jenkins"
       },
       "versions": [
         "1.6"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The Package name is incorrect. It is recommended to change it to "org.jenkins-ci.plugins:kmap-jenkins". Reference source: https://mvnrepository.com/artifact/org.jenkins-ci.plugins/kmap-jenkins You can see the Maven coordinates here