### PR TITLE
[GHSA-g6h2-4x64-c59x] Improper Restriction of XML External Entity Reference Jenkins Token Macro Plugin

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-g6h2-4x64-c59x/GHSA-g6h2-4x64-c59x.json
+++ b/advisories/github-reviewed/2022/05/GHSA-g6h2-4x64-c59x/GHSA-g6h2-4x64-c59x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g6h2-4x64-c59x",
-  "modified": "2022-06-28T23:09:04Z",
+  "modified": "2023-12-13T10:01:00Z",
   "published": "2022-05-24T16:47:43Z",
   "aliases": [
     "CVE-2019-10337"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.jenkins-ci.plugins:oken-macro"
+        "name": "org.jenkins-ci.plugins:token-macro"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The Package name is incorrect. It is recommended to change it to "org.jenkins-ci.plugins:token-macro". Reference source: https://mvnrepository.com/artifact/org.jenkins-ci.plugins/token-macro You can see the Maven coordinates here