### PR TITLE
[GHSA-922h-x9qv-2274] Jenkins PegDown Formatter Plugin has Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-922h-x9qv-2274/GHSA-922h-x9qv-2274.json
+++ b/advisories/github-reviewed/2022/05/GHSA-922h-x9qv-2274/GHSA-922h-x9qv-2274.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.jenkins-ci.plugins:pegdown-formatte"
+        "name": "org.jenkins-ci.plugins:pegdown-formatter"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The Package name is incorrect. It is recommended to change it to "org.jenkins-ci.plugins:pegdown-formatter". Reference source: https://mvnrepository.com/artifact/org.jenkins-ci.plugins/pegdown-formatter You can see the Maven coordinates here