### PR TITLE
[GHSA-c5q2-7r4c-mv6g]: add missing package to the list of affected packages

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-c5q2-7r4c-mv6g/GHSA-c5q2-7r4c-mv6g.json
+++ b/advisories/github-reviewed/2024/03/GHSA-c5q2-7r4c-mv6g/GHSA-c5q2-7r4c-mv6g.json
@@ -71,6 +71,22 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/square/go-jose"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.6.0"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION

As reported in https://pkg.go.dev/vuln/GO-2024-2631, the go module `gopkg.in/square/go-jose.v2` is also affected by this reported vulnerability. Despite of been a deprecated repository, there is still a lot of software using it. So it'd be great to add it to this list of affected packages.