### PR TITLE
[GHSA-6wvf-f2vw-3425] github.com/containers/image allows unexpected authenticated registry accesses

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-6wvf-f2vw-3425/GHSA-6wvf-f2vw-3425.json
+++ b/advisories/github-reviewed/2024/05/GHSA-6wvf-f2vw-3425/GHSA-6wvf-f2vw-3425.json
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "5.30.0"
             },
             {
               "fixed": "5.30.1"
@@ -44,10 +44,48 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "5.30.0"
             },
             {
               "fixed": "5.30.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/containers/image"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.29.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/containers/image/v5"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.29.3"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
For some products, updating to v5.29.3 is easier than v5.30.1. However, if they do that, many vuln scanners will still claim they are vulnerable as v5.29.3 < v5.30.1. Adding this make it clear v5.29.3 is also safe. See https://github.com/containers/image/releases/tag/v5.29.3 for proof.