### PR TITLE
Update GHSA-rx7p-m6c3-777g.json

### DIFF
--- a/advisories/unreviewed/2024/05/GHSA-rx7p-m6c3-777g/GHSA-rx7p-m6c3-777g.json
+++ b/advisories/unreviewed/2024/05/GHSA-rx7p-m6c3-777g/GHSA-rx7p-m6c3-777g.json
@@ -1,42 +1,54 @@
 {
-  "schema_version": "1.4.0",
-  "id": "GHSA-rx7p-m6c3-777g",
-  "modified": "2024-05-31T21:30:52Z",
-  "published": "2024-05-31T21:30:52Z",
-  "aliases": [
-    "CVE-2024-5564"
-  ],
-  "details": "A vulnerability was found in libndp. This flaw allows a local malicious user to cause a buffer overflow in NetworkManager, triggered by sending a malformed IPv6 router advertisement packet. This issue occurred as libndp was not correctly validating the route length information.",
-  "severity": [
+  "mitigation": "Currently there is no mitigation available for this vulnerability.  Please make sure to update as the fixes become available.",
+  "affected_release": null,
+  "package_state": [
     {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "product_name": "Red Hat Enterprise Linux 7",
+      "fix_state": "Under investigation",
+      "package_name": "libndp",
+      "cpe": "cpe:/o:redhat:enterprise_linux:7"
+    },
+    {
+      "product_name": "Red Hat Enterprise Linux 8",
+      "fix_state": "Under investigation",
+      "package_name": "libndp",
+      "cpe": "cpe:/o:redhat:enterprise_linux:8"
+    },
+    {
+      "product_name": "Red Hat Enterprise Linux 9",
+      "fix_state": "Under investigation",
+      "package_name": "libndp",
+      "cpe": "cpe:/o:redhat:enterprise_linux:9"
     }
   ],
-  "affected": [
-
+  "threat_severity": "Important",
+  "public_date": "2024-05-31T00:00:00Z",
+  "bugzilla": {
+    "description": "libndp: buffer overflow in route information length field",
+    "id": "2284122",
+    "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2284122"
+  },
+  "cvss": {
+    "cvss_base_score": "",
+    "cvss_scoring_vector": "",
+    "status": ""
+  },
+  "cvss3": {
+    "cvss3_base_score": "7.4",
+    "cvss3_scoring_vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+    "status": "draft"
+  },
+  "iava": "",
+  "cwe": "CWE-120",
+  "statement": "Red Hat rates this as an Important severity, as a local attacker may gain enough information to jeopardize the environment's confidentiality, integrity and availability.",
+  "acknowledgement": "Upstream acknowledges Evgeny Vereshchagin as the original reporter.",
+  "name": "CVE-2024-5564",
+  "document_distribution": "",
+  "details": [
+    "A vulnerability was found in libndp. This flaw allows a local malicious user to cause a buffer overflow in NetworkManager, triggered by sending a malformed IPv6 router advertisement packet. This issue occurred as libndp was not correctly validating the route length information.",
+    "A vulnerability was found in libndp. This flaw allows a local malicious user to cause a buffer overflow in NetworkManager, triggered by sending a malformed IPv6 router advertisement packet. This issue occurred as libndp was not correctly validating the route length information."
   ],
   "references": [
-    {
-      "type": "ADVISORY",
-      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-5564"
-    },
-    {
-      "type": "WEB",
-      "url": "https://access.redhat.com/security/cve/CVE-2024-5564"
-    },
-    {
-      "type": "WEB",
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2284122"
-    }
-  ],
-  "database_specific": {
-    "cwe_ids": [
-      "CWE-120"
-    ],
-    "severity": "HIGH",
-    "github_reviewed": false,
-    "github_reviewed_at": null,
-    "nvd_published_at": "2024-05-31T19:15:08Z"
-  }
+    "https://www.cve.org/CVERecord?id=CVE-2024-5564\nhttps://nvd.nist.gov/vuln/detail/CVE-2024-5564"
+  ]
 }


### PR DESCRIPTION
A vulnerability was found in libndp. This flaw allows a local malicious user to cause a buffer overflow in NetworkManager, triggered by sending a malformed IPv6 router advertisement packet. This issue occurred as libndp was not correctly validating the route length information.",
    "A vulnerability was found in libndp. This flaw allows a local malicious user to cause a buffer overflow in NetworkManager, triggered by sending a malformed IPv6 router advertisement packet. This issue occurred as libndp was not correctly validating the route length information.