### PR TITLE
[GHSA-rgx7-8wqv-m224] ThreeTen Backport v1.6.8 was discovered to contain an...

### DIFF
--- a/advisories/unreviewed/2024/04/GHSA-rgx7-8wqv-m224/GHSA-rgx7-8wqv-m224.json
+++ b/advisories/unreviewed/2024/04/GHSA-rgx7-8wqv-m224/GHSA-rgx7-8wqv-m224.json
@@ -1,17 +1,33 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rgx7-8wqv-m224",
-  "modified": "2024-04-08T18:30:48Z",
+  "modified": "2024-04-08T18:30:53Z",
   "published": "2024-04-08T18:30:48Z",
   "aliases": [
     "CVE-2024-23082"
   ],
+  "summary": "Integer overflow in ThreeTen Backport v1.6.8",
   "details": "ThreeTen Backport v1.6.8 was discovered to contain an integer overflow via the component org.threeten.bp.format.DateTimeFormatter::parse(CharSequence, ParsePosition).",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -28,7 +44,7 @@
     },
     {
       "type": "WEB",
-      "url": "http://threeten.com"
+      "url": "https://www.threeten.org/threetenbp"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Summary

**Comments**
Fix one wrong URL in the `References` section.