### PR TITLE
[GHSA-8hqg-whrw-pv92] Ollama does not validate the format of the digest (sha256 with 64 hex digits)

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-8hqg-whrw-pv92/GHSA-8hqg-whrw-pv92.json
+++ b/advisories/github-reviewed/2024/05/GHSA-8hqg-whrw-pv92/GHSA-8hqg-whrw-pv92.json
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "https://github.com/ollama/ollama"
+        "name": "github.com/ollama/ollama"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Removed protocol information from package name as this is the usual procedure with other GHSAs. Moreover, having package names starting with "https://" leads to import warnings in OWASP Dependency-Track, e.g.:

`[GitHubAdvisoryMirrorTask] Unable to create purl from GitHub Vulnerability. Skipping GO : https://github.com/ollama/ollama for: GHSA-8hqg-whrw-pv92`