### PR TITLE
[GHSA-qjqp-xr96-cj99] Trix Editor Arbitrary Code Execution Vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-qjqp-xr96-cj99/GHSA-qjqp-xr96-cj99.json
+++ b/advisories/github-reviewed/2024/05/GHSA-qjqp-xr96-cj99/GHSA-qjqp-xr96-cj99.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qjqp-xr96-cj99",
-  "modified": "2024-05-15T14:20:37Z",
+  "modified": "2024-05-15T14:20:38Z",
   "published": "2024-05-07T16:49:24Z",
   "aliases": [
     "CVE-2024-34341"
@@ -52,6 +52,44 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "actiontext"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "7.0"
+            },
+            {
+              "fixed": "7.0.8.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "actiontext"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "7.1"
+            },
+            {
+              "fixed": "7.1.3.3"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [
@@ -80,12 +118,24 @@
       "url": "https://github.com/basecamp/trix/commit/841ff19b53f349915100bca8fcb488214ff93554"
     },
     {
+      "type": "WEB",
+      "url": "https://discuss.rubyonrails.org/t/xss-vulnerabilities-in-trix-editor/85803"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/basecamp/trix"
     },
     {
       "type": "WEB",
       "url": "https://github.com/basecamp/trix/releases/tag/v2.1.1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://rubyonrails.org/2024/5/17/Rails-Versions-7-0-8-2-and-7-1-3-3-have-been-released"
+    },
+    {
+      "type": "WEB",
+      "url": "https://rubyonrails.org/2024/5/17/Rails-Versions-7-0-8-3-has-been-released"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Suggesting adding the actiontext component of Rails versions 7.0 and 7.1 as documented as being affected by the Rails team at https://discuss.rubyonrails.org/t/xss-vulnerabilities-in-trix-editor/85803
https://rubyonrails.org/2024/5/17/Rails-Versions-7-0-8-3-has-been-released
https://rubyonrails.org/2024/5/17/Rails-Versions-7-0-8-2-and-7-1-3-3-have-been-released

Not sure if this is the appropriate way to manage these situations where one product embeds another, but seems reasonable.