### PR TITLE
[GHSA-cjcc-p67m-7qxm] Unsafe Reflection in base Component class in yiisoft/yii2

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-cjcc-p67m-7qxm/GHSA-cjcc-p67m-7qxm.json
+++ b/advisories/github-reviewed/2024/06/GHSA-cjcc-p67m-7qxm/GHSA-cjcc-p67m-7qxm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cjcc-p67m-7qxm",
-  "modified": "2024-06-02T22:30:39Z",
+  "modified": "2024-06-02T22:30:40Z",
   "published": "2024-06-02T22:30:39Z",
   "aliases": [
     "CVE-2024-4990"
@@ -34,7 +34,7 @@
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 2.0.49"
+        "last_known_affected_version_range": "<= 2.0.49.3"
       }
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Dependabot is issuing upgrades for 2.0.49.1 as its above 2.0.49, but the fix is not until 2.0.50. This will prevent Dependabot improperly upgrading projects and calling it "resolved". So we correct the affected version property.

You can see the fix in 2.0.50 - https://github.com/yiisoft/yii2/blob/master/framework/CHANGELOG.md#2050-may-30-2024