### PR TITLE
[GHSA-qg5r-95m4-mjgj] Reflected Cross-site Scripting in yiisoft/yii2 Debug mode

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-qg5r-95m4-mjgj/GHSA-qg5r-95m4-mjgj.json
+++ b/advisories/github-reviewed/2024/06/GHSA-qg5r-95m4-mjgj/GHSA-qg5r-95m4-mjgj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qg5r-95m4-mjgj",
-  "modified": "2024-06-02T22:27:54Z",
+  "modified": "2024-06-02T22:27:55Z",
   "published": "2024-06-02T22:27:54Z",
   "aliases": [
     "CVE-2024-32877"
@@ -25,16 +25,13 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.0.49.3"
+              "introduced": "2.0.43"
             },
             {
               "fixed": "2.0.50"
             }
           ]
         }
-      ],
-      "versions": [
-        "2.0.49.3"
       ]
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Just reviewing the 2 recent Yii2 CVEs and both were improperly tagged with "affected versions" - sending poor Dependabot on a rampage of mistakes.

This vulnerability was introduced in 2.0.43 as seen here (https://github.com/yiisoft/yii2/commit/8cc9aeb2f0b2ffe02fb54a817064e9da75512706) and referenced in the CVE as such. This means the proper range is greater than (or equal) to 2.0.43 and less than 2.0.50 (where it was patched)