### PR TITLE
[GHSA-6hr9-4692-fch9] OS Command Injection in effect

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-6hr9-4692-fch9/GHSA-6hr9-4692-fch9.json
+++ b/advisories/github-reviewed/2022/02/GHSA-6hr9-4692-fch9/GHSA-6hr9-4692-fch9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6hr9-4692-fch9",
-  "modified": "2021-07-28T22:11:47Z",
+  "modified": "2023-02-01T05:05:41Z",
   "published": "2022-02-10T23:45:54Z",
   "aliases": [
     "CVE-2020-7624"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "npm",
-        "name": "effect"
+        "name": ""
       },
       "ranges": [
         {
@@ -26,9 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "1.0.4"
             }
           ]
         }
@@ -39,6 +36,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-7624"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/Javascipt/effect"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location

**Comments**
This vulnerability is not related to the npm package "effect": https://www.npmjs.com/package/effect.
It does not seem to be tied to a package manager at all. The GitHub project claims to be for the Node project "effect", but the actual npm package is entirely different.
In addition, the Snyk advisory has revoked this vulnerability. This advisory should probably be withdrawn.