### PR TITLE
[GHSA-c5q2-7r4c-mv6g] Go JOSE vulnerable to Improper Handling of Highly Compressed Data (Data Amplification)

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-c5q2-7r4c-mv6g/GHSA-c5q2-7r4c-mv6g.json
+++ b/advisories/github-reviewed/2024/03/GHSA-c5q2-7r4c-mv6g/GHSA-c5q2-7r4c-mv6g.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c5q2-7r4c-mv6g",
-  "modified": "2024-05-31T14:03:15Z",
+  "modified": "2024-05-31T14:03:17Z",
   "published": "2024-03-07T22:54:44Z",
   "aliases": [
     "CVE-2024-28180"
   ],
   "summary": "Go JOSE vulnerable to Improper Handling of Highly Compressed Data (Data Amplification)",
-  "details": "### Impact\nAn attacker could send a JWE containing compressed data that used large amounts of memory and CPU when decompressed by Decrypt or DecryptMulti. Those functions now return an error if the decompressed data would exceed 250kB or 10x the compressed size (whichever is larger). Thanks to Enze Wang@Alioth and Jianjun Chen@Zhongguancun Lab (@zer0yu and @chenjj) for reporting.\n\n### Patches\nThe problem is fixed in v4.0.1, v3.0.3, v2.6.3\n\n",
+  "details": "### Impact\nAn attacker could send a JWE containing compressed data that used large amounts of memory and CPU when decompressed by Decrypt or DecryptMulti. Those functions now return an error if the decompressed data would exceed 250kB or 10x the compressed size (whichever is larger). Thanks to Enze Wang@Alioth and Jianjun Chen@Zhongguancun Lab (@zer0yu and @chenjj) for reporting.\n\n### Patches\ngopkg.in/square/go-jose.v2 is achieved and will not be receiving any security-updates\nUpgrade to below mentioned go package versions:\ngithub.com/go-jose/go-jose/v3@v3.0.3\ngithub.com/go-jose/go-jose/v4@v4.0.1\ngopkg.in/go-jose/go-jose.v2@v2.6.3\n\n\n",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Patch description is ambiguous as mentioned versions are not available for gopkg.in/square/go-jose.v2