### PR TITLE
[GHSA-2p57-rm9w-gvfp] ip SSRF improper categorization in isPublic

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-2p57-rm9w-gvfp/GHSA-2p57-rm9w-gvfp.json
+++ b/advisories/github-reviewed/2024/06/GHSA-2p57-rm9w-gvfp/GHSA-2p57-rm9w-gvfp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2p57-rm9w-gvfp",
-  "modified": "2024-06-02T22:29:29Z",
+  "modified": "2024-06-02T22:29:30Z",
   "published": "2024-06-02T22:29:29Z",
   "aliases": [
     "CVE-2024-29415"
@@ -25,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.0.1"
+              "fixed": "2.0.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.0.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Updated the versions based on https://github.com/advisories/GHSA-78xj-cgh5-2h22.