### PR TITLE
[GHSA-wx5j-54mm-rqqq] HTTP request smuggling in netty

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-wx5j-54mm-rqqq/GHSA-wx5j-54mm-rqqq.json
+++ b/advisories/github-reviewed/2021/12/GHSA-wx5j-54mm-rqqq/GHSA-wx5j-54mm-rqqq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wx5j-54mm-rqqq",
-  "modified": "2023-08-04T20:07:19Z",
+  "modified": "2023-08-16T05:02:15Z",
   "published": "2021-12-09T19:09:17Z",
   "aliases": [
     "CVE-2021-43797"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.0.0"
+              "introduced": "4.0.0.Beta2"
             },
             {
               "fixed": "4.1.71.Final"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to [Patch](https://github.com/netty/netty/commit/07aa6b5938a8b6ed7a6586e066400e2643897323), this vulnerability was introduced from 4.0.0.Beta2.