### PR TITLE
[GHSA-cqqj-4p63-rrmm] HTTP Request Smuggling in Netty

### DIFF
--- a/advisories/github-reviewed/2020/02/GHSA-cqqj-4p63-rrmm/GHSA-cqqj-4p63-rrmm.json
+++ b/advisories/github-reviewed/2020/02/GHSA-cqqj-4p63-rrmm/GHSA-cqqj-4p63-rrmm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cqqj-4p63-rrmm",
-  "modified": "2021-08-25T17:26:45Z",
+  "modified": "2023-08-16T05:02:06Z",
   "published": "2020-02-21T18:55:24Z",
   "aliases": [
     "CVE-2019-20444"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.0.0"
+              "introduced": "4.0.0.Beta1"
             },
             {
               "fixed": "4.1.44"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to [Patch](https://github.com/netty/netty/commit/07aa6b5938a8b6ed7a6586e066400e2643897323), this vulnerability was introduced from 4.0.0.Beta1.