### PR TITLE
[GHSA-6phf-73q6-gh87] Insecure Deserialization in Apache Commons Beanutils

### DIFF
--- a/advisories/github-reviewed/2020/06/GHSA-6phf-73q6-gh87/GHSA-6phf-73q6-gh87.json
+++ b/advisories/github-reviewed/2020/06/GHSA-6phf-73q6-gh87/GHSA-6phf-73q6-gh87.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6phf-73q6-gh87",
-  "modified": "2022-02-08T22:07:58Z",
+  "modified": "2023-01-27T05:02:43Z",
   "published": "2020-06-15T20:36:17Z",
   "aliases": [
     "CVE-2019-10086"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.9.0"
             },
             {
               "fixed": "1.9.4"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to [Patch](https://github.com/apache/commons-beanutils/commit/dd48f4e589462a8cdb1f29bbbccb35d6b0291d58), this vulnerability was introduced from 1.9.0.