### PR TITLE
[GHSA-wx54-3278-m5g4] Integer overflow in BCrypt class in Spring Security

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-wx54-3278-m5g4/GHSA-wx54-3278-m5g4.json
+++ b/advisories/github-reviewed/2022/05/GHSA-wx54-3278-m5g4/GHSA-wx54-3278-m5g4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wx54-3278-m5g4",
-  "modified": "2022-06-02T22:17:28Z",
+  "modified": "2023-01-27T05:03:09Z",
   "published": "2022-05-20T00:00:38Z",
   "aliases": [
     "CVE-2022-22976"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "5.2.0.RELEASE"
             },
             {
               "fixed": "5.5.7"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to [Patch](https://github.com/spring-projects/spring-security/commit/a40f73521c0dd88b879ff6165d280e78bdf8154f), this vulnerability was introduced from 5.2.0.RELEASE.