### PR TITLE
[GHSA-q62h-jw38-24vh] Uncaught Exception in zip4j

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-q62h-jw38-24vh/GHSA-q62h-jw38-24vh.json
+++ b/advisories/github-reviewed/2022/02/GHSA-q62h-jw38-24vh/GHSA-q62h-jw38-24vh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q62h-jw38-24vh",
-  "modified": "2022-04-11T19:15:59Z",
+  "modified": "2023-02-03T05:06:15Z",
   "published": "2022-02-25T00:01:04Z",
   "aliases": [
     "CVE-2022-24615"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0"
             },
             {
               "fixed": "2.10.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to [Patch](https://github.com/srikanth-lingala/zip4j/commit/35122fd19b3f1fae531d9e20d54e8dc894414dab), this vulnerability was introduced from 2.0.