### PR TITLE
[GHSA-m5hf-m3r2-xq53] hutool-core was discovered to contain a stack overflow via NumberUtil.toBigDecimal method

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-m5hf-m3r2-xq53/GHSA-m5hf-m3r2-xq53.json
+++ b/advisories/github-reviewed/2023/12/GHSA-m5hf-m3r2-xq53/GHSA-m5hf-m3r2-xq53.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m5hf-m3r2-xq53",
-  "modified": "2024-01-09T17:11:11Z",
+  "modified": "2024-01-31T12:51:11Z",
   "published": "2023-12-27T21:31:01Z",
   "aliases": [
     "CVE-2023-51080"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "5.8.22"
+              "introduced": "5.8.23"
             },
             {
               "fixed": "5.8.25"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
https://nvd.nist.gov/vuln/detail/CVE-2023-51080