### PR TITLE
[GHSA-hrmr-f5m6-m9pq] Moderate severity vulnerability that affects org.apache.commons:commons-compress

### DIFF
--- a/advisories/github-reviewed/2018/10/GHSA-hrmr-f5m6-m9pq/GHSA-hrmr-f5m6-m9pq.json
+++ b/advisories/github-reviewed/2018/10/GHSA-hrmr-f5m6-m9pq/GHSA-hrmr-f5m6-m9pq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hrmr-f5m6-m9pq",
-  "modified": "2022-02-08T22:08:23Z",
+  "modified": "2023-02-01T05:03:50Z",
   "published": "2018-10-19T16:41:27Z",
   "aliases": [
     "CVE-2018-11771"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.7"
             },
             {
               "fixed": "1.18"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
https://nvd.nist.gov/vuln/detail/CVE-2018-11771#range-11747091