### PR TITLE
[GHSA-hvh4-5qr6-3v7r] Observable Timing Discrepancy in pypqc

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-hvh4-5qr6-3v7r/GHSA-hvh4-5qr6-3v7r.json
+++ b/advisories/github-reviewed/2024/06/GHSA-hvh4-5qr6-3v7r/GHSA-hvh4-5qr6-3v7r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hvh4-5qr6-3v7r",
-  "modified": "2024-06-05T16:56:35Z",
+  "modified": "2024-06-05T16:56:38Z",
   "published": "2024-06-05T16:56:35Z",
   "aliases": [
 
@@ -23,9 +23,6 @@
           "events": [
             {
               "introduced": "0.0.4"
-            },
-            {
-              "last_affected": "0.0.6.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
1. This only affects the Mac OS version of the package.
2. No fix is released yet, and package version 0.0.6.X is not receiving security updates as 0.0.7.X is a non-breaking upgrade. Whoever filed this as "fixed in versions \>= 0.0.6.2" did so wrongly, unless they have some information I'm not privy to. The latest release, 0.0.7, is also affected.