### PR TITLE
[GHSA-m4pq-fv2w-6hrw] Deno's deno_runtime vulnerable to interactive permission prompt spoofing via improper ANSI stripping

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-m4pq-fv2w-6hrw/GHSA-m4pq-fv2w-6hrw.json
+++ b/advisories/github-reviewed/2024/03/GHSA-m4pq-fv2w-6hrw/GHSA-m4pq-fv2w-6hrw.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "crates.io",
-        "name": "deno_runtime"
+        "name": "deno"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The [original advisory](https://github.com/denoland/deno/security/advisories/GHSA-m4pq-fv2w-6hrw) does indicate `deno_runtime` as the package; however, the version constraints do not appear to align with the [available versions for deno_runtime](https://crates.io/crates/deno_runtime/versions) since all publised versions for that particular crate are still pre-1.0, so it would seem that perhaps `deno` would be the better package name to use here given the current version ranges.

Alternatively the version ranges could be updated to reflect the specific versioning for the `deno_runtime` sub-component, but I wasn't entirely sure how to figure that out