### PR TITLE
[GHSA-624g-8qjg-8qxf] Conform contains a Prototype Pollution Vulnerability in `parseWith...` function

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-624g-8qjg-8qxf/GHSA-624g-8qjg-8qxf.json
+++ b/advisories/github-reviewed/2024/04/GHSA-624g-8qjg-8qxf/GHSA-624g-8qjg-8qxf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-624g-8qjg-8qxf",
-  "modified": "2024-05-31T20:32:54Z",
+  "modified": "2024-05-31T20:33:47Z",
   "published": "2024-04-23T21:15:55Z",
   "aliases": [
     "CVE-2024-32866"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.1.1"
+              "fixed": "1.1.1, 0.9.2"
             }
           ]
         }
@@ -50,7 +50,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.1.1"
+              "fixed": "1.1.1, 0.9.2"
             }
           ]
         }
@@ -72,7 +72,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.1.1"
+              "fixed": "1.1.1, 0.9.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
An author published a patch to another version: 0.9.2
https://github.com/edmundhung/conform/security/advisories/GHSA-624g-8qjg-8qxf
Here is a commit: https://github.com/edmundhung/conform/commit/cb604dd58b99e2d12716d901a23bfca724e741ef