### PR TITLE
[GHSA-25w4-hfqg-4r52] Quarkus: authorization flaw in quarkus resteasy reactive and classic

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-25w4-hfqg-4r52/GHSA-25w4-hfqg-4r52.json
+++ b/advisories/github-reviewed/2024/04/GHSA-25w4-hfqg-4r52/GHSA-25w4-hfqg-4r52.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-25w4-hfqg-4r52",
-  "modified": "2024-04-25T19:54:40Z",
+  "modified": "2024-04-25T19:54:41Z",
   "published": "2024-04-25T18:30:39Z",
   "aliases": [
     "CVE-2023-5675"
@@ -48,6 +48,44 @@
             },
             {
               "fixed": "3.9.0.CR1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.quarkus:quarkus-resteasy-reactive-common-deployment"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.2.10.Final"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.quarkus:quarkus-resteasy-reactive-common"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.2.10.Final"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
See https://quarkus.io/blog/quarkus-3-2-10-final-released/, CVE-2023-5675 is mentioned as fixed in this release note. I've pinged them re 3.8.4/5 LTS and they have responded it should also be fixed in the current LTS stream - but I haven't found any written prove so far.