### PR TITLE
[GHSA-cjcc-p67m-7qxm] Unsafe Reflection in base Component class in yiisoft/yii2

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-cjcc-p67m-7qxm/GHSA-cjcc-p67m-7qxm.json
+++ b/advisories/github-reviewed/2024/06/GHSA-cjcc-p67m-7qxm/GHSA-cjcc-p67m-7qxm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cjcc-p67m-7qxm",
-  "modified": "2024-06-03T20:18:32Z",
+  "modified": "2024-06-03T20:18:33Z",
   "published": "2024-06-02T22:30:39Z",
   "aliases": [
     "CVE-2024-4990"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.0.50"
+              "fixed": "2.0.49.4, 2.0.50"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.0.49.4"
+      }
     }
   ],
   "references": [
@@ -45,8 +48,16 @@
       "url": "https://github.com/yiisoft/yii2/commit/628d406bfafb80fc32147837888c0057d89a021e"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/yiisoft/yii2/commit/62d081f18c3602d09e7d075bba3a0ca5c313f0b4"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/yiisoft/yii2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/yiisoft/yii2/blob/2.0.49.x/framework/CHANGELOG.md#20494-june-4-2024"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Fix was backported to 2.0.49.x line: https://github.com/yiisoft/yii2/pull/20183