### PR TITLE
[GHSA-3hrr-xwvg-hxvr] Keycloak DoS via account lockout

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-3hrr-xwvg-hxvr/GHSA-3hrr-xwvg-hxvr.json
+++ b/advisories/github-reviewed/2024/02/GHSA-3hrr-xwvg-hxvr/GHSA-3hrr-xwvg-hxvr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3hrr-xwvg-hxvr",
-  "modified": "2024-02-29T20:10:52Z",
+  "modified": "2024-02-29T20:10:54Z",
   "published": "2024-02-29T03:33:17Z",
   "aliases": [
     "CVE-2024-1722"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "23.0.5"
+              "fixed": "24.0.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 23.0.5"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This was discussed at https://github.com/keycloak/keycloak/issues/29603 and addressed by https://github.com/keycloak/keycloak/pull/27408 as per [this comment](https://github.com/keycloak/keycloak/issues/29603#issuecomment-2127499627). That PR was merged on `2024-03-01T15:14:27Z`.

[Keycloak v24.0.0](https://github.com/keycloak/keycloak/releases/tag/24.0.0#:~:text=27297), released on `2024-03-04T09:49:41Z`, already contains the fix.