### PR TITLE
[GHSA-mx3p-fhpw-x6rv] TCPDF vulnerable to Regular Expression Denial of Service

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-mx3p-fhpw-x6rv/GHSA-mx3p-fhpw-x6rv.json
+++ b/advisories/github-reviewed/2024/04/GHSA-mx3p-fhpw-x6rv/GHSA-mx3p-fhpw-x6rv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mx3p-fhpw-x6rv",
-  "modified": "2024-05-02T03:30:32Z",
+  "modified": "2024-05-02T03:30:33Z",
   "published": "2024-04-19T18:31:11Z",
   "aliases": [
     "CVE-2024-22640"
@@ -25,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "6.7.4"
+              "fixed": "6.7.5"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 6.7.4"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
CVE appears to have been patched in version 6.7.5
https://github.com/tecnickcom/TCPDF/compare/6.7.4...6.7.5