### PR TITLE
[GHSA-qc99-g3wm-hgxr] Django Arbitrary Code Execution

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-qc99-g3wm-hgxr/GHSA-qc99-g3wm-hgxr.json
+++ b/advisories/github-reviewed/2022/05/GHSA-qc99-g3wm-hgxr/GHSA-qc99-g3wm-hgxr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qc99-g3wm-hgxr",
-  "modified": "2024-05-14T17:18:37Z",
+  "modified": "2024-05-14T17:18:38Z",
   "published": "2022-05-01T17:44:04Z",
   "aliases": [
     "CVE-2007-0404"
@@ -22,16 +22,13 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0.95"
+              "introduced": "0.90"
             },
             {
-              "fixed": "1.0"
+              "fixed": "0.91, 0.95, 1.0"
             }
           ]
         }
-      ],
-      "versions": [
-        "0.95"
       ]
     }
   ],
@@ -43,6 +40,18 @@
     {
       "type": "WEB",
       "url": "https://github.com/django/django/commit/518d406e53"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/6eefa521be3c658dc0b38f8d62d52e9801e198ab"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/a132d411c6986418ee6c0edc331080aa792fee6e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/django/django/commit/d31e39173c29537e6a1613278c93634c18a3206e"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
add three patches for three versions:
https://github.com/django/django/commit/6eefa521be3c658dc0b38f8d62d52e9801e198ab	v0.90
https://github.com/django/django/commit/d31e39173c29537e6a1613278c93634c18a3206e	v0.91
https://github.com/django/django/commit/a132d411c6986418ee6c0edc331080aa792fee6e	v0.95
the official report shows them: https://docs.djangoproject.com/en/3.2/releases/security/

the vulnerable versions are also updated according to the official vulnerability report:
https://www.djangoproject.com/weblog/2006/aug/16/compilemessages/
