### PR TITLE
lightning RCE is not fixed in 2.2.2

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-cgwc-qvrx-rf7f/GHSA-cgwc-qvrx-rf7f.json
+++ b/advisories/github-reviewed/2024/06/GHSA-cgwc-qvrx-rf7f/GHSA-cgwc-qvrx-rf7f.json
@@ -7,7 +7,7 @@
     "CVE-2024-5452"
   ],
   "summary": "Remote code execution in pytorch lightning",
-  "details": "A remote code execution (RCE) vulnerability exists in the lightning-ai/pytorch-lightning library version 2.2.1 due to improper handling of deserialized user input and mismanagement of dunder attributes by the `deepdiff` library. The library uses `deepdiff.Delta` objects to modify application state based on frontend actions. However, it is possible to bypass the intended restrictions on modifying dunder attributes, allowing an attacker to construct a serialized delta that passes the deserializer whitelist and contains dunder attributes. When processed, this can be exploited to access other modules, classes, and instances, leading to arbitrary attribute write and total RCE on any self-hosted pytorch-lightning application in its default configuration, as the delta endpoint is enabled by default.",
+  "details": "A remote code execution (RCE) vulnerability exists in the lightning-ai/pytorch-lightning library due to improper handling of deserialized user input and mismanagement of dunder attributes by the `deepdiff` library. The library uses `deepdiff.Delta` objects to modify application state based on frontend actions. However, it is possible to bypass the intended restrictions on modifying dunder attributes, allowing an attacker to construct a serialized delta that passes the deserializer whitelist and contains dunder attributes. When processed, this can be exploited to access other modules, classes, and instances, leading to arbitrary attribute write and total RCE on any self-hosted pytorch-lightning application in its default configuration, as the delta endpoint is enabled by default.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -26,9 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "2.2.1"
             }
           ]
         }


### PR DESCRIPTION
GHSA-cgwc-qvrx-rf7f advisory is not solved in version 2.2.2 for lightning, at least version 2.2.5 is vulnerable