### PR TITLE
[GHSA-rf65-fc2p-2gjv] joblib v1.4.2 was discovered to contain a deserialization...

### DIFF
--- a/advisories/unreviewed/2024/05/GHSA-rf65-fc2p-2gjv/GHSA-rf65-fc2p-2gjv.json
+++ b/advisories/unreviewed/2024/05/GHSA-rf65-fc2p-2gjv/GHSA-rf65-fc2p-2gjv.json
@@ -1,17 +1,33 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rf65-fc2p-2gjv",
-  "modified": "2024-05-17T21:31:47Z",
+  "modified": "2024-05-17T21:32:12Z",
   "published": "2024-05-17T21:31:47Z",
   "aliases": [
     "CVE-2024-34997"
   ],
-  "details": "joblib v1.4.2 was discovered to contain a deserialization vulnerability via the component joblib.numpy_pickle::NumpyArrayWrapper().read_array().",
+  "summary": "Dispute of the CVE",
+  "details": "joblib v1.4.2 was discovered to contain a deserialization vulnerability via the component joblib.numpy_pickle::NumpyArrayWrapper().read_array().\n",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "joblib"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Summary

**Comments**


Here, the `NumpyArrayWrapper` is used internally to persist numpy arrays in the context of sharing objects between two processes/distributed experiments/caching. 
The same issue is present natively in the `pickle` protocol, but it is used in this context, as the pickle is produced by the main process, which should have a secure connection with the worker processes. For `joblib.load` there is a note stating it should `never be used to load files from untrusted sources`.

So I think this security alert can be dropped.