### PR TITLE
[GHSA-cr7j-rwmv-vgch] aimeos-core arbitrary file uopload vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-cr7j-rwmv-vgch/GHSA-cr7j-rwmv-vgch.json
+++ b/advisories/github-reviewed/2024/06/GHSA-cr7j-rwmv-vgch/GHSA-cr7j-rwmv-vgch.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cr7j-rwmv-vgch",
-  "modified": "2024-06-07T21:56:01Z",
+  "modified": "2024-06-07T21:56:03Z",
   "published": "2024-06-07T21:31:54Z",
   "aliases": [
     "CVE-2024-36811"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2024.04.1"
             },
             {
               "fixed": "2024.04.5"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS

**Comments**
Duplicate of https://github.com/aimeos/aimeos-core/security/advisories/GHSA-rhc2-23c2-ww7c
Affected versions are only 2024.04.x below 2024.04.5