### PR TITLE
[GHSA-cchp-3rq6-69wj] events2 TYPO3 extension insecure direct object reference (IDOR) vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-cchp-3rq6-69wj/GHSA-cchp-3rq6-69wj.json
+++ b/advisories/github-reviewed/2024/06/GHSA-cchp-3rq6-69wj/GHSA-cchp-3rq6-69wj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cchp-3rq6-69wj",
-  "modified": "2024-06-21T15:07:37Z",
+  "modified": "2024-06-21T15:07:38Z",
   "published": "2024-06-21T09:30:26Z",
   "aliases": [
     "CVE-2024-38874"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:L"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:L/VA:L/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -74,7 +70,8 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-284"
+      "CWE-284",
+      "CWE-639"
     ],
     "severity": "MODERATE",
     "github_reviewed": true,


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs

**Comments**
I believe that CWE-639 + CWE-284 more accurately reflect the specific nature of this IDOR vulnerability.


[reference]

[CWE-639: Authorization Bypass Through User-Controlled Key](https://cwe.mitre.org/data/definitions/639.html)