### PR TITLE
[GHSA-m6q9-p373-g5q8] Keycloak's unvalidated cross-origin messages in checkLoginIframe leads to DDoS

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-m6q9-p373-g5q8/GHSA-m6q9-p373-g5q8.json
+++ b/advisories/github-reviewed/2024/04/GHSA-m6q9-p373-g5q8/GHSA-m6q9-p373-g5q8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m6q9-p373-g5q8",
-  "modified": "2024-06-24T06:30:54Z",
+  "modified": "2024-06-24T06:30:55Z",
   "published": "2024-04-17T18:24:38Z",
   "aliases": [
     "CVE-2024-1249"
@@ -62,6 +62,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-1249"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/keycloak/keycloak/commit/9d9817e15a07195f16f554b7f60ee3a918369e26"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Added fix commit related to the this patch from 24.0.3