### PR TITLE
[GHSA-ww39-953v-wcq6] glob-parent vulnerable to Regular Expression Denial of Service in enclosure regex

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-ww39-953v-wcq6/GHSA-ww39-953v-wcq6.json
+++ b/advisories/github-reviewed/2021/06/GHSA-ww39-953v-wcq6/GHSA-ww39-953v-wcq6.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ww39-953v-wcq6",
-  "modified": "2023-11-29T00:42:41Z",
+  "modified": "2023-11-29T00:42:42Z",
   "published": "2021-06-07T21:56:34Z",
   "aliases": [
     "CVE-2020-28469"
   ],
   "summary": "glob-parent vulnerable to Regular Expression Denial of Service in enclosure regex",
-  "details": "This affects the package glob-parent before 5.1.2. The enclosure regex used to check for strings ending in enclosure containing path separator.",
+  "details": "This affects the package glob-parent after (and including) version 3.0.0, and before 5.1.2. The enclosure regex used to check for strings ending in enclosure containing path separator.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -20,17 +20,12 @@
         "ecosystem": "npm",
         "name": "glob-parent"
       },
-      "ecosystem_specific": {
-        "affected_functions": [
-          "(glob-parent).globParent"
-        ]
-      },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.0.0"
             },
             {
               "fixed": "5.1.2"


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Version 2.0.0 did not use RegEx to detect and extract the parent path from a glob string. It used do-while loop and  the`path.dirname` method:
https://github.com/gulpjs/glob-parent/tree/f5974fd556d2d8428de3521be394771ae4fd23f3
https://github.com/gulpjs/glob-parent/blob/f5974fd556d2d8428de3521be394771ae4fd23f3/index.js

Also, the PoC of the ReDoS does not work for version 2.0.0.