### PR TITLE
[GHSA-jjfh-589g-3hjx] Spring Boot denial of service vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-jjfh-589g-3hjx/GHSA-jjfh-589g-3hjx.json
+++ b/advisories/github-reviewed/2023/11/GHSA-jjfh-589g-3hjx/GHSA-jjfh-589g-3hjx.json
@@ -6,8 +6,8 @@
   "aliases": [
     "CVE-2023-34055"
   ],
-  "summary": "Spring Boot denial of service vulnerability",
-  "details": "In Spring Boot versions 2.7.0 - 2.7.17, 3.0.0-3.0.12 and 3.1.0-3.1.5, it is possible for a user to provide specially crafted HTTP requests that may cause a denial-of-service (DoS) condition.\n\nSpecifically, an application is vulnerable when all of the following are true:\n\n  *  the application uses Spring MVC or Spring WebFlux\n  *  org.springframework.boot:spring-boot-actuator is on the classpath",
+  "summary": "Spring Boot Actuator denial of service vulnerability",
+  "details": "In Spring Boot Actuator versions 2.7.0 - 2.7.17, 3.0.0-3.0.12 and 3.1.0-3.1.5, it is possible for a user to provide specially crafted HTTP requests that may cause a denial-of-service (DoS) condition.\n\nSpecifically, an application is vulnerable when all of the following are true:\n\n  *  the application uses Spring MVC or Spring WebFlux\n  *  org.springframework.boot:spring-boot-actuator is on the classpath",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.springframework.boot:spring-boot"
+        "name": "org.springframework.boot:spring-boot-actuator"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.springframework.boot:spring-boot"
+        "name": "org.springframework.boot:spring-boot-actuator"
       },
       "ranges": [
         {
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.springframework.boot:spring-boot"
+        "name": "org.springframework.boot:spring-boot-actuator"
       },
       "ranges": [
         {
@@ -85,6 +85,10 @@
     {
       "type": "WEB",
       "url": "https://security.netapp.com/advisory/ntap-20231221-0010"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKBOOT-6226862"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Summary

**Comments**
The spring-boot-actuator is part of the spring-boot project/repository. 
The vulnerable code is in the `org.springframework.boot:spring-boot-actuator` jar.

Snyk also tags this as such:
https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKBOOT-6226862