### PR TITLE
[GHSA-j628-q885-8gr5] Keycloak vulnerable to log Injection during WebAuthn authentication or registration

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-j628-q885-8gr5/GHSA-j628-q885-8gr5.json
+++ b/advisories/github-reviewed/2024/04/GHSA-j628-q885-8gr5/GHSA-j628-q885-8gr5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j628-q885-8gr5",
-  "modified": "2024-04-25T22:22:43Z",
+  "modified": "2024-04-25T22:22:44Z",
   "published": "2024-04-17T18:24:03Z",
   "aliases": [
     "CVE-2023-6484"
@@ -62,6 +62,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6484"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/keycloak/keycloak/issues/25078"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/keycloak/keycloak/commit/110f64a8146d0817252f90cf4b5e6a62aa897aff"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Improve the reference by attaching issue link and code fix commit link 