### PR TITLE
[GHSA-8grg-q944-cch5] SQL Injection in Hibernate ORM

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-8grg-q944-cch5/GHSA-8grg-q944-cch5.json
+++ b/advisories/github-reviewed/2022/02/GHSA-8grg-q944-cch5/GHSA-8grg-q944-cch5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8grg-q944-cch5",
-  "modified": "2022-05-03T02:28:28Z",
+  "modified": "2023-02-01T05:05:29Z",
   "published": "2022-02-10T23:05:04Z",
   "aliases": [
     "CVE-2019-14900"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.infinispan:infinispan-hibernate-cache-v53"
+        "name": "org.hibernate:hibernate-core"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.infinispan:infinispan-hibernate-cache-v53"
+        "name": "org.hibernate:hibernate-core"
       },
       "ranges": [
         {
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.infinispan:infinispan-hibernate-cache-v53"
+        "name": "org.hibernate:hibernate-core"
       },
       "ranges": [
         {
@@ -83,11 +83,27 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/hibernate/hibernate-orm/commit/3f3c1ab50604ab9ba99e25d2016fb85f3ba9dcd4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hibernate/hibernate-orm/commit/646b383f959eff18d58081b1a574f0d777d353da"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hibernate/hibernate-orm/commit/e0e22ea256c1906235d6a8e90b79c4ce33d0861f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/hibernate/hibernate-orm/commit/eebf01fbf3c2550ee70cdc9c1b02b52e330c8c36"
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1666499"
     },
     {
       "type": "PACKAGE",
-      "url": "https://github.com/infinispan/infinispan"
+      "url": "https://github.com/hibernate/hibernate-orm"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location

**Comments**
Currently listed 'org.infinispan:infinispan-hibernate-cache-v53' package does not match with the CVE description nor does it match with other CVE sources: https://nvd.nist.gov/vuln/detail/CVE-2019-14900 and https://security.snyk.io/vuln/SNYK-JAVA-ORGHIBERNATE-584563

Also added fix commit links for various branches.