### PR TITLE
[GHSA-q24v-hpg3-v3jp] Reactor Netty HTTP Server denial of service vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-q24v-hpg3-v3jp/GHSA-q24v-hpg3-v3jp.json
+++ b/advisories/github-reviewed/2023/11/GHSA-q24v-hpg3-v3jp/GHSA-q24v-hpg3-v3jp.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "io.projectreactor.netty:reactor-netty-http"
+        "name": "io.projectreactor.netty:reactor-netty-core"
       },
       "ranges": [
         {
@@ -37,7 +37,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "io.projectreactor.netty:reactor-netty-http"
+        "name": "io.projectreactor.netty:reactor-netty-core"
       },
       "ranges": [
         {
@@ -58,6 +58,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-34054"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/reactor/reactor-netty/commit/4ddbb1b9b985bb72290110ebae468a54e7f19420"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/reactor/reactor-netty/commit/e5891cba5cb070eb99d9fcda5da2358b608b4900"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The affected package name is actually io.projectreactor.netty:reactor-netty-core.
Code fixes are located in reactor-netty-core. See the added commit links for the CVE. 
