### PR TITLE
[GHSA-qqcv-vg9f-5rr3] litellm vulnerable to improper access control in team management

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-qqcv-vg9f-5rr3/GHSA-qqcv-vg9f-5rr3.json
+++ b/advisories/github-reviewed/2024/06/GHSA-qqcv-vg9f-5rr3/GHSA-qqcv-vg9f-5rr3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qqcv-vg9f-5rr3",
-  "modified": "2024-06-28T14:34:15Z",
+  "modified": "2024-06-28T14:34:16Z",
   "published": "2024-06-27T21:32:08Z",
   "aliases": [
     "CVE-2024-5710"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.40.28"
+              "last_affected": "1.34.34"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The affected version is wrong in the "Affected products" section