### PR TITLE
[GHSA-c25h-c27q-5qpv] Keycloak leaks configured LDAP bind credentials through the Keycloak admin console

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-c25h-c27q-5qpv/GHSA-c25h-c27q-5qpv.json
+++ b/advisories/github-reviewed/2024/06/GHSA-c25h-c27q-5qpv/GHSA-c25h-c27q-5qpv.json
@@ -93,6 +93,42 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/keycloak/keycloak/issues/30434"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/keycloak/keycloak/commit/0d0530046b9cb4b0d74d2fdefc9bd04f1d20cac0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/keycloak/keycloak/commit/1f56a9e48bf96c3bcb18dfc6cd93e3dd16f281f1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/keycloak/keycloak/commit/bde8568d4174a7072f7c7bb507d2c7d05824b1a6"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rmartinc/keycloak/commit/02bb60505f8c4472d7564f71a8eb38450f861fd5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rmartinc/keycloak/commit/446476adf9ad320278104f38684779d2a83c318a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rmartinc/keycloak/commit/768f5d1d48a2ad981c08067104c8e10eb433cd6c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rmartinc/keycloak/commit/81336a510fcd03e804c9140c58ae7c390c0fe098"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rmartinc/keycloak/commit/d30512c07aa0f225c30e2c9b49ac16912a91ba13"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/security/cve/CVE-2024-5967"
     },
     {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
update the issue for this cve on GitHub: https://github.com/keycloak/keycloak/issues/30434

 and 8 patch commits for diverse versions (including backporting):
https://github.com/rmartinc/keycloak/commit/02bb60505f8c4472d7564f71a8eb38450f861fd5
https://github.com/rmartinc/keycloak/commit/768f5d1d48a2ad981c08067104c8e10eb433cd6c
https://github.com/rmartinc/keycloak/commit/d30512c07aa0f225c30e2c9b49ac16912a91ba13
https://github.com/rmartinc/keycloak/commit/446476adf9ad320278104f38684779d2a83c318a
https://github.com/rmartinc/keycloak/commit/81336a510fcd03e804c9140c58ae7c390c0fe098
https://github.com/keycloak/keycloak/commit/bde8568d4174a7072f7c7bb507d2c7d05824b1a6
https://github.com/keycloak/keycloak/commit/1f56a9e48bf96c3bcb18dfc6cd93e3dd16f281f1
https://github.com/keycloak/keycloak/commit/0d0530046b9cb4b0d74d2fdefc9bd04f1d20cac0


The patch commits are all shown in the issue, and commit msgs also show their intention.
