### PR TITLE
[GHSA-4mgv-m5cm-f9h7] Vault GitHub Action did not correctly mask multi-line secrets in output

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4mgv-m5cm-f9h7/GHSA-4mgv-m5cm-f9h7.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4mgv-m5cm-f9h7/GHSA-4mgv-m5cm-f9h7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4mgv-m5cm-f9h7",
-  "modified": "2024-01-25T19:58:46Z",
+  "modified": "2024-01-25T19:58:48Z",
   "published": "2022-05-24T19:01:50Z",
   "aliases": [
     "CVE-2021-32074"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
HashiCorp vault-action (aka Vault GitHub Action) before 2.2.0 allows attackers to obtain sensitive information from log files because a multi-line secret was not correctly registered with GitHub Actions for log masking.