### PR TITLE
[GHSA-3h5v-q93c-6h6q] ws affected by a DoS when handling a request with many HTTP headers

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-3h5v-q93c-6h6q/GHSA-3h5v-q93c-6h6q.json
+++ b/advisories/github-reviewed/2024/06/GHSA-3h5v-q93c-6h6q/GHSA-3h5v-q93c-6h6q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3h5v-q93c-6h6q",
-  "modified": "2024-06-17T19:09:10Z",
+  "modified": "2024-06-17T19:09:12Z",
   "published": "2024-06-17T19:09:10Z",
   "aliases": [
     "CVE-2024-37890"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
I'm not sure how to fix, but https://github.com/prebid/Prebid.js/security/dependabot/152 is not generating a pr despite reporting being able to upgrade to patched version 7.5.10. the security advisory says the earliest fixed version is in 8.17.1 and fails to generate a pull request