### PR TITLE
[GHSA-gqm2-2gcx-p88w] Incorrect Permission Assignment for Critical Resource in Jenkins Credentials Binding Plugin

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-gqm2-2gcx-p88w/GHSA-gqm2-2gcx-p88w.json
+++ b/advisories/github-reviewed/2022/01/GHSA-gqm2-2gcx-p88w/GHSA-gqm2-2gcx-p88w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gqm2-2gcx-p88w",
-  "modified": "2023-10-27T16:26:22Z",
+  "modified": "2023-10-27T16:26:23Z",
   "published": "2022-01-13T00:01:03Z",
   "aliases": [
     "CVE-2022-20616"
@@ -18,26 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.jenkins-ci.plugins:credentials"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "1.25"
-            },
-            {
-              "fixed": "1.27.1"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.jenkins-ci.plugins:credentials"
+        "name": "org.jenkins-ci.plugins:credentials-binding"
       },
       "ranges": [
         {
@@ -47,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.24.1"
+              "fixed": "1.27.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Based on the vulnerability description and the security notice released by Jenkins, it is more reasonable that the component affected by this vulnerability should be org.jenkins-ci.plugins:credentials-binding.
Reference links:
[1] https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-2342
[2] https://security.snyk.io/vuln/SNYK-JAVA-ORGJENKINSCIPLUGINS-2359741
Vulnerability details:
Missing permission check in Credentials Binding Plugin allows validating secret file credentials IDs
SECURITY-2342 / CVE-2022-20616
Severity (CVSS): Low
Affected plugin: credentials-binding
Description:
Credentials Binding Plugin 1.27 and earlier does not perform a permission check in a method implementing form validation.
This allows attackers with Overall/Read access to validate if a credential ID refers to a secret file credential and whether it’s a zip file.
Credentials Binding Plugin 1.27.1 performs permission checks when validating secret file credentials IDs.