### PR TITLE
[GHSA-22wj-vf5f-wrvj] Password exposure in H2 Database 

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-22wj-vf5f-wrvj/GHSA-22wj-vf5f-wrvj.json
+++ b/advisories/github-reviewed/2022/11/GHSA-22wj-vf5f-wrvj/GHSA-22wj-vf5f-wrvj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-22wj-vf5f-wrvj",
-  "modified": "2024-05-14T21:58:52Z",
+  "modified": "2024-05-14T21:58:53Z",
   "published": "2022-11-23T21:30:31Z",
   "aliases": [
     "CVE-2022-45868"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.4.198"
             },
             {
               "fixed": "2.2.220"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Relevant code wasn't included until version 1.4.198. [Snyk](https://security.snyk.io/vuln/SNYK-JAVA-COMH2DATABASE-3146851)
This matches the code too: [vulnerable](https://github.com/h2database/h2database/blob/96832bf5a97cdc0adc1f2066ed61c54990d66ab5/h2/src/main/org/h2/server/web/WebServer.java#L346-L347) vs. [non-vulnerable](https://github.com/h2database/h2database/blob/version-1.4.196/h2/src/main/org/h2/server/web/WebServer.java#L302)
