### PR TITLE
[GHSA-r726-vmfq-j9j3]  Open Redirect Vulnerability in jupyter-server

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-r726-vmfq-j9j3/GHSA-r726-vmfq-j9j3.json
+++ b/advisories/github-reviewed/2023/08/GHSA-r726-vmfq-j9j3/GHSA-r726-vmfq-j9j3.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r726-vmfq-j9j3",
-  "modified": "2023-09-01T17:44:16Z",
+  "modified": "2023-11-11T05:01:47Z",
   "published": "2023-08-29T23:34:22Z",
   "aliases": [
     "CVE-2023-39968"
   ],
   "summary": " Open Redirect Vulnerability in jupyter-server",
-  "details": "### Impact\n\nOpen Redirect Vulnerability. Maliciously crafted login links to known Jupyter Servers  can cause successful login or an already logged-in session to be redirected to arbitrary sites, which should be restricted to Jupyter Server-served URLs.\n\n\n### Patches\n\nUpgrade to Jupyter Server 2.7.2\n\n### Workarounds\n\nNone.\n\n### References\n\nVulnerability reported by user davwwwx via the [bug bounty program](https://app.intigriti.com/programs/jupyter/jupyter/detail) [sponsored by the European Commission](https://commission.europa.eu/news/european-commissions-open-source-programme-office-starts-bug-bounties-2022-01-19_en) and hosted on the [Intigriti platform](https://www.intigriti.com/).\n\n- https://blog.xss.am/2023/08/CVE-2023-39968-jupyter-token-leak/\n",
+  "details": "### Impact\n\nOpen Redirect Vulnerability. Maliciously crafted login links to known Jupyter Servers  can cause successful login or an already logged-in session to be redirected to arbitrary sites, which should be restricted to Jupyter Server-served URLs.\n\n\n### Patches\n\nUpgrade to Jupyter Server 2.7.2\n\n### Workarounds\n\nNone.\n\n### References\n\nVulnerability reported by user davwwwx via the [bug bounty program](https://app.intigriti.com/programs/jupyter/jupyter/detail) [sponsored by the European Commission](https://commission.europa.eu/news/european-commissions-open-source-programme-office-starts-bug-bounties-2022-01-19_en) and hosted on the [Intigriti platform](https://www.intigriti.com/).\n\n- https://blog.xss.am/2023/08/cve-2023-39968-jupyter-token-leak/\n",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
typo in a URL  https://blog.xss.am/2023/08/CVE-2023-39968-jupyter-token-leak/ to  https://blog.xss.am/2023/08/cve-2023-39968-jupyter-token-leak/