### PR TITLE
[GHSA-hw49-2p59-3mhj] The net/http HTTP/1.1 client mishandled the case where a...

### DIFF
--- a/advisories/unreviewed/2024/07/GHSA-hw49-2p59-3mhj/GHSA-hw49-2p59-3mhj.json
+++ b/advisories/unreviewed/2024/07/GHSA-hw49-2p59-3mhj/GHSA-hw49-2p59-3mhj.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hw49-2p59-3mhj",
-  "modified": "2024-07-03T00:34:11Z",
+  "modified": "2024-07-03T00:34:21Z",
   "published": "2024-07-03T00:34:10Z",
   "aliases": [
     "CVE-2024-24791"
   ],
+  "summary": "CVE-2024-24791",
   "details": "The net/http HTTP/1.1 client mishandled the case where a server responds to a request with an \"Expect: 100-continue\" header with a non-informational (200 or higher) status. This mishandling could leave a client connection in an invalid state, where the next request sent on the connection will fail. An attacker sending a request to a net/http/httputil.ReverseProxy proxy can exploit this mishandling to cause a denial of service by sending \"Expect: 100-continue\" requests which elicit a non-informational response from the backend. Each such request leaves the proxy with an invalid connection, and causes one subsequent request using that connection to fail.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.21.0"
+            },
+            {
+              "fixed": "1.22.5"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
Missing version constraint for the CVE. 
Source: https://go-review.googlesource.com/c/go/+/591255 (merged into 1.21 and 1.22 release branch)