### PR TITLE
[GHSA-hh32-7344-cg2f] Authorization bypass in Spring Security

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-hh32-7344-cg2f/GHSA-hh32-7344-cg2f.json
+++ b/advisories/github-reviewed/2022/05/GHSA-hh32-7344-cg2f/GHSA-hh32-7344-cg2f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hh32-7344-cg2f",
-  "modified": "2022-06-03T21:11:32Z",
+  "modified": "2023-04-12T13:11:37Z",
   "published": "2022-05-20T00:00:39Z",
   "aliases": [
     "CVE-2022-22978"
@@ -48,6 +48,25 @@
             },
             {
               "fixed": "5.6.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework.security:spring-security-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.4.11"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
According to the description of the vulnerability announcement Affected Spring Products and Versions at https://spring.io/security/cve-2022-22978.
The affected version has an error and is recommended to be modified to 5.6.0<=version<5.6.4, 5.5.0<=version<5.5.7, version<5.4.11
Reference link: https://spring.io/security/cve-2022-22978
The detailed description is as follows:
Affected Spring Products and Versions
Spring Security
5.4.x prior to 5.4.11
5.5.x prior to 5.5.7
5.6.x prior to 5.6.4
Earlier unsupported versions
Mitigation
Users should update to a version that includes fixes. 5.5.x users should upgrade to 5.5.7 or greater. 5.6.x users should upgrade to 5.6.4 or greater. Releases that have fixed this issue include: