### PR TITLE
[GHSA-rc57-9r3x-98cq] XML External Entity Reference in drools

### DIFF
--- a/advisories/github-reviewed/2022/06/GHSA-rc57-9r3x-98cq/GHSA-rc57-9r3x-98cq.json
+++ b/advisories/github-reviewed/2022/06/GHSA-rc57-9r3x-98cq/GHSA-rc57-9r3x-98cq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rc57-9r3x-98cq",
-  "modified": "2022-06-29T20:38:41Z",
+  "modified": "2023-01-27T05:04:30Z",
   "published": "2022-06-17T00:01:28Z",
   "aliases": [
     "CVE-2021-41411"
@@ -45,7 +45,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/kiegroup/drools/pull/3808"
+      "url": "https://github.com/apache/incubator-kie-drools/pull/3808"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- References

**Comments**
The Drools project has moved in GitHub to the Apache Incubator, so the link to PR 3808 was broken.