### PR TITLE
[GHSA-248v-346w-9cwc] Certifi removes GLOBALTRUST root certificate

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-248v-346w-9cwc/GHSA-248v-346w-9cwc.json
+++ b/advisories/github-reviewed/2024/07/GHSA-248v-346w-9cwc/GHSA-248v-346w-9cwc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-248v-346w-9cwc",
-  "modified": "2024-07-05T21:32:15Z",
+  "modified": "2024-07-05T21:32:16Z",
   "published": "2024-07-05T20:06:40Z",
   "aliases": [
     "CVE-2024-39689"
@@ -9,10 +9,7 @@
   "summary": "Certifi removes GLOBALTRUST root certificate",
   "details": "Certifi 2024.07.04 removes root certificates from \"GLOBALTRUST\" from the root store. These are in the process of being removed from Mozilla's trust store.\n\nGLOBALTRUST's root certificates are being removed pursuant to an investigation which identified \"long-running and unresolved compliance issues\". Conclusions of Mozilla's investigation can be found [here]( https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/XpknYMPO8dI).",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
-    }
+
   ],
   "affected": [
     {
@@ -61,7 +58,7 @@
     "cwe_ids": [
       "CWE-345"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2024-07-05T20:06:40Z",
     "nvd_published_at": "2024-07-05T19:15:10Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
This is clearly not a vulnerability, just a change to the certificate list.