### PR TITLE
[GHSA-8hmh-mhqv-7638] PartialBufferOutputStream2 in GeoServer before 1.6.1 and...

### DIFF
--- a/advisories/unreviewed/2022/05/GHSA-8hmh-mhqv-7638/GHSA-8hmh-mhqv-7638.json
+++ b/advisories/unreviewed/2022/05/GHSA-8hmh-mhqv-7638/GHSA-8hmh-mhqv-7638.json
@@ -1,17 +1,55 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8hmh-mhqv-7638",
-  "modified": "2022-05-17T05:51:58Z",
+  "modified": "2023-01-28T05:05:08Z",
   "published": "2022-05-17T05:51:58Z",
   "aliases": [
     "CVE-2008-7227"
   ],
+  "summary": "PartialBufferOutputStream2 flush issues",
   "details": "PartialBufferOutputStream2 in GeoServer before 1.6.1 and 1.7.0-beta1 attempts to flush buffer contents even when it is handling an \"in memory buffer,\" which prevents the reporting of a service exception, with unknown impact and attack vectors.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.geoserver:gs-main"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.6.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.geoserver.web:gs-web-app"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.6.1"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -20,7 +58,7 @@
     },
     {
       "type": "WEB",
-      "url": "http://jira.codehaus.org/browse/GEOS-1747"
+      "url": "https://osgeo-org.atlassian.net/browse/GEOS-1747"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Summary

**Comments**
Updating the link to the geoserver issue tracker, adding maven ecosystem coordinates reflecting projects current best practices.