### PR TITLE
[GHSA-h658-qqv9-qwv8] Apache NiFi vulnerable to Cross-site Scripting

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-h658-qqv9-qwv8/GHSA-h658-qqv9-qwv8.json
+++ b/advisories/github-reviewed/2024/07/GHSA-h658-qqv9-qwv8/GHSA-h658-qqv9-qwv8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h658-qqv9-qwv8",
-  "modified": "2024-07-08T14:59:49Z",
+  "modified": "2024-07-08T14:59:51Z",
   "published": "2024-07-08T09:32:22Z",
   "aliases": [
     "CVE-2024-37389"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:L/A:N"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:N/VA:N/SC:L/SI:L/SA:N"
     }
   ],
   "affected": [
@@ -70,6 +66,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/apache/nifi/commit/1ea0bc1f7fa90ecff0ceb8b0c91a9aebeb05893b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://advisory.abay.sh/cve-2024-37389"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Add a reference link