### PR TITLE
[GHSA-74r5-g7vc-j2v2] zerovec-derive incorrectly uses `#[repr(packed)]`

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-74r5-g7vc-j2v2/GHSA-74r5-g7vc-j2v2.json
+++ b/advisories/github-reviewed/2024/07/GHSA-74r5-g7vc-j2v2/GHSA-74r5-g7vc-j2v2.json
@@ -1,21 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-74r5-g7vc-j2v2",
-  "modified": "2024-07-08T18:39:18Z",
+  "modified": "2024-07-08T18:39:19Z",
   "published": "2024-07-08T18:39:18Z",
   "aliases": [
 
   ],
   "summary": "zerovec-derive incorrectly uses `#[repr(packed)]`",
-  "details": "The affected versions make unsafe memory accesses under the assumption that `#[repr(packed)]` has a guaranteed field order. \n\nThe Rust specification does not guarantee this, and https://github.com/rust-lang/rust/pull/125360 (1.80.0-beta) starts \nreordering fields of `#[repr(packed)]` structs, leading to illegal memory accesses.\n\nThe patched versions `0.9.7` and `0.10.4` use `#[repr(C, packed)]`, which guarantees field order.\n",
+  "details": "The affected versions make unsafe memory accesses under the assumption that `#[repr(packed)]` has a guaranteed field order. \n\nThe Rust specification does not guarantee this, and https://github.com/rust-lang/rust/pull/125360 (1.80.0-beta) starts \nreordering fields of `#[repr(packed)]` structs, leading to illegal memory accesses.\n\nThe patched versions `0.9.7` and `0.10.3` use `#[repr(C, packed)]`, which guarantees field order.\n",
   "severity": [
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:L/AC:L/AT:N/PR:N/UI:N/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -32,7 +28,7 @@
               "introduced": "0.10.0"
             },
             {
-              "fixed": "0.10.4"
+              "fixed": "0.10.3"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
According to the comment, the version in which the vulnerability was fixed is 0.10.3, and version 0.10.4 is currently unpublished. In RUSTSEC advisory-db PR #2007, the patched version was updated to 0.10.3

comment: https://github.com/unicode-org/icu4x/issues/5196#issuecomment-2214711069
PR: https://github.com/rustsec/advisory-db/pull/2007