### PR TITLE
[GHSA-74r5-g7vc-j2v2] zerovec-derive incorrectly uses `#[repr(packed)]`

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-74r5-g7vc-j2v2/GHSA-74r5-g7vc-j2v2.json
+++ b/advisories/github-reviewed/2024/07/GHSA-74r5-g7vc-j2v2/GHSA-74r5-g7vc-j2v2.json
@@ -7,7 +7,7 @@
 
   ],
   "summary": "zerovec-derive incorrectly uses `#[repr(packed)]`",
-  "details": "The affected versions make unsafe memory accesses under the assumption that `#[repr(packed)]` has a guaranteed field order. \n\nThe Rust specification does not guarantee this, and https://github.com/rust-lang/rust/pull/125360 (1.80.0-beta) starts \nreordering fields of `#[repr(packed)]` structs, leading to illegal memory accesses.\n\nThe patched versions `0.9.7` and `0.10.4` use `#[repr(C, packed)]`, which guarantees field order.\n",
+  "details": "The affected versions make unsafe memory accesses under the assumption that `#[repr(packed)]` has a guaranteed field order. \n\nThe Rust specification does not guarantee this, and https://github.com/rust-lang/rust/pull/125360 (1.80.0-beta) starts \nreordering fields of `#[repr(packed)]` structs, leading to illegal memory accesses.\n\nThe patched versions `0.9.7` and `0.10.3` use `#[repr(C, packed)]`, which guarantees field order.\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -32,7 +32,7 @@
               "introduced": "0.10.0"
             },
             {
-              "fixed": "0.10.4"
+              "fixed": "0.10.3"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
According to the [comment](https://github.com/unicode-org/icu4x/issues/5196#issuecomment-2214711069), the version in which the vulnerability was fixed is `0.10.3`, and version `0.10.4` is currently unpublished (unicode-org/icu4x#5197 was closed). In PR rustsec/advisory-db#2007, the patched version was updated to `0.10.3`