### PR TITLE
[GHSA-gc58-v8h3-x2gr] Incorrect Default Permissions in Apache Tomcat

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-gc58-v8h3-x2gr/GHSA-gc58-v8h3-x2gr.json
+++ b/advisories/github-reviewed/2022/02/GHSA-gc58-v8h3-x2gr/GHSA-gc58-v8h3-x2gr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gc58-v8h3-x2gr",
-  "modified": "2022-02-09T23:01:49Z",
+  "modified": "2023-02-01T05:05:24Z",
   "published": "2022-02-09T23:01:49Z",
   "aliases": [
     "CVE-2020-8022"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": ""
       },
       "ranges": [
         {
@@ -26,28 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "8.0.53"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "9.0.0"
-            },
-            {
-              "fixed": "9.0.35"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It appears that this affected the way tomcat was packaged within specific distributions rather than actually affecting the maven artifacts per https://lists.apache.org/thread/0z644xfjo49pn2oxcp9qslkvhhw4tb7q.  I wasn't sure how to best show that though, should this just be marked as withdrawn or something?