### PR TITLE
[GHSA-phg7-8mm9-gj88] EGroupware mishandles an ORDER BY clause

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-phg7-8mm9-gj88/GHSA-phg7-8mm9-gj88.json
+++ b/advisories/github-reviewed/2024/07/GHSA-phg7-8mm9-gj88/GHSA-phg7-8mm9-gj88.json
@@ -1,21 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-phg7-8mm9-gj88",
-  "modified": "2024-07-09T21:40:33Z",
+  "modified": "2024-07-08T15:00:37Z",
   "published": "2024-07-07T15:31:12Z",
   "aliases": [
     "CVE-2024-40614"
   ],
   "summary": "EGroupware mishandles an ORDER BY clause",
-  "details": "EGroupware before 23.1.20240624 mishandles an ORDER BY clause.",
+  "details": "EGroupware before 23.1.20240624 mishandles an ORDER BY clause. This leads to json.php?menuaction=EGroupware\\Api\\Etemplate\\Widget\\Nextmatch::ajax_get_rows sort.id SQL injection by authenticated users for Address Book or InfoLog sorting.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
     }
   ],
   "affected": [
@@ -67,13 +63,21 @@
     {
       "type": "WEB",
       "url": "https://syss.de"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.syss.de/fileadmin/dokumente/Publikationen/Advisories/SYSS-2024-047.txt"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.syss.de/pentest-blog/sql-injection-schwachstelle-in-egroupware-syss-2024-047"
     }
   ],
   "database_specific": {
     "cwe_ids": [
       "CWE-89"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-07-08T15:00:36Z",
     "nvd_published_at": "2024-07-07T15:15:09Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- References
- Severity

**Comments**
Changed references and description to official MITRE details. Also changed CVSS vector because a user account is needed for this vulnerability