### PR TITLE
[GHSA-43wq-xrcm-3vgr] @discordjs/opus vulnerable to Denial of Service

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-43wq-xrcm-3vgr/GHSA-43wq-xrcm-3vgr.json
+++ b/advisories/github-reviewed/2024/07/GHSA-43wq-xrcm-3vgr/GHSA-43wq-xrcm-3vgr.json
@@ -1,21 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-43wq-xrcm-3vgr",
-  "modified": "2024-07-10T20:23:30Z",
+  "modified": "2024-07-10T20:23:31Z",
   "published": "2024-07-10T06:33:51Z",
   "aliases": [
     "CVE-2024-21521"
   ],
   "summary": "@discordjs/opus vulnerable to Denial of Service",
-  "details": "All versions of the package @discordjs/opus are vulnerable to Denial of Service (DoS) due to providing an input object with a property toString to several different functions. Exploiting this vulnerability could lead to a system crash.",
+  "details": "All versions of the package @discordjs/opus are vulnerable to Denial of Service (DoS) due to providing an input object with a property toString to several different functions. Exploiting this vulnerability could lead to a process crash.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
+      "score": "CVSS:3.1/AV:P/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L"
     }
   ],
   "affected": [
@@ -63,9 +59,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-400"
+      "CWE-20"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2024-07-10T20:23:30Z",
     "nvd_published_at": "2024-07-10T05:15:10Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity

**Comments**
The code in question (https://github.com/discordjs/opus/blob/814e500c2785c5207ace19650192629beba2728b/src/node-opus.cc#L47-L48) does lack checks to ensure the arguments provided in are castable to a number, but this is not something that can be exploited remotely. OpusEncoders should not be made ever with user-provided values that aren't sanitized, as it could potentially cause far bigger issues in opus itself