### PR TITLE
[GHSA-248v-346w-9cwc] Certifi removes GLOBALTRUST root certificate

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-248v-346w-9cwc/GHSA-248v-346w-9cwc.json
+++ b/advisories/github-reviewed/2024/07/GHSA-248v-346w-9cwc/GHSA-248v-346w-9cwc.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-248v-346w-9cwc",
-  "modified": "2024-07-08T15:38:30Z",
+  "modified": "2024-07-08T15:38:32Z",
   "published": "2024-07-05T20:06:40Z",
   "aliases": [
     "CVE-2024-39689"
   ],
   "summary": "Certifi removes GLOBALTRUST root certificate",
-  "details": "Certifi 2024.07.04 removes root certificates from \"GLOBALTRUST\" from the root store. These are in the process of being removed from Mozilla's trust store.\n\nGLOBALTRUST's root certificates are being removed pursuant to an investigation which identified \"long-running and unresolved compliance issues\". Conclusions of Mozilla's investigation can be found [here]( https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/XpknYMPO8dI).",
+  "details": "Certifi 2024.7.4 removes root certificates from \"GLOBALTRUST\" from the root store. These are in the process of being removed from Mozilla's trust store.\n\nGLOBALTRUST's root certificates are being removed pursuant to an investigation which identified \"long-running and unresolved compliance issues\". Conclusions of Mozilla's investigation can be found [here]( https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/XpknYMPO8dI).",
   "severity": [
 
   ],
@@ -22,10 +22,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2021.05.30"
+              "introduced": "2021.5.30"
             },
             {
-              "fixed": "2024.07.04"
+              "fixed": "2024.7.4"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
On Pypi, versions do not have leading zeros. Tag `2024.07.04` in [python-certify](https://github.com/certifi/python-certifi/tags) becomes `2024.7.4` in [Pypi versions](https://pypi.org/project/certifi/2024.7.4/#history). Same goes with `2021.05.30` which becomes `2021.5.30` in Pypi.

The difference in versions numbers opened a vulnerability alert on one of my repos. which ended up being a false positive.
