### PR TITLE
[GHSA-876p-c77m-x2hc] ag-grid-community were discovered to contain a prototype pollution via the _.mergeDeep function

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-876p-c77m-x2hc/GHSA-876p-c77m-x2hc.json
+++ b/advisories/github-reviewed/2024/07/GHSA-876p-c77m-x2hc/GHSA-876p-c77m-x2hc.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-876p-c77m-x2hc",
-  "modified": "2024-07-03T20:03:13Z",
+  "modified": "2024-07-03T20:03:14Z",
   "published": "2024-07-01T15:32:17Z",
   "aliases": [
     "CVE-2024-38996"
   ],
   "summary": "ag-grid-community were discovered to contain a prototype pollution via the _.mergeDeep function",
-  "details": "ag-grid-community v31.3.2 and ag-grid-enterprise v31.3.2 were discovered to contain a prototype pollution via the _.mergeDeep function. This vulnerability allows attackers to execute arbitrary code or cause a Denial of Service (DoS) via injecting arbitrary properties.",
+  "details": "ag-grid-community v31.3.2 and ag-grid-enterprise v31.3.2 were discovered to contain a prototype pollution via the _.mergeDeep function. This vulnerability allows attackers to execute arbitrary code or cause a Denial of Service (DoS) via injecting arbitrary properties.\n\n**Update: This issue is now fixed in AG Grid v32.0.1. Please upgrade AG Grid to v32.0.1 to resolve this issue.**",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -20,6 +20,19 @@
         "ecosystem": "npm",
         "name": "ag-grid-enterprise"
       },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "31.3.2"
+            },
+            {
+              "fixed": "32.0.1"
+            }
+          ]
+        }
+      ],
       "versions": [
         "31.3.2"
       ]
@@ -29,6 +42,19 @@
         "ecosystem": "npm",
         "name": "ag-grid-community"
       },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "31.3.2"
+            },
+            {
+              "fixed": "32.0.1"
+            }
+          ]
+        }
+      ],
       "versions": [
         "31.3.2"
       ]


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
AG Grid has resolved this security vulnerability in v32.0.1 which is now available.

Specifically, this issue was fixed by:
https://github.com/ag-grid/ag-grid/pull/8290