### PR TITLE
[GHSA-x6xm-h7hm-7p9q] Async <= 2.6.4 and <= 3.2.5 are vulnerable to ReDoS ...

### DIFF
--- a/advisories/unreviewed/2024/07/GHSA-x6xm-h7hm-7p9q/GHSA-x6xm-h7hm-7p9q.json
+++ b/advisories/unreviewed/2024/07/GHSA-x6xm-h7hm-7p9q/GHSA-x6xm-h7hm-7p9q.json
@@ -1,22 +1,46 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x6xm-h7hm-7p9q",
-  "modified": "2024-07-01T21:31:15Z",
+  "modified": "2024-07-01T21:31:22Z",
   "published": "2024-07-01T21:31:15Z",
   "aliases": [
     "CVE-2024-39249"
   ],
-  "details": "Async <= 2.6.4 and <= 3.2.5 are vulnerable to ReDoS (Regular Expression Denial of Service) while parsing function in autoinject function.",
+  "summary": "[invalid]",
+  "details": "~~Async <= 2.6.4 and <= 3.2.5 are vulnerable to ReDoS (Regular Expression Denial of Service) while parsing function in autoinject function.~~",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-39249"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/caolan/async/issues/1975"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/zunak/CVE-2024-39249/issues/1"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Summary

**Comments**
See newly added references. This is an invalid CVE. The regex is theoretically but not practically vulnerable to ReDoS. The CVE is not exploitable since it does not rely on user-supplied text.