### PR TITLE
[GHSA-4wm9-3qmv-gvxj] jsonic was discovered to contain a prototype pollution via the function empty.

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-4wm9-3qmv-gvxj/GHSA-4wm9-3qmv-gvxj.json
+++ b/advisories/github-reviewed/2024/07/GHSA-4wm9-3qmv-gvxj/GHSA-4wm9-3qmv-gvxj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4wm9-3qmv-gvxj",
-  "modified": "2024-07-05T17:46:56Z",
+  "modified": "2024-07-05T17:46:57Z",
   "published": "2024-07-01T15:32:13Z",
   "aliases": [
     "CVE-2024-38993"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:H/UI:R/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -54,7 +54,7 @@
       "CWE-1321",
       "CWE-94"
     ],
-    "severity": "CRITICAL",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2024-07-01T21:52:44Z",
     "nvd_published_at": "2024-07-01T13:15:04Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
False accusation of criticality. These are internal helper functions, not explicitly documented or intended for usage by the user.