### PR TITLE
[GHSA-w7rc-rwvf-8q5r] The `size` option isn't honored after following a redirect in node-fetch

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-w7rc-rwvf-8q5r/GHSA-w7rc-rwvf-8q5r.json
+++ b/advisories/github-reviewed/2020/09/GHSA-w7rc-rwvf-8q5r/GHSA-w7rc-rwvf-8q5r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w7rc-rwvf-8q5r",
-  "modified": "2023-04-21T19:34:08Z",
+  "modified": "2023-04-21T19:34:09Z",
   "published": "2020-09-10T17:46:21Z",
   "aliases": [
     "CVE-2020-15168"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0.0"
             },
             {
               "fixed": "2.6.1"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The change that caused this vulnerability, is recreating the request options (without the size option) for the new redirect fetch.
In the previous versions, it just used the original options which had the size value.
It was added in the commit in version 2.0.0: https://github.com/node-fetch/node-fetch/commit/b1cd2dd438a17e4e4412365bc33ab4d542e34930
