### PR TITLE
[GHSA-qfjh-mvq6-c5p8] Jan path traversal vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-qfjh-mvq6-c5p8/GHSA-qfjh-mvq6-c5p8.json
+++ b/advisories/github-reviewed/2024/06/GHSA-qfjh-mvq6-c5p8/GHSA-qfjh-mvq6-c5p8.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qfjh-mvq6-c5p8",
-  "modified": "2024-06-11T19:56:05Z",
+  "modified": "2024-06-11T19:56:06Z",
   "published": "2024-06-04T21:32:20Z",
   "aliases": [
     "CVE-2024-36858"
   ],
   "summary": "Jan path traversal vulnerability",
-  "details": "An arbitrary file upload vulnerability in the /v1/app/writeFileSync interface of Jan v0.4.12 allows attackers to execute arbitrary code via uploading a crafted file.",
+  "details": "> An arbitrary file upload vulnerability in the /v1/app/writeFileSync interface of Jan v0.4.12 allows attackers to execute arbitrary code via uploading a crafted file.\nR‌esolved in Jan v0.5.2",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Resolved product: Jan v0.5.2

**Comments**
Jan resolved the issue in Jan v0.5.2, and depre‌‌cated the @janhq/core pac‌‌kage. Could you kindly double-check if the problem still exists?