### PR TITLE
[GHSA-49jc-r788-3fc9] gix refs and paths with reserved Windows device names access the devices

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-49jc-r788-3fc9/GHSA-49jc-r788-3fc9.json
+++ b/advisories/github-reviewed/2024/05/GHSA-49jc-r788-3fc9/GHSA-49jc-r788-3fc9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-49jc-r788-3fc9",
-  "modified": "2024-07-08T16:20:16Z",
+  "modified": "2024-07-08T16:20:17Z",
   "published": "2024-05-22T14:13:24Z",
   "aliases": [
     "CVE-2024-35197"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:L"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:A/VC:N/VI:L/VA:L/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -109,25 +105,6 @@
             },
             {
               "fixed": "0.63.0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "crates.io",
-        "name": "gix-fs"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "0.11.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This removes `gix-fs` as an affected crate, as I have already done in [the repo-level advisory](https://github.com/Byron/gitoxide/security/advisories/GHSA-49jc-r788-3fc9). As discussed at https://github.com/Byron/gitoxide/discussions/1437#discussioncomment-9954713, a reexamination of this vulnerability revealed that, while the other listed crates were affected, `gix-fs` was not.

This mistake here was mine in my original analysis. As detailed in https://github.com/Byron/gitoxide/discussions/1437, this and another vulnerability of higher severity (CVE-2024-35186) were fixed together. The affected crates overlap but are not exactly the same. It was known that `gix-ref` was affected here and not there, but I had missed that `gix-fs` was affected only in the other vulnerability and not this one.

Because the rest of the information appears correct and seems to withstand reexamination, and because existing summaries of this vulnerability and descriptions associated with its CVE, such as the [NVD entry](https://nvd.nist.gov/vuln/detail/CVE-2024-35197), do not actually mention `gix-fs`, I think the only needed change is to delist it from the advisory.