### PR TITLE
[GHSA-hhwc-gh8h-9rrp] Apache Wicket: Remote code execution via XSLT injection

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-hhwc-gh8h-9rrp/GHSA-hhwc-gh8h-9rrp.json
+++ b/advisories/github-reviewed/2024/07/GHSA-hhwc-gh8h-9rrp/GHSA-hhwc-gh8h-9rrp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hhwc-gh8h-9rrp",
-  "modified": "2024-07-12T21:00:43Z",
+  "modified": "2024-07-12T21:00:44Z",
   "published": "2024-07-12T15:31:26Z",
   "aliases": [
     "CVE-2024-36522"
@@ -15,7 +15,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.wicket:wicket-core"
+        "name": "org.apache.wicket:wicket-util"
       },
       "ranges": [
         {
@@ -34,7 +34,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.wicket:wicket-core"
+        "name": "org.apache.wicket:wicket-util"
       },
       "ranges": [
         {
@@ -53,7 +53,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.wicket:wicket-core"
+        "name": "org.apache.wicket:wicket-util"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
XSLTResourceStream.java is in wicket-util see https://github.com/apache/wicket/blob/d7533716bf63b44c73a4a87193087762cd22f858/wicket-util/src/main/java/org/apache/wicket/util/resource/XSLTResourceStream.java#L4.  Also, apache have in many cases started adding more precise affected maven artifacts to [their cve 5 record data](https://github.com/CVEProject/cvelistV5/blob/a23d19ff53a681bd80ee7e0573f61d3a75cbee13/cves/2024/36xxx/CVE-2024-36522.json#L18), so it may be worth looking into if any of GitHub's parsing might be able to take advantage of that when available