### PR TITLE
[GHSA-f4c9-cqv8-9v98] Insufficient Granularity of Access Control in JSDom

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-f4c9-cqv8-9v98/GHSA-f4c9-cqv8-9v98.json
+++ b/advisories/github-reviewed/2022/05/GHSA-f4c9-cqv8-9v98/GHSA-f4c9-cqv8-9v98.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f4c9-cqv8-9v98",
-  "modified": "2022-06-22T18:50:49Z",
+  "modified": "2023-01-29T05:05:43Z",
   "published": "2022-05-24T17:42:20Z",
   "aliases": [
     "CVE-2021-20066"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -57,6 +57,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://security.snyk.io/vuln/SNYK-JS-JSDOM-1075447"
+    },
+    {
+      "type": "WEB",
       "url": "https://www.tenable.com/security/research/tra-2021-05"
     }
   ],
@@ -64,7 +68,7 @@
     "cwe_ids": [
       "CWE-1220"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2022-06-22T18:50:49Z",
     "nvd_published_at": "2021-02-16T20:15:00Z"


### PR DESCRIPTION
**Updates**
- CVSS
- References
- Severity

**Comments**
As mentioned in Snyk and in the GitHub issue comment written by lib maintainer, the issue is no longer deemed a vulnerability. Please remove the classification as a vulnerability.