### PR TITLE
[GHSA-f4c9-cqv8-9v98] Insufficient Granularity of Access Control in JSDom

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-f4c9-cqv8-9v98/GHSA-f4c9-cqv8-9v98.json
+++ b/advisories/github-reviewed/2022/05/GHSA-f4c9-cqv8-9v98/GHSA-f4c9-cqv8-9v98.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f4c9-cqv8-9v98",
-  "modified": "2024-07-17T16:50:06Z",
+  "modified": "2024-07-17T16:50:07Z",
   "published": "2022-05-24T17:42:20Z",
   "aliases": [
     "CVE-2021-20066"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "npm",
-        "name": "jsdom"
+        "name": ""
       },
       "ranges": [
         {
@@ -26,16 +26,10 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "fixed": "16.5.0"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 16.4.0"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Removing the affected product. This is not a vulnerability 