### PR TITLE
[GHSA-rfmp-97jj-h8m6] Improper Output Neutralization for Logs in Spring Framework

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-rfmp-97jj-h8m6/GHSA-rfmp-97jj-h8m6.json
+++ b/advisories/github-reviewed/2022/05/GHSA-rfmp-97jj-h8m6/GHSA-rfmp-97jj-h8m6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rfmp-97jj-h8m6",
-  "modified": "2022-06-22T18:25:00Z",
+  "modified": "2023-01-27T05:03:22Z",
   "published": "2022-05-24T19:19:04Z",
   "aliases": [
     "CVE-2021-22096"
@@ -41,6 +41,50 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.springframework:spring-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.2.0"
+            },
+            {
+              "fixed": "5.2.18"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 5.2.17"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework:spring"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.3.0"
+            },
+            {
+              "fixed": "5.3.11"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 5.3.10"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework:spring"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
If spring-core is affected, it means the spring package is also affected since spring was relocated to spring-core.