### PR TITLE
[GHSA-fq57-m32w-cmv5] DuckDB <=0.9.2 and DuckDB extension-template <=0.9.2 are...

### DIFF
--- a/advisories/unreviewed/2024/01/GHSA-fq57-m32w-cmv5/GHSA-fq57-m32w-cmv5.json
+++ b/advisories/unreviewed/2024/01/GHSA-fq57-m32w-cmv5/GHSA-fq57-m32w-cmv5.json
@@ -1,20 +1,33 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fq57-m32w-cmv5",
-  "modified": "2024-02-06T00:30:25Z",
+  "modified": "2024-02-06T00:30:26Z",
   "published": "2024-01-30T03:30:30Z",
   "aliases": [
     "CVE-2024-22682"
   ],
-  "details": "DuckDB <=0.9.2 and DuckDB extension-template <=0.9.2 are vulnerable to malicious extension injection via the custom extension feature.",
+  "summary": "Replacing a binary with a malicious binary results in malicious code execution when the malicious binary is run",
+  "details": "Replacing a binary with a malicious binary results in malicious code execution when the malicious binary is run",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-    }
+
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "GitHub Actions",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -28,9 +41,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-89"
+
     ],
-    "severity": "CRITICAL",
+    "severity": "LOW",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2024-01-30T01:16:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Summary

**Comments**
The CVE requires *existing* privileged access to the users machine. The attack vector is "replacing an existing binary on the users' machine with a new binary that has malicious code injected into it". Every binary on every machine is vulnerable to this attack vector, including trivial programs like "ls". 

Apologies if this is not the right place to make such a suggestion. Several users have pinged us about this bogus CVE as it has a critical vulnerability. I've also reached out to NIST for a re-score request. 