### PR TITLE
[GHSA-m425-mq94-257g] gRPC-Go HTTP/2 Rapid Reset vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-m425-mq94-257g/GHSA-m425-mq94-257g.json
+++ b/advisories/github-reviewed/2023/10/GHSA-m425-mq94-257g/GHSA-m425-mq94-257g.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m425-mq94-257g",
-  "modified": "2023-10-25T21:17:37Z",
+  "modified": "2023-10-25T21:17:39Z",
   "published": "2023-10-25T21:17:37Z",
   "aliases": [
 


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
I believe this relates to CVE-2023-44487.  Why isn't it referenced anywhere on https://github.com/advisories/GHSA-m425-mq94-257g?