### PR TITLE
[GHSA-cqmj-92xf-r6r9] Insufficient validation when decoding a Socket.IO packet

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-cqmj-92xf-r6r9/GHSA-cqmj-92xf-r6r9.json
+++ b/advisories/github-reviewed/2023/05/GHSA-cqmj-92xf-r6r9/GHSA-cqmj-92xf-r6r9.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cqmj-92xf-r6r9",
-  "modified": "2023-06-05T21:07:58Z",
+  "modified": "2023-11-11T05:00:35Z",
   "published": "2023-05-23T19:55:13Z",
   "aliases": [
     "CVE-2023-32695"
   ],
   "summary": "Insufficient validation when decoding a Socket.IO packet",
-  "details": "### Impact\n\nA specially crafted Socket.IO packet can trigger an uncaught exception on the Socket.IO server, thus killing the Node.js process.\n\n```\nTypeError: Cannot convert object to primitive value\n       at Socket.emit (node:events:507:25)\n       at .../node_modules/socket.io/lib/socket.js:531:14\n```\n\n### Patches\n\nA fix has been released today (2023/05/22):\n\n- https://github.com/socketio/socket.io-parser/commit/3b78117bf6ba7e99d7a5cfc1ba54d0477554a7f3, included in `socket.io-parser@4.2.3`\n- https://github.com/socketio/socket.io-parser/commit/2dc3c92622dad113b8676be06f23b1ed46b02ced, included in `socket.io-parser@3.4.3`\n\n| `socket.io` version | `socket.io-parser` version                                                                              | Needs minor update?                  |\n|---------------------|---------------------------------------------------------------------------------------------------------|--------------------------------------|\n| `4.5.2...latest`    | `~4.2.0` ([ref](https://github.com/socketio/socket.io/commit/9890b036cf942f6b6ad2afeb6a8361c32cd5d528)) | `npm audit fix` should be sufficient |\n| `4.1.3...4.5.1`     | `~4.1.1` ([ref](https://github.com/socketio/socket.io/commit/7c44893d7878cd5bba1eff43150c3e664f88fb57)) | Please upgrade to `socket.io@4.6.x`  |\n| `3.0.5...4.1.2`     | `~4.0.3` ([ref](https://github.com/socketio/socket.io/commit/752dfe3b1e5fecda53dae899b4a39e6fed5a1a17)) | Please upgrade to `socket.io@4.6.x`  |\n| `3.0.0...3.0.4`     | `~4.0.1` ([ref](https://github.com/socketio/socket.io/commit/1af3267e3f5f7884214cf2ca4d5282d620092fb0)) | Please upgrade to `socket.io@4.6.x`  |\n| `2.3.0...2.5.0`     | `~3.4.0` ([ref](https://github.com/socketio/socket.io/commit/cf39362014f5ff13a17168b74772c43920d6e4fd)) | `npm audit fix` should be sufficient |\n\n\n### Workarounds\n\nThere is no known workaround except upgrading to a safe version.\n\n### For more information\n\nIf you have any questions or comments about this advisory:\n\n- Open a discussion [here](https://github.com/socketio/socket.io/discussions)\n\nThanks to [@rafax00](https://github.com/rafax00) for the responsible disclosure.\n",
+  "details": "### Impact\n\nA specially crafted Socket.IO packet can trigger an uncaught exception on the Socket.IO server, thus killing the Node.js process.\n\n```\nTypeError: Cannot convert object to primitive value\n       at Socket.emit (node:events:507:25)\n       at .../node_modules/socket.io/lib/socket.js:531:14\n```\n\n### Patches\n\nA fix has been released today (2023/05/22):\n\n- https://github.com/socketio/socket.io-parser/commit/3b78117bf6ba7e99d7a5cfc1ba54d0477554a7f3, included in `socket.io-parser@4.2.3`\n- https://github.com/socketio/socket.io-parser/commit/2dc3c92622dad113b8676be06f23b1ed46b02ced, included in `socket.io-parser@3.4.3`\n\nAnother fix has been released for the `3.3.x` branch:\n\n- https://github.com/socketio/socket.io-parser/commit/ee006607495eca4ec7262ad080dd3a91439a5ba4, included in `socket.io-parser@3.3.4`\n\n| `socket.io` version | `socket.io-parser` version                                                                              | Needs minor update?                  |\n|---------------------|---------------------------------------------------------------------------------------------------------|--------------------------------------|\n| `4.5.2...latest`    | `~4.2.0` ([ref](https://github.com/socketio/socket.io/commit/9890b036cf942f6b6ad2afeb6a8361c32cd5d528)) | `npm audit fix` should be sufficient |\n| `4.1.3...4.5.1`     | `~4.1.1` ([ref](https://github.com/socketio/socket.io/commit/7c44893d7878cd5bba1eff43150c3e664f88fb57)) | Please upgrade to `socket.io@4.6.x`  |\n| `3.0.5...4.1.2`     | `~4.0.3` ([ref](https://github.com/socketio/socket.io/commit/752dfe3b1e5fecda53dae899b4a39e6fed5a1a17)) | Please upgrade to `socket.io@4.6.x`  |\n| `3.0.0...3.0.4`     | `~4.0.1` ([ref](https://github.com/socketio/socket.io/commit/1af3267e3f5f7884214cf2ca4d5282d620092fb0)) | Please upgrade to `socket.io@4.6.x`  |\n| `2.3.0...2.5.0`     | `~3.4.0` ([ref](https://github.com/socketio/socket.io/commit/cf39362014f5ff13a17168b74772c43920d6e4fd)) | `npm audit fix` should be sufficient |\n\n\n### Workarounds\n\nThere is no known workaround except upgrading to a safe version.\n\n### For more information\n\nIf you have any questions or comments about this advisory:\n\n- Open a discussion [here](https://github.com/socketio/socket.io/discussions)\n\nThanks to [@rafax00](https://github.com/rafax00) for the responsible disclosure.\n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -15,6 +15,25 @@
     }
   ],
   "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "socket.io-parser"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.4.0"
+            },
+            {
+              "fixed": "3.4.3"
+            }
+          ]
+        }
+      ]
+    },
     {
       "package": {
         "ecosystem": "npm",
@@ -44,10 +63,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.4.0"
+              "introduced": "0"
             },
             {
-              "fixed": "3.4.3"
+              "fixed": "3.3.4"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
The fix was backported in branch `3.3.x` and released in version `3.3.4`.