### PR TITLE
[GHSA-vr58-44ch-j77g] Seaweedfs filer server before 3.69 contain a SQ…

### DIFF
--- a/advisories/unreviewed/2024/07/GHSA-vr58-44ch-j77g/GHSA-vr58-44ch-j77g.json
+++ b/advisories/unreviewed/2024/07/GHSA-vr58-44ch-j77g/GHSA-vr58-44ch-j77g.json
@@ -1,0 +1,58 @@
+{
+    "schema_version": "1.4.0",
+    "id": "GHSA-vr58-44ch-j77g",
+    "modified": "2024-07-23T02:35:07Z",
+    "published": "2024-07-23T02:35:07Z",
+    "aliases": [
+      "CVE-2024-40120"
+    ],
+    "summary": "Seaweedfs filer server before 3.69 contain a SQL injection vulnerability at weed/filer/abstract_sql/abstract_sql_store.go",
+    "details": "Seaweedfs filer server before 3.69 contain a SQL injection vulnerability at weed/filer/abstract_sql/abstract_sql_store.go. This could lead to unauthorized access to the database, data leakage, data manipulation, or even complete compromise of the database server.",
+    "severity": [
+      {
+        "type": "CVSS_V3",
+        "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+      }
+    ],
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "Go",
+          "name": "github.com/seaweedfs/seaweedfs"
+        },
+        "ranges": [
+          {
+            "type": "ECOSYSTEM",
+            "events": [
+              {
+                "introduced": "2.22"
+              },
+              {
+                "fixed": "3.69"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "references": [
+      {
+        "type": "REPORT",
+        "url": "https://github.com/seaweedfs/seaweedfs/issues/5710"
+      },
+      {
+        "type": "FIX",
+        "url": "https://github.com/seaweedfs/seaweedfs/commit/9ac1023362000f6e8e58c9d278653f5926a0d90e"
+      },
+      {
+        "type": "FIX",
+        "url": "https://github.com/seaweedfs/seaweedfs/releases/tag/3.69"
+      }
+    ],
+    "database_specific": {
+      "cwe_ids": [
+        "CWE-89"
+      ],
+      "severity": "HIGH"
+    }
+  }


### PR DESCRIPTION
Add a new advisory GHSA-vr58-44ch-j77g.
Seaweedfs filer server before 3.69 contain a SQL injection vulnerability at weed/filer/abstract_sql/abstract_sql_store.go.