### PR TITLE
[GHSA-q25c-c977-4cmh] Server-Side Request Forgery in langchain

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-q25c-c977-4cmh/GHSA-q25c-c977-4cmh.json
+++ b/advisories/github-reviewed/2024/06/GHSA-q25c-c977-4cmh/GHSA-q25c-c977-4cmh.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q25c-c977-4cmh",
-  "modified": "2024-06-06T22:41:06Z",
+  "modified": "2024-06-06T22:41:07Z",
   "published": "2024-06-06T21:30:36Z",
   "aliases": [
     "CVE-2024-3095"
   ],
-  "summary": "Server-Side Request Forgery in langchain",
-  "details": "A Server-Side Request Forgery (SSRF) vulnerability exists in the Web Research Retriever component of langchain-ai/langchain version 0.1.5. The vulnerability arises because the Web Research Retriever does not restrict requests to remote internet addresses, allowing it to reach local addresses. This flaw enables attackers to execute port scans, access local services, and in some scenarios, read instance metadata from cloud environments. The vulnerability is particularly concerning as it can be exploited to abuse the Web Explorer server as a proxy for web attacks on third parties and interact with servers in the local network, including reading their response data. This could potentially lead to arbitrary code execution, depending on the nature of the local services. The vulnerability is limited to GET requests, as POST requests are not possible, but the impact on confidentiality, integrity, and availability is significant due to the potential for stolen credentials and state-changing interactions with internal APIs.",
+  "summary": "Server-Side Request Forgery in langchain-community.retrievers.web_research.WebResearchRetriever",
+  "details": "A Server-Side Request Forgery (SSRF) vulnerability exists in the Web Research Retriever component in langchain-community (langchain-community.retrievers.web_research.WebResearchRetriever).\n\nThe vulnerability arises because the Web Research Retriever does not restrict requests to remote internet addresses, allowing it to reach local addresses. This flaw enables attackers to execute port scans, access local services, and in some scenarios, read instance metadata from cloud environments. The vulnerability is particularly concerning as it can be exploited to abuse the Web Explorer server as a proxy for web attacks on third parties and interact with servers in the local network, including reading their response data. This could potentially lead to arbitrary code execution, depending on the nature of the local services. The vulnerability is limited to GET requests, as POST requests are not possible, but the impact on confidentiality, integrity, and availability is significant due to the potential for stolen credentials and state-changing interactions with internal APIs.\n\nThe patched code:\n* Requires users to opt-in\n* Suggests using a proxy to prevent requests to local addresses",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "PyPI",
-        "name": "langchain"
+        "name": "langchain-community"
       },
       "ranges": [
         {
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.1.5"
+              "fixed": "0.2.9"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.2.8"
+      }
     }
   ],
   "references": [
@@ -41,8 +44,16 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-3095"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/langchain-ai/langchain/pull/24451"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/langchain-ai/langchain"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/langchain-ai/langchain/releases/tag/langchain-community%3D%3D0.2.9"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Summary

**Comments**
Patch has been released:

https://github.com/langchain-ai/langchain/pull/24451
https://github.com/langchain-ai/langchain/releases/tag/langchain-community%3D%3D0.2.9

The original CVE was not associated with the correct package. Huntr does not support mono-repos at the moment, so many issues get classified as corresponding to langchain package, even though the code corresponds to the langchain-community package. The report iself was also unclear and did not differentiate between the repository vs. the package.