### PR TITLE
[GHSA-5pcm-hx3q-hm94] PyTorch before v2.2.0 was discovered to contain a heap...

### DIFF
--- a/advisories/unreviewed/2024/04/GHSA-5pcm-hx3q-hm94/GHSA-5pcm-hx3q-hm94.json
+++ b/advisories/unreviewed/2024/04/GHSA-5pcm-hx3q-hm94/GHSA-5pcm-hx3q-hm94.json
@@ -1,17 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5pcm-hx3q-hm94",
-  "modified": "2024-04-17T21:30:49Z",
+  "modified": "2024-07-03T18:35:11Z",
   "published": "2024-04-17T21:30:48Z",
   "aliases": [
     "CVE-2024-31580"
   ],
+  "summary": "Heap-based Buffer Overflow",
   "details": "PyTorch before v2.2.0 was discovered to contain a heap buffer overflow vulnerability in the component /runtime/vararg_functions.cpp. This vulnerability allows attackers to cause a Denial of Service (DoS) via a crafted input.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "torch"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.2.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -25,13 +44,17 @@
     {
       "type": "WEB",
       "url": "https://gist.github.com/1047524396/038c78f2f007345e6f497698ace2aa3d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.snyk.io/vuln/SNYK-PYTHON-TORCH-6649934"
     }
   ],
   "database_specific": {
     "cwe_ids": [
       "CWE-122"
     ],
-    "severity": null,
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2024-04-17T19:15:07Z"


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Severity
- Summary

**Comments**
https://security.snyk.io/vuln/SNYK-PYTHON-TORCH-6649934