### PR TITLE
[GHSA-x3m3-4wpv-5vgc] jrburke requirejs vulnerable to prototype pollution

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-x3m3-4wpv-5vgc/GHSA-x3m3-4wpv-5vgc.json
+++ b/advisories/github-reviewed/2024/07/GHSA-x3m3-4wpv-5vgc/GHSA-x3m3-4wpv-5vgc.json
@@ -9,10 +9,7 @@
   "summary": "jrburke requirejs vulnerable to prototype pollution",
   "details": "jrburke requirejs v2.3.6 was discovered to contain a prototype pollution via the function `s.contexts._.configure`. This vulnerability allows attackers to execute arbitrary code or cause a Denial of Service (DoS) via injecting arbitrary properties.",
   "severity": [
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/E:P"
-    }
+
   ],
   "affected": [
     {
@@ -28,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.3.6"
+              "fixed": "2.3.7"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.3.6"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
requirejs fixed Prototype Pollution Vulnerability in 2.3.7

See more info: 
https://github.com/requirejs/r.js/issues/1015
https://github.com/requirejs/requirejs/issues/1854
https://security.snyk.io/vuln/SNYK-JS-REQUIREJS-5416713