### PR TITLE
[GHSA-p343-9qwp-pqxv] Neo4j Cypher component mishandles IMMUTABLE privileges

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-p343-9qwp-pqxv/GHSA-p343-9qwp-pqxv.json
+++ b/advisories/github-reviewed/2024/05/GHSA-p343-9qwp-pqxv/GHSA-p343-9qwp-pqxv.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p343-9qwp-pqxv",
-  "modified": "2024-07-05T20:53:14Z",
+  "modified": "2024-07-05T20:53:15Z",
   "published": "2024-05-07T18:30:34Z",
   "aliases": [
     "CVE-2024-34517"
   ],
   "summary": "Neo4j Cypher component mishandles IMMUTABLE privileges",
-  "details": "The Cypher component in Neo4j before 5.19.0 mishandles IMMUTABLE privileges.",
+  "details": "The Cypher component in Neo4j versions above 5.0.0 and below 5.19.0 mishandles IMMUTABLE privileges.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:N"
     }
   ],
   "affected": [
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "5.0.0"
             },
             {
               "fixed": "5.19.0"
@@ -65,7 +65,7 @@
     "cwe_ids": [
       "CWE-269"
     ],
-    "severity": "CRITICAL",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-05-07T19:59:41Z",
     "nvd_published_at": "2024-05-07T18:15:08Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity

**Comments**
The vulnerability was published by the vendor: https://neo4j.com/security/cve-2024-34517/
It requires admin privileges to exploit and is only relevant in Enterprise editions between versions 5.0.0 and 5.0.18