### PR TITLE
[GHSA-328p-362g-r48j] ag-grid packages vulnerable to Prototype Pollution

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-328p-362g-r48j/GHSA-328p-362g-r48j.json
+++ b/advisories/github-reviewed/2024/07/GHSA-328p-362g-r48j/GHSA-328p-362g-r48j.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-328p-362g-r48j",
-  "modified": "2024-07-12T14:00:45Z",
+  "modified": "2024-07-12T14:00:46Z",
   "published": "2024-07-01T15:32:20Z",
   "aliases": [
     "CVE-2024-39001"
   ],
   "summary": "ag-grid packages vulnerable to Prototype Pollution",
-  "details": "ag-grid-enterprise v31.3.2 was discovered to contain a prototype pollution via the component _ModuleSupport.jsonApply. This vulnerability allows attackers to execute arbitrary code or cause a Denial of Service (DoS) via injecting arbitrary properties.",
+  "details": "ag-grid-enterprise v31.3.2 was discovered to contain a prototype pollution via the component _mergeDeep, _ModuleSupport.jsonApply,  _ModuleSupport.setPath, _Util.jsonApply. \n\nThis vulnerability allows attackers to execute arbitrary code or cause a Denial of Service (DoS) via injecting arbitrary properties.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "32.0.1"
+              "fixed": "32.0.2"
             }
           ]
         }
@@ -66,7 +66,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "32.0.1"
+              "fixed": "32.0.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
I've updated the table above listing the affected versions and the fixed versions for all the packages originally reported in this issue.

I've updated the description to list all the functions which are affected by this vulnerability.

Please update the advisory database with this information.