### PR TITLE
[GHSA-v23v-6jw2-98fq] Authz zero length regression

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-v23v-6jw2-98fq/GHSA-v23v-6jw2-98fq.json
+++ b/advisories/github-reviewed/2024/07/GHSA-v23v-6jw2-98fq/GHSA-v23v-6jw2-98fq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v23v-6jw2-98fq",
-  "modified": "2024-07-30T10:18:57Z",
+  "modified": "2024-07-30T10:18:58Z",
   "published": "2024-07-30T10:18:57Z",
   "aliases": [
     "CVE-2024-41110"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H"
     }
   ],
   "affected": [
@@ -48,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "24.0.0"
+              "introduced": "26.0.0"
             },
             {
               "fixed": "26.1.4"
@@ -71,6 +67,25 @@
             },
             {
               "fixed": "27.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/docker/docker"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "24.0.0"
+            },
+            {
+              "fixed": "25.0.6"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Add patch for 25.0.6 per https://github.com/moby/moby/releases/tag/v25.0.6