### PR TITLE
[GHSA-x72p-g37q-4xr9] SFTPGo's JWT implmentation lacks certain security measures

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-x72p-g37q-4xr9/GHSA-x72p-g37q-4xr9.json
+++ b/advisories/github-reviewed/2024/07/GHSA-x72p-g37q-4xr9/GHSA-x72p-g37q-4xr9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-x72p-g37q-4xr9",
-  "modified": "2024-07-26T21:37:16Z",
+  "modified": "2024-07-26T21:37:18Z",
   "published": "2024-07-22T09:31:55Z",
   "aliases": [
     "CVE-2024-40430"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This CVE is invalid because it relies on cookie theft and the cookie was not stolen by exploiting an application layer vulnerability (e.g. XSS).

The reported issue affects every application that uses cookies.

If you steal users' cookies, you can obviously impersonate them and access their resources; this is a security issue if you can steal the cookie by exploiting a vulnerability in the application (SFTPGo in this case), but that's not what happens here.

This is not new: for example, Google is working on a new standard, [Device Bound Session Credentials (DBSC)](https://blog.chromium.org/2024/04/fighting-cookie-theft-using-device.html), to mitigate issues like this.

The blog post also reports an Insecure Direct Object Reference (IDOR) vulnerability. Without stealing a cookie, no IDOR is possible, proper access controls are in place.