### PR TITLE
[GHSA-mv48-hcvh-8jj8] Vitejs Vite before v2.9.13 vulnerable to directory traversal via crafted URL to victim's service

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-mv48-hcvh-8jj8/GHSA-mv48-hcvh-8jj8.json
+++ b/advisories/github-reviewed/2022/08/GHSA-mv48-hcvh-8jj8/GHSA-mv48-hcvh-8jj8.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mv48-hcvh-8jj8",
-  "modified": "2022-08-30T20:17:43Z",
+  "modified": "2023-01-28T05:01:35Z",
   "published": "2022-08-19T00:00:20Z",
   "aliases": [
     "CVE-2022-35204"
   ],
-  "summary": "Vitejs Vite before v2.9.13 vulnerable to directory traversal via crafted URL to victim's service",
-  "details": "Vitejs Vite before v2.9.13 was discovered to allow attackers to perform a directory traversal via a crafted URL to the victim's service.",
+  "summary": "Vite before v2.9.13 vulnerable to directory traversal via crafted URL to victim's service",
+  "details": "Vite before v2.9.13 was discovered to allow attackers to perform a directory traversal via a crafted URL to the victim's service.",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Description
- Summary

**Comments**
I've removed the redundant "Vitejs" from the dependency's name.