### PR TITLE
[GHSA-mr7h-w2qc-ffc2] pytorch-lightning vulnerable to Arbitrary File Write via /v1/runs API endpoint

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-mr7h-w2qc-ffc2/GHSA-mr7h-w2qc-ffc2.json
+++ b/advisories/github-reviewed/2024/06/GHSA-mr7h-w2qc-ffc2/GHSA-mr7h-w2qc-ffc2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mr7h-w2qc-ffc2",
-  "modified": "2024-06-28T21:09:29Z",
+  "modified": "2024-06-28T21:09:31Z",
   "published": "2024-06-27T21:32:08Z",
   "aliases": [
     "CVE-2024-5980"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.3.1"
+              "fixed": "2.3.3"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.3.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The code in question was removed: https://github.com/Lightning-AI/pytorch-lightning/pull/20039. 
Release: https://github.com/Lightning-AI/pytorch-lightning/releases/tag/2.3.3