### PR TITLE
[GHSA-v23v-6jw2-98fq] Update patched version to the proper one

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-v23v-6jw2-98fq/GHSA-v23v-6jw2-98fq.json
+++ b/advisories/github-reviewed/2024/07/GHSA-v23v-6jw2-98fq/GHSA-v23v-6jw2-98fq.json
@@ -32,45 +32,7 @@
               "introduced": "19.03.0"
             },
             {
-              "fixed": "23.0.14"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Go",
-        "name": "github.com/docker/docker"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "26.0.0"
-            },
-            {
-              "fixed": "26.1.4"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Go",
-        "name": "github.com/docker/docker"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "27.0.0"
-            },
-            {
-              "fixed": "27.1.0"
+              "fixed": "> 23.0.14"
             }
           ]
         }
@@ -90,6 +52,44 @@
             },
             {
               "fixed": "25.0.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/docker/docker"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "26.0.0"
+            },
+            {
+              "fixed": "26.1.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/docker/docker"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "27.0.0"
+            },
+            {
+              "fixed": "27.1.1"
             }
           ]
         }


### PR DESCRIPTION
It appears that the fixed version mentioned in the advisory is incorrect. According to the [Docker Security Advisory](https://www.docker.com/blog/docker-security-advisory-docker-engine-authz-plugin/), the updated versions should be `> v23.0.14`, `> v26.1.4`, and `> v27.1.0`.

For verification, I reviewed the code and found discrepancies in the advisory.

For example: In the 26.0 branch, the CVE fix [commit](https://github.com/moby/moby/commit/411e817ddf710ff8e08fa193da80cb78af708191) is included in version [v26.1.5](https://github.com/moby/moby/blob/411e817ddf710ff8e08fa193da80cb78af708191/pkg/authorization/authz.go#L58) but is not present in [v26.1.4](https://github.com/moby/moby/blob/v26.1.4/pkg/authorization/authz.go).

Additionally, the advisory mentions a version `v23.0.14`, but there is no release tag for this version in the [GitHub repository](https://github.com/moby/moby/tags).

According to the [upstream description](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-41110), **"Patches have also been merged into the master, 19.03, 20.0, 23.0, 24.0, 25.0, 26.0, and 26.1 release branches."** Therefore, any new tags released for the 19.03, 20.0, or 23.0 branches should include the fixed version.