### PR TITLE
[GHSA-7726-43hg-m23v] OpenAM FreeMarker template injection

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-7726-43hg-m23v/GHSA-7726-43hg-m23v.json
+++ b/advisories/github-reviewed/2024/07/GHSA-7726-43hg-m23v/GHSA-7726-43hg-m23v.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7726-43hg-m23v",
-  "modified": "2024-07-25T14:15:32Z",
+  "modified": "2024-07-25T14:15:33Z",
   "published": "2024-07-25T14:15:32Z",
   "aliases": [
     "CVE-2024-41667"
   ],
   "summary": "OpenAM FreeMarker template injection",
-  "details": "OpenAM is an open access management solution. In versions 15.0.3 and prior, the `getCustomLoginUrlTemplate` method in RealmOAuth2ProviderSettings.java is vulnerable to template injection due to its usage of user input. Although the developer intended to implement a custom URL for handling login to override the default PingOne Advanced Identity Cloud login page,they did not restrict the `CustomLoginUrlTemplate`, allowing it to be set freely. Commit fcb8432aa77d5b2e147624fe954cb150c568e0b8 introduces `TemplateClassResolver.SAFER_RESOLVER` to disable the resolution of commonly exploited classes in FreeMarker template injection. As of time of publication, this fix is expected to be part of version 15.0.4.",
+  "details": "OpenAM is an open access management solution. In versions 15.0.3 and prior, the `getCustomLoginUrlTemplate` method in RealmOAuth2ProviderSettings.java is vulnerable to template injection due to its usage of user input. Although the developer intended to implement a custom URL for handling login to override the default OpenAM login page, they did not restrict the `CustomLoginUrlTemplate`, allowing it to be set freely. Commit fcb8432aa77d5b2e147624fe954cb150c568e0b8 introduces `TemplateClassResolver.SAFER_RESOLVER` to disable the resolution of commonly exploited classes in FreeMarker template injection. As of time of publication, this fix is expected to be part of version 15.0.4.",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Removing reference to "PingOne Advanced Identity Cloud" which is not related to OpenIdentityPlatform's OpenAM product and is therefore misleading.