### PR TITLE
[GHSA-28mc-g557-92m7] @75lb/deep-merge Prototype Pollution vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-28mc-g557-92m7/GHSA-28mc-g557-92m7.json
+++ b/advisories/github-reviewed/2024/07/GHSA-28mc-g557-92m7/GHSA-28mc-g557-92m7.json
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -32,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.1.1"
+              "fixed": "1.1.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.1.1"
+      }
     }
   ],
   "references": [
@@ -61,7 +60,7 @@
     "cwe_ids": [
       "CWE-1321"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-07-31T15:29:36Z",
     "nvd_published_at": "2024-07-30T20:15:03Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity

**Comments**
1.1.2 released containing https://github.com/75lb/deep-merge/commit/a68541fac3c2372f1ca67effad825990ad8046e1