### PR TITLE
[GHSA-qppj-fm5r-hxr3] HTTP/2 Stream Cancellation Attack

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-qppj-fm5r-hxr3/GHSA-qppj-fm5r-hxr3.json
+++ b/advisories/github-reviewed/2023/10/GHSA-qppj-fm5r-hxr3/GHSA-qppj-fm5r-hxr3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qppj-fm5r-hxr3",
-  "modified": "2024-08-02T10:36:34Z",
+  "modified": "2024-08-02T10:36:37Z",
   "published": "2023-10-10T21:28:24Z",
   "aliases": [
     "CVE-2023-44487"
@@ -12,32 +12,9 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "SwiftURL",
-        "name": "github.com/apple/swift-nio-http2"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.28.0"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "Go",
@@ -117,7 +94,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -136,7 +113,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -155,7 +132,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -174,7 +151,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -261,6 +238,25 @@
             },
             {
               "fixed": "8.5.94"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "SwiftURL",
+        "name": "github.com/apple/swift-nio-http2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.28.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
`tomcat` -> `tomcat-coyote` as the affected maven artifact id per the fix commits (example https://github.com/apache/tomcat/commit/944332bb15bd2f3bf76ec2caeb1ff0a58a3bc628 taken from https://tomcat.apache.org/security-8.html#Fixed_in_Apache_Tomcat_8.5.94)