### PR TITLE
[GHSA-78h3-pg4x-j8cv] libxmljs vulnerable to type confusion when parsing specially crafted XML

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-78h3-pg4x-j8cv/GHSA-78h3-pg4x-j8cv.json
+++ b/advisories/github-reviewed/2024/05/GHSA-78h3-pg4x-j8cv/GHSA-78h3-pg4x-j8cv.json
@@ -6,7 +6,7 @@
   "aliases": [
     "CVE-2024-34394"
   ],
-  "summary": "libxmljs vulnerable to type confusion when parsing specially crafted XML",
+  "summary": "libxmljs2 vulnerable to type confusion when parsing specially crafted XML",
   "details": "libxmljs2 is vulnerable to a type confusion vulnerability when parsing a specially crafted XML while invoking the `namespaces()` function (which invokes `XmlNode::get_local_namespaces()`) on a grand-child of a node that refers to an entity. This vulnerability can lead to denial of service and remote code execution.",
   "severity": [
     {
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.0.11"
+              "last_affected": "0.35.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
There are two packages with very similar names "libxmljs" and "libxmljs2". Apparently libxmljs2 is the one with the vulnerability, but the information about affected versions did not match the package version, which is currently "0.35.0", instead of "1.0.11" which is "libxmljs" latest version. Note that libxmljs2 does not depend on libxmljs.