### PR TITLE
[GHSA-g3ch-rx76-35fx] vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-g3ch-rx76-35fx/GHSA-g3ch-rx76-35fx.json
+++ b/advisories/github-reviewed/2024/07/GHSA-g3ch-rx76-35fx/GHSA-g3ch-rx76-35fx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g3ch-rx76-35fx",
-  "modified": "2024-07-23T16:26:53Z",
+  "modified": "2024-07-23T16:26:54Z",
   "published": "2024-07-23T15:31:09Z",
   "aliases": [
     "CVE-2024-6783"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS

**Comments**
Vulnerability requires prior JS code execution rights in order to pollute DOM styling properties via prototypal inheritance.

In other words, you need to be able to load a library or execute some other arbitrary code in order to utilize the exploit. 

Which begs the question: If the attacker can already execute arbitrary code, why bother with the exploit? They're only going to create more work for themselves in order to gain the same level of rights they already had. 