### PR TITLE
[GHSA-v23v-6jw2-98fq] Authz zero length regression

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-v23v-6jw2-98fq/GHSA-v23v-6jw2-98fq.json
+++ b/advisories/github-reviewed/2024/07/GHSA-v23v-6jw2-98fq/GHSA-v23v-6jw2-98fq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v23v-6jw2-98fq",
-  "modified": "2024-08-01T17:14:45Z",
+  "modified": "2024-08-01T17:14:47Z",
   "published": "2024-07-30T10:18:57Z",
   "aliases": [
     "CVE-2024-41110"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H"
     }
   ],
   "affected": [
@@ -32,26 +28,7 @@
               "introduced": "19.03.0"
             },
             {
-              "fixed": "23.0.14"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Go",
-        "name": "github.com/docker/docker"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "26.0.0"
-            },
-            {
-              "fixed": "26.1.4"
+              "fixed": "23.0.15"
             }
           ]
         }
@@ -70,7 +47,26 @@
               "introduced": "27.0.0"
             },
             {
-              "fixed": "27.1.0"
+              "fixed": "27.1.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/docker/docker"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "26.0.0"
+            },
+            {
+              "fixed": "26.1.5"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Addresses the fix versions being incorrect from the comment in https://github.com/github/advisory-database/pull/4644#issuecomment-2258762705

Note that 23.0.15 is not actually tagged or released, but the commit is in the 23.x branch if they ever do tag a release there.  The other option would be to modify the `>= 24.0.0, < 25.0.6` range to be `>= 19.03.0, < 25.0.6` and drop the 23.x range