### PR TITLE
[GHSA-cgvx-9447-vcch] ntlk unsafe deserialization vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-cgvx-9447-vcch/GHSA-cgvx-9447-vcch.json
+++ b/advisories/github-reviewed/2024/06/GHSA-cgvx-9447-vcch/GHSA-cgvx-9447-vcch.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cgvx-9447-vcch",
-  "modified": "2024-06-28T21:11:25Z",
+  "modified": "2024-08-04T05:01:05Z",
   "published": "2024-06-28T00:33:31Z",
   "aliases": [
     "CVE-2024-39705"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:A/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -32,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.8.1"
+              "fixed": "3.8.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.8.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
In NLTK 3.8.2, the data.load() function no longer allows to to unpickle classses or functions. The latest version is available from https://pypi.org/project/nltk/