### PR TITLE
[GHSA-3mpp-xfvh-qh37] node-ipc behavior change

### DIFF
--- a/advisories/github-reviewed/2022/03/GHSA-3mpp-xfvh-qh37/GHSA-3mpp-xfvh-qh37.json
+++ b/advisories/github-reviewed/2022/03/GHSA-3mpp-xfvh-qh37/GHSA-3mpp-xfvh-qh37.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-3mpp-xfvh-qh37",
-  "modified": "2022-03-16T23:54:35Z",
+  "modified": "2023-01-11T05:05:38Z",
   "published": "2022-03-16T23:54:35Z",
   "aliases": [
 
@@ -23,6 +23,9 @@
           "events": [
             {
               "introduced": "11.0.0"
+            },
+            {
+              "fixed": "12.0.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
https://github.com/RIAEvangelist/node-ipc/compare/10.1.0...12.0.0
the latest package.json does not include peacenotwar malware anymore