### PR TITLE
[GHSA-g3ch-rx76-35fx] vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-g3ch-rx76-35fx/GHSA-g3ch-rx76-35fx.json
+++ b/advisories/github-reviewed/2024/07/GHSA-g3ch-rx76-35fx/GHSA-g3ch-rx76-35fx.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g3ch-rx76-35fx",
-  "modified": "2024-08-09T18:44:52Z",
+  "modified": "2024-08-09T18:44:53Z",
   "published": "2024-07-23T15:31:09Z",
   "aliases": [
     "CVE-2024-6783"
   ],
   "summary": "vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)",
-  "details": "A vulnerability has been discovered in vue-template-compiler, that allows an attacker to perform XSS via prototype pollution. The attacker could change the prototype chain of some properties such as `Object.prototype.staticClass` or `Object.prototype.staticStyle` to execute arbitrary JavaScript code. Vue 2 has reached End-of-Life. This vulnerability has been patched in Vue 3.",
+  "details": "A vulnerability has been discovered in `vue-template-compiler`, that allows an attacker to perform XSS via prototype pollution.\n\nThe attacker who has prior arbitrary code execution rights could change the prototype chain of some properties such as `Object.prototype.staticClass` or `Object.prototype.staticStyle` to execute arbitrary JavaScript code via the template compiler.\n\nVue 2 has reached End-of-Life. This vulnerability has been patched in Vue 3.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -53,7 +53,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2024-07-23T16:26:53Z",
     "nvd_published_at": "2024-07-23T15:15:06Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity

**Comments**
Please bear in mind that no escalation of privileges is attained through the successful use of this vulnerability.

An attacker using this approach to pollute the prototype chain and use the vulnerability would need to have prior code execution rights by loading a library or some other form of script injection. The result after exploiting the vulnerability is that they are able to perform XSS or execute some other arbitrary code via the template compiler, which they would have been able to do in any case in order to successfully use the vulnerability.

As stated in section 2 of the CVSS guidance, severity scoring should be based on the delta between the rights the attacker had _before_ and _after_ using the vulnerability:

https://www.first.org/cvss/v3.1/user-guide#2-3-2-Score-Based-on-Privileges-Gained-not-Attained

> CVSS analysts should consider the privileges the attacker has prior to exploiting a vulnerability and compare those to the privileges they have after exploitation. The change in privileges is then captured in the Impact Metrics, i.e., Confidentiality, Integrity and Availability.

There is therefore no overall change to the Confidentiality, Integrity and Availability scoring for this CVE. Rendering the severity score as 0.