### PR TITLE
[GHSA-49q7-c7j4-3p7m] Elliptic allows BER-encoded signatures

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-49q7-c7j4-3p7m/GHSA-49q7-c7j4-3p7m.json
+++ b/advisories/github-reviewed/2024/08/GHSA-49q7-c7j4-3p7m/GHSA-49q7-c7j4-3p7m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-49q7-c7j4-3p7m",
-  "modified": "2024-08-08T14:59:58Z",
+  "modified": "2024-08-08T14:59:59Z",
   "published": "2024-08-02T09:31:35Z",
   "aliases": [
     "CVE-2024-42461"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N/E:U"
     }
   ],
   "affected": [
@@ -32,11 +28,14 @@
               "introduced": "5.2.1"
             },
             {
-              "last_affected": "6.5.6"
+              "fixed": "6.5.7"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 6.5.6"
+      }
     }
   ],
   "references": [
@@ -57,7 +56,7 @@
     "cwe_ids": [
       "CWE-347"
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-08-05T13:51:26Z",
     "nvd_published_at": "2024-08-02T07:16:10Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity

**Comments**
Fixed in 6.5.7.

See more info:
https://github.com/indutny/elliptic/pull/317
https://security.snyk.io/vuln/SNYK-JS-ELLIPTIC-7577917