### PR TITLE
[GHSA-47mc-qmh2-mqj4] Automad arbitrary file upload vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-47mc-qmh2-mqj4/GHSA-47mc-qmh2-mqj4.json
+++ b/advisories/github-reviewed/2024/07/GHSA-47mc-qmh2-mqj4/GHSA-47mc-qmh2-mqj4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-47mc-qmh2-mqj4",
-  "modified": "2024-07-19T22:39:49Z",
+  "modified": "2024-08-08T05:09:01Z",
   "published": "2024-07-19T21:31:11Z",
   "aliases": [
     "CVE-2024-40400"
@@ -11,11 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:L"
     }
   ],
   "affected": [
@@ -32,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.0.0-alpha.5"
+              "fixed": "2.0.0-alpha.5"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.0.0-alpha.4"
+      }
     }
   ],
   "references": [
@@ -49,10 +48,6 @@
       "url": "https://github.com/marcantondahmen/automad/issues/106"
     },
     {
-      "type": "WEB",
-      "url": "https://github.com/marcantondahmen/automad/commit/112f070ccf423931c9bb2b36f9a26c345e1ef56e"
-    },
-    {
       "type": "PACKAGE",
       "url": "https://github.com/marcantondahmen/automad"
     }
@@ -61,7 +56,7 @@
     "cwe_ids": [
       "CWE-434"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-07-19T22:39:49Z",
     "nvd_published_at": "2024-07-19T19:15:09Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- References
- Severity

**Comments**
Dear GitHub Security Curators Team,

I, the maintainer of the affected repository, would like to correct some of the details regarding this report:

1. In contrast to the mentioned affected versions, the vulnerability was fixed with version 2.0.0-alpha.5. The linked issue #106 clearly states this.
2. The release date was already June 30th, but this entry was updated last week without mentioning the fix.
3. The vulnerability was reported as a CVE entry three weeks after the fix was released, why?
4. The linked commit is totally unrelated.
5. In order to exploit the vulnerability one has to an admin user. A malicious file has to be prepared and uploaded manually by the admin. Usually there is only one admin per site and that is the owner. That is relevant and should be mentioned.

