### PR TITLE
[GHSA-fpph-mqc8-h6q5] Unrestricted File Upload affecting automad

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-fpph-mqc8-h6q5/GHSA-fpph-mqc8-h6q5.json
+++ b/advisories/github-reviewed/2023/12/GHSA-fpph-mqc8-h6q5/GHSA-fpph-mqc8-h6q5.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fpph-mqc8-h6q5",
-  "modified": "2023-12-29T18:35:29Z",
+  "modified": "2023-12-29T18:35:31Z",
   "published": "2023-12-21T18:30:23Z",
   "aliases": [
     "CVE-2023-7036"
   ],
   "summary": "Unrestricted File Upload affecting automad",
-  "details": "A vulnerability was found in automad up to 1.10.9. This affects the function upload of the file `FileCollectionController.php` of the component `Content Type Handler`. The manipulation leads to unrestricted upload. The attack may be launched remotely and an exploit has been disclosed publicly.",
+  "details": "A vulnerability was found in automad up to 1.10.9. This affects the function upload of the file `FileCollectionController.php` of the component `Content Type Handler`.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:L"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:L"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description

**Comments**
Only admins, usually there is only one, can upload files. No hack is required to inject JS to a site since it is intended behaviour to upload JS snippets to pages.