### PR TITLE
[GHSA-q5q3-qm26-9jwm] Authenticated Blind SSRF in automad/automad

### DIFF
--- a/advisories/github-reviewed/2023/12/GHSA-q5q3-qm26-9jwm/GHSA-q5q3-qm26-9jwm.json
+++ b/advisories/github-reviewed/2023/12/GHSA-q5q3-qm26-9jwm/GHSA-q5q3-qm26-9jwm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q5q3-qm26-9jwm",
-  "modified": "2023-12-29T19:32:20Z",
+  "modified": "2023-12-29T19:32:23Z",
   "published": "2023-12-21T18:30:23Z",
   "aliases": [
     "CVE-2023-7037"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [
@@ -61,7 +61,7 @@
     "cwe_ids": [
       "CWE-918"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2023-12-29T19:32:20Z",
     "nvd_published_at": "2023-12-21T17:15:09Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
Only admins with full server access can import files from urls and therefore scan ports of their own server. This is not exploitable or at least nonsensical.