### PR TITLE
[GHSA-f6fj-c8gc-64v6] A vulnerability has been found in automad up to 1.10.9...

### DIFF
--- a/advisories/unreviewed/2022/04/GHSA-f6fj-c8gc-64v6/GHSA-f6fj-c8gc-64v6.json
+++ b/advisories/unreviewed/2022/04/GHSA-f6fj-c8gc-64v6/GHSA-f6fj-c8gc-64v6.json
@@ -1,20 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f6fj-c8gc-64v6",
-  "modified": "2022-05-12T00:02:00Z",
+  "modified": "2023-01-30T05:03:59Z",
   "published": "2022-04-30T00:00:36Z",
   "aliases": [
     "CVE-2022-1536"
   ],
-  "details": "A vulnerability has been found in automad up to 1.10.9 and classified as problematic. This vulnerability affects the Dashboard. The manipulation of the argument title with the input Home</title><script>alert(\"home\")</script><title> leads to a cross site scripting. The attack can be initiated remotely but requires an authentication. The exploit details have disclosed to the public and may be used.",
+  "summary": "CVE-2022-1536",
+  "details": "This is not a realistic or exploitable attack vector. An admin user with the highest level of privileges is the only one who can exploit this. And the admin is also the only one affected by this. It is also documented as intended behaviour.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -32,9 +48,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-79"
+
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2022-04-29T13:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Description
- Severity
- Summary

**Comments**
This can only be exploited by the owner (admin) of a page and can only be used against the owner (admin) of the page. I guess that is not a realistic attack vector.