### PR TITLE
[GHSA-977x-g7h5-7qgw] Elliptic's ECDSA missing check for whether leading bit of r and s is zero

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-977x-g7h5-7qgw/GHSA-977x-g7h5-7qgw.json
+++ b/advisories/github-reviewed/2024/08/GHSA-977x-g7h5-7qgw/GHSA-977x-g7h5-7qgw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-977x-g7h5-7qgw",
-  "modified": "2024-08-15T17:53:05Z",
+  "modified": "2024-08-15T17:53:06Z",
   "published": "2024-08-02T09:31:35Z",
   "aliases": [
     "CVE-2024-42460"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N/E:U"
     }
   ],
   "affected": [
@@ -68,7 +64,7 @@
     "cwe_ids": [
       "CWE-130"
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-08-05T13:51:05Z",
     "nvd_published_at": "2024-08-02T07:16:10Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity

**Comments**
This seems to have been patched in version 6.5.7:
https://github.com/indutny/elliptic/pull/317
https://github.com/indutny/elliptic/compare/v6.5.6...v6.5.7