### PR TITLE
[GHSA-88g2-r9rw-g55h] gitoxide-core does not neutralize special characters for terminals

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-88g2-r9rw-g55h/GHSA-88g2-r9rw-g55h.json
+++ b/advisories/github-reviewed/2024/08/GHSA-88g2-r9rw-g55h/GHSA-88g2-r9rw-g55h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-88g2-r9rw-g55h",
-  "modified": "2024-08-22T16:41:28Z",
+  "modified": "2024-08-22T16:41:29Z",
   "published": "2024-08-22T16:41:28Z",
   "aliases": [
     "CVE-2024-43785"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -32,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.39.1"
+              "last_affected": "0.41.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Although newer versions than 0.39.1 of the [`gitoxide-core`](https://crates.io/crates/gitoxide-core/versions) crate have been released, that is coincidental and the changes in those versions are unrelated to this vulnerability, which is not yet patched. Therefore, this updates the upper bound of `gitoxide-core` versions known to be affected.

This is the same change as just made in the repository-local advisory https://github.com/Byron/gitoxide/security/advisories/GHSA-88g2-r9rw-g55h.