### PR TITLE
[GHSA-869f-px86-vj84] Mattermost Plugin Channel Export versions <=1.0.0 fail to...

### DIFF
--- a/advisories/unreviewed/2024/08/GHSA-869f-px86-vj84/GHSA-869f-px86-vj84.json
+++ b/advisories/unreviewed/2024/08/GHSA-869f-px86-vj84/GHSA-869f-px86-vj84.json
@@ -6,6 +6,7 @@
   "aliases": [
     "CVE-2024-43105"
   ],
+  "summary": "Mattermost Plugin Channel Export does not restrict concurrent runs of the /export command allowing users to consume excessive resources ",
   "details": "Mattermost Plugin Channel Export versions <=1.0.0 fail to restrict concurrent runs of the /export command which allows a user to consume excessive resource by running the /export command multiple times at once.",
   "severity": [
     {
@@ -14,12 +15,41 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/mattermost/mattermost-plugin-channel-export"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.0.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.0.0"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43105"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mattermost/mattermost-plugin-channel-export/commit/bb6da1f6bedd6cefe2276d6493b5541843c543a6"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/mattermost/mattermost-plugin-channel-export"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References
- Source code location
- Summary

**Comments**
https://github.com/mattermost/mattermost-plugin-channel-export/commit/bb6da1f6bedd6cefe2276d6493b5541843c543a6
https://github.com/c0rydoras/cves/tree/main/CVE-2024-43105