### PR TITLE
[GHSA-rv9v-r4vm-gj8x] Miniscript allows stack consumption

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-rv9v-r4vm-gj8x/GHSA-rv9v-r4vm-gj8x.json
+++ b/advisories/github-reviewed/2024/08/GHSA-rv9v-r4vm-gj8x/GHSA-rv9v-r4vm-gj8x.json
@@ -7,15 +7,11 @@
     "CVE-2024-44073"
   ],
   "summary": "Miniscript allows stack consumption",
-  "details": "The Miniscript (aka rust-miniscript) library before 12.2.0 for Rust allows stack consumption because it does not properly track tree depth.",
+  "details": "The affected versions are wrong.\n\n9.2, 10.2, 11.2 and 12.2 are all fine.",
   "severity": [
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/E:U"
     }
   ],
   "affected": [
@@ -32,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "12.2.0"
+              "fixed": "9.2.0, 10.2.0, 11.2.0, 12.2.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 9.2.0"
+      }
     }
   ],
   "references": [
@@ -70,7 +69,7 @@
       "CWE-770",
       "CWE-787"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2024-08-19T18:25:09Z",
     "nvd_published_at": "2024-08-19T03:15:03Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Severity

**Comments**
"affected verisons" are wrong, resulting in false positives.