### PR TITLE
[GHSA-fwhr-88qx-h9g7] Missing security headers in Action Pack on non-HTML responses

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-fwhr-88qx-h9g7/GHSA-fwhr-88qx-h9g7.json
+++ b/advisories/github-reviewed/2024/06/GHSA-fwhr-88qx-h9g7/GHSA-fwhr-88qx-h9g7.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fwhr-88qx-h9g7",
-  "modified": "2024-06-05T21:54:36Z",
+  "modified": "2024-06-05T21:54:37Z",
   "published": "2024-06-04T22:26:24Z",
   "aliases": [
     "CVE-2024-28103"
   ],
   "summary": "Missing security headers in Action Pack on non-HTML responses",
-  "details": "# Permissions-Policy is Only Served on HTML Content-Type\n\nThe application configurable Permissions-Policy is only served on responses\nwith an HTML related Content-Type.\n\nThis has been assigned the CVE identifier CVE-2024-28103.\n\n\nVersions Affected:  >= 6.1.0\nNot affected:       < 6.1.0\nFixed Versions:     6.1.7.8, 7.0.8.4, and 7.1.3.4\n\nImpact\n------\nResponses with a non-HTML Content-Type are not serving the configured Permissions-Policy. There are certain non-HTML Content-Types that would benefit from having the Permissions-Policy enforced.\n\n\nReleases\n--------\nThe fixed releases are available at the normal locations.\n\nWorkarounds\n-----------\nN/A\n\nPatches\n-------\nTo aid users who aren't able to upgrade immediately we have provided patches for\nthe supported release series in accordance with our \n[maintenance policy](https://guides.rubyonrails.org/maintenance_policy.html#security-issues)\nregarding security issues. They are in git-am format and consist of a\nsingle changeset.\n\n* 6-1-include-permissions-policy-header-on-non-html.patch - Patch for 6.1 series\n* 7-0-include-permissions-policy-header-on-non-html.patch - Patch for 7.0 series\n* 7-1-include-permissions-policy-header-on-non-html.patch - Patch for 7.1 series\n\n\n\nCredits\n-------\n\nThank you [shinkbr](https://hackerone.com/shinkbr) for reporting this!",
+  "details": "# Permissions-Policy is Only Served on HTML Content-Type\n\nThe application configurable Permissions-Policy is only served on responses\nwith an HTML related Content-Type.\n\nThis has been assigned the CVE identifier CVE-2024-28103.\n\n\nVersions Affected:  >= 6.1.0\nNot affected:       < 6.1.0\nFixed Versions:     6.1.7.8, 7.0.8.4,  7.1.3.4 and 7.1.4 \n\nImpact\n------\nResponses with a non-HTML Content-Type are not serving the configured Permissions-Policy. There are certain non-HTML Content-Types that would benefit from having the Permissions-Policy enforced.\n\n\nReleases\n--------\nThe fixed releases are available at the normal locations.\n\nWorkarounds\n-----------\nN/A\n\nPatches\n-------\nTo aid users who aren't able to upgrade immediately we have provided patches for\nthe supported release series in accordance with our \n[maintenance policy](https://guides.rubyonrails.org/maintenance_policy.html#security-issues)\nregarding security issues. They are in git-am format and consist of a\nsingle changeset.\n\n* 6-1-include-permissions-policy-header-on-non-html.patch - Patch for 6.1 series\n* 7-0-include-permissions-policy-header-on-non-html.patch - Patch for 7.0 series\n* 7-1-include-permissions-policy-header-on-non-html.patch - Patch for 7.1 series\n\n\n\nCredits\n-------\n\nThank you [shinkbr](https://hackerone.com/shinkbr) for reporting this!",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -66,11 +66,14 @@
               "introduced": "7.1.0"
             },
             {
-              "fixed": "7.1.3.4"
+              "fixed": "7.1.3.4, 7.1.4 "
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 7.1.3.4"
+      }
     },
     {
       "package": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
During the time of publishing this CVE, actionpack rubygem 7.1.3.4 version might be the latest one. 
But, we have actionpack 7.1.4 version released on August 22, 2024 and i even tested the 7.1.4 version in one my test environment using Dependabot (and other tools) - there were no indication of  CVE-2024-28103 on this version. 

Reference GH repo: https://github.com/rahg0/ruby-log/blob/main/Gemfile.lock
 