### PR TITLE
[GHSA-g8h2-j9pm-4xx2] Automad Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-g8h2-j9pm-4xx2/GHSA-g8h2-j9pm-4xx2.json
+++ b/advisories/github-reviewed/2024/08/GHSA-g8h2-j9pm-4xx2/GHSA-g8h2-j9pm-4xx2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-g8h2-j9pm-4xx2",
-  "modified": "2024-08-23T22:52:12Z",
+  "modified": "2024-08-23T22:52:13Z",
   "published": "2024-08-23T21:30:42Z",
   "aliases": [
     "CVE-2024-40111"
@@ -11,11 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:N/VA:N/SC:L/SI:L/SA:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -30,9 +26,6 @@
           "events": [
             {
               "introduced": "0"
-            },
-            {
-              "last_affected": "2.0.0-alpha.4"
             }
           ]
         }
@@ -59,9 +52,9 @@
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-79"
+
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2024-08-23T22:52:12Z",
     "nvd_published_at": "2024-08-23T21:15:07Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- CWEs
- Severity

**Comments**
Hello, as the maintainer of this project I would like to comment the following:

1. Please look at the security policy, before publishing such reports. Exactly this case is described there and is in fact intended behaviour! Maintainers don't write this for fun.
2. Please make sure you understand the underlying architecture of the project, the way sessions work and user privileges. All this is well documented in the main docs as well as the security policy.
3. A similar case was removed last week by the GitHub advisory team for being an obvious false positive. This is basically the same case here.
4. The security policy clearly states, how to communicate vulnerabilities. This here doesn't help.

Context: The report says, a user can inject JS code into the template. Please be aware that that user must be the (probably only) admin on a site. He has to update the template code in order to render pages. The field that is mentioned is a JS field. There is no injection, it is supposed to contain JS. 

Aside from being the only admin, that user is also the only user who has a session that could be exploited. It is absolute non-sensical that the fact that an admin changes a template is considered a vulnerability. This scenario is documented as well in the security policy. Did the reporter ever read a single line of it?

If this here is considered a vulnerability, than every static HTML page that serves JS code is as well a vulnerability.

This report shows clearly a tremendous lack of research and understanding of the project. We as open-source maintainers are flooded with nonsense reports like this and this is a dangerous development. It doesn't make the web safer. It distracts from real threats and kills time without adding any value. We all take security very seriously. That is part of open-source. 

We not only develop software, most of us also write documentation, most of the time unpaid out of pure enthusiasm. At leaset doing one's homework and looking at the documentation must be expected before submitting such a report again and again and agian!

Please remove this advisory. We just went through the same process with almost the same content last week here.
