### PR TITLE
[GHSA-328p-362g-r48j] ag-grid packages vulnerable to Prototype Pollution

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-328p-362g-r48j/GHSA-328p-362g-r48j.json
+++ b/advisories/github-reviewed/2024/07/GHSA-328p-362g-r48j/GHSA-328p-362g-r48j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-328p-362g-r48j",
-  "modified": "2024-07-12T14:00:45Z",
+  "modified": "2024-07-12T14:00:46Z",
   "published": "2024-07-01T15:32:20Z",
   "aliases": [
     "CVE-2024-39001"
@@ -101,6 +101,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/ag-grid/ag-grid"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.ag-grid.com/changelog/?fixVersion=31.3.4"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Hello,

For this vulnerability AG-Grid has also made a fix for v31.3.4, but I do not understand the UI of this form on how to include this correctly in the affected products without breaking it, my bad!

Source: https://www.ag-grid.com/changelog/?fixVersion=31.3.4