### PR TITLE
[GHSA-328p-362g-r48j] ag-grid packages vulnerable to Prototype Pollution

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-328p-362g-r48j/GHSA-328p-362g-r48j.json
+++ b/advisories/github-reviewed/2024/07/GHSA-328p-362g-r48j/GHSA-328p-362g-r48j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-328p-362g-r48j",
-  "modified": "2024-07-12T14:00:45Z",
+  "modified": "2024-07-12T14:00:46Z",
   "published": "2024-07-01T15:32:20Z",
   "aliases": [
     "CVE-2024-39001"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "32.0.0"
             },
             {
               "fixed": "32.0.1"
@@ -44,7 +44,26 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "32.0.0"
+            },
+            {
+              "fixed": "32.0.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ag-grid-enterprise"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "32.0.0"
             },
             {
               "fixed": "32.0.1"
@@ -66,7 +85,45 @@
               "introduced": "0"
             },
             {
-              "fixed": "32.0.1"
+              "fixed": "31.3.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ag-grid-community"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "31.3.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@ag-grid-enterprise/charts"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "31.3.4"
             }
           ]
         }
@@ -101,6 +158,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/ag-grid/ag-grid"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.ag-grid.com/changelog/?fixVersion=31.3.4"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
AG-Grid also implemented a fix for this in their 31.3.x version: https://www.ag-grid.com/changelog/?fixVersion=31.3.4

Hopefully this also fixes outdated npm audit information