### PR TITLE
[GHSA-c427-hjc3-wrfw] Cross-site scripting in Swagger-UI

### DIFF
--- a/advisories/github-reviewed/2019/10/GHSA-c427-hjc3-wrfw/GHSA-c427-hjc3-wrfw.json
+++ b/advisories/github-reviewed/2019/10/GHSA-c427-hjc3-wrfw/GHSA-c427-hjc3-wrfw.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c427-hjc3-wrfw",
-  "modified": "2022-07-29T17:54:58Z",
+  "modified": "2023-01-27T05:01:59Z",
   "published": "2019-10-15T19:27:05Z",
   "aliases": [
     "CVE-2019-17495"
   ],
   "summary": "Cross-site scripting in Swagger-UI",
-  "details": "A Cascading Style Sheets (CSS) injection vulnerability in Swagger UI before 3.23.11 allows attackers to use the Relative Path Overwrite (RPO) technique to perform CSS-based input field value exfiltration, such as exfiltration of a CSRF token value. In other words, this product intentionally allows the embedding of untrusted JSON data from remote servers, but it was not previously known that <style>@import within the JSON data was a functional attack method.",
+  "details": "A Cascading Style Sheets (CSS) injection vulnerability in Swagger UI before 3.23.11 allows attackers to use the Relative Path Overwrite (RPO) technique to perform CSS-based input field value exfiltration, such as exfiltration of a CSRF token value. In other words, this product intentionally allows the embedding of untrusted JSON data from remote servers, but it was not previously known that <style>@import within the JSON data was a functional attack method",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -17,8 +17,8 @@
   "affected": [
     {
       "package": {
-        "ecosystem": "npm",
-        "name": "swagger-ui"
+        "ecosystem": "Maven",
+        "name": "springfox-swagger-ui"
       },
       "ranges": [
         {
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "3.23.11"
+              "fixed": "2.10.0"
             }
           ]
         }
@@ -71,6 +71,10 @@
     {
       "type": "WEB",
       "url": "https://lists.apache.org/thread.html/ref70b940c4f69560d29d6ba792d6c82865e74de3dcad4c92d99b1f8f@%3Ccommits.airflow.apache.org%3E"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.snyk.io/vuln/maven?search=CVE-2019-17495"
     },
     {
       "type": "WEB",


### PR DESCRIPTION

The jar files contains the vulnerable npm files so the maven should registry should be also concluded as vulnerable 