### PR TITLE
[GHSA-4v6p-cxf9-98rf] Allocation of Resources Without Limits or Throttling in metadata-extractor

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-4v6p-cxf9-98rf/GHSA-4v6p-cxf9-98rf.json
+++ b/advisories/github-reviewed/2022/02/GHSA-4v6p-cxf9-98rf/GHSA-4v6p-cxf9-98rf.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4v6p-cxf9-98rf",
-  "modified": "2022-03-07T19:35:30Z",
+  "modified": "2023-02-03T05:06:28Z",
   "published": "2022-02-25T00:01:05Z",
   "aliases": [
     "CVE-2022-24614"
   ],
   "summary": "Allocation of Resources Without Limits or Throttling in metadata-extractor",
-  "details": "When reading a specially crafted JPEG file, metadata-extractor up to 2.16.0 can be made to allocate large amounts of memory that finally leads to an out-of-memory error even for very small inputs. This could be used to mount a denial of service attack against services that use metadata-extractor library.",
+  "details": "When reading a specially crafted JPEG file, metadata-extractor up to 2.17.0 can be made to allocate large amounts of memory that finally leads to an out-of-memory error even for very small inputs. This could be used to mount a denial of service attack against services that use metadata-extractor library.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.16.0"
+              "fixed": "2.18.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.17.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Per conversation in this issue thread: https://github.com/drewnoakes/metadata-extractor/issues/561

The OOM associated with this CVE was addressed in version 2.18.0: https://github.com/drewnoakes/metadata-extractor/releases/tag/2.18.0

The fix PR: https://github.com/drewnoakes/metadata-extractor/pull/570