### PR TITLE
[GHSA-j5jg-j64j-c6rq] An issue in apollocongif apollo v.2.2.0 allows a remote...

### DIFF
--- a/advisories/unreviewed/2024/08/GHSA-j5jg-j64j-c6rq/GHSA-j5jg-j64j-c6rq.json
+++ b/advisories/unreviewed/2024/08/GHSA-j5jg-j64j-c6rq/GHSA-j5jg-j64j-c6rq.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j5jg-j64j-c6rq",
-  "modified": "2024-08-26T18:33:33Z",
+  "modified": "2024-08-26T18:34:34Z",
   "published": "2024-08-20T15:32:13Z",
   "aliases": [
     "CVE-2024-42662"
   ],
-  "details": "An issue in apollocongif apollo v.2.2.0 allows a remote attacker to obtain sensitive information via a crafted request.",
+  "summary": "Misconfigured Access Control In Apollo Apollo-Adminservice",
+  "details": "A security flaw in the Apollo configuration management software, version 2.2.0, could allow attractor to steal sensitive information by sending a specially designed request. \n",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -14,7 +15,28 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.ctrip.framework.apollo:apollo-adminservice"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.3.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.2.0"
+      }
+    }
   ],
   "references": [
     {
@@ -32,7 +54,7 @@
   ],
   "database_specific": {
     "cwe_ids": [
-
+      "CWE-284"
     ],
     "severity": "HIGH",
     "github_reviewed": false,


### PR DESCRIPTION
**Updates**
- Affected products
- CWEs
- Description
- Summary

**Comments**
The CVE author provided a link (https://gist.github.com/len0m0/f0886d579de6c075506ab543e054dc7d) and referenced information from a previous Apollo vulnerability (https://github.com/apolloconfig/apollo/security/advisories/GHSA-xpmx-h7xq-xffh) to fill in missing details.