### PR TITLE
[GHSA-62wp-583h-jvfj] In AFL++ 4.05c, the CmpLog component uses the current...

### DIFF
--- a/advisories/unreviewed/2023/02/GHSA-62wp-583h-jvfj/GHSA-62wp-583h-jvfj.json
+++ b/advisories/unreviewed/2023/02/GHSA-62wp-583h-jvfj/GHSA-62wp-583h-jvfj.json
@@ -1,20 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-62wp-583h-jvfj",
-  "modified": "2023-03-03T00:30:45Z",
+  "modified": "2023-03-10T05:06:03Z",
   "published": "2023-02-21T06:30:15Z",
   "aliases": [
     "CVE-2023-26266"
   ],
+  "summary": "AFL++ v4.05c local privilege escalation vulnerability",
   "details": "In AFL++ 4.05c, the CmpLog component uses the current working directory to resolve and execute unprefixed fuzzing targets, allowing code execution.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:L/I:L/A:L"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -30,7 +46,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "CRITICAL",
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2023-02-21T04:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity
- Summary

**Comments**
it is a local vuln that requires user interaction, and result is access to a different user account.
It does not affect another product but this form requires to put something ...