### PR TITLE
[GHSA-5qxq-95fv-whxm] An issue was discovered in Matrix libolm (aka Olm)...

### DIFF
--- a/advisories/unreviewed/2024/08/GHSA-5qxq-95fv-whxm/GHSA-5qxq-95fv-whxm.json
+++ b/advisories/unreviewed/2024/08/GHSA-5qxq-95fv-whxm/GHSA-5qxq-95fv-whxm.json
@@ -1,20 +1,39 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5qxq-95fv-whxm",
-  "modified": "2024-08-22T21:31:29Z",
+  "modified": "2024-08-22T21:32:33Z",
   "published": "2024-08-22T18:31:22Z",
   "aliases": [
     "CVE-2024-45192"
   ],
-  "details": "An issue was discovered in Matrix libolm (aka Olm) through 3.2.16. Cache-timing attacks can occur due to use of base64 when decoding group session keys. NOTE: This vulnerability only affects products that are no longer supported by the maintainer.",
+  "summary": "Cache-timing attacks due to use of base64 when decoding group session keys in libolm",
+  "details": "An issue was discovered in Matrix libolm through 3.2.16. Cache-timing attacks can occur due to use of base64 when decoding group session keys. NOTE: This vulnerability only affects products that are no longer supported by the maintainer.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:L/I:N/A:N"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "libolm"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.2.16"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -42,7 +61,7 @@
     "cwe_ids": [
       "CWE-385"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2024-08-22T16:15:10Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Description
- Severity
- Summary

**Comments**
"Olm" is a protocol, not the software library with the vulnerability.
The CVSS score was inaccurate.
I am a member of the Matrix.org Foundation security team.
I was forced to select an "ecosystem" even if this advisory is for a C++ project.