### PR TITLE
[GHSA-4265-ccf5-phj5] Apache Commons Compress: OutOfMemoryError unpacking broken Pack200 file

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-4265-ccf5-phj5/GHSA-4265-ccf5-phj5.json
+++ b/advisories/github-reviewed/2024/02/GHSA-4265-ccf5-phj5/GHSA-4265-ccf5-phj5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4265-ccf5-phj5",
-  "modified": "2024-03-07T18:30:27Z",
+  "modified": "2024-03-07T18:30:28Z",
   "published": "2024-02-19T09:30:52Z",
   "aliases": [
     "CVE-2024-26308"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
     }
   ],
   "affected": [
@@ -61,7 +61,7 @@
     "cwe_ids": [
       "CWE-770"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-02-20T23:59:29Z",
     "nvd_published_at": "2024-02-19T09:15:38Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
Updated vector accrding to the NVD: https://nvd.nist.gov/vuln/detail/CVE-2024-26308