### PR TITLE
[GHSA-49gw-vxvf-fc2g] The various Is methods (IsPrivate, IsLoopback, etc) did...

### DIFF
--- a/advisories/unreviewed/2024/06/GHSA-49gw-vxvf-fc2g/GHSA-49gw-vxvf-fc2g.json
+++ b/advisories/unreviewed/2024/06/GHSA-49gw-vxvf-fc2g/GHSA-49gw-vxvf-fc2g.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-49gw-vxvf-fc2g",
-  "modified": "2024-06-18T18:31:18Z",
+  "modified": "2024-06-18T18:32:21Z",
   "published": "2024-06-05T18:30:34Z",
   "aliases": [
     "CVE-2024-24790"
   ],
+  "summary": "The various Is methods did not work as expected for IPv4-mapped IPv6 addresses, returning false for addresses which would return true in their traditional IPv4 forms.",
   "details": "The various Is methods (IsPrivate, IsLoopback, etc) did not work as expected for IPv4-mapped IPv6 addresses, returning false for addresses which would return true in their traditional IPv4 forms.",
   "severity": [
     {
@@ -14,7 +15,44 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "net/netip"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.21.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "net/netip"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.22.4"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
**Updates**
- Affected products
- Summary

**Comments**
The package name and affected versions are not showing on the github advisory. I believe this might be the reason for which dependabot did not flag it.

I'm also not sure how to specify that the issue affects go 1.22.0 through 1.22.4