### PR TITLE
[GHSA-w7pm-cc4v-f3g8] Deserialization of Untrusted Data in Liferay Portal

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-w7pm-cc4v-f3g8/GHSA-w7pm-cc4v-f3g8.json
+++ b/advisories/github-reviewed/2022/05/GHSA-w7pm-cc4v-f3g8/GHSA-w7pm-cc4v-f3g8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w7pm-cc4v-f3g8",
-  "modified": "2024-08-14T12:54:33Z",
+  "modified": "2024-08-14T12:55:45Z",
   "published": "2022-05-24T17:12:05Z",
   "aliases": [
     "CVE-2020-7961"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -32,13 +28,13 @@
               "introduced": "0"
             },
             {
-              "fixed": "7.2.1"
+              "fixed": "4.35.3"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 7.2.0"
+        "last_known_affected_version_range": "<= 4.35.2"
       }
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The Version of com.liferay.portal.kernel does _not_ match the version of Liferay Portal. The CVE is reported for Liferay Portal prior to 7.2.1 CE GA2, which contains according to https://github.com/liferay/liferay-portal/blob/7.2.1-ga2/portal-kernel/bnd.bnd the package com.liferay.portal.kernel:4.35.3