### PR TITLE
[GHSA-45rp-q25w-4426] pretix Stored Cross-site Scripting vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-45rp-q25w-4426/GHSA-45rp-q25w-4426.json
+++ b/advisories/github-reviewed/2024/08/GHSA-45rp-q25w-4426/GHSA-45rp-q25w-4426.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-45rp-q25w-4426",
-  "modified": "2024-08-23T18:51:02Z",
+  "modified": "2024-08-23T18:51:03Z",
   "published": "2024-08-23T15:30:34Z",
   "aliases": [
     "CVE-2024-8113"
@@ -10,8 +10,8 @@
   "details": "Stored XSS in organizer and event settings of pretix up to 2024.7.0 allows malicious event organizers to inject HTML tags into e-mail previews on settings page. The default Content Security Policy of pretix prevents execution of attacker-provided scripts, making exploitation unlikely. However, combined with a CSP bypass (which is not currently known) the vulnerability could be used to impersonate other organizers or staff users.",
   "severity": [
     {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:H/AT:P/PR:H/UI:P/VC:H/VI:H/VA:N/SC:N/SI:N/SA:N/E:X/CR:X/IR:X/AR:X/MAV:X/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:U/V:X/RE:L/U:Green"
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:C/C:L/I:L/A:L"
     }
   ],
   "affected": [
@@ -57,7 +57,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-08-23T18:51:02Z",
     "nvd_published_at": "2024-08-23T15:15:17Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS
- Severity

**Comments**
Even though <script> tags could be inserted into the control panel using this vulnerability, they wouldn't be executed by the browser, due to a Content Security Policy blocking inline and remote scripts. Therefore, the security impact on a typical pretix installation is low.