### PR TITLE
Don't run branch deletion on fork PRs.

### DIFF
--- a/.github/workflows/delete_staging_and_head_branches.yaml
+++ b/.github/workflows/delete_staging_and_head_branches.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   delete-staging-and-head-branches:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
      - uses: actions/checkout@v2


### PR DESCRIPTION
This fixes a very low risk security issue in the workflow, as someone could delete arbitrary branches by creating PRs. The workflow is only intended for non-fork PRs, so this just enforces that.

Had originally submitted through bug bounty but it wasn't considered serious enough so I am making a PR to fix it instead.