### PR TITLE
[GHSA-hxwh-jpp2-84pm] Flask-CORS allows the `Access-Control-Allow-Private-Network` CORS header to be set to true by default

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-hxwh-jpp2-84pm/GHSA-hxwh-jpp2-84pm.json
+++ b/advisories/github-reviewed/2024/08/GHSA-hxwh-jpp2-84pm/GHSA-hxwh-jpp2-84pm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hxwh-jpp2-84pm",
-  "modified": "2024-08-21T14:45:02Z",
+  "modified": "2024-08-21T14:45:04Z",
   "published": "2024-08-18T21:31:07Z",
   "aliases": [
     "CVE-2024-6221"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -32,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "4.0.1"
+              "fixed": "5.0.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.0.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Made configurable in 4.0.2, defaulting to false in 5.0.0:

https://github.com/corydolphin/flask-cors/issues/362
https://github.com/corydolphin/flask-cors/pull/363
https://github.com/corydolphin/flask-cors/pull/368
