### PR TITLE
[GHSA-8x94-hmjh-97hq] Django vulnerable to Reflected File Download attack 

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-8x94-hmjh-97hq/GHSA-8x94-hmjh-97hq.json
+++ b/advisories/github-reviewed/2022/08/GHSA-8x94-hmjh-97hq/GHSA-8x94-hmjh-97hq.json
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.2"
+              "introduced": "0"
             },
             {
               "fixed": "3.2.15"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The vulnerability exists in earlier versions as well.
See the listing in Snyk - https://security.snyk.io/vuln/SNYK-PYTHON-DJANGO-2968205
For example version 2.2.28 - https://github.com/django/django/blob/2.2.28/django/http/response.py#L445C56-L445C64