### PR TITLE
[GHSA-4vvj-4cpr-p986] Webpack's AutoPublicPathRuntimeModule has a DOM Clobbering Gadget that leads to XSS

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-4vvj-4cpr-p986/GHSA-4vvj-4cpr-p986.json
+++ b/advisories/github-reviewed/2024/08/GHSA-4vvj-4cpr-p986/GHSA-4vvj-4cpr-p986.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4vvj-4cpr-p986",
-  "modified": "2024-08-27T19:50:40Z",
+  "modified": "2024-08-27T19:50:41Z",
   "published": "2024-08-27T19:50:40Z",
   "aliases": [
     "CVE-2024-43788"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:H/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -29,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "5.0.0"
             },
             {
               "fixed": "5.94.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
v4 and below of Webpack are not affected by this vulnerability. See https://github.com/webpack/webpack/issues/18718#issuecomment-2326296270.