### PR TITLE
[GHSA-cxww-7g56-2vh6] @actions/download-artifact has an Arbitrary File Write via artifact extraction

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-cxww-7g56-2vh6/GHSA-cxww-7g56-2vh6.json
+++ b/advisories/github-reviewed/2024/09/GHSA-cxww-7g56-2vh6/GHSA-cxww-7g56-2vh6.json
@@ -1,21 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cxww-7g56-2vh6",
-  "modified": "2024-09-03T20:55:34Z",
+  "modified": "2024-09-03T20:55:35Z",
   "published": "2024-09-03T20:55:34Z",
   "aliases": [
 
   ],
   "summary": "@actions/download-artifact has an Arbitrary File Write via artifact extraction",
-  "details": "### Impact\n\nVersions of `actions/download-artifact` before 4.1.7 are vulnerable to arbitrary file write when downloading and extracting a specifically crafted artifact that contains path traversal filenames.\n\n### Patches\n\nUpgrade to version 4.1.7 or higher. Alternatively use 'v4' tag which points to the latest and secure version.\n\n### References\n\n- https://snyk.io/research/zip-slip-vulnerability\n- https://github.com/actions/download-artifact/releases/tag/v4.1.7\n\n### CVE\n\nCVE-2024-42471\n\n### Credits\n\nJustin Taft from Google",
+  "details": "### Impact\n\nVersions of `actions/download-artifact` before 2.1.7 are vulnerable to arbitrary file write when downloading and extracting a specifically crafted artifact that contains path traversal filenames.\n\n### Patches\n\nUpgrade to version 2.1.7 or higher. Alternatively use 'v4' tag which points to the latest and secure version.\n\n### References\n\n- https://snyk.io/research/zip-slip-vulnerability\n- https://github.com/actions/download-artifact/releases/tag/v2.1.7\n\n### CVE\n\nCVE-2024-42471\n\n### Credits\n\nJustin Taft from Google",
   "severity": [
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:N"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -32,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.1.7"
+              "fixed": "2.1.7"
             }
           ]
         }
@@ -50,7 +46,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/actions/download-artifact/releases/tag/v4.1.7"
+      "url": "https://github.com/actions/download-artifact/releases/tag/v2.1.7"
     },
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
CVE-2024-42471 affects version 2.1.7 not 4.1.7. Go re-read the linked CVE.