### PR TITLE
[GHSA-6q32-hq47-5qq3] @actions/artifact has an Arbitrary File Write via artifact extraction

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-6q32-hq47-5qq3/GHSA-6q32-hq47-5qq3.json
+++ b/advisories/github-reviewed/2024/09/GHSA-6q32-hq47-5qq3/GHSA-6q32-hq47-5qq3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6q32-hq47-5qq3",
-  "modified": "2024-09-03T20:08:30Z",
+  "modified": "2024-09-03T20:08:31Z",
   "published": "2024-09-03T20:08:30Z",
   "aliases": [
     "CVE-2024-42471"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:N"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -29,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0.0"
             },
             {
               "fixed": "2.1.7"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The @actions/artifact v1 does not depend on unzip-stream v0.3.1, which contains the vulnerability[1] , so the v1 version, used by both @actions/upload-artifact v3 and @actions/download-artifact v3, is not affected by this CVE.

[1]: https://github.com/mhr3/unzip-stream/security/advisories/GHSA-6jrj-vc65-c983