### PR TITLE
[GHSA-ghg6-32f9-2jp7] XXE in PHPSpreadsheet encoding is returned

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-ghg6-32f9-2jp7/GHSA-ghg6-32f9-2jp7.json
+++ b/advisories/github-reviewed/2024/08/GHSA-ghg6-32f9-2jp7/GHSA-ghg6-32f9-2jp7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ghg6-32f9-2jp7",
-  "modified": "2024-08-29T17:58:27Z",
+  "modified": "2024-08-29T17:58:28Z",
   "published": "2024-08-29T17:58:27Z",
   "aliases": [
     "CVE-2024-45048"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -33,6 +29,25 @@
             },
             {
               "fixed": "2.2.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "phpoffice/phpspreadsheet"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.29.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
based on newly updated version of PhpSpreadsheet (1.29.1), https://github.com/PHPOffice/PhpSpreadsheet/security/advisories/GHSA-ghg6-32f9-2jp7