### PR TITLE
[GHSA-ghg6-32f9-2jp7] XXE in PHPSpreadsheet encoding is returned

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-ghg6-32f9-2jp7/GHSA-ghg6-32f9-2jp7.json
+++ b/advisories/github-reviewed/2024/08/GHSA-ghg6-32f9-2jp7/GHSA-ghg6-32f9-2jp7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ghg6-32f9-2jp7",
-  "modified": "2024-08-29T17:58:27Z",
+  "modified": "2024-08-29T17:58:28Z",
   "published": "2024-08-29T17:58:27Z",
   "aliases": [
     "CVE-2024-45048"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -32,7 +28,29 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.2.1"
+              "fixed": "2.2.1, 1.29.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.2.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "phpoffice/phpspreadsheet"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.29.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Patch appears to have been backported to v1.29.1, see https://github.com/PHPOffice/PhpSpreadsheet/releases/tag/1.29.1