### PR TITLE
[GHSA-wgmf-q9vr-vww6] PhpSpreadsheet HTML writer is vulnerable to Cross-Site Scripting via style information

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-wgmf-q9vr-vww6/GHSA-wgmf-q9vr-vww6.json
+++ b/advisories/github-reviewed/2024/08/GHSA-wgmf-q9vr-vww6/GHSA-wgmf-q9vr-vww6.json
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:A/VC:N/VI:N/VA:N/SC:L/SI:L/SA:N"
     }
   ],
   "affected": [
@@ -30,6 +26,25 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "1.29.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "phpoffice/phpspreadsheet"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0"
             },
             {
               "fixed": "2.1.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Also fixed version 1^ in https://github.com/PHPOffice/PhpSpreadsheet/releases/tag/1.29.1