### PR TITLE
[GHSA-cfxw-4h78-h7fw] DNSJava DNSSEC Bypass

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-cfxw-4h78-h7fw/GHSA-cfxw-4h78-h7fw.json
+++ b/advisories/github-reviewed/2024/07/GHSA-cfxw-4h78-h7fw/GHSA-cfxw-4h78-h7fw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cfxw-4h78-h7fw",
-  "modified": "2024-07-22T16:55:11Z",
+  "modified": "2024-08-01T05:06:15Z",
   "published": "2024-07-22T14:33:41Z",
   "aliases": [
     "CVE-2024-25638"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:L"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:N/SC:H/SI:H/SA:L"
     }
   ],
   "affected": [
@@ -50,7 +46,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/dnsjava/dnsjava/commit/bc51df1c455e6c9fb7cbd42fcb6d62d16047818d"
+      "url": "https://github.com/dnsjava/dnsjava/commit/2073a0cdea2c560465f7ac0cc56f202e6fc39705"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The link is wrong, added the right commit addressing the vulnerability - https://github.com/dnsjava/dnsjava/commit/2073a0cdea2c560465f7ac0cc56f202e6fc39705