### PR TITLE
[GHSA-mmwx-rj87-vfgr] DNSJava affected by KeyTrap - NSEC3 closest encloser proof can exhaust CPU resources

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-mmwx-rj87-vfgr/GHSA-mmwx-rj87-vfgr.json
+++ b/advisories/github-reviewed/2024/07/GHSA-mmwx-rj87-vfgr/GHSA-mmwx-rj87-vfgr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mmwx-rj87-vfgr",
-  "modified": "2024-07-22T15:30:55Z",
+  "modified": "2024-08-01T05:06:15Z",
   "published": "2024-07-22T14:46:59Z",
   "aliases": [
 
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -51,6 +47,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/dnsjava/dnsjava"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2023-50868"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
https://github.com/dnsjava/dnsjava/commit/711af79be3214f52daa5c846b95766dc0a075116 was assigned 
CVE-2023-50868