### PR TITLE
[GHSA-j9wf-vvm6-4r9w] Unverified Ownership in Kubernetes

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-j9wf-vvm6-4r9w/GHSA-j9wf-vvm6-4r9w.json
+++ b/advisories/github-reviewed/2022/02/GHSA-j9wf-vvm6-4r9w/GHSA-j9wf-vvm6-4r9w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j9wf-vvm6-4r9w",
-  "modified": "2022-10-31T15:56:21Z",
+  "modified": "2023-01-29T05:06:36Z",
   "published": "2022-02-08T21:50:34Z",
   "aliases": [
     "CVE-2020-8554"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.22.0"
+              "fixed": "1.21.0-alpha.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.22.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
CVE-2020-8554 was addressed in commit 9d81c4e. However, upon analyzing the commit, we observed that the patch version (v1.21.0-alpha.1)