### PR TITLE
[GHSA-v435-xc8x-wvr9] Bouncy Castle affected by timing side-channel for RSA key exchange ("The Marvin Attack")

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-v435-xc8x-wvr9/GHSA-v435-xc8x-wvr9.json
+++ b/advisories/github-reviewed/2024/05/GHSA-v435-xc8x-wvr9/GHSA-v435-xc8x-wvr9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v435-xc8x-wvr9",
-  "modified": "2024-06-14T15:31:25Z",
+  "modified": "2024-06-14T15:32:27Z",
   "published": "2024-05-14T15:32:54Z",
   "aliases": [
     "CVE-2024-30171"
@@ -200,63 +200,6 @@
             },
             {
               "fixed": "2.3.1"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.bouncycastle:bcpkix-jdk18on"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.78"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.bouncycastle:bcpkix-jdk15to18"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.78"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.bouncycastle:bcpkix-jdk14"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.78"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
As can be seen in the fixing commits - 
https://github.com/bcgit/bc-java/commit/d7d5e735abd64bf0f413f54fd9e495fc02400fb0
https://github.com/bcgit/bc-java/commit/e0569dcb1dea9d421d84fc4c5c5688fe101afa2d
The fixes are affecting jcajce, tls, crypto modules, while the bcpkix jar doesn't include those modules - https://github.com/bcgit/bc-java/blob/r1rv77/ant/bc%2B-build.xml#L804-L819 .
Hence, bcpkix packages aren't affected by this vulnerability.