### PR TITLE
[GHSA-m44j-cfrm-g8qc] Bouncy Castle crafted signature and public key can be used to trigger an infinite loop

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-m44j-cfrm-g8qc/GHSA-m44j-cfrm-g8qc.json
+++ b/advisories/github-reviewed/2024/05/GHSA-m44j-cfrm-g8qc/GHSA-m44j-cfrm-g8qc.json
@@ -150,63 +150,6 @@
     },
     {
       "package": {
-        "ecosystem": "Maven",
-        "name": "org.bouncycastle:bcpkix-jdk18on"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.78"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.bouncycastle:bcpkix-jdk15to18"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.78"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.bouncycastle:bcpkix-jdk14"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.78"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
         "ecosystem": "NuGet",
         "name": "BouncyCastle"
       },
@@ -248,6 +191,14 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-30172"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/bcgit/bc-java/commit/9c165791b68a204678b48ec11e4e579754c2ea49"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/bcgit/bc-java/commit/ebe1c75579170072dc59b8dee2b55ce31663178f"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
As can be seen in the fixing commits - 
https://github.com/bcgit/bc-java/commit/9c165791b68a204678b48ec11e4e579754c2ea49
https://github.com/bcgit/bc-java/commit/ebe1c75579170072dc59b8dee2b55ce31663178f
The fixes are affecting math module, while the bcpkix jar doesn't include this module - https://github.com/bcgit/bc-java/blob/r1rv77/ant/bc%2B-build.xml#L804-L819 .
Hence, bcpkix packages aren't affected by this vulnerability.