### PR TITLE
[GHSA-8xfc-gm6g-vgpv] Bouncy Castle certificate parsing issues cause high CPU usage during parameter evaluation.

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-8xfc-gm6g-vgpv/GHSA-8xfc-gm6g-vgpv.json
+++ b/advisories/github-reviewed/2024/05/GHSA-8xfc-gm6g-vgpv/GHSA-8xfc-gm6g-vgpv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8xfc-gm6g-vgpv",
-  "modified": "2024-08-15T21:38:13Z",
+  "modified": "2024-08-15T21:38:17Z",
   "published": "2024-05-14T15:32:54Z",
   "aliases": [
     "CVE-2024-29857"
@@ -151,63 +151,6 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.bouncycastle:bcpkix-jdk18on"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.78"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.bouncycastle:bcpkix-jdk15to18"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.78"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.bouncycastle:bcpkix-jdk14"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.78"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
         "name": "org.bouncycastle:bc-fips"
       },
       "ranges": [
@@ -271,6 +214,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/bcgit/bc-csharp/commit/56daa6eac526f165416d17f661422d60de0dfd63"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/bcgit/bc-java/commit/efc498ca4caa340ac2fe11f2efee06c1a294501f"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
As can be seen in the fixing commits -
https://github.com/bcgit/bc-java/commit/fee80dd230e7fba132d03a34f1dd1d6aae0d0281
https://github.com/bcgit/bc-java/commit/efc498ca4caa340ac2fe11f2efee06c1a294501f 
The fixes are affecting math module, while the bcpkix jar doesn't include this module - https://github.com/bcgit/bc-java/blob/r1rv77/ant/bc%2B-build.xml#L804-L819 .
Hence, bcpkix packages aren't affected by this vulnerability.