### PR TITLE
[GHSA-m3jw-62m7-jjcm] typed-ast Out-of-bounds Read

### DIFF
--- a/advisories/github-reviewed/2019/12/GHSA-m3jw-62m7-jjcm/GHSA-m3jw-62m7-jjcm.json
+++ b/advisories/github-reviewed/2019/12/GHSA-m3jw-62m7-jjcm/GHSA-m3jw-62m7-jjcm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m3jw-62m7-jjcm",
-  "modified": "2023-09-05T14:46:42Z",
+  "modified": "2023-09-05T14:46:43Z",
   "published": "2019-12-02T18:02:02Z",
   "aliases": [
     "CVE-2019-19274"
@@ -28,7 +28,7 @@
               "introduced": "1.3.0"
             },
             {
-              "fixed": "1.4.0"
+              "fixed": ">=1.3.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
1.3.2 contains the fixes for this out-of-bounds-read: https://github.com/python/typed_ast/compare/1.3.1...1.3.2

Snyk provides a vulnerability correctly targeting 1.3.2 as fixed for this CVE - https://security.snyk.io/vuln/SNYK-PYTHON-TYPEDAST-535627
NVD CPE also only targets 1.3.0 and 1.3.1, as well as the CVE description  - https://nvd.nist.gov/vuln/detail/CVE-2019-19274