### PR TITLE
[GHSA-6j75-5wfj-gh66] Twig has a possible sandbox bypass

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-6j75-5wfj-gh66/GHSA-6j75-5wfj-gh66.json
+++ b/advisories/github-reviewed/2024/09/GHSA-6j75-5wfj-gh66/GHSA-6j75-5wfj-gh66.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6j75-5wfj-gh66",
-  "modified": "2024-09-09T21:46:01Z",
+  "modified": "2024-09-09T21:46:02Z",
   "published": "2024-09-09T20:19:26Z",
   "aliases": [
     "CVE-2024-45411"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:N/VI:N/VA:N/SC:H/SI:H/SA:H"
     }
   ],
   "affected": [
@@ -68,6 +64,28 @@
           "events": [
             {
               "introduced": "3.0.0"
+            },
+            {
+              "fixed": "3.11.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.11.0"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "twig/twig"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.12.0"
             },
             {
               "fixed": "3.14.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Update the advisory to account for the backporting of the patch in a 3.11.1 release.

this matches the updated advisory at https://github.com/twigphp/Twig/security/advisories/GHSA-6j75-5wfj-gh66