### PR TITLE
[GHSA-pwh8-58vv-vw48] Jetty's OpenId Revoked authentication allows one request

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-pwh8-58vv-vw48/GHSA-pwh8-58vv-vw48.json
+++ b/advisories/github-reviewed/2023/09/GHSA-pwh8-58vv-vw48/GHSA-pwh8-58vv-vw48.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pwh8-58vv-vw48",
-  "modified": "2023-09-15T13:36:10Z",
+  "modified": "2024-01-22T20:31:21Z",
   "published": "2023-09-15T13:36:10Z",
   "aliases": [
     "CVE-2023-41900"
@@ -28,7 +28,7 @@
               "introduced": "9.4.21"
             },
             {
-              "fixed": "9.4.52"
+              "fixed": "9.4.52.v20230823"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The 9.x line fix version was incomplete, meaning any automation could not use that version as is. With this fix the .patch version can be dropped in to resolve the issue.