### PR TITLE
[GHSA-58qw-p7qm-5rvh] Eclipse Jetty XmlParser allows arbitrary DOCTYPE declarations

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-58qw-p7qm-5rvh/GHSA-58qw-p7qm-5rvh.json
+++ b/advisories/github-reviewed/2023/07/GHSA-58qw-p7qm-5rvh/GHSA-58qw-p7qm-5rvh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-58qw-p7qm-5rvh",
-  "modified": "2023-09-05T22:39:31Z",
+  "modified": "2023-09-05T22:39:32Z",
   "published": "2023-07-10T21:52:39Z",
   "aliases": [
 
@@ -25,16 +25,16 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "10.0.0-alpha0"
+              "introduced": "11.0.0-alpha0"
             },
             {
-              "fixed": "10.0.16"
+              "fixed": "11.0.16"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 10.0.15"
+        "last_known_affected_version_range": "<= 11.0.15"
       }
     },
     {
@@ -47,16 +47,16 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "11.0.0-alpha0"
+              "introduced": "10.0.0-alpha0"
             },
             {
-              "fixed": "11.0.16"
+              "fixed": "10.0.16"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 11.0.15"
+        "last_known_affected_version_range": "<= 10.0.15"
       }
     },
     {
@@ -94,7 +94,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "9.4.52"
+              "fixed": "9.4.52.v20230823"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The 9.x line fix version was incomplete, meaning any automation could not use that version as is. With this fix the .patch version can be dropped in to resolve the issue.