### PR TITLE
[GHSA-8xfx-rj4p-23jm] Calling any of the Parse functions on Go source code...

### DIFF
--- a/advisories/unreviewed/2024/09/GHSA-8xfx-rj4p-23jm/GHSA-8xfx-rj4p-23jm.json
+++ b/advisories/unreviewed/2024/09/GHSA-8xfx-rj4p-23jm/GHSA-8xfx-rj4p-23jm.json
@@ -1,22 +1,64 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8xfx-rj4p-23jm",
-  "modified": "2024-09-06T21:32:28Z",
+  "modified": "2024-09-06T21:32:33Z",
   "published": "2024-09-06T21:32:28Z",
   "aliases": [
     "CVE-2024-34155"
   ],
-  "details": "Calling any of the Parse functions on Go source code which contains deeply nested literals can cause a panic due to stack exhaustion.",
+  "summary": "Stack exhaustion in all Parse functions in go/parser",
+  "details": "### Impact\n_What kind of vulnerability is it?_\n\nCalling any of the Parse functions on Go source code which contains deeply nested literals can cause a panic due to stack exhaustion.\n\n### Patches\n_Has the problem been patched? What versions should users upgrade to?_\n\nUsers should upgrade to go1.23.1 or go1.22.7.\n\n### Workarounds\n_Is there a way for users to fix or remediate the vulnerability without upgrading?_\n\nThere are no safe alternatives to upgrading.\n\n### For more information\nIf you have any questions or comments about this advisory:\n* Open an issue in [Go](https://github.com/golang/go/issues/)",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "go/parser"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.23.0-0"
+            },
+            {
+              "fixed": "1.23.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "go/parser"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.22.7"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-34155"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/golang/go"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Source code location
- Summary

**Comments**
Added information to advisory because vulnerability has since been patched: https://github.com/golang/go/commit/dd20195 and https://groups.google.com/g/golang-dev/c/S9POB9NCTdk
