### PR TITLE
[GHSA-mmwx-rj87-vfgr] DNSJava affected by KeyTrap - NSEC3 closest encloser proof can exhaust CPU resources

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-mmwx-rj87-vfgr/GHSA-mmwx-rj87-vfgr.json
+++ b/advisories/github-reviewed/2024/07/GHSA-mmwx-rj87-vfgr/GHSA-mmwx-rj87-vfgr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mmwx-rj87-vfgr",
-  "modified": "2024-09-04T14:27:34Z",
+  "modified": "2024-09-04T14:27:35Z",
   "published": "2024-07-22T14:46:59Z",
   "aliases": [
 
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -29,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.5.0"
             },
             {
               "fixed": "3.6.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Based on https://github.com/dnsjava/dnsjava/commit/711af79be3214f52daa5c846b95766dc0a075116
Vulnerability is irrelevant to the origin version, the entire fix is in dnssec folder, which was only added in version 3.5, as per changelog