### PR TITLE
[GHSA-crjg-w57m-rqqf] DNSJava vulnerable to KeyTrap - Denial-of-Service Algorithmic Complexity Attacks

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-crjg-w57m-rqqf/GHSA-crjg-w57m-rqqf.json
+++ b/advisories/github-reviewed/2024/07/GHSA-crjg-w57m-rqqf/GHSA-crjg-w57m-rqqf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-crjg-w57m-rqqf",
-  "modified": "2024-09-04T14:29:10Z",
+  "modified": "2024-09-04T14:29:12Z",
   "published": "2024-07-22T17:30:19Z",
   "aliases": [
 
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -29,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "3.5.0"
             },
             {
               "fixed": "3.6.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Based on https://github.com/dnsjava/dnsjava/commit/07ac36a11578cc1bce0cd8ddf2fe568f062aee78 and https://github.com/dnsjava/dnsjava/commit/3ddc45ce8cdb5c2274e10b7401416f497694e1cf
Vulnerability is irrelevant to the origin version, the fix is in `dnssec` folder, which was only added in version 3.5, as per changelog