### PR TITLE
[GHSA-9wv6-86v2-598j] path-to-regexp outputs backtracking regular expressions

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-9wv6-86v2-598j/GHSA-9wv6-86v2-598j.json
+++ b/advisories/github-reviewed/2024/09/GHSA-9wv6-86v2-598j/GHSA-9wv6-86v2-598j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9wv6-86v2-598j",
-  "modified": "2024-09-10T16:14:09Z",
+  "modified": "2024-09-10T16:14:10Z",
   "published": "2024-09-09T20:19:15Z",
   "aliases": [
     "CVE-2024-45296"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/E:P"
     }
   ],
   "affected": [
@@ -49,6 +45,25 @@
           "events": [
             {
               "introduced": "0.2.0"
+            },
+            {
+              "fixed": "1.9.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "path-to-regexp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0"
             },
             {
               "fixed": "8.0.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Fix has been backported to 1.x branch, 1.9.0 is now also not vulnerable.