### PR TITLE
[GHSA-9wv6-86v2-598j] path-to-regexp outputs backtracking regular expressions

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-9wv6-86v2-598j/GHSA-9wv6-86v2-598j.json
+++ b/advisories/github-reviewed/2024/09/GHSA-9wv6-86v2-598j/GHSA-9wv6-86v2-598j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9wv6-86v2-598j",
-  "modified": "2024-09-10T16:14:09Z",
+  "modified": "2024-09-10T16:14:10Z",
   "published": "2024-09-09T20:19:15Z",
   "aliases": [
     "CVE-2024-45296"
@@ -12,10 +12,6 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/E:P"
     }
   ],
   "affected": [
@@ -48,10 +44,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0.2.0"
+              "introduced": "4.0.0"
             },
             {
               "fixed": "8.0.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "path-to-regexp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.2.0-3.3.0"
+            },
+            {
+              "fixed": "3.3.0"
             }
           ]
         }
@@ -73,7 +88,15 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/pillarjs/path-to-regexp/commit/2eb12934fc1f15d3b9bad010709717fc53a14b8e"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/pillarjs/path-to-regexp/commit/60f2121e9b66b7b622cc01080df0aabda9eedee6"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pillarjs/path-to-regexp/commit/d31670ae8f6e69cbfd56e835742195b7d10942ef"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
release 3.3.0 was published to resolve this issue --> https://github.com/pillarjs/path-to-regexp/releases/tag/v3.3.0

code fix = https://github.com/pillarjs/path-to-regexp/commit/d31670ae8f6e69cbfd56e835742195b7d10942ef
tag bump for this fix = https://github.com/pillarjs/path-to-regexp/commit/2eb12934fc1f15d3b9bad010709717fc53a14b8e