### PR TITLE
[GHSA-9wv6-86v2-598j] path-to-regexp outputs backtracking regular expressions

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-9wv6-86v2-598j/GHSA-9wv6-86v2-598j.json
+++ b/advisories/github-reviewed/2024/09/GHSA-9wv6-86v2-598j/GHSA-9wv6-86v2-598j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9wv6-86v2-598j",
-  "modified": "2024-09-11T17:17:47Z",
+  "modified": "2024-09-11T17:17:48Z",
   "published": "2024-09-09T20:19:15Z",
   "aliases": [
     "CVE-2024-45296"
@@ -12,32 +12,9 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/E:P"
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "path-to-regexp"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0.2.0"
-            },
-            {
-              "fixed": "1.9.0"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "npm",
@@ -67,7 +44,26 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.0.0"
+              "introduced": "0.2.0"
+            },
+            {
+              "fixed": "1.9.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "path-to-regexp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "7.0.0"
             },
             {
               "fixed": "8.0.0"
@@ -90,6 +86,25 @@
             },
             {
               "fixed": "3.3.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "path-to-regexp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.0.0"
+            },
+            {
+              "fixed": "6.3.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Version 6.3.0 patched in https://github.com/pillarjs/path-to-regexp/pull/324