### PR TITLE
[GHSA-mv6w-j4xc-qpfw] Argo CD leaks repository credentials in user-facing error messages and in logs

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-mv6w-j4xc-qpfw/GHSA-mv6w-j4xc-qpfw.json
+++ b/advisories/github-reviewed/2023/02/GHSA-mv6w-j4xc-qpfw/GHSA-mv6w-j4xc-qpfw.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mv6w-j4xc-qpfw",
-  "modified": "2024-08-07T19:51:08Z",
+  "modified": "2024-08-07T19:51:09Z",
   "published": "2023-02-08T22:37:10Z",
   "aliases": [
     "CVE-2023-25163"
@@ -15,25 +15,6 @@
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "Go",
-        "name": "github.com/argoproj/argo-cd"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.6.0-rc1"
-            },
-            {
-              "fixed": "2.6.1"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "Go",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The versions of `github.com/argoproj/argo-cd` don't exist (it's `github.com/argoproj/argo-cd/v2`)