### PR TITLE
[GHSA-jjjh-jjxp-wpff] Uncontrolled Resource Consumption in Jackson-databind

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-jjjh-jjxp-wpff/GHSA-jjjh-jjxp-wpff.json
+++ b/advisories/github-reviewed/2022/10/GHSA-jjjh-jjxp-wpff/GHSA-jjjh-jjxp-wpff.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jjjh-jjxp-wpff",
-  "modified": "2024-03-15T00:14:43Z",
+  "modified": "2024-03-15T00:14:44Z",
   "published": "2022-10-03T00:00:31Z",
   "aliases": [
     "CVE-2022-42003"
@@ -47,7 +47,7 @@
               "introduced": "2.13.0"
             },
             {
-              "fixed": "2.13.4.2"
+              "fixed": "2.13.4.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
it seems like CVE-2022-42003 was fixed in jackson-databind with version 2.13.4.1 (12-Oct-2022) according to the release notes: https://github.com/FasterXML/jackson-databind/blob/04a6719805a26b4e5699285b7110ec1bfd655365/release-notes/VERSION-2.x#L561