### PR TITLE
[GHSA-fcgg-qgxg-2g2x] EC-CUBE Open redirect vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-fcgg-qgxg-2g2x/GHSA-fcgg-qgxg-2g2x.json
+++ b/advisories/github-reviewed/2022/05/GHSA-fcgg-qgxg-2g2x/GHSA-fcgg-qgxg-2g2x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fcgg-qgxg-2g2x",
-  "modified": "2024-04-25T20:40:54Z",
+  "modified": "2024-04-25T20:40:58Z",
   "published": "2022-05-14T01:36:14Z",
   "aliases": [
     "CVE-2018-16191"
@@ -32,10 +32,7 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 3.0.16"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
EC-CUBE 3.0.16 - is vulnerable, < 3.0.16 means that 3.0.16 is not in affected range, but it is in