### PR TITLE
[GHSA-f5jx-v2mg-438v] ColdFusion versions 2023.6, 2021.12 and earlier are...

### DIFF
--- a/advisories/unreviewed/2024/09/GHSA-f5jx-v2mg-438v/GHSA-f5jx-v2mg-438v.json
+++ b/advisories/unreviewed/2024/09/GHSA-f5jx-v2mg-438v/GHSA-f5jx-v2mg-438v.json
@@ -1,20 +1,36 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f5jx-v2mg-438v",
-  "modified": "2024-09-13T12:30:47Z",
+  "modified": "2024-09-13T12:30:53Z",
   "published": "2024-09-13T12:30:47Z",
   "aliases": [
     "CVE-2024-45113"
   ],
+  "summary": "Test - Ignore",
   "details": "ColdFusion versions 2023.6, 2021.12 and earlier are affected by an Improper Authentication vulnerability that could result in privilege escalation. An attacker could exploit this vulnerability to gain unauthorized access and affect the integrity of the application. Exploitation of this issue does not require user interaction.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:P/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -30,7 +46,7 @@
     "cwe_ids": [
       "CWE-287"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2024-09-13T10:15:16Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Severity
- Summary

**Comments**
Test - Ignore