### PR TITLE
[GHSA-m3px-vjxr-fx4m] Filament Excel Vulnerable to Path Traversal Attack on Export Download Endpoint

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-m3px-vjxr-fx4m/GHSA-m3px-vjxr-fx4m.json
+++ b/advisories/github-reviewed/2024/08/GHSA-m3px-vjxr-fx4m/GHSA-m3px-vjxr-fx4m.json
@@ -1,18 +1,14 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m3px-vjxr-fx4m",
-  "modified": "2024-08-12T18:36:10Z",
+  "modified": "2024-08-12T18:36:14Z",
   "published": "2024-08-12T18:36:10Z",
   "aliases": [
     "CVE-2024-42485"
   ],
   "summary": "Filament Excel Vulnerable to Path Traversal Attack on Export Download Endpoint",
-  "details": "### Impact\nThe export download route `/filament-excel/{path}` allowed downloading any file without login when the webserver allows `../` in the URL. \n\n### Patches\nPatched with Version v2.3.3\n\n### Credits\nThanks to Kevin Pohl for reporting this.\n\n",
+  "details": "### Impact\nThe export download route `/filament-excel/{path}` allowed downloading any file without login when the webserver allows `../` in the URL. \n\n### Patches\nPatched with Version v2.3.3, v.1.1.14\n\n### Credits\nThanks to Kevin Pohl for reporting this.\n\n",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N"
@@ -33,6 +29,25 @@
             },
             {
               "fixed": "2.3.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "pxlrbt/filament-excel"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.1.14"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Description

**Comments**
CVE: https://github.com/pxlrbt/filament-excel/security/advisories/GHSA-m3px-vjxr-fx4m, Repo: https://github.com/pxlrbt/filament-excel/releases/tag/v1.1.14