### PR TITLE
[GHSA-wp7w-vx86-vj9h] Podman Elevated Container Privileges

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-wp7w-vx86-vj9h/GHSA-wp7w-vx86-vj9h.json
+++ b/advisories/github-reviewed/2022/05/GHSA-wp7w-vx86-vj9h/GHSA-wp7w-vx86-vj9h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wp7w-vx86-vj9h",
-  "modified": "2023-07-21T21:42:33Z",
+  "modified": "2023-07-21T21:42:36Z",
   "published": "2022-05-13T01:34:58Z",
   "aliases": [
     "CVE-2018-10856"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/containers/podman/v4"
+        "name": "github.com/containers/podman"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Incorrect major version of podman package specified
Compare https://deps.dev/go/github.com%2Fcontainers%2Fpodman/v1.4.2/versions with https://deps.dev/go/github.com%2Fcontainers%2Fpodman%2Fv4/v4.9.5/versions