### PR TITLE
[GHSA-p976-h52c-26p6] Rancher vulnerable to Privilege Escalation via manipulation of Secrets

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-p976-h52c-26p6/GHSA-p976-h52c-26p6.json
+++ b/advisories/github-reviewed/2023/06/GHSA-p976-h52c-26p6/GHSA-p976-h52c-26p6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p976-h52c-26p6",
-  "modified": "2023-06-06T02:00:28Z",
+  "modified": "2023-11-09T05:01:51Z",
   "published": "2023-06-06T02:00:28Z",
   "aliases": [
     "CVE-2023-22647"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "rancher/rancher"
+        "name": "github.com/rancher/rancher"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Correct the package name