### PR TITLE
[GHSA-4v7x-pqxf-cx7m] net/http, x/net/http2: close connections when receiving too many headers

### DIFF
--- a/advisories/github-reviewed/2024/04/GHSA-4v7x-pqxf-cx7m/GHSA-4v7x-pqxf-cx7m.json
+++ b/advisories/github-reviewed/2024/04/GHSA-4v7x-pqxf-cx7m/GHSA-4v7x-pqxf-cx7m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4v7x-pqxf-cx7m",
-  "modified": "2024-05-02T18:59:04Z",
+  "modified": "2024-05-02T18:59:06Z",
   "published": "2024-04-04T21:30:32Z",
   "aliases": [
     "CVE-2023-45288"
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "net/http"
+        "name": "stdlib"
       },
       "ranges": [
         {
@@ -56,7 +56,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "net/http"
+        "name": "stdlib"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Go seems to express stdlib package vulnerabilities like in https://osv.dev/vulnerability/GO-2024-2687