### PR TITLE
[GHSA-w97f-w3hq-36g2] Keycloak Denial of Service vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-w97f-w3hq-36g2/GHSA-w97f-w3hq-36g2.json
+++ b/advisories/github-reviewed/2024/09/GHSA-w97f-w3hq-36g2/GHSA-w97f-w3hq-36g2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w97f-w3hq-36g2",
-  "modified": "2024-09-10T19:41:54Z",
+  "modified": "2024-09-10T19:41:57Z",
   "published": "2024-09-10T18:30:44Z",
   "aliases": [
     "CVE-2023-6841"
@@ -9,10 +9,6 @@
   "summary": "Keycloak Denial of Service vulnerability",
   "details": "A denial of service vulnerability was found in keycloak where the amount of attributes per object is not limited,an attacker by sending repeated HTTP requests could cause a resource exhaustion when the application send back rows with long attribute values.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
@@ -32,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "25.0.5"
+              "fixed": ">= 24.0.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 24.0.0"
+      }
     }
   ],
   "references": [
@@ -61,7 +60,7 @@
     "cwe_ids": [
       "CWE-231"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2024-09-10T19:41:54Z",
     "nvd_published_at": "2024-09-10T17:15:15Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Severity

**Comments**
The issue was fixed in the latest releases of Keycloak due to the introduction of a new feature named User Profile.