### PR TITLE
[GHSA-hxwh-jpp2-84pm] Flask-CORS allows the `Access-Control-Allow-Private-Network` CORS header to be set to true by default

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-hxwh-jpp2-84pm/GHSA-hxwh-jpp2-84pm.json
+++ b/advisories/github-reviewed/2024/08/GHSA-hxwh-jpp2-84pm/GHSA-hxwh-jpp2-84pm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hxwh-jpp2-84pm",
-  "modified": "2024-09-09T17:38:38Z",
+  "modified": "2024-09-03T14:44:53Z",
   "published": "2024-08-18T21:31:07Z",
   "aliases": [
     "CVE-2024-6221"
@@ -9,10 +9,6 @@
   "summary": "Flask-CORS allows the `Access-Control-Allow-Private-Network` CORS header to be set to true by default",
   "details": "A vulnerability in corydolphin/flask-cors version 4.0.1 allows the `Access-Control-Allow-Private-Network` CORS header to be set to true by default, without any configuration option. This behavior can expose private network resources to unauthorized external access, leading to significant security risks such as data breaches, unauthorized access to sensitive information, and potential network intrusions.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N"
@@ -33,6 +29,25 @@
             },
             {
               "fixed": "5.0.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "flask-cors"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.0.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
4.0.2 also fixes the problem, not only 5.0.0