### PR TITLE
[GHSA-78vg-7v27-hj67] auditor-bundle vulnerable to Cross-site Scripting because name of entity does not get escaped

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-78vg-7v27-hj67/GHSA-78vg-7v27-hj67.json
+++ b/advisories/github-reviewed/2024/09/GHSA-78vg-7v27-hj67/GHSA-78vg-7v27-hj67.json
@@ -7,12 +7,8 @@
     "CVE-2024-45592"
   ],
   "summary": "auditor-bundle vulnerable to Cross-site Scripting because name of entity does not get escaped",
-  "details": "### Summary\nUnescaped entity property enables Javascript injection.\n\n### Details\nI think this is possible because %source_label% in twig macro is not escaped. Therefore script tags can be inserted and are executed.\n\n### PoC\n- clone example project https://github.com/DamienHarper/auditor-bundle-demo\n- create author with FullName <script>alert()</script>\n- delete author\n- view audit of authors\n- alert is displayed\n\n### Impact\npersistent XSS. JS can be injected and executed.\n",
+  "details": "### Summary\nUnescaped entity property enables Javascript injection.\n\n### Details\nI think this is possible because %source_label% in twig macro is not escaped. Therefore script tags can be inserted and are executed.\n\n### PoC\n- clone example project https://github.com/DamienHarper/auditor-bundle-demo\n- create author with FullName <script>alert()</script>\n- delete author\n- view audit of authors\n- alert is displayed\n\n### Impact\npersistent XSS. JS can be injected and executed.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:L/A:L"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:P/VC:N/VI:N/VA:N/SC:H/SI:L/SA:L"
@@ -32,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "6.0.0"
+              "fixed": "5.2.6"
             }
           ]
         }
@@ -55,13 +51,17 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/DamienHarper/auditor-bundle"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/DamienHarper/auditor-bundle/releases"
     }
   ],
   "database_specific": {
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-09-10T15:53:10Z",
     "nvd_published_at": "2024-09-10T16:15:21Z"

--- a/advisories/github-reviewed/2024/09/GHSA-78vg-7v27-hj67/GHSA-78vg-7v27-hj67.json
+++ b/advisories/github-reviewed/2024/09/GHSA-78vg-7v27-hj67/GHSA-78vg-7v27-hj67.json
@@ -10,8 +10,8 @@
   "details": "### Summary\nUnescaped entity property enables Javascript injection.\n\n### Details\nI think this is possible because %source_label% in twig macro is not escaped. Therefore script tags can be inserted and are executed.\n\n### PoC\n- clone example project https://github.com/DamienHarper/auditor-bundle-demo\n- create author with FullName <script>alert()</script>\n- delete author\n- view audit of authors\n- alert is displayed\n\n### Impact\npersistent XSS. JS can be injected and executed.",
   "severity": [
     {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:P/VC:N/VI:N/VA:N/SC:H/SI:L/SA:L"
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:L/A:L"
     }
   ],
   "affected": [
@@ -54,14 +54,14 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/DamienHarper/auditor-bundle/releases"
+      "url": "https://github.com/DamienHarper/auditor-bundle/releases/tag/5.2.6"
     }
   ],
   "database_specific": {
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2024-09-10T15:53:10Z",
     "nvd_published_at": "2024-09-10T16:15:21Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Description
- References
- Severity

**Comments**
The versions affected are <5.2.6 because in the 5.2.6 has been fixed according to the releases