### PR TITLE
[GHSA-2p57-rm9w-gvfp] ip SSRF improper categorization in isPublic

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-2p57-rm9w-gvfp/GHSA-2p57-rm9w-gvfp.json
+++ b/advisories/github-reviewed/2024/06/GHSA-2p57-rm9w-gvfp/GHSA-2p57-rm9w-gvfp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2p57-rm9w-gvfp",
-  "modified": "2024-09-03T19:59:01Z",
+  "modified": "2024-09-03T19:59:02Z",
   "published": "2024-06-02T22:29:29Z",
   "aliases": [
     "CVE-2024-29415"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Will install @vue/devtools@6.6.4, which is a breaking change
node_modules/ip
  @vue/devtools-electron  *
  Depends on vulnerable versions of ip
  node_modules/@vue/devtools-electron
    @vue/devtools  >=7.0.0
    Depends on vulnerable versions of @vue/devtools-electron
    node_modules/@vue/devtools