### PR TITLE
[GHSA-h92q-fgpp-qhrq] CoreDNS Cache Poisoning via a birthday attack

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-h92q-fgpp-qhrq/GHSA-h92q-fgpp-qhrq.json
+++ b/advisories/github-reviewed/2024/09/GHSA-h92q-fgpp-qhrq/GHSA-h92q-fgpp-qhrq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h92q-fgpp-qhrq",
-  "modified": "2024-09-18T22:50:13Z",
+  "modified": "2024-09-18T22:50:14Z",
   "published": "2024-09-18T21:30:48Z",
   "aliases": [
     "CVE-2023-30464"
@@ -9,10 +9,6 @@
   "summary": "CoreDNS Cache Poisoning via a birthday attack",
   "details": "CoreDNS through 1.10.1 enables attackers to achieve DNS cache poisoning and inject fake responses via a birthday attack.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
@@ -57,7 +53,7 @@
     "cwe_ids": [
 
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-09-18T22:50:13Z",
     "nvd_published_at": "2024-09-18T21:15:13Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Severity

**Comments**
improve