### PR TITLE
[GHSA-f2jm-rw3h-6phg] LangChain pickle deserialization of untrusted data

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-f2jm-rw3h-6phg/GHSA-f2jm-rw3h-6phg.json
+++ b/advisories/github-reviewed/2024/09/GHSA-f2jm-rw3h-6phg/GHSA-f2jm-rw3h-6phg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f2jm-rw3h-6phg",
-  "modified": "2024-09-17T21:23:31Z",
+  "modified": "2024-09-17T21:23:34Z",
   "published": "2024-09-17T12:30:32Z",
   "aliases": [
     "CVE-2024-5998"
@@ -9,10 +9,6 @@
   "summary": "LangChain pickle deserialization of untrusted data",
   "details": "A vulnerability in the `FAISS.deserialize_from_bytes` function of langchain-ai/langchain allows for pickle deserialization of untrusted data. This can lead to the execution of arbitrary commands via the `os.system` function. The issue affects versions prior to 0.2.10.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:P/AC:L/PR:L/UI:R/S:U/C:H/I:L/A:L"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:A/VC:H/VI:H/VA:L/SC:N/SI:N/SA:N"
@@ -22,7 +18,7 @@
     {
       "package": {
         "ecosystem": "PyPI",
-        "name": "langchain"
+        "name": "langchain-community"
       },
       "ranges": [
         {
@@ -46,7 +42,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/langchain-ai/langchain/commit/604dfe2d99246b0c09f047c604f0c63eafba31e7"
+      "url": "https://github.com/langchain-ai/langchain/commit/77209f315efd13442ec51c67719ba37dfaa44511"
     },
     {
       "type": "PACKAGE",
@@ -61,7 +57,7 @@
     "cwe_ids": [
       "CWE-502"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2024-09-17T21:23:31Z",
     "nvd_published_at": "2024-09-17T12:15:02Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- References
- Severity

**Comments**
The link to the fix commit and affected package are wrong.
It's a common mistake to mark `langchain` as affected instead of `langchain-community`, as they both live in the same repository.