### PR TITLE
[GHSA-mv48-hcvh-8jj8] Vite before v2.9.13 vulnerable to directory traversal via crafted URL to victim's service

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-mv48-hcvh-8jj8/GHSA-mv48-hcvh-8jj8.json
+++ b/advisories/github-reviewed/2022/08/GHSA-mv48-hcvh-8jj8/GHSA-mv48-hcvh-8jj8.json
@@ -7,11 +7,11 @@
     "CVE-2022-35204"
   ],
   "summary": "Vite before v2.9.13 vulnerable to directory traversal via crafted URL to victim's service",
-  "details": "Path Traversal vulnerability in serveStaticMiddleware and serveRawFsMiddleware in Vitejs/vite <v2.9.13 and Vitejs/vite <v3.0.0-beta.3 allows the remote attacker to read arbitrary files by accessing into a specially crafted URL to the victim's service.\n\n",
+  "details": "Vite before v2.9.13 was discovered to allow attackers to perform a directory traversal via a crafted URL to the victim's service.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
     }
   ],
   "affected": [
@@ -47,14 +47,11 @@
               "introduced": "0"
             },
             {
-              "fixed": "3.0.0-beta.4"
+              "fixed": "3.0.0-beta.3"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 3.0.0-beta.3"
-      }
+      ]
     }
   ],
   "references": [

--- a/advisories/github-reviewed/2022/08/GHSA-mv48-hcvh-8jj8/GHSA-mv48-hcvh-8jj8.json
+++ b/advisories/github-reviewed/2022/08/GHSA-mv48-hcvh-8jj8/GHSA-mv48-hcvh-8jj8.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mv48-hcvh-8jj8",
-  "modified": "2024-08-02T19:27:17Z",
+  "modified": "2024-08-02T19:27:18Z",
   "published": "2022-08-19T00:00:20Z",
   "aliases": [
     "CVE-2022-35204"
   ],
   "summary": "Vite before v2.9.13 vulnerable to directory traversal via crafted URL to victim's service",
-  "details": "Vite before v2.9.13 was discovered to allow attackers to perform a directory traversal via a crafted URL to the victim's service.",
+  "details": "Path Traversal vulnerability in serveStaticMiddleware and serveRawFsMiddleware in Vitejs/vite <v2.9.13 and Vitejs/vite <v3.0.0-beta.3 allows the remote attacker to read arbitrary files by accessing into a specially crafted URL to the victim's service.\n\n",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N"
     }
   ],
   "affected": [
@@ -33,6 +33,28 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "vite"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.0-beta.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 3.0.0-beta.3"
+      }
     }
   ],
   "references": [
@@ -61,7 +83,7 @@
     "cwe_ids": [
       "CWE-22"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2022-08-30T20:17:43Z",
     "nvd_published_at": "2022-08-18T19:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Description
- Severity

**Comments**
Correct affected products , change CVSS score for correction. (I am the initial reporter of this vulnerabiltiy.)