### PR TITLE
[GHSA-mg8j-w93w-xjgc] Drupal Full Path Disclosure

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-mg8j-w93w-xjgc/GHSA-mg8j-w93w-xjgc.json
+++ b/advisories/github-reviewed/2024/08/GHSA-mg8j-w93w-xjgc/GHSA-mg8j-w93w-xjgc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mg8j-w93w-xjgc",
-  "modified": "2024-09-03T20:31:27Z",
+  "modified": "2024-09-03T20:31:28Z",
   "published": "2024-08-29T12:31:05Z",
   "aliases": [
     "CVE-2024-45440"
@@ -9,7 +9,10 @@
   "summary": "Drupal Full Path Disclosure",
   "details": "`core/authorize.php` in Drupal 11.x-dev allows Full Path Disclosure (even when error logging is None) if the value of `hash_salt` is `file_get_contents` of a file that does not exist.",
   "severity": [
-
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+    }
   ],
   "affected": [
     {
@@ -35,9 +38,19 @@
         "ecosystem": "Packagist",
         "name": "drupal/core"
       },
-      "versions": [
-        "11.x-dev"
-      ]
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "8.0.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 12.0.0"
+      }
     }
   ],
   "references": [
@@ -58,7 +71,7 @@
     "cwe_ids": [
       "CWE-497"
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-08-29T18:05:46Z",
     "nvd_published_at": "2024-08-29T11:15:27Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Severity

**Comments**
NIST added CVSS score on 9/19  -- https://nvd.nist.gov/vuln/detail/CVE-2024-45440

Confirmation given by Drupal Core Team Committer poker10 (also a member of the Drupal Security Team) that the fault code has existed since 2010 in response to confirmation testing against tagged releases  8.0.0, 8.9.20, 9.5.11, 10.3.2, and 11.0.1 (latest tagged releases at time of testing in each major branch, along with oldest suspected vulnerable tagged release) https://www.drupal.org/project/drupal/issues/3457781#comment-15755727

The release constraint could be more strict using the below constraints, however the issue has not yet been fixed in any development branches and the vendor continues to tag new releases. 
```
11.x-dev
>=8.0.0, <= 10.2.8
>= 10.3.0, <= 10.3.5 
>=11.0.0, <= 11.0.4
```