### PR TITLE
[GHSA-973x-65j7-xcf4] Decompressors can crash the JVM and leak memory content in Aircompressor

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-973x-65j7-xcf4/GHSA-973x-65j7-xcf4.json
+++ b/advisories/github-reviewed/2024/06/GHSA-973x-65j7-xcf4/GHSA-973x-65j7-xcf4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-973x-65j7-xcf4",
-  "modified": "2024-06-02T22:30:02Z",
+  "modified": "2024-06-02T22:30:03Z",
   "published": "2024-06-02T22:30:02Z",
   "aliases": [
     "CVE-2024-36114"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It looks like Dependabot has identified a critical security vulnerability in the `io.airlift:aircompressor` package. This vulnerability affects all versions below 0.27 and can lead to JVM crashes or memory leaks, potentially exposing sensitive information².

To resolve this issue, you have two options:
1. **Allow Dependabot to automatically create a pull request** to update the dependency.
2. **Manually upgrade** `io.airlift:aircompressor` to version 0.27 or later in your `settings.gradle.kts` file.

Updating to version 0.27 or newer will fix the issue by ensuring that the decompressors do not access memory outside the bounds of the given byte arrays or byte buffers².

If you need more detailed guidance on configuring Dependabot security updates, you can refer to the [GitHub Docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates)¹.

Is there anything else you'd like to know or need help with regarding this update?

¹: [GitHub Docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates)
²: [GitHub Advisory Database](https://github.com/advisories/GHSA-973x-65j7-xcf4)

Source : conversation avec Copilot, 22/09/2024
(1) CVE-2024-36114 - GitHub Advisory Database. https://github.com/advisories/GHSA-973x-65j7-xcf4.
(2) Configuring Dependabot security updates - GitHub Docs. https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates.
(3) About Dependabot security updates - GitHub Docs. https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates.
(4) undefined. https://example.com.
(5) undefined. https://nvd.nist.gov/vuln/detail/CVE-2024-36114.