### PR TITLE
[GHSA-2jv5-9r88-3w3p] python-multipart vulnerable to Content-Type Header ReDoS

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-2jv5-9r88-3w3p/GHSA-2jv5-9r88-3w3p.json
+++ b/advisories/github-reviewed/2024/02/GHSA-2jv5-9r88-3w3p/GHSA-2jv5-9r88-3w3p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-2jv5-9r88-3w3p",
-  "modified": "2024-02-16T23:41:48Z",
+  "modified": "2024-02-16T23:41:49Z",
   "published": "2024-02-12T17:28:12Z",
   "aliases": [
     "CVE-2024-24762"
@@ -35,50 +35,6 @@
       ],
       "database_specific": {
         "last_known_affected_version_range": "<= 0.0.6"
-      }
-    },
-    {
-      "package": {
-        "ecosystem": "PyPI",
-        "name": "fastapi"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "0.109.1"
-            }
-          ]
-        }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 0.109.0"
-      }
-    },
-    {
-      "package": {
-        "ecosystem": "PyPI",
-        "name": "starlette"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "0.36.2"
-            }
-          ]
-        }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 0.36.1"
       }
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Starlette is not vulnerable to this vulnerability, only python-multipart is. Fixing commit https://github.com/encode/starlette/commit/13e5c26a27f4903924624736abd6131b2da80cc5 only bumps python-multipart version.

fastapi is not vulnerable to this vulnerability, only python-multipart is. Fixing commit https://github.com/tiangolo/fastapi/commit/9d34ad0ee8a0dfbbcce06f76c2d5d851085024fc only bumps python-multipart version.