### PR TITLE
[GHSA-mv8g-fhh6-6267] Django user with hardcoded password created when running tests on Oracle

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-mv8g-fhh6-6267/GHSA-mv8g-fhh6-6267.json
+++ b/advisories/github-reviewed/2022/05/GHSA-mv8g-fhh6-6267/GHSA-mv8g-fhh6-6267.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mv8g-fhh6-6267",
-  "modified": "2024-09-18T15:59:29Z",
+  "modified": "2024-09-18T15:59:34Z",
   "published": "2022-05-17T00:27:18Z",
   "aliases": [
     "CVE-2016-9013"
@@ -9,10 +9,6 @@
   "summary": "Django user with hardcoded password created when running tests on Oracle",
   "details": "Django 1.8.x before 1.8.16, 1.9.x before 1.9.11, and 1.10.x before 1.10.3 use a hardcoded password for a temporary database user created when running tests with an Oracle database, which makes it easier for remote attackers to obtain access to the database server by leveraging failure to manually specify a password in the database settings TEST dictionary.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
It looks like you're dealing with a security issue related to a hardcoded password in Django when running tests with an Oracle database. This issue affects Django versions from 1.9a1 to 1.9.11, 1.8.x before 1.8.16, and 1.10.x before 1.10.3. The recommended solution is to upgrade Django to version 3.2.15 or later¹.

Here's a quick summary of the steps you can take:
1. **Upgrade Django**: Update your `requirements.txt` or equivalent file to use Django version 3.2.15 or later. For example:
   ```plaintext
   Django>=3.2.15
   ```
2. **Review Security Alerts**: Ensure that all other security alerts are addressed by updating the relevant packages.
3. **Test Thoroughly**: After upgrading, run your tests to ensure that everything works as expected and that the security issue is resolved.

If you need more detailed guidance on managing passwords and security in Django, you can refer to the [Django documentation on password management](https://docs.djangoproject.com/en/4.2/topics/auth/passwords/)².

Is there anything specific you'd like help with regarding this update?

¹: [Django security update details](https://www.djangoproject.com/weblog/2024/sep/03/security-releases/)
²: [Django password management documentation](https://docs.djangoproject.com/en/4.2/topics/auth/passwords/)

Source : conversation avec Copilot, 23/09/2024
(1) Password management in Django | Documentation de Django. https://docs.djangoproject.com/fr/4.2/topics/auth/passwords/.
(2) Django security releases issued: 5.1.1, 5.0.9, and 4.2.16. https://www.djangoproject.com/weblog/2024/sep/03/security-releases/.
(3) Password management in Django. https://docs.djangoproject.com/en/5.1/topics/auth/passwords/.
(4) Django Login, Logout, Signup, Password Change, and Password Reset. https://learndjango.com/tutorials/django-login-and-logout-tutorial.