### PR TITLE
[GHSA-mv48-hcvh-8jj8] Vite before v2.9.13 vulnerable to directory traversal via crafted URL to victim's service

### DIFF
--- a/advisories/github-reviewed/2022/08/GHSA-mv48-hcvh-8jj8/GHSA-mv48-hcvh-8jj8.json
+++ b/advisories/github-reviewed/2022/08/GHSA-mv48-hcvh-8jj8/GHSA-mv48-hcvh-8jj8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mv48-hcvh-8jj8",
-  "modified": "2024-08-02T19:27:17Z",
+  "modified": "2024-08-02T19:27:18Z",
   "published": "2022-08-19T00:00:20Z",
   "aliases": [
     "CVE-2022-35204"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
     }
   ],
   "affected": [
@@ -29,6 +29,25 @@
             },
             {
               "fixed": "2.9.13"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "vite"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.0-beta.3"
             }
           ]
         }
@@ -61,7 +80,7 @@
     "cwe_ids": [
       "CWE-22"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2022-08-30T20:17:43Z",
     "nvd_published_at": "2022-08-18T19:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Severity

**Comments**
Corrected affected products , changed CVSS score for correction. (I am the initial reporter of this vulnerabiltiy.)