### PR TITLE
[GHSA-76p3-8jx3-jpfq] Prototype pollution in webpack loader-utils

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-76p3-8jx3-jpfq/GHSA-76p3-8jx3-jpfq.json
+++ b/advisories/github-reviewed/2022/10/GHSA-76p3-8jx3-jpfq/GHSA-76p3-8jx3-jpfq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-76p3-8jx3-jpfq",
-  "modified": "2022-11-04T20:29:12Z",
+  "modified": "2023-09-21T22:15:51Z",
   "published": "2022-10-13T12:00:28Z",
   "aliases": [
     "CVE-2022-37601"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The **prototype pollution vulnerability** in `webpack loader-utils` (CVE-2022-37601) affects versions prior to 1.4.1 and 2.0.3¹². This vulnerability occurs in the `parseQuery` function within `parseQuery.js`, where an attacker can manipulate the `name` variable to modify the prototype of objects¹².

To address this issue, you can:
1. **Upgrade `loader-utils`** to version 3.2.1 or later.
2. **Update your `package-lock.json`** file to ensure all dependencies are using the patched version.

Here's an example of how to update your dependencies:
```json
"dependencies": {
  "loader-utils": ">=3.2.1"
},
"devDependencies": {
  "loader-utils": ">=3.2.1"
}
```

By upgrading to the patched version, you can mitigate the security risks associated with this vulnerability.

Is there anything else you'd like to know or need help with regarding this update?

¹: [GitHub Advisory Database](https://github.com/advisories/GHSA-76p3-8jx3-jpfq)
²: [Snyk Vulnerability Database](https://security.snyk.io/vuln/SNYK-JS-LOADERUTILS-3043105)

Source : conversation avec Copilot, 23/09/2024
(1) Prototype pollution in webpack loader-utils · CVE-2022-37601 - GitHub. https://github.com/advisories/GHSA-76p3-8jx3-jpfq.
(2) Prototype Pollution in loader-utils | CVE-2022-37601 | Snyk. https://security.snyk.io/vuln/SNYK-JS-LOADERUTILS-3043105.
(3) CVE-2022-37601: Prototype Pollution in webpack loader-utils - Vulert. https://vulert.com/vuln-db/CVE-2022-37601.
(4) undefined. https://github.com/webpack/loader-utils/releases/tag/v2.0.3.
(5) undefined. https://github.com/webpack/loader-utils/releases/tag/v1.4.1.
(6) undefined. https://dl.acm.org/doi/abs/10.1145/3488932.3497769.
(7) undefined. https://dl.acm.org/doi/pdf/10.1145/3488932.3497769.
(8) undefined. https://lists.debian.org/debian-lts-announce/2022/12/msg00044.html.
(9) undefined. http://users.encs.concordia.ca/~mmannan/publications/JS-vulnerability-aisaccs2022.pdf.
(10) NVD - CVE-2022-37601. https://nvd.nist.gov/vuln/detail/CVE-2022-37601.
(11) CVE-2022-37601 - OpenCVE. https://www.opencve.io/cve/CVE-2022-37601.
(12) Security Bulletin: Decision Optimization in IBM Cloud Pak for Data is .... https://www.ibm.com/support/pages/security-bulletin-decision-optimization-ibm-cloud-pak-data-vulnerable-webpack-loader-utils-vulnerability-cve-2022-37601.
(13) CVE-2022-37601: Improperly Controlled Modification of Object ... - GitLab. https://advisories.gitlab.com/pkg/npm/loader-utils/CVE-2022-37601/.
(14) undefined. https://github.com/webpack/loader-utils/blob/d9f4e23cf411d8556f8bac2d3bf05a6e0103b568/lib/parseQuery.js.
(15) undefined. https://github.com/webpack/loader-utils/issues/212.
(16) undefined. https://github.com/xmldom/xmldom/issues/436.