### PR TITLE
[GHSA-6f62-3596-g6w7] HTTP Request Smuggling in ruby webrick

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-6f62-3596-g6w7/GHSA-6f62-3596-g6w7.json
+++ b/advisories/github-reviewed/2024/09/GHSA-6f62-3596-g6w7/GHSA-6f62-3596-g6w7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6f62-3596-g6w7",
-  "modified": "2024-09-23T20:43:55Z",
+  "modified": "2024-09-23T20:43:56Z",
   "published": "2024-09-22T03:30:30Z",
   "aliases": [
     "CVE-2024-47220"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.8.1"
+              "fixed": "1.8.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.8.1"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The version 1.8.2 seems to fix the issue: https://github.com/ruby/webrick/issues/145#issuecomment-2369994610