### PR TITLE
[GHSA-622h-h2p8-743x] JWT token compromise can allow malicious actions including Remote Code Execution (RCE) 

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-622h-h2p8-743x/GHSA-622h-h2p8-743x.json
+++ b/advisories/github-reviewed/2023/10/GHSA-622h-h2p8-743x/GHSA-622h-h2p8-743x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-622h-h2p8-743x",
-  "modified": "2023-10-06T20:43:52Z",
+  "modified": "2023-10-06T20:43:53Z",
   "published": "2023-10-06T20:43:52Z",
   "aliases": [
     "CVE-2023-32188"
@@ -25,11 +25,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "5.2.2"
+              "fixed": ">=0.0.0-20231003121714-be746957ee7c"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 0.0.0-20230930010431-57d107118e92"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It was recently found in our team that the affected versions and patched versions in this advisory don't reflect the correct go mod versions used in our repo and result in a few false positive findings reported by vulnerability scanners.  We have corrected the version in our repo's advisories (https://github.com/neuvector/neuvector/security/advisories/GHSA-622h-h2p8-743x). We hope the versions in GitHub advisories can also be corrected. 
