### PR TITLE
[GHSA-f5fw-25gw-5m92] Apache Hadoop’s RunJar.run() does not set permissions for...

### DIFF
--- a/advisories/unreviewed/2024/09/GHSA-f5fw-25gw-5m92/GHSA-f5fw-25gw-5m92.json
+++ b/advisories/unreviewed/2024/09/GHSA-f5fw-25gw-5m92/GHSA-f5fw-25gw-5m92.json
@@ -1,22 +1,45 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f5fw-25gw-5m92",
-  "modified": "2024-09-25T09:30:46Z",
+  "modified": "2024-09-25T09:30:52Z",
   "published": "2024-09-25T09:30:46Z",
   "aliases": [
     "CVE-2024-23454"
   ],
+  "summary": "Apache Hadoop: Temporary File Local Information Disclosure",
   "details": "Apache Hadoop’s RunJar.run() does not set permissions for temporary directory by default. If sensitive data will be present in this file, all the other local users may be able to view the content.\nThis is because, on unix-like systems, the system temporary directory is\nshared between all local users. As such, files written in this directory,\nwithout setting the correct posix permissions explicitly, may be viewable\nby all other local users.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.hadoop:hadoop-common"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.4.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23454"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/hadoop"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
Title, range, location