### PR TITLE
[GHSA-48cr-j2cx-mcr8] Inadequate Encryption Strength vulnerability in Apache...

### DIFF
--- a/advisories/unreviewed/2024/09/GHSA-48cr-j2cx-mcr8/GHSA-48cr-j2cx-mcr8.json
+++ b/advisories/unreviewed/2024/09/GHSA-48cr-j2cx-mcr8/GHSA-48cr-j2cx-mcr8.json
@@ -6,17 +6,43 @@
   "aliases": [
     "CVE-2024-40761"
   ],
+  "summary": "Apache Answer: Avatar URL leaked user email addresses",
   "details": "Inadequate Encryption Strength vulnerability in Apache Answer.\n\nThis issue affects Apache Answer: through 1.3.5.\n\nUsing the MD5 value of a user's email to access Gravatar is insecure and can lead to the leakage of user email. The official recommendation is to use SHA256 instead.\nUsers are recommended to upgrade to version 1.4.0, which fixes the issue.",
   "severity": [
 
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/apache/incubator-answer"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.4.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.3.5"
+      }
+    }
   ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-40761"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/apache/incubator-answer"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
Title, location, range