### PR TITLE
[GHSA-f78j-4w3g-4q65] StimulusReflex arbitrary method call

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-f78j-4w3g-4q65/GHSA-f78j-4w3g-4q65.json
+++ b/advisories/github-reviewed/2024/03/GHSA-f78j-4w3g-4q65/GHSA-f78j-4w3g-4q65.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f78j-4w3g-4q65",
-  "modified": "2024-03-18T18:33:40Z",
+  "modified": "2024-03-18T18:33:44Z",
   "published": "2024-03-12T15:44:49Z",
   "aliases": [
     "CVE-2024-28121"
@@ -63,10 +63,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.5.0.pre0"
+              "introduced": "3.5.0-pre0"
             },
             {
-              "fixed": "3.5.0.rc4"
+              "fixed": "3.5.0-rc4"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The NPM package uses SemVer (or at least SemVer formatted) versions. 3.5.0.pre0 and 3.5.0.rc4 are not valid SemVer versions and are not versions that exist on NPM for this package. I've noticed that some old NPM packages used to have non-SemVer versions, but that doesn't seem to be the case with this package.