### PR TITLE
[GHSA-j76j-rqwj-jmvv] Keycloak Session Fixation vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-j76j-rqwj-jmvv/GHSA-j76j-rqwj-jmvv.json
+++ b/advisories/github-reviewed/2024/09/GHSA-j76j-rqwj-jmvv/GHSA-j76j-rqwj-jmvv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j76j-rqwj-jmvv",
-  "modified": "2024-09-09T22:33:50Z",
+  "modified": "2024-09-09T22:33:52Z",
   "published": "2024-09-09T21:31:22Z",
   "aliases": [
     "CVE-2024-7341"
@@ -9,10 +9,6 @@
   "summary": "Keycloak Session Fixation vulnerability",
   "details": "A session fixation issue was discovered in the SAML adapters provided by Keycloak. The session ID and JSESSIONID cookie are not changed at login time, even when `the turnOffChangeSessionIdOnLogin` option is configured. This flaw allows an attacker who hijacks the current session before authentication to trigger session fixation.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
@@ -29,48 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "25.0.0"
-            },
-            {
-              "last_affected": "25.0.2"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.keycloak:keycloak-services"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
               "introduced": "0"
             },
             {
-              "fixed": "22.0.12"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.keycloak:keycloak-services"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "23.0.0"
-            },
-            {
-              "fixed": "24.0.7"
+              "fixed": "25.0.5"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
This issue was fixed in 25.0.5, and not in 25.0.2 as stated now; see https://github.com/keycloak/keycloak/issues/32754