### PR TITLE
[GHSA-vp98-w2p3-mv35] Apache Log4j 1.x (EOL) allows Denial of Service (DoS)

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-vp98-w2p3-mv35/GHSA-vp98-w2p3-mv35.json
+++ b/advisories/github-reviewed/2023/03/GHSA-vp98-w2p3-mv35/GHSA-vp98-w2p3-mv35.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vp98-w2p3-mv35",
-  "modified": "2023-04-20T14:22:42Z",
+  "modified": "2023-05-05T21:40:18Z",
   "published": "2023-03-10T15:30:43Z",
   "aliases": [
     "CVE-2023-26464"
@@ -28,7 +28,7 @@
               "introduced": "1.0.4"
             },
             {
-              "fixed": "2.0.0"
+              "fixed": "2.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The version number of log4j core in mvnrepository is 2.0 instead of 2.0.0