### PR TITLE
[GHSA-59hf-mpf8-pqjh] Mattermost versions 9.11.x <= 9.11.0 and 9.5.x <= 9.5.8...

### DIFF
--- a/advisories/unreviewed/2024/09/GHSA-59hf-mpf8-pqjh/GHSA-59hf-mpf8-pqjh.json
+++ b/advisories/unreviewed/2024/09/GHSA-59hf-mpf8-pqjh/GHSA-59hf-mpf8-pqjh.json
@@ -1,20 +1,58 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-59hf-mpf8-pqjh",
-  "modified": "2024-09-26T21:31:11Z",
+  "modified": "2024-09-26T09:31:47Z",
   "published": "2024-09-26T09:31:42Z",
   "aliases": [
     "CVE-2024-47003"
   ],
-  "details": "Mattermost versions 9.11.x <= 9.11.0 and 9.5.x <= 9.5.8 fail to validate that the message of the permalink post is a string, which allows an attacker to send a non-string value as the message of a permalink post and crash the frontend.",
+  "summary": "Mattermost fails to strip `embeds` from `metadata` when broadcasting `posted` events",
+  "details": "Mattermost does not strip `embeds` from `metadata` when broadcasting `posted` events.\n\nThis allows users to include arbitrary embeds in posts, which are then broadcasted via websockets. This can be exploited in many ways, for example to create permalinks with fully customizable content or to trigger a client Side Denial of Service (DoS) by sending a permalink with a non-string message.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:L"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/mattermost/mattermost/server/v8"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.11.0"
+            },
+            {
+              "fixed": "9.11.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/mattermost/mattermost/server/v8"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.5.7"
+            },
+            {
+              "fixed": "9.5.8"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -23,14 +61,26 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/mattermost/mattermost/pull/27878"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mattermost/mattermost/pull/27879"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/mattermost/mattermost"
+    },
+    {
+      "type": "WEB",
       "url": "https://mattermost.com/security-updates"
     }
   ],
   "database_specific": {
     "cwe_ids": [
-      "CWE-400"
+
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2024-09-26T08:15:06Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- CWEs
- Description
- References
- Severity
- Source code location
- Summary

**Comments**
- CVSS: use CVSS from NVD https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?name=CVE-2024-47003&vector=AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H&version=3.1&source=NIST

- CWE: this is in not Uncontrolled Resource Consumption

- add affected products from description

- adjust description of vulnerability and not just DoS (see https://github.com/c0rydoras/cves/tree/main/CVE-2024-47003)

- add fixes to references