### PR TITLE
[GHSA-f522-ffg8-j8r6] Regular Expression Denial of Service in is-my-json-valid

### DIFF
--- a/advisories/github-reviewed/2017/10/GHSA-f522-ffg8-j8r6/GHSA-f522-ffg8-j8r6.json
+++ b/advisories/github-reviewed/2017/10/GHSA-f522-ffg8-j8r6/GHSA-f522-ffg8-j8r6.json
@@ -7,7 +7,7 @@
     "CVE-2016-2537"
   ],
   "summary": "Regular Expression Denial of Service in is-my-json-valid",
-  "details": "Version of `is-my-json-valid` before 1.4.1 or 2.17.2 are vulnerable to regular expression denial of service (ReDoS) via the email validation function.\n\n\n## Recommendation\n\nUpdate to version 1.4.1, 2.17.2 or later.",
+  "details": "It is possible to block the event loop when specially crafted user input is allowed into a validator using the `utc-millisec` format.\n\n\"The Regular expression Denial of Service (ReDoS) is a Denial of Service attack, that exploits the fact that most Regular Expression implementations may reach extreme situations that cause them to work very slowly (exponentially related to input size). An attacker can then cause a program using a Regular Expression to enter these extreme situations and then hang for a very long time.\" [1]",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -25,29 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.0.0"
-            },
-            {
-              "fixed": "2.17.2"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "is-my-json-valid"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
               "introduced": "0"
             },
             {
-              "fixed": "1.4.1"
+              "fixed": "2.12.4"
             }
           ]
         }


### PR DESCRIPTION
### Updates
- Details
- Affected version range
- Fixed version

### Comments
This GHSA-ID corresponds to [NSWG-ECO-76](https://github.com/nodejs/security-wg/blob/26cf94dd6bd22393449e1fbf2dcf975fd71cb82c/vuln/npm/76.json).
When I compare it with [NSWG-ECO-76](https://github.com/nodejs/security-wg/blob/26cf94dd6bd22393449e1fbf2dcf975fd71cb82c/vuln/npm/76.json), the details, affected version range, and fixed version appear to be incorrect.