### PR TITLE
[GHSA-xpp6-8r3j-ww43] Undertow Denial of Service vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-xpp6-8r3j-ww43/GHSA-xpp6-8r3j-ww43.json
+++ b/advisories/github-reviewed/2024/07/GHSA-xpp6-8r3j-ww43/GHSA-xpp6-8r3j-ww43.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xpp6-8r3j-ww43",
-  "modified": "2024-09-19T21:33:28Z",
+  "modified": "2024-09-19T21:34:30Z",
   "published": "2024-07-08T21:31:40Z",
   "aliases": [
     "CVE-2024-5971"
@@ -9,10 +9,6 @@
   "summary": "Undertow Denial of Service vulnerability",
   "details": "A vulnerability was found in Undertow, where the chunked response hangs after the body was flushed. The response headers and body were sent but the client would continue waiting as Undertow does not send the expected `0\\r\\n` termination of the chunked response. This results in uncontrolled resource consumption, leaving the server side to a denial of service attack. This happens only with Java 17 TLSv1.3 scenarios.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
@@ -32,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.3.14.Final"
+              "fixed": "2.3.15.Final"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.3.14.Final"
+      }
     }
   ],
   "references": [
@@ -87,6 +86,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/undertow-io/undertow"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.redhat.com/browse/UNDERTOW-2413"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- References

**Comments**
The CVE has been fixed with undertow version `2.3.15.Final`. See the vendor ticket for reference: https://issues.redhat.com/browse/UNDERTOW-2413