### PR TITLE
[GHSA-jm9x-rx9x-wpqj] pgAdmin versions 8.11 and earlier are vulnerable to a...

### DIFF
--- a/advisories/unreviewed/2024/09/GHSA-jm9x-rx9x-wpqj/GHSA-jm9x-rx9x-wpqj.json
+++ b/advisories/unreviewed/2024/09/GHSA-jm9x-rx9x-wpqj/GHSA-jm9x-rx9x-wpqj.json
@@ -1,20 +1,39 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jm9x-rx9x-wpqj",
-  "modified": "2024-09-23T18:30:34Z",
+  "modified": "2024-09-23T21:30:47Z",
   "published": "2024-09-23T18:30:34Z",
   "aliases": [
     "CVE-2024-9014"
   ],
+  "summary": "OAuth2 authentication security flaw in pgAdmin vulnerable up to version 8.11, allowing exposure of client ID and secret through improper OAuth2 configuration",
   "details": "pgAdmin versions 8.11 and earlier are vulnerable to a security flaw in OAuth2 authentication. This vulnerability allows an attacker to potentially obtain the client ID and secret, leading to unauthorized access to user data.",
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "pgadmin4"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "8.12"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -24,13 +43,17 @@
     {
       "type": "WEB",
       "url": "https://github.com/pgadmin-org/pgadmin4/issues/7945"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/pgadmin-org/pgadmin4"
     }
   ],
   "database_specific": {
     "cwe_ids": [
       "CWE-522"
     ],
-    "severity": "CRITICAL",
+    "severity": "HIGH",
     "github_reviewed": false,
     "github_reviewed_at": null,
     "nvd_published_at": "2024-09-23T17:15:14Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Severity
- Source code location
- Summary

**Comments**
* Added the title
* Added the source code location
* Added the affected versions and patched version
* Re-assessed the CVSS scoring