### PR TITLE
[GHSA-rrr8-f88r-h8q6] find-my-way has a ReDoS vulnerability in multiparametric routes

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-rrr8-f88r-h8q6/GHSA-rrr8-f88r-h8q6.json
+++ b/advisories/github-reviewed/2024/09/GHSA-rrr8-f88r-h8q6/GHSA-rrr8-f88r-h8q6.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rrr8-f88r-h8q6",
-  "modified": "2024-09-18T19:22:55Z",
+  "modified": "2024-09-18T19:22:56Z",
   "published": "2024-09-18T15:52:33Z",
   "aliases": [
     "CVE-2024-45813"
@@ -9,10 +9,6 @@
   "summary": "find-my-way has a ReDoS vulnerability in multiparametric routes",
   "details": "### Impact\n\nA bad regular expression is generated any time you have two parameters within a single segment, when adding a `-` at the end, like `/:a-:b-`.\n\n### Patches\n\nUpdate to find-my-way v8.2.2 or v9.0.1. or subsequent versions.\n\n### Workarounds\n\nNo known workarounds.\n\n### References\n\n- [CVE-2024-45296](https://github.com/advisories/GHSA-9wv6-86v2-598j)\n- [Detailed blog post about `path-to-regexp` vulnerability](https://blakeembrey.com/posts/2024-09-web-redos/)",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
@@ -29,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.1.1"
             },
             {
               "fixed": "8.2.2"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
`follow-my-way` v4.1.0 is NOT exploitable by CVE-2024-45813. The following test does NOT fail on Node 12 NPM 6 follow-my-way v4.1.0:

```javascript
test('prevent back-tracking', (t) => {
  t.plan(0)
  t.setTimeout(20)
  const findMyWay = FindMyWay({
    defaultRoute: () => {
      t.fail('route not matched')
    }
  })
  findMyWay.on('GET', '/:foo-:bar-', (req, res, params) => {})
  findMyWay.find('GET', '/' + '-'.repeat(200000000) + 'a', { host: 'fastify.io' })
})
```

The reason is that CVE-2024-45813 exploits mechanism that does not exist in v4.1.0. CVE-2024-45813 exploits a mechanism to check the validity of a given regex, and could cause a ReDoS. At some point after 4.1.0, the maintainer transformed the function `router.prototype._on` to use loops instead of recursion. This mechanism does NOT exist in version 4.1.0.