### PR TITLE
[GHSA-vr8j-hgmm-jh9r] openssl-src subject to DoS by double-checked locking

### DIFF
--- a/advisories/github-reviewed/2022/12/GHSA-vr8j-hgmm-jh9r/GHSA-vr8j-hgmm-jh9r.json
+++ b/advisories/github-reviewed/2022/12/GHSA-vr8j-hgmm-jh9r/GHSA-vr8j-hgmm-jh9r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vr8j-hgmm-jh9r",
-  "modified": "2024-08-02T16:01:26Z",
+  "modified": "2024-08-02T16:01:27Z",
   "published": "2022-12-13T18:30:33Z",
   "aliases": [
     "CVE-2022-3996"
@@ -9,10 +9,6 @@
   "summary": "openssl-src subject to DoS by double-checked locking",
   "details": "If an X.509 certificate contains a malformed policy constraint and policy processing is enabled, then a write lock will be taken twice recursively. On some operating systems (most widely: Windows) this results in a denial of service when the affected process hangs. Policy processing being enabled on a publicly facing server is not considered to be a common setup. Policy processing is enabled by passing the `-policy' argument to the command line utilities or by calling either `X509_VERIFY_PARAM_add0_policy()' or `X509_VERIFY_PARAM_set1_policies()' functions.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
@@ -29,10 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.0.0"
+              "introduced": "300.0.0"
             },
             {
-              "fixed": "3.0.8"
+              "fixed": "300.0.12"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
Per https://crates.io/crates/openssl-src/versions it looks like the first versions of the rust crate that corresponded to version 3.0.0 of openssl was 300.0.0 and the first version that corresponded to v3.0.8 was 300.0.12.  It is the same openssl affected range as on https://github.com/advisories/GHSA-29xx-hcv2-c4cp