### PR TITLE
[GHSA-j24h-xcpc-9jw8] Add org.eclipse.core.resources and org.eclipse.help as affected

### DIFF
--- a/advisories/github-reviewed/2023/11/GHSA-j24h-xcpc-9jw8/GHSA-j24h-xcpc-9jw8.json
+++ b/advisories/github-reviewed/2023/11/GHSA-j24h-xcpc-9jw8/GHSA-j24h-xcpc-9jw8.json
@@ -37,6 +37,44 @@
     {
       "package": {
         "ecosystem": "Maven",
+        "name": "org.eclipse.platform:org.eclipse.core.resources"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.19.100"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.platform:org.eclipse.help"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.10.100"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
         "name": "org.eclipse.platform:org.eclipse.platform"
       },
       "ranges": [


### PR DESCRIPTION
- core.resources is affected as per https://mvnrepository.com/artifact/org.eclipse.platform/org.eclipse.core.resources/3.19.0 and https://deps.dev/maven/org.eclipse.platform%3Aorg.eclipse.core.resources/3.19.0 
- help is affected as per https://mvnrepository.com/artifact/org.eclipse.platform/org.eclipse.help/3.10.0 and https://deps.dev/maven/org.eclipse.platform%3Aorg.eclipse.help/3.10.0