### PR TITLE
[GHSA-hh32-7344-cg2f] Authorization bypass in Spring Security

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-hh32-7344-cg2f/GHSA-hh32-7344-cg2f.json
+++ b/advisories/github-reviewed/2022/05/GHSA-hh32-7344-cg2f/GHSA-hh32-7344-cg2f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hh32-7344-cg2f",
-  "modified": "2024-07-05T14:16:52Z",
+  "modified": "2024-07-05T14:16:53Z",
   "published": "2022-05-20T00:00:39Z",
   "aliases": [
     "CVE-2022-22978"
@@ -15,25 +15,6 @@
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.springframework.security:spring-security-core"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "5.5.0"
-            },
-            {
-              "fixed": "5.5.7"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "Maven",
@@ -63,10 +44,86 @@
           "type": "ECOSYSTEM",
           "events": [
             {
+              "introduced": "5.5.0"
+            },
+            {
+              "fixed": "5.5.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework.security:spring-security-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
               "introduced": "0"
             },
             {
               "fixed": "5.4.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework.security:spring-security-web"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.4.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework.security:spring-security-web"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.5.0"
+            },
+            {
+              "fixed": "5.5.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework.security:spring-security-web"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.6.0"
+            },
+            {
+              "fixed": "5.6.4"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
- CVE-2022-22978 is caused by RegexRequestMatcher.class (https://spring.io/security/cve-2022-22978)
- RegexRequestMatcher.class is located in spring-security-web-5.3.4.RELEASE.jar but grype only outputs spring-security-core as a path. (https://github.com/spring-projects/spring-security/blob/main/web/src/main/java/org/springframework/security/web/util/matcher/RegexRequestMatcher.java)
