### PR TITLE
[GHSA-7fh5-64p2-3v2j] PostCSS line return parsing error

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-7fh5-64p2-3v2j/GHSA-7fh5-64p2-3v2j.json
+++ b/advisories/github-reviewed/2023/09/GHSA-7fh5-64p2-3v2j/GHSA-7fh5-64p2-3v2j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7fh5-64p2-3v2j",
-  "modified": "2023-10-10T21:32:38Z",
+  "modified": "2023-11-05T05:05:37Z",
   "published": "2023-09-30T00:31:10Z",
   "aliases": [
     "CVE-2023-44270"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The PostCSS line return parsing error is a known issue that affects versions of PostCSS before 8.4.31. This vulnerability, identified as CVE-2023-44270, can cause discrepancies when parsing external CSS, particularly with line returns (`\r`). An attacker can exploit this by crafting CSS that includes parts parsed by PostCSS as comments, which then get incorrectly included in the output as CSS nodes (rules, properties) despite being originally in a comment¹².

### Steps to Resolve the Issue

1. **Update PostCSS**:
   Ensure you are using PostCSS version 8.4.31 or later. You can update your dependency in `package.json`:
   ```json
   {
     "dependencies": {
       "postcss": "^8.4.31"
     }
   }
   ```

2. **Install the Updated Version**:
   Run the following command to install the updated version:
   ```bash
   npm install
   ```

3. **Verify the Update**:
   Check that the correct version is installed:
   ```bash
   npm list postcss
   ```

### Example of Updating PostCSS in a Project

Here’s a quick example of how you might update PostCSS in a project:

1. **Update `package.json`**:
   ```json
   {
     "name": "your-project",
     "version": "1.0.0",
     "dependencies": {
       "postcss": "^8.4.31"
     }
   }
   ```

2. **Run the Update**:
   ```bash
   npm install
   ```

3. **Check the Installed Version**:
   ```bash
   npm list postcss
   ```

By following these steps, you can mitigate the vulnerability and ensure your project is secure.

If you have any specific questions or need further assistance, feel free to ask!

¹: [GitHub Advisory Database](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
²: [GitLab Advisory Database](https://advisories.gitlab.com/pkg/npm/postcss/CVE-2023-44270/)

Source : conversation avec Copilot, 05/10/2024
(1) PostCSS line return parsing error · CVE-2023-44270 - GitHub. https://github.com/advisories/GHSA-7fh5-64p2-3v2j.
(2) Dependent PostCSS line return parsing error #673 - GitHub. https://github.com/webpack-contrib/postcss-loader/issues/673.
(3) PostCSS line return parsing error | GitLab Advisory Database. https://advisories.gitlab.com/pkg/npm/postcss/CVE-2023-44270/.
(4) CVE-2023-44270 | GitLab Advisory Database. https://advisories.gitlab.com/advisory/advnpm_postcss_CVE_2023_44270.html.
(5) undefined. https://nvd.nist.gov/vuln/detail/CVE-2023-44270.
(6) undefined. https://github.com/postcss/postcss/blob/main/lib/tokenize.js.
(7) undefined. https://github.com/postcss/postcss/releases/tag/8.4.31.