### PR TITLE
[GHSA-mpg4-rc92-vx8v] fast-xml-parser vulnerable to ReDOS at currency parsing

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-mpg4-rc92-vx8v/GHSA-mpg4-rc92-vx8v.json
+++ b/advisories/github-reviewed/2024/07/GHSA-mpg4-rc92-vx8v/GHSA-mpg4-rc92-vx8v.json
@@ -1,18 +1,14 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mpg4-rc92-vx8v",
-  "modified": "2024-07-29T19:47:36Z",
+  "modified": "2024-09-11T18:49:13Z",
   "published": "2024-07-29T17:46:16Z",
   "aliases": [
     "CVE-2024-41818"
   ],
   "summary": "fast-xml-parser vulnerable to ReDOS at currency parsing",
-  "details": "### Summary\nA ReDOS exists on currency.js  was discovered by Gauss Security Labs R&D team.\n\n### Details\nhttps://github.com/NaturalIntelligence/fast-xml-parser/blob/master/src/v5/valueParsers/currency.js#L10\ncontains a vulnerable regex \n\n### PoC\npass the following string '\\t'.repeat(13337)  + '.'\n\n### Impact\nDenial of service during currency parsing in experimental version 5 of fast-xml-parser-library\n\nhttps://gauss-security.com",
+  "details": "### Summary\nA ReDOS exists on currency.js  was discovered by Gauss Security Labs R&D team.\n\n### Details\nhttps://github.com/NaturalIntelligence/fast-xml-parser/blob/master/src/v5/valueParsers/currency.js#L17\ncontains a vulnerable regex \n\n### PoC\npass the following string '\\t'.repeat(13337)  + '.'\n\n### Impact\nDenial of service during currency parsing in experimental version 5 of fast-xml-parser-library\n\nhttps://gauss-security.com",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Description

**Comments**
https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/src/v5/valueParsers/currency.js#L10 does not contain a RegEx, but I can see in a previous version of the file, i.e. https://github.com/NaturalIntelligence/fast-xml-parser/blob/ba5f35e7680468acd7906eaabb2f69e28ed8b2aa/src/v5/valueParsers/currency.js that, at some point, `currencyCheckRegex` was on line 10.  