### PR TITLE
[GHSA-r7pg-v2c8-mfg3] Apache Avro Java SDK: Arbitrary Code Execution when reading Avro Data (Java SDK)

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-r7pg-v2c8-mfg3/GHSA-r7pg-v2c8-mfg3.json
+++ b/advisories/github-reviewed/2024/10/GHSA-r7pg-v2c8-mfg3/GHSA-r7pg-v2c8-mfg3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r7pg-v2c8-mfg3",
-  "modified": "2024-10-03T16:52:52Z",
+  "modified": "2024-10-03T16:52:56Z",
   "published": "2024-10-03T12:30:48Z",
   "aliases": [
     "CVE-2024-47561"
@@ -9,10 +9,6 @@
   "summary": "Apache Avro Java SDK: Arbitrary Code Execution when reading Avro Data (Java SDK)",
   "details": "Schema parsing in the Java SDK of Apache Avro 1.11.3 and previous versions allows bad actors to execute arbitrary code.\nUsers are recommended to upgrade to version 1.11.4  or 1.12.0, which fix this issue.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
@@ -22,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.avro:avro-parent"
+        "name": "org.apache.avro:avro"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
The package name was incorrectly set to 'org.apache.avro:avro-parent', which caused vulnerability scanners to miss this vulnerability. For reference, see this issue reported on Grype: https://github.com/anchore/grype/issues/2165

I've changed the package name to 'org.apache.avro:avro'