### PR TITLE
[GHSA-78wr-2p64-hpwj] Apache Commons IO: Possible denial of service attack on untrusted input to XmlStreamReader

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-78wr-2p64-hpwj/GHSA-78wr-2p64-hpwj.json
+++ b/advisories/github-reviewed/2024/10/GHSA-78wr-2p64-hpwj/GHSA-78wr-2p64-hpwj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-78wr-2p64-hpwj",
-  "modified": "2024-10-03T16:52:23Z",
+  "modified": "2024-10-03T16:52:26Z",
   "published": "2024-10-03T12:30:48Z",
   "aliases": [
     "CVE-2024-47554"
@@ -10,12 +10,8 @@
   "details": "Uncontrolled Resource Consumption vulnerability in Apache Commons IO.\n\nThe `org.apache.commons.io.input.XmlStreamReader` class may excessively consume CPU resources when processing maliciously crafted input.\n\n\nThis issue affects Apache Commons IO: from 2.0 before 2.14.0.\n\nUsers are recommended to upgrade to version 2.14.0 or later, which fixes the issue.",
   "severity": [
     {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
-    {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -57,7 +53,7 @@
     "cwe_ids": [
       "CWE-400"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2024-10-03T16:52:23Z",
     "nvd_published_at": "2024-10-03T12:15:02Z"


### PR DESCRIPTION
**Updates**
- CVSS v3
- CVSS v4
- Severity

**Comments**
No NVD assessments currently available, maintainers self assessed as low per https://lists.apache.org/thread/6ozr91rr9cj5lm0zyhv30bsp317hk5z1