### PR TITLE
[GHSA-rf5m-h8q9-9w6q] Information Disclosure in TYPO3 Page Tree

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-rf5m-h8q9-9w6q/GHSA-rf5m-h8q9-9w6q.json
+++ b/advisories/github-reviewed/2024/10/GHSA-rf5m-h8q9-9w6q/GHSA-rf5m-h8q9-9w6q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rf5m-h8q9-9w6q",
-  "modified": "2024-10-08T14:37:08Z",
+  "modified": "2024-10-08T14:37:09Z",
   "published": "2024-10-08T14:37:08Z",
   "aliases": [
     "CVE-2024-47780"
@@ -9,10 +9,6 @@
   "summary": "Information Disclosure in TYPO3 Page Tree",
   "details": "### Problem\nBackend users could see items in the backend page tree without having access if the mounts pointed to pages restricted for their user/group, or if no mounts were configured but the pages allowed access to \"everybody.\" However, affected users could not manipulate these pages.\n\n### Solution\nUpdate to TYPO3 versions 10.4.46 ELTS, 11.5.40 LTS, 12.4.21 LTS, 13.3.1 that fix the problem described.\n\n### Credits\nThanks to Peter Schuler who reported this issue and to TYPO3 core & security team member Oliver Hader who fixed the issue.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N"
@@ -67,14 +63,39 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "11.0.0"
             },
             {
               "fixed": "11.5.40"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 11.5.39"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "typo3/cms-backend"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.0.0"
+            },
+            {
+              "fixed": "10.4.46"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 10.4.45"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
The affected versions were incorrectly taken from the vendor advisory at https://github.com/TYPO3/typo3/security/advisories/GHSA-rf5m-h8q9-9w6q