### PR TITLE
[GHSA-q4m3-2j7h-f7xw] Cross-Site Scripting in jquery

### DIFF
--- a/advisories/github-reviewed/2020/05/GHSA-q4m3-2j7h-f7xw/GHSA-q4m3-2j7h-f7xw.json
+++ b/advisories/github-reviewed/2020/05/GHSA-q4m3-2j7h-f7xw/GHSA-q4m3-2j7h-f7xw.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q4m3-2j7h-f7xw",
-  "modified": "2023-09-08T21:03:13Z",
+  "modified": "2023-10-05T05:03:32Z",
   "published": "2020-05-20T16:18:01Z",
   "aliases": [
     "CVE-2020-7656"
   ],
   "summary": "Cross-Site Scripting in jquery",
-  "details": "Versions of `jquery` prior to 1.9.0 are vulnerable to Cross-Site Scripting. The load method fails to recognize and remove `<script>` HTML tags that contain a whitespace character, i.e: `</script >`, which results in the enclosed script logic to be executed. This allows attackers to execute arbitrary JavaScript in a victim's browser.\n\n\n## Recommendation\n\nUpgrade to version 1.9.0 or later.",
+  "details": "Versions of `jquery` from 1.2.1 to 1.9.0 are vulnerable to Cross-Site Scripting. The load method fails to recognize and remove `<script>` HTML tags that contain a whitespace character, i.e: `</script >`, which results in the enclosed script logic to be executed. This allows attackers to execute arbitrary JavaScript in a victim's browser.\n\n\n## Recommendation\n\nUpgrade to version 1.9.0 or later.",
   "severity": [
     {
       "type": "CVSS_V3",


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
Test cases on https://research.insecurelabs.org/jquery/test/ Select CVE-2020-7656 from the issue list and click "Run" and it will load all versions of jQuery and try to exploit the bug for each version.
The load method does not support fragments before version 1.2, so <1.2 are not vulnerable.
Version 1.2 itself, adds the script but it does not execute.
The "Affected products" list was not updated as version 1.2 and earlier do not exist as packages in the ecosystems.
Only the description was updated.