### PR TITLE
[GHSA-mpg4-rc92-vx8v] fast-xml-parser vulnerable to ReDOS at currency parsing

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-mpg4-rc92-vx8v/GHSA-mpg4-rc92-vx8v.json
+++ b/advisories/github-reviewed/2024/07/GHSA-mpg4-rc92-vx8v/GHSA-mpg4-rc92-vx8v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mpg4-rc92-vx8v",
-  "modified": "2024-10-07T19:56:52Z",
+  "modified": "2024-10-07T19:56:54Z",
   "published": "2024-07-29T17:46:16Z",
   "aliases": [
     "CVE-2024-41818"
@@ -9,10 +9,6 @@
   "summary": "fast-xml-parser vulnerable to ReDOS at currency parsing",
   "details": "### Summary\nA ReDOS that exists on currency.js was discovered by Gauss Security Labs R&D team.\n\n### Details\nhttps://github.com/NaturalIntelligence/fast-xml-parser/blob/v4.4.0/src/v5/valueParsers/currency.js#L10 contains a vulnerable regex \n\n### PoC\npass the following string '\\t'.repeat(13337)  + '.'\n\n### Impact\nDenial of service during currency parsing in experimental version 5 of fast-xml-parser-library\n\nhttps://gauss-security.com",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
@@ -29,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.3.5"
             },
             {
               "fixed": "4.4.1"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
The vulnerable regex is added in tag v4.3.5 (commit ba5f35e7680468acd7906eaabb2f69e28ed8b2aa)