### PR TITLE
[GHSA-5824-cm3x-3c38] Vyper has incorrectly allocated named re-entrancy locks

### DIFF
--- a/advisories/github-reviewed/2023/08/GHSA-5824-cm3x-3c38/GHSA-5824-cm3x-3c38.json
+++ b/advisories/github-reviewed/2023/08/GHSA-5824-cm3x-3c38/GHSA-5824-cm3x-3c38.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5824-cm3x-3c38",
-  "modified": "2023-08-09T14:27:57Z",
+  "modified": "2023-11-04T05:04:49Z",
   "published": "2023-08-09T14:27:57Z",
   "aliases": [
     "CVE-2023-39363"
@@ -9,10 +9,7 @@
   "summary": "Vyper has incorrectly allocated named re-entrancy locks",
   "details": "### Impact\n\nIn versions 0.2.15, 0.2.16 and 0.3.0, named re-entrancy locks are allocated incorrectly. Each function using a named re-entrancy lock gets a unique lock regardless of the key, allowing cross-function re-entrancy in contracts compiled with the susceptible versions. A specific set of conditions is required to result in misbehavior of affected contracts, specifically:\n\n- A `.vy` contract compiled with either of the following `vyper` versions: `0.2.15`, `0.2.16`, `0.3.0`\n- A primary function that utilizes the `@nonreentrant` decorator with a specific `key` and does not strictly follow the check-effects-interaction pattern (i.e. contains an external call to an untrusted party before storage updates)\n- A secondary function that utilizes the same `key` and would be affected by the improper state caused by the primary function\n\n### Patches\nhttps://github.com/vyperlang/vyper/pull/2439, https://github.com/vyperlang/vyper/pull/2514\n\n### Workarounds\nUpgrade to 0.3.1 or higher\n\n### References\nTechnical post-mortem report: https://hackmd.io/@vyperlang/HJUgNMhs2",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N"
-    }
+
   ],
   "affected": [
     {
@@ -73,7 +70,7 @@
     "cwe_ids": [
       "CWE-863"
     ],
-    "severity": "MODERATE",
+    "severity": "CRITICAL",
     "github_reviewed": true,
     "github_reviewed_at": "2023-08-09T14:27:57Z",
     "nvd_published_at": "2023-08-07T19:15:11Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Severity

**Comments**
This issue resulted in multiple hack totalling USD 61m loss.
https://cointelegraph.com/news/curve-vyper-exploit-whole-story-so-far