### PR TITLE
[GHSA-pp84-v3mw-gg4w] Taipy 3.1.1 affected by CVEs on flask-core and pymongo

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-pp84-v3mw-gg4w/GHSA-pp84-v3mw-gg4w.json
+++ b/advisories/github-reviewed/2024/08/GHSA-pp84-v3mw-gg4w/GHSA-pp84-v3mw-gg4w.json
@@ -7,7 +7,7 @@
 
   ],
   "summary": "Taipy 3.1.1 affected by CVEs on flask-core and pymongo",
-  "details": "### Summary\nCVEs on 3.1.1\n\nFixed on patch versions: >=3.1.2 \nand on major releases: >=4.0.0\n\n### Details\n\n### CVE-2024-1681: flask-core <4.0.1 \nlatest version of taipy 3.1.1 needs <=4.0.0 \n\n### CVE-2024-5629: pymongo <4.6.3 \nlatest version of taipy 3.1.1 needs <=4.6.1 \n\n### PoC\nplease upgrade to these versions \n\n### Impact\npre-commit breaks",
+  "details": "### Summary\nIndirect CVEs affect Taipy 3.1.1\n\n### Details\nTaipy 3.1.1 is affected by two existing CVEs:\nCVE-2024-1681 affects flask-core <4.0.1  and taipy 3.1.1 needs <=4.0.0 \nCVE-2024-5629 affects pymongo <4.6.3  and taipy 3.1.1 needs <=4.6.1 \n\nPlease see References for further details.\n\n### PoC\nplease upgrade to the following versions:\n\nFixed on patch versions: >=3.1.2 \nand on major releases: >=4.0.0\n\n### Impact\npre-commit breaks when using dependency Taipy 3.1.1",
   "severity": [
 
   ],
@@ -37,12 +37,24 @@
   ],
   "references": [
     {
-      "type": "WEB",
-      "url": "https://github.com/Avaiga/taipy/security/advisories/GHSA-pp84-v3mw-gg4w"
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-1681"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-5629"
     },
     {
       "type": "PACKAGE",
       "url": "https://github.com/Avaiga/taipy"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-84pr-m4jr-85g5"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-m87m-mmvp-v9qm"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
Linking existing CVEs to References to pass publishing steps. 
 