### PR TITLE
[GHSA-4f8r-qqr9-fq8j] Incorrect delegation lookups can make go-tuf download the wrong artifact

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-4f8r-qqr9-fq8j/GHSA-4f8r-qqr9-fq8j.json
+++ b/advisories/github-reviewed/2024/10/GHSA-4f8r-qqr9-fq8j/GHSA-4f8r-qqr9-fq8j.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4f8r-qqr9-fq8j",
-  "modified": "2024-10-09T22:22:45Z",
+  "modified": "2024-10-09T22:22:46Z",
   "published": "2024-10-01T18:13:25Z",
   "aliases": [
     "CVE-2024-47534"
@@ -9,10 +9,6 @@
   "summary": "Incorrect delegation lookups can make go-tuf download the wrong artifact",
   "details": "During the ongoing work on the TUF conformance test suite, we have come across a test that reveals what we believe is a bug in go-tuf with security implications. The bug exists in go-tuf delegation tracing and could result in downloading the wrong artifact. \n\nWe have come across this issue in the test in this PR: https://github.com/theupdateframework/tuf-conformance/pull/115.\n\nThe test - `test_graph_traversal` - sets up a repository with a series of delegations, invokes the clients `refresh()` and then checks the order in which the client traced the delegations. The test shows that the go-tuf client inconsistently traces the delegations in a wrong way. For example, [during one CI run](https://github.com/theupdateframework/tuf-conformance/pull/115#issuecomment-2275625542), the `two-level-delegations` test case triggered a wrong order. The delegations in this look as such:\n\n```python\n\"two-level-delegations\": DelegationsTestCase(\n        delegations=[\n            DelegationTester(\"targets\", \"A\"),\n            DelegationTester(\"targets\", \"B\"),\n            DelegationTester(\"B\", \"C\"),\n        ],\n        visited_order=[\"A\", \"B\", \"C\"],\n    ),\n```\n\nHere, `targets` delegate to `\"A\"`, and to `\"B\"`, and `\"B\"` delegates to `\"C\"`. The client should trace the delegations in the order `\"A\"` then `\"B\"` then `\"C\"` but in this particular CI run, go-tuf traced the delegations `\"B\"->\"C\"->\"A\"`.\n\nIn a subsequent CI run, this test case did not fail, but [another one did](https://github.com/theupdateframework/tuf-conformance/pull/115#issuecomment-2275640487).\n\n@jku has done a bit of debugging and believes that the returned map of `GetRolesForTarget` returns a map that causes this behavior:\n\nhttps://github.com/theupdateframework/go-tuf/blob/f95222bdd22d2ac4e5b8ed6fe912b645e213c3b5/metadata/metadata.go#L565-L580\n\nWe believe that this map should be an ordered list instead of a map.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N"
@@ -51,7 +47,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.0.1"
+              "last_affected": "0.7.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
There are two different packages of go-tuf:
- https://pkg.go.dev/github.com/theupdateframework/go-tuf
- https://pkg.go.dev/github.com/theupdateframework/go-tuf/v2

The advisory data does not look correct - as the latest version of go-tuf (at the time of writing). is v0.7.0. However we're wrongly classifying that this is fixed in v2.0.1. There is no such version for this go-tuf package. The fix only exists in go-tuf/v2.

If we compare to here:
 - https://pkg.go.dev/vuln/GO-2024-3166

That data source correctly makes a distinction between the versions, and it does list there is no fixed version in go-tuf (i.e non-v2). 

As further evidence, we can see here where they merged what looks to be the fix, into the v2.x release train:
 - https://github.com/theupdateframework/go-tuf/commit/f36420caba9edbfdfd64f95a9554c0836d9cf819

But there is no such merge for v0.7.0, which had a release cut back in November 2023.