### PR TITLE
[GHSA-jqfv-jrvq-95jm] Apache XML Graphics FOP XML External Entity Reference ('XXE') vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-jqfv-jrvq-95jm/GHSA-jqfv-jrvq-95jm.json
+++ b/advisories/github-reviewed/2024/10/GHSA-jqfv-jrvq-95jm/GHSA-jqfv-jrvq-95jm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jqfv-jrvq-95jm",
-  "modified": "2024-10-09T15:26:12Z",
+  "modified": "2024-10-09T15:26:14Z",
   "published": "2024-10-09T12:30:52Z",
   "aliases": [
     "CVE-2024-28168"
@@ -9,10 +9,6 @@
   "summary": "Apache XML Graphics FOP XML External Entity Reference ('XXE') vulnerability",
   "details": "Improper Restriction of XML External Entity Reference ('XXE') vulnerability in Apache XML Graphics FOP.\n\nThis issue affects Apache XML Graphics FOP: 2.9.\n\nUsers are recommended to upgrade to version 2.10, which fixes the issue.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:L/SC:N/SI:N/SA:N"
@@ -32,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.9"
+              "fixed": "2.10"
             }
           ]
         }
@@ -51,6 +47,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/apache/xmlgraphics-fop"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.apache.org/jira/browse/FOP-3168"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- References

**Comments**
Changelog at https://xmlgraphics.apache.org/security.html indicates 2.10 is released with the fix