### PR TITLE
[GHSA-65wh-g8x8-gm2h] Apache NiFi vulnerable to Deserialization of Untrusted Data

### DIFF
--- a/advisories/github-reviewed/2023/06/GHSA-65wh-g8x8-gm2h/GHSA-65wh-g8x8-gm2h.json
+++ b/advisories/github-reviewed/2023/06/GHSA-65wh-g8x8-gm2h/GHSA-65wh-g8x8-gm2h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-65wh-g8x8-gm2h",
-  "modified": "2023-06-21T13:48:24Z",
+  "modified": "2023-11-10T05:04:42Z",
   "published": "2023-06-12T18:30:18Z",
   "aliases": [
     "CVE-2023-34212"
@@ -18,7 +18,26 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.nifi:nifi-jms-bundle"
+        "name": "org.apache.nifi:nifi-jms-processors"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.8.0"
+            },
+            {
+              "fixed": "1.22.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.nifi:nifi-jms-processors-nar"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The `nifi-jms-processors` JAR module contains the affected classes, and the `nifi-jms-processors-nar` NAR module includes the `nifi-jms-processors` JAR. The `nifi-jms-bundle` is the parent module of these two modules, but does not contain the affected class files.