### PR TITLE
[GHSA-hxjp-q6c3-38fx] XML External Entity Reference in Apache NiFi

### DIFF
--- a/advisories/github-reviewed/2023/02/GHSA-hxjp-q6c3-38fx/GHSA-hxjp-q6c3-38fx.json
+++ b/advisories/github-reviewed/2023/02/GHSA-hxjp-q6c3-38fx/GHSA-hxjp-q6c3-38fx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hxjp-q6c3-38fx",
-  "modified": "2023-02-17T21:32:15Z",
+  "modified": "2023-02-17T21:32:18Z",
   "published": "2023-02-10T09:30:23Z",
   "aliases": [
     "CVE-2023-22832"
@@ -18,7 +18,26 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.nifi:nifi"
+        "name": "org.apache.nifi:nifi-ccda-processors"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.2.0"
+            },
+            {
+              "fixed": "1.20.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.nifi:nifi-ccda-nar"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The `nifi-ccda-processors` JAR contains the `ExtractCCDAAttributes` class and the `nifi-ccda-nar` includes the `nifi-ccda-processors` JAR.