### PR TITLE
[GHSA-7h5p-mmpp-hgmm] Nuclei Template Signature Verification Bypass

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-7h5p-mmpp-hgmm/GHSA-7h5p-mmpp-hgmm.json
+++ b/advisories/github-reviewed/2024/09/GHSA-7h5p-mmpp-hgmm/GHSA-7h5p-mmpp-hgmm.json
@@ -10,8 +10,8 @@
   "details": "## Summary\nA vulnerability has been identified in Nuclei's template signature verification system that could allow an attacker to bypass the signature check and possibly execute malicious code via custom code template.\n\n## Affected Component\nThe vulnerability is present in the template signature verification process, specifically in the `signer` package.\n\n## Description\nThe vulnerability stems from a discrepancy between how the signature verification process and the YAML parser handle newline characters, combined with the way multiple signatures are processed. This allows an attacker to inject malicious content into a template while maintaining a valid signature for the benign part of the template.\n\n### Affected Users\n1. **CLI Users:** Those executing **custom code templates** from unverified sources. This includes templates authored by third parties or obtained from unverified repositories.\n2. **SDK Users:** Developers integrating Nuclei into their platforms, particularly if they permit the execution of **custom code templates** by end-users.\n\n> [!NOTE]\n> Code templates are disabled as default, users have to explicitly enable with `-code` option. \n\n## Proof of Concept\n\n```yaml\nid: example-template\ninfo:\n  name: Example Template\n# Other benign content...\n# digest: <valid_signature_for_benign_content>\n# digest: <another_signature>\\r\ncode:\\r\n  - engine:\\r\n      - sh\\r\n      - bash\\r\n    source: |\\r\n      id\\r\n```\n### Patches\n1. The vulnerability is addressed in Nuclei v3.3.2 Users are strongly recommended to update to this version to mitigate the security risk.\n2. Fix reference - https://github.com/projectdiscovery/nuclei/commit/0da993afe6d41b4b1b814e8fad23a2acba13c60a\n\n### Mitigation\n- **Immediate Upgrade**: The primary recommendation is to upgrade to Nuclei v3.2.0, where the vulnerability has been patched.\n- **Avoid Unverified Templates**: As an interim measure, users should refrain from using custom templates if unable to upgrade immediately. Only trusted, [verified templates](https://github.com/projectdiscovery/nuclei-templates) should be executed.\n\n### Workarounds\nIf you are unable to upgrade nuclei, disable running custom code templates as workaround.\n\n## Acknowledgments\n\nWe would like to thank [Guy Goldenberg](https://github.com/GuyGoldenberg) from Wiz who reported this to us via our security email, [security@projectdiscovery.io](mailto:security@projectdiscovery.io).",
   "severity": [
     {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:A/VC:N/VI:N/VA:N/SC:H/SI:H/SA:N"
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:N"
     }
   ],
   "affected": [
@@ -57,7 +57,7 @@
     "cwe_ids": [
       "CWE-78"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2024-09-04T17:38:24Z",
     "nvd_published_at": "2024-09-04T16:15:06Z"

--- a/advisories/github-reviewed/2024/09/GHSA-7h5p-mmpp-hgmm/GHSA-7h5p-mmpp-hgmm.json
+++ b/advisories/github-reviewed/2024/09/GHSA-7h5p-mmpp-hgmm/GHSA-7h5p-mmpp-hgmm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7h5p-mmpp-hgmm",
-  "modified": "2024-09-04T20:24:42Z",
+  "modified": "2024-09-04T20:24:43Z",
   "published": "2024-09-04T17:38:24Z",
   "aliases": [
     "CVE-2024-43405"
@@ -9,10 +9,6 @@
   "summary": "Nuclei Template Signature Verification Bypass",
   "details": "## Summary\nA vulnerability has been identified in Nuclei's template signature verification system that could allow an attacker to bypass the signature check and possibly execute malicious code via custom code template.\n\n## Affected Component\nThe vulnerability is present in the template signature verification process, specifically in the `signer` package.\n\n## Description\nThe vulnerability stems from a discrepancy between how the signature verification process and the YAML parser handle newline characters, combined with the way multiple signatures are processed. This allows an attacker to inject malicious content into a template while maintaining a valid signature for the benign part of the template.\n\n### Affected Users\n1. **CLI Users:** Those executing **custom code templates** from unverified sources. This includes templates authored by third parties or obtained from unverified repositories.\n2. **SDK Users:** Developers integrating Nuclei into their platforms, particularly if they permit the execution of **custom code templates** by end-users.\n\n> [!NOTE]\n> Code templates are disabled as default, users have to explicitly enable with `-code` option. \n\n## Proof of Concept\n\n```yaml\nid: example-template\ninfo:\n  name: Example Template\n# Other benign content...\n# digest: <valid_signature_for_benign_content>\n# digest: <another_signature>\\r\ncode:\\r\n  - engine:\\r\n      - sh\\r\n      - bash\\r\n    source: |\\r\n      id\\r\n```\n### Patches\n1. The vulnerability is addressed in Nuclei v3.3.2 Users are strongly recommended to update to this version to mitigate the security risk.\n2. Fix reference - https://github.com/projectdiscovery/nuclei/commit/0da993afe6d41b4b1b814e8fad23a2acba13c60a\n\n### Mitigation\n- **Immediate Upgrade**: The primary recommendation is to upgrade to Nuclei v3.2.0, where the vulnerability has been patched.\n- **Avoid Unverified Templates**: As an interim measure, users should refrain from using custom templates if unable to upgrade immediately. Only trusted, [verified templates](https://github.com/projectdiscovery/nuclei-templates) should be executed.\n\n### Workarounds\nIf you are unable to upgrade nuclei, disable running custom code templates as workaround.\n\n## Acknowledgments\n\nWe would like to thank [Guy Goldenberg](https://github.com/GuyGoldenberg) from Wiz who reported this to us via our security email, [security@projectdiscovery.io](mailto:security@projectdiscovery.io).",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:N"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:A/VC:N/VI:N/VA:N/SC:H/SI:H/SA:N"
@@ -22,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/projectdiscovery/nuclei"
+        "name": "github.com/projectdiscovery/nuclei/v3"
       },
       "ranges": [
         {
@@ -61,7 +57,7 @@
     "cwe_ids": [
       "CWE-78"
     ],
-    "severity": "HIGH",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-09-04T17:38:24Z",
     "nvd_published_at": "2024-09-04T16:15:06Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v4

**Comments**
The actual vulnerable package is `github.com/projectdiscovery/nuclei/v3` and not `github.com/projectdiscovery/nuclei`