### PR TITLE
[GHSA-7h5p-mmpp-hgmm] Nuclei Template Signature Verification Bypass - Update Affected Packages

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-7h5p-mmpp-hgmm/GHSA-7h5p-mmpp-hgmm.json
+++ b/advisories/github-reviewed/2024/09/GHSA-7h5p-mmpp-hgmm/GHSA-7h5p-mmpp-hgmm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7h5p-mmpp-hgmm",
-  "modified": "2024-09-04T20:24:42Z",
+  "modified": "2024-10-14T07:35:43Z",
   "published": "2024-09-04T17:38:24Z",
   "aliases": [
     "CVE-2024-43405"
@@ -22,7 +22,7 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/projectdiscovery/nuclei"
+        "name": "github.com/projectdiscovery/nuclei/v3"
       },
       "ranges": [
         {


### PR DESCRIPTION
The actual vulnerable package is `github.com/projectdiscovery/nuclei/v3` and not `github.com/projectdiscovery/nuclei`