### PR TITLE
[GHSA-9623-mqmm-5rcf] Undertow vulnerable to Race Condition

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-9623-mqmm-5rcf/GHSA-9623-mqmm-5rcf.json
+++ b/advisories/github-reviewed/2024/08/GHSA-9623-mqmm-5rcf/GHSA-9623-mqmm-5rcf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9623-mqmm-5rcf",
-  "modified": "2024-10-07T21:33:28Z",
+  "modified": "2024-10-07T21:34:32Z",
   "published": "2024-08-21T15:30:54Z",
   "aliases": [
     "CVE-2024-7885"
@@ -9,10 +9,6 @@
   "summary": "Undertow vulnerable to Race Condition",
   "details": "A vulnerability was found in Undertow where the ProxyProtocolReadListener reuses the same StringBuilder instance across multiple requests. This issue occurs when the parseProxyProtocolV1 method processes multiple requests on the same HTTP connection. As a result, different requests may share the same StringBuilder instance, potentially leading to information leakage between requests or responses. In some cases, a value from a previous request or response may be erroneously reused, which could lead to unintended data exposure. This issue primarily results in errors and connection termination but creates a risk of data leakage in multi-request environments.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
@@ -32,7 +28,26 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.3.15.Final"
+              "fixed": "2.2.36.Final"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.undertow:undertow-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.3.0.Alpha1"
+            },
+            {
+              "fixed": "2.3.17.Final"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
According to the instructions in the warehouse release record（ https://github.com/undertow-io/undertow/releases ）The vulnerability was fixed in 2.2.36 Final and 2.3.17 Final.