### PR TITLE
[GHSA-qg25-hgjv-cg9q] Improper Neutralization of Special Elements in Output Used by a Downstream Component in Apache Groovy

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-qg25-hgjv-cg9q/GHSA-qg25-hgjv-cg9q.json
+++ b/advisories/github-reviewed/2022/05/GHSA-qg25-hgjv-cg9q/GHSA-qg25-hgjv-cg9q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qg25-hgjv-cg9q",
-  "modified": "2022-07-06T20:16:53Z",
+  "modified": "2023-01-27T05:02:15Z",
   "published": "2022-05-13T01:25:41Z",
   "aliases": [
     "CVE-2015-3253"
@@ -19,6 +19,28 @@
       "package": {
         "ecosystem": "Maven",
         "name": "org.codehaus.groovy:groovy"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.7.0"
+            },
+            {
+              "fixed": "2.4.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.4.3"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.codehaus.groovy:groovy-all"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
groovy-all also contains the core groovy so every vulnerability in the core groovy is included in the groovy-all.