### PR TITLE
[GHSA-9442-gm4v-r222] Undertow's url-encoded request path information can be broken on ajp-listener

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-9442-gm4v-r222/GHSA-9442-gm4v-r222.json
+++ b/advisories/github-reviewed/2024/06/GHSA-9442-gm4v-r222/GHSA-9442-gm4v-r222.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.3.0.Alpha1"
             },
             {
               "fixed": "2.3.14.Final"
@@ -86,17 +86,13 @@
     {
       "type": "WEB",
       "url": "https://issues.redhat.com/browse/JBEAP-26268"
-    },
-    {
-      "type": "WEB",
-      "url": "https://issues.redhat.com/browse/UNDERTOW-2334"
     }
   ],
   "database_specific": {
     "cwe_ids": [
       "CWE-400"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2024-06-20T16:22:33Z",
     "nvd_published_at": "2024-06-20T15:15:50Z"

--- a/advisories/github-reviewed/2024/06/GHSA-9442-gm4v-r222/GHSA-9442-gm4v-r222.json
+++ b/advisories/github-reviewed/2024/06/GHSA-9442-gm4v-r222/GHSA-9442-gm4v-r222.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9442-gm4v-r222",
-  "modified": "2024-09-09T18:30:28Z",
+  "modified": "2024-09-09T18:31:30Z",
   "published": "2024-06-20T15:31:19Z",
   "aliases": [
     "CVE-2024-6162"
@@ -9,10 +9,6 @@
   "summary": "Undertow's url-encoded request path information can be broken on ajp-listener",
   "details": "A vulnerability was found in Undertow, where URL-encoded request paths can be mishandled during concurrent requests on the AJP listener. This issue arises because the same buffer is used to decode the paths for multiple requests simultaneously, leading to incorrect path information being processed. As a result, the server may attempt to access the wrong path, causing errors such as \"404 Not Found\" or other application failures. This flaw can potentially lead to a denial of service, as legitimate resources become inaccessible due to the path mix-up.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
@@ -33,6 +29,25 @@
             },
             {
               "fixed": "2.3.14.Final"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "io.undertow:undertow-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.2.33.Final"
             }
           ]
         }
@@ -71,6 +86,10 @@
     {
       "type": "WEB",
       "url": "https://issues.redhat.com/browse/JBEAP-26268"
+    },
+    {
+      "type": "WEB",
+      "url": "https://issues.redhat.com/browse/UNDERTOW-2334"
     }
   ],
   "database_specific": {

--- a/advisories/github-reviewed/2024/06/GHSA-9442-gm4v-r222/GHSA-9442-gm4v-r222.json
+++ b/advisories/github-reviewed/2024/06/GHSA-9442-gm4v-r222/GHSA-9442-gm4v-r222.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N"
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -92,7 +92,7 @@
     "cwe_ids": [
       "CWE-400"
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2024-06-20T16:22:33Z",
     "nvd_published_at": "2024-06-20T15:15:50Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- References

**Comments**
The fix for CVE-2024-6162 also got backported on the `2.2.x` branch to version `2.2.33.Final` and higher.

For reference, see:
* https://issues.redhat.com/browse/UNDERTOW-2334
* https://github.com/undertow-io/undertow/commit/a28ac53076e2fa532266d25e0c0b1a01d0e9d2cf
* https://github.com/undertow-io/undertow/pull/1612