### PR TITLE
[GHSA-crmj-qh74-2r36] Exiv2  has a denial of service due to unbounded recursion in QuickTimeVideo::multipleEntriesDecoder

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-crmj-qh74-2r36/GHSA-crmj-qh74-2r36.json
+++ b/advisories/github-reviewed/2024/10/GHSA-crmj-qh74-2r36/GHSA-crmj-qh74-2r36.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-crmj-qh74-2r36",
-  "modified": "2024-10-17T17:13:24Z",
+  "modified": "2024-10-17T17:13:25Z",
   "published": "2024-10-17T17:13:24Z",
   "aliases": [
     "CVE-2024-25112"
@@ -25,10 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.16.0"
             },
             {
-              "last_affected": "0.17.1"
+              "fixed": "0.16.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Per the [upstream advisory for libexiv2](https://github.com/Exiv2/exiv2/security/advisories/GHSA-crmj-qh74-2r36), only versions 0.28.0 and 0.28.1 are affected, and after inspection of the wheels available for the [exiv2 on PyPI](https://pypi.org/project/exiv2/), I believe only v0.16.0 is potentially affected:

| pypi exiv2 version| bundled libexiv2 version | affected |
| ----------------- | ----------------------- | ------- |
| 0.16.0 | 0.28.1 |true |
| 0.16.1 |0.27.7 | false |
| 0.16.2 | 0.27.7 | false |
| 0.16.2.post1 | 0.27.7 | false |
| 0.16.3 | 0.28.2 | false |