### PR TITLE
[GHSA-ch8g-2w9c-j286] Tencent libpag through 4.3.51 has an integer overflow in...

### DIFF
--- a/advisories/unreviewed/2024/05/GHSA-ch8g-2w9c-j286/GHSA-ch8g-2w9c-j286.json
+++ b/advisories/unreviewed/2024/05/GHSA-ch8g-2w9c-j286/GHSA-ch8g-2w9c-j286.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-ch8g-2w9c-j286",
-  "modified": "2024-07-03T18:38:46Z",
+  "modified": "2024-07-03T18:38:47Z",
   "published": "2024-05-03T06:30:35Z",
   "aliases": [
     "CVE-2024-34408"
   ],
+  "summary": "Heap-based Buffer Overflow",
   "details": "Tencent libpag through 4.3.51 has an integer overflow in DecodeStream::checkEndOfFile() in codec/utils/DecodeStream.cpp via a crafted PAG (Portable Animated Graphics) file.",
   "severity": [
     {
@@ -14,7 +15,25 @@
     }
   ],
   "affected": [
-
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": ""
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "4.3.51"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
     {
@@ -28,6 +47,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/Tencent/libpag/pull/2243"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/Tencent/libpag"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
https://security.snyk.io/vuln/SNYK-UNMANAGED-TENCENTLIBPAG-6809047