### PR TITLE
[GHSA-846m-99qv-67mg] Ollama can extract members of a ZIP archive outside of the parent directory

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-846m-99qv-67mg/GHSA-846m-99qv-67mg.json
+++ b/advisories/github-reviewed/2024/08/GHSA-846m-99qv-67mg/GHSA-846m-99qv-67mg.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-846m-99qv-67mg",
-  "modified": "2024-08-29T18:05:18Z",
+  "modified": "2024-08-29T18:05:19Z",
   "published": "2024-08-29T03:30:49Z",
   "aliases": [
     "CVE-2024-45436"
@@ -9,10 +9,6 @@
   "summary": "Ollama can extract members of a ZIP archive outside of the parent directory",
   "details": "`extractFromZipFile` in `model.go` in Ollama before 0.1.47 can extract members of a ZIP archive outside of the parent directory.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N"
@@ -59,6 +55,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/ollama/ollama/compare/v0.1.46...v0.1.47"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pankass/CVE-2024-45436"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- References

**Comments**
Add vulnerability exploit poc