### PR TITLE
[GHSA-m4gq-x24j-jpmf] Mermaid allows prototype pollution in bundled version of DOMPurify

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-m4gq-x24j-jpmf/GHSA-m4gq-x24j-jpmf.json
+++ b/advisories/github-reviewed/2024/10/GHSA-m4gq-x24j-jpmf/GHSA-m4gq-x24j-jpmf.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m4gq-x24j-jpmf",
-  "modified": "2024-10-22T18:17:02Z",
+  "modified": "2024-10-22T18:17:03Z",
   "published": "2024-10-22T18:17:02Z",
   "aliases": [
 
   ],
-  "summary": "Mermaid allows prototype pollution in bundled version of DOMPurify",
+  "summary": "Prototype pollution vulnerability found in Mermaid's DOMPurify integration",
   "details": "The following bundled files within the Mermaid NPM package contain a bundled version of DOMPurify that is vulnerable to https://github.com/cure53/DOMPurify/security/advisories/GHSA-mmhx-hmjr-r674, potentially resulting in an XSS attack.\n\nThis affects the built:\n\n- `dist/mermaid.min.js`\n- `dist/mermaid.js`\n- `dist/mermaid.esm.mjs`\n- `dist/mermaid.esm.min.mjs`\n\nThis will also affect users that use the above files via a CDN link, e.g. `https://cdn.jsdelivr.net/npm/mermaid@10.9.2/dist/mermaid.min.js`\n\n**Users that use the default NPM export of `mermaid`, e.g. `import mermaid from 'mermaid'`, or the `dist/mermaid.core.mjs` file, do not use this bundled version of DOMPurify, and can easily update using their package manager with something like `npm audit fix`.**\n\n### Patches\n\n- `develop` branch: 6c785c93166c151d27d328ddf68a13d9d65adc00\n- backport to v10: 92a07ffe40aab2769dd1c3431b4eb5beac282b34",
   "severity": [
     {


### PR DESCRIPTION
**Updates**
- Summary

**Comments**
Prototype pollution vulnerability found in Mermaid's DOMPurify integration