### PR TITLE
[GHSA-88g2-r9rw-g55h] gitoxide-core does not neutralize special characters for terminals

### DIFF
--- a/advisories/github-reviewed/2024/08/GHSA-88g2-r9rw-g55h/GHSA-88g2-r9rw-g55h.json
+++ b/advisories/github-reviewed/2024/08/GHSA-88g2-r9rw-g55h/GHSA-88g2-r9rw-g55h.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-88g2-r9rw-g55h",
-  "modified": "2024-08-23T13:42:37Z",
+  "modified": "2024-08-23T13:42:38Z",
   "published": "2024-08-22T16:41:28Z",
   "aliases": [
     "CVE-2024-43785"
@@ -10,34 +10,11 @@
   "details": "### Summary\n\nThe `gix` and `ein` commands write pathnames and other metadata literally to terminals, even if they contain characters terminals treat specially, including ANSI escape sequences. This sometimes allows an untrusted repository to misrepresent its contents and to alter or concoct error messages.\n\n### Details\n\n`gitoxide-core`, which provides most underlying functionality of the `gix` and `ein` commands, does not neutralize newlines, backspaces, or control characters—including those that form ANSI escape sequences—that appear in a repository's paths, author and committer names, commit messages, or other metadata. Such text may be written as part of the output of a command, as well as appearing in error messages when an operation fails.\n\nANSI escape sequences are of particular concern because, when printed to a terminal, they can change colors, including to render subsequent text unreadable; reposition the cursor to write text in a different location, including where text has already been written; clear the terminal; set the terminal title-bar text to arbitrary values; render the terminal temporarily unusable; and other such operations.\n\nThe effect is mostly an annoyance. But the author of a malicious repository who can predict how information from the repository may be accessed can cause files in the repository to be concealed or otherwise misrepresented, as well as rewrite all or part of error messages, or mimic error messages convincingly by repositioning the cursor and writing colored text.\n\n### PoC\n\nOn a Unix-like system in a POSIX-compatible shell, run:\n\n```sh\ngit init misleading-path\ncd misleading-path\ntouch \"$(printf '\\033]0;Boo!\\007\\033[2K\\r\\033[91mError: Repository is corrupted. Run \\033[96mEVIL_COMMAND\\033[91m to attempt recovery.\\033[0m')\"\ngit add .\ngit commit -m 'Initial commit'\n```\n\nIn the repository—or, if desired, in a clone of it, to show that this is exploitable by getting a user to clone an untrusted repository—run this command, which outputs entries in a three-column form showing type, hash, and filename:\n\n```sh\ngix tree entries\n```\n\nAlthough the output is of that form, it does not appear to be. Instead, the output in a terminal looks like this, colorized to appear to be an error message, with `EVIL_COMMAND` in another color, and with no other text:\n\n```text\nError: Repository is corrupted. Run EVIL_COMMAND to attempt recovery.\n```\n\nIn some terminals, a beep or other sound will be made. In most terminals, the title bar text will be changed to `Boo!`, though in some shells this may be immediately undone when printing the prompt. These elements are included to showcase the abilities of ANSI escape sequences, but they are not usually themselves threats.\n\nTo see what is actually produced, `gix tree entries` can be piped to a command that displays special characters symbolically, such as `less` or `cat -v` if available.\n\n```text\nBLOB e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 ESC]0;Boo!^GESC[2K^MESC[91mError: Repository is corrupted. Run ESC[96mEVIL_COMMANDESC[91m to attempt recovery.ESC[0m\n```\n\nThat shows the effect on `gix tree entries`, but various other commands are also affected, and the escape sequences and other special characters can also appear in non-path metadata, such as in the `user.name` used to create a commit.\n\n### Impact\n\nFor users who do not clone or operate in clones of untrusted repositories, there is no impact.\n\nWindows is much less affected than Unix-like systems due to limitations on what characters can appear in filenames, and because traditionally Windows terminals do not support as many ANSI escape sequences.\n\nBecause different `gix` and `ein` commands display different data in different formats, the author of a malicious repository must guess how it will be used, which complicates crafting truly convincing output, though it may be possible to craft a repository where `gix clone` fails to clone it but produces a misleading message.\n\nAlthough this is mainly exploitable on systems *other* than Windows, in the ability to produce misleading output this superficially resembles CVE-2024-35197. But this is much more limited, because:\n\n- The misleading output can only be made to go where the application is already sending output. Redirection is not defeated, and devices to access cannot be chosen by the attacker.\n- The misleading output can only be take place *when* the application is already producing output. This limitation complicates the production of believable messages.\n- Only terminals are affected. Even if a standard stream is redirected to another file or device, these special characters would not have a special effect, unless echoed later without sanitization.\n- Reading and blocking cannot be performed.\n- Applications other than the gitoxide `gix` and `ein` executables are unaffected. The exception is if another application uses `gitoxide-core`. But this is explicitly discouraged in the `gitoxide-core` documentation and is believed to be rare.",
   "severity": [
     {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N"
-    },
-    {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "crates.io",
-        "name": "gitoxide-core"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "last_affected": "0.41.0"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "crates.io",
@@ -51,7 +28,26 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.37.0"
+              "last_affected": "0.38.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "crates.io",
+        "name": "gitoxide-core"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "0.42.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
This low-risk vulnerability, tracked in https://github.com/GitoxideLabs/gitoxide/issues/1534, has not yet been patched, but new versions of the affected crates `gitoxide-core` and `gitoxide` have been released. This edit bumps their version upper bounds accordingly, to reflect that this is unpatched in all existing versions of those crates.

I have already made this change in [the repo-level GHSA advisory](https://github.com/GitoxideLabs/gitoxide/security/advisories/GHSA-88g2-r9rw-g55h). No corresponding change is required in the [NVD entry](https://nvd.nist.gov/vuln/detail/CVE-2024-43785) or the [RUSTSEC advisory](https://rustsec.org/advisories/RUSTSEC-2024-0364.html), since those do not specify explicit affected-version ranges. So this global GHSA is the only thing that (still) needs to be updated for this.

Although this is not the kind of vulnerability that is likely to go away due to seemingly unrelated changes, to make sure that this edit is correct I have verified experimentally that the vulnerability is still present with the new versions, and that the proof-of-concept procedure in this advisory still succeeds at demonstrating it.

This lists CVSS v3 as having been edited here, but I did not modify that. I believe that is due to changes that have been made in the advisory database itself, and that the same CVSS base scores will be listed both before and after this revision. So I am not worried about that.

(Sometimes, I have observed that edits to advisories that contain complex constructions involving backslashes--including in Markdown code blocks--have resulted in the introduction of additional backslashes, which cause the content to become incorrect, to be made when the changes from the PR are merged, even though the incorrect material has not appeared in the revisions themselves. #4777 details the most recent time I have observed this to occur. My hope is that this will not happen here, since this is only editing metadata. However, I will watch for it and, if it arises, then I will either attempt to fix it or open an issue to request help with it, as was successful in #4777.)