### PR TITLE
[GHSA-6757-jp84-gxfx] Improper Input Validation in PyYAML

### DIFF
--- a/advisories/github-reviewed/2021/04/GHSA-6757-jp84-gxfx/GHSA-6757-jp84-gxfx.json
+++ b/advisories/github-reviewed/2021/04/GHSA-6757-jp84-gxfx/GHSA-6757-jp84-gxfx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6757-jp84-gxfx",
-  "modified": "2024-10-25T21:35:10Z",
+  "modified": "2024-10-25T21:35:11Z",
   "published": "2021-04-20T16:14:24Z",
   "aliases": [
     "CVE-2020-1747"
@@ -9,10 +9,6 @@
   "summary": "Improper Input Validation in PyYAML",
   "details": "A vulnerability was discovered in the PyYAML library in versions before 5.3.1, where it is susceptible to arbitrary code execution when it processes untrusted YAML files through the full_load method or with the FullLoader loader. Applications that use the library to process untrusted input may be vulnerable to this flaw. An attacker could use this flaw to execute arbitrary code on the system by abusing the python/object/new constructor.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
@@ -29,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "5.1.b1"
             },
             {
               "fixed": "5.3.1"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
CVE is only relevant since version 5.1b1, see [snyk](https://security.snyk.io/vuln/SNYK-PYTHON-PYYAML-559098) as reference.