### PR TITLE
[GHSA-4gc7-5j7h-4qph] Spring Framework DataBinder Case Sensitive Match Exception

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-4gc7-5j7h-4qph/GHSA-4gc7-5j7h-4qph.json
+++ b/advisories/github-reviewed/2024/10/GHSA-4gc7-5j7h-4qph/GHSA-4gc7-5j7h-4qph.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4gc7-5j7h-4qph",
-  "modified": "2024-10-22T19:08:21Z",
+  "modified": "2024-10-22T19:08:22Z",
   "published": "2024-10-18T06:30:32Z",
   "aliases": [
     "CVE-2024-38820"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "6.1.0"
+              "introduced": "0"
             },
             {
               "fixed": "6.1.14"
@@ -44,29 +44,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "6.0.0"
+              "introduced": "6.2.0-M1"
             },
             {
-              "fixed": "6.0.25"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.springframework:spring-context"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "5.3.41"
+              "fixed": "6.2.0-RC2"
             }
           ]
         }
@@ -77,6 +58,10 @@
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-38820"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/issues/33708"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The 6.0.25 and 5.3.41 versions of org.springframework:spring-context were not found in the central repository or any platform. According to the Milestones listed at https://github.com/spring-projects/spring-framework/issues/33708 and the merged tags at https://github.com/spring-projects/spring-framework/commit/23656aebc6c7d0f9faff1080981eb4d55eff296c, the vulnerability should be fixed in versions 6.1.14 and 6.2.0-RC2.