### PR TITLE
[GHSA-h6gj-6jjq-h8g9] jQuery UI vulnerable to XSS when refreshing a checkboxradio with an HTML-like initial text label

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-h6gj-6jjq-h8g9/GHSA-h6gj-6jjq-h8g9.json
+++ b/advisories/github-reviewed/2022/07/GHSA-h6gj-6jjq-h8g9/GHSA-h6gj-6jjq-h8g9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-h6gj-6jjq-h8g9",
-  "modified": "2022-08-10T22:17:46Z",
+  "modified": "2023-09-26T18:07:36Z",
   "published": "2022-07-18T17:07:36Z",
   "aliases": [
     "CVE-2022-31160"
@@ -66,7 +66,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "7.0.0"
+              "last_affected": "7.0.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
jquery-ui-rails 7.0.0 bundles jquery-ui 1.13.0, so this vulnerability is *not* patched in 7.0.0. There is currently no patched version of jquery-ui-rails.

https://github.com/jquery-ui-rails/jquery-ui-rails/blob/master/VERSIONS.md