### PR TITLE
[GHSA-fc9h-whq2-v747] Valid ECDSA signatures erroneously rejected in Elliptic

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-fc9h-whq2-v747/GHSA-fc9h-whq2-v747.json
+++ b/advisories/github-reviewed/2024/10/GHSA-fc9h-whq2-v747/GHSA-fc9h-whq2-v747.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-fc9h-whq2-v747",
-  "modified": "2024-10-17T22:05:18Z",
+  "modified": "2024-10-17T22:05:19Z",
   "published": "2024-10-15T15:30:56Z",
   "aliases": [
     "CVE-2024-48948"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "6.5.7"
+              "fixed": "6.6.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 6.5.7"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
A fix has been provided by the package author:
https://github.com/indutny/elliptic/commit/34c853478cec1be4e37260ed2cb12cdbdc6402cf