### PR TITLE
[GHSA-qvqm-h22r-4cp9] Laravel Framework RCE Vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-qvqm-h22r-4cp9/GHSA-qvqm-h22r-4cp9.json
+++ b/advisories/github-reviewed/2022/05/GHSA-qvqm-h22r-4cp9/GHSA-qvqm-h22r-4cp9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-qvqm-h22r-4cp9",
-  "modified": "2024-06-10T18:48:50Z",
+  "modified": "2024-06-10T18:48:51Z",
   "published": "2022-05-14T00:56:30Z",
   "aliases": [
     "CVE-2018-15133"
@@ -47,11 +47,14 @@
               "introduced": "5.6.0"
             },
             {
-              "last_affected": "5.6.29"
+              "fixed": ">=5.6.30"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 5.6.29"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Based on the following source, adding 5.6.30 as a fix version.
https://laravel.com/docs/5.6/upgrade#upgrade-5.6.30