### PR TITLE
[GHSA-xhg6-9j5j-w4vf] DotNetZip Directory Traversal vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/11/GHSA-xhg6-9j5j-w4vf/GHSA-xhg6-9j5j-w4vf.json
+++ b/advisories/github-reviewed/2024/11/GHSA-xhg6-9j5j-w4vf/GHSA-xhg6-9j5j-w4vf.json
@@ -1,18 +1,14 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xhg6-9j5j-w4vf",
-  "modified": "2024-11-18T23:41:14Z",
+  "modified": "2024-11-18T23:41:15Z",
   "published": "2024-11-13T15:31:37Z",
   "aliases": [
     "CVE-2024-48510"
   ],
   "summary": "DotNetZip Directory Traversal vulnerability",
-  "details": "Directory Traversal vulnerability in DotNetZip v.1.16.0 and before allows a remote attacker to execute arbitrary code via the src/Zip.Shared/ZipEntry.Extract.cs component",
+  "details": "Directory Traversal vulnerability in DotNetZip v.1.16.0 and before allows a remote attacker to execute arbitrary code via the src/Zip.Shared/ZipEntry.Extract.cs component\n\n**Notice**: ProDotNetZip provides compatibility with existing code and can be used as a drop-in replacement for DotNetZip. The vulnerability in DotNetZip has been fixed in ProDotNetZip as of version 1.19.0.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:L/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
@@ -51,11 +47,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.18.0"
+              "fixed": "1.19.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.18.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Description

**Comments**
The provided patch has been applied to ProDotNetZip and a new version 1.19.0 has been released on Nuget.