### PR TITLE
[GHSA-4fr2-j4g9-mppf] Prototype Pollution in deephas

### DIFF
--- a/advisories/github-reviewed/2021/09/GHSA-4fr2-j4g9-mppf/GHSA-4fr2-j4g9-mppf.json
+++ b/advisories/github-reviewed/2021/09/GHSA-4fr2-j4g9-mppf/GHSA-4fr2-j4g9-mppf.json
@@ -9,10 +9,7 @@
   "summary": "Prototype Pollution in deephas",
   "details": "Prototype pollution vulnerability in 'deephas' versions 1.0.0 through 1.0.5 allows attacker to cause a denial of service and may lead to remote code execution.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-    }
+
   ],
   "affected": [
     {
@@ -58,7 +55,7 @@
       "CWE-1321",
       "CWE-915"
     ],
-    "severity": "CRITICAL",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2021-07-26T18:25:52Z",
     "nvd_published_at": "2020-11-12T18:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- Severity

**Comments**
The advisory claiming a prototype pollution vulnerability in deephas versions 1.0.0 through 1.0.5 is a false positive. While the link to the original advisory is broken, I’ve traced the data flow in the codebase and reviewed the maintainer’s test suite. Below is my analysis, supported by the provided proof-of-concept:

```js
var dh = require("deephas"),
obj = {};
dh.set(obj,'__proto__.isAdmin',true);
console.log({}.isAdmin) // this suppose to return true.
```

Upon analyzing the relevant code block, the issue appears to be misunderstood:

```js
        var items = str.split('.');
        var initial = items.slice(0, items.length - 1); // ['__proto__']
        var last = items.slice(items.length - 1); // polluted
        var test = initial.reduce(indexTrue, obj); // {} << fail reference to the prototype
        test[last] = val;  // {}.isAdmin = true <-- the property is created but not in the prototype 
```

The path __proto__.isAdmin is serialized into properties and processed as follows:
	1.	On Line 4, the reduce function fails to reference the prototype, meaning no link to Object.prototype is established.
	2.	As a result, the statement test[last] = val on Line 5 creates the property isAdmin on the object test, but only as a direct property. It does not modify the global prototype.
	
Since the prototype reference fails, no pollution occurs, and the proof-of-concept does not achieve the expected behavior.

Given this analysis, I kindly request that this advisory be removed from the database to prevent unnecessary confusion.