### PR TITLE
[GHSA-w3c8-7r8f-9jp8] Spring MVC controller vulnerable to a DoS attack

### DIFF
--- a/advisories/github-reviewed/2024/11/GHSA-w3c8-7r8f-9jp8/GHSA-w3c8-7r8f-9jp8.json
+++ b/advisories/github-reviewed/2024/11/GHSA-w3c8-7r8f-9jp8/GHSA-w3c8-7r8f-9jp8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-w3c8-7r8f-9jp8",
-  "modified": "2024-12-11T18:49:21Z",
+  "modified": "2024-12-11T18:49:24Z",
   "published": "2024-11-18T06:30:35Z",
   "aliases": [
     "CVE-2024-38828"
@@ -26,6 +26,9 @@
           "events": [
             {
               "introduced": "5.3.0"
+            },
+            {
+              "fixed": "6.0.0, 5.3.42"
             }
           ]
         }
@@ -50,7 +53,9 @@
     }
   ],
   "database_specific": {
-    "cwe_ids": [],
+    "cwe_ids": [
+
+    ],
     "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2024-11-18T20:05:11Z",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This is showing v6 as vulnerable, which is incorrect