### PR TITLE
[GHSA-4vc8-pg5c-vg4x] Keycloak's improper input validation allows using email as username

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-4vc8-pg5c-vg4x/GHSA-4vc8-pg5c-vg4x.json
+++ b/advisories/github-reviewed/2024/06/GHSA-4vc8-pg5c-vg4x/GHSA-4vc8-pg5c-vg4x.json
@@ -1,9 +1,11 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4vc8-pg5c-vg4x",
-  "modified": "2024-06-12T19:41:05Z",
+  "modified": "2024-06-12T19:41:06Z",
   "published": "2024-06-12T19:41:05Z",
-  "aliases": [],
+  "aliases": [
+
+  ],
   "summary": "Keycloak's improper input validation allows using email as username",
   "details": "Keycloak allows the use of email as a username and doesn't check that an account with this email already exists. That could lead to the unability to reset/login with email for the user. This is caused by usernames being evaluated before emails.",
   "severity": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
CVE Id is mentioned in https://github.com/keycloak/keycloak/security/advisories/GHSA-4vc8-pg5c-vg4x
But there Is no field to update it here, can it be updated to CVE-2021-3754