### PR TITLE
[GHSA-xgfv-xpx8-qhcr] Improper Verification of SAML Responses Leading to Privilege Escalation in Keycloak

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-xgfv-xpx8-qhcr/GHSA-xgfv-xpx8-qhcr.json
+++ b/advisories/github-reviewed/2024/10/GHSA-xgfv-xpx8-qhcr/GHSA-xgfv-xpx8-qhcr.json
@@ -3,7 +3,9 @@
   "id": "GHSA-xgfv-xpx8-qhcr",
   "modified": "2024-10-14T20:54:52Z",
   "published": "2024-10-14T20:54:52Z",
-  "aliases": [],
+  "aliases": [
+    "CVE-2024-8698"
+  ],
   "summary": "Improper Verification of SAML Responses Leading to Privilege Escalation in Keycloak",
   "details": "A flaw exists in the SAML signature validation method within the Keycloak XMLSignatureUtil class. The method incorrectly determines whether a SAML signature is for the full document or only for specific assertions based on the position of the signature in the XML document, rather than the Reference element used to specify the signed element. This flaw allows attackers to create crafted responses that can bypass the validation, potentially leading to privilege escalation or impersonation attacks.",
   "severity": [


### PR DESCRIPTION
Updates

- Affected products

Comments
Adding CVE as alias