### PR TITLE
[GHSA-xmmm-jw76-q7vg] One Time Passcode (OTP) is valid longer than expiration timeSeverity

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-xmmm-jw76-q7vg/GHSA-xmmm-jw76-q7vg.json
+++ b/advisories/github-reviewed/2024/10/GHSA-xmmm-jw76-q7vg/GHSA-xmmm-jw76-q7vg.json
@@ -3,7 +3,9 @@
   "id": "GHSA-xmmm-jw76-q7vg",
   "modified": "2024-10-14T20:56:43Z",
   "published": "2024-10-14T20:56:43Z",
-  "aliases": [],
+  "aliases": [
+    "CVE-2024-7318"
+  ],
   "summary": "One Time Passcode (OTP) is valid longer than expiration timeSeverity",
   "details": "A vulnerability was found in Keycloak. Expired OTP codes are still usable when using FreeOTP when the OTP token period is set to 30 seconds (default). Instead of expiring and deemed unusable around 30 seconds in, the tokens are valid for an additional 30 seconds totaling 1 minute. A one time passcode that is valid longer than its expiration time increases the attack window for malicious actors to abuse the system and compromise accounts. Additionally, it increases the attack surface because at any given time, two OTPs are valid.",
   "severity": [


### PR DESCRIPTION
Updates

- Affected products

Comments

Adding CVE as alias