### PR TITLE
[GHSA-5rxp-2rhr-qwqv] Session fixation in Elytron SAML adapters

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-5rxp-2rhr-qwqv/GHSA-5rxp-2rhr-qwqv.json
+++ b/advisories/github-reviewed/2024/10/GHSA-5rxp-2rhr-qwqv/GHSA-5rxp-2rhr-qwqv.json
@@ -3,7 +3,9 @@
   "id": "GHSA-5rxp-2rhr-qwqv",
   "modified": "2024-10-14T20:55:49Z",
   "published": "2024-10-14T20:55:49Z",
-  "aliases": [],
+  "aliases": [
+    "CVE-2024-7341"
+  ],
   "summary": "Session fixation in Elytron SAML adapters",
   "details": "A session fixation issue was discovered in the SAML adapters provided by Keycloak. The session ID and JSESSIONID cookie are not changed at login time, even when the turnOffChangeSessionIdOnLogin option is configured. This flaw allows an attacker who hijacks the current session before authentication to trigger session fixation.",
   "severity": [


### PR DESCRIPTION
Updates

- Affected products

Comments

Adding CVE as alias