### PR TITLE
[GHSA-xpw8-rcwv-8f8p] io.netty:netty-codec-http2 vulnerable to HTTP/2 Rapid Reset Attack

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-xpw8-rcwv-8f8p/GHSA-xpw8-rcwv-8f8p.json
+++ b/advisories/github-reviewed/2023/10/GHSA-xpw8-rcwv-8f8p/GHSA-xpw8-rcwv-8f8p.json
@@ -3,7 +3,9 @@
   "id": "GHSA-xpw8-rcwv-8f8p",
   "modified": "2023-11-06T22:08:35Z",
   "published": "2023-10-10T22:22:54Z",
-  "aliases": [],
+  "aliases": [
+    "CVE-2023-44487"
+  ],
   "summary": "io.netty:netty-codec-http2 vulnerable to HTTP/2 Rapid Reset Attack",
   "details": "A client might overload the server by issue frequent RST frames. This can cause a massive amount of load on the remote system and so cause a DDOS attack. \n\n### Impact\nThis is a DDOS attack, any http2 server is affected and so you should update as soon as possible.\n\n### Patches\nThis is patched in version 4.1.100.Final.\n\n### Workarounds\nA user can limit the amount of RST frames that are accepted per connection over a timeframe manually using either an own `Http2FrameListener` implementation or an `ChannelInboundHandler` implementation (depending which http2 API is used).\n\n### References\n- https://www.cve.org/CVERecord?id=CVE-2023-44487\n- https://blog.cloudflare.com/technical-breakdown-http2-rapid-reset-ddos-attack/\n- https://cloud.google.com/blog/products/identity-security/google-cloud-mitigated-largest-ddos-attack-peaking-above-398-million-rps/",
   "severity": [


### PR DESCRIPTION
Updates

- Affected products

Comments

Adding CVE as alias