### PR TITLE
[GHSA-9gqh-q4cx-f2h9] Update the CVSS 3.x Attack Complexity from Low to High

### DIFF
--- a/advisories/github-reviewed/2019/02/GHSA-9gqh-q4cx-f2h9/GHSA-9gqh-q4cx-f2h9.json
+++ b/advisories/github-reviewed/2019/02/GHSA-9gqh-q4cx-f2h9/GHSA-9gqh-q4cx-f2h9.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
# Summary

The CVSS 3.x Attack Complexity for CVE-2016-1059 / GHSA-9gqh-q4cx-f2h9 should be classified as High instead of Low, based on the requirement for the attacker to obtain **a privileged network position**. This aligns directly with the CVSS 3.x definition of High Attack Complexity, which states that a successful attack demands “some measurable amount of effort […] in preparation or execution against the vulnerable component before a successful attack can be expected.”

> In scenarios where an attacker has **a privileged network position**, they can modify or read such resources at will. While the exact severity of impact for a vulnerability like this is highly variable and depends on the behavior of the package itself, it ranges from being able to read sensitive information all the way up to and including remote code execution. (Excerpt of CVE-2016-1059 / GHSA-9gqh-q4cx-f2h9)

> A successful attack depends on conditions beyond the attacker's control. That is, a successful attack cannot be accomplished at will, but requires the attacker to **invest in some measurable amount of effort in preparation or execution against the vulnerable component before a successful attack can be expected**. (Excerpt of CVSS 3.x Specification)

# Supporting Examples
The following CVEs have similar phrasing and CVSS 3.x Attack Complexity = High:

| ID                                   | CVSS 3.x                                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
|:-------------------------------------|:---------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| CVE-2016-10673 / GHSA-m8pw-h8qj-rgj9 | CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H | Affected versions of `ipip-coffee` insecurely download resources over HTTP. **In scenarios where an attacker has a privileged network position**, they can modify or read such resources at will. This could impact the integrity and availability of the data being used to make geolocation decisions by an application. [...]                                                                                                                                                              |
| CVE-2016-10652 / GHSA-r36x-p5pv-9mfx | CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H | Affected versions of `prebuild-lwip` insecurely download resources over HTTP. **In scenarios where an attacker has a privileged network position**, they can modify or read such resources at will. While the exact severity of impact for a vulnerability like this is highly variable and depends on the behavior of the package itself, it ranges from being able to read sensitive information all the way up to and including remote code execution.  [...]                                    |
| CVE-2016-10593 / GHSA-92qm-hc53-jjrj | CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H | Affected versions of `ibapi` insecurely download an executable over an unencrypted HTTP connection. **In scenarios where an attacker has a privileged network position**, it is possible to intercept the response and replace the executable with a malicious one, resulting in code execution on the system running `ibapi`. [...]                                                                                                                                                           |
| CVE-2016-10633 / GHSA-4pf7-579w-f4gm | CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H | Affected versions of `dwebp-bin` insecurely download an executable over an unencrypted HTTP connection. **In scenarios where an attacker has a privileged network position, it is possible to intercept the response and replace the executable with a malicious one, resulting in code execution on the system running `dwebp-bin`. [...]                                                                                                                                                          |
| CVE-2016-10618 / GHSA-8r98-rqg5-4vm3 | CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H | Affected versions of `node-browser` insecurely downloads resources over HTTP. **In scenarios where an attacker has a privileged network position**, they can modify or read such resources at will. While the exact severity of impact for a vulnerability like this is highly variable and depends on the behavior of the package itself, it ranges from being able to read sensitive information all the way up to and including remote code execution.  [...]                  |
| CVE-2016-10632 / GHSA-hxhm-3vj9-6cqh | CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H | Affected versions of `apk-parser2` insecurely download an executable over an unencrypted HTTP connection. **In scenarios where an attacker has a privileged network position**, it is possible to intercept the response and replace the executable with a malicious one, resulting in code execution on the system running `apk-parser2`.  [...]                                                                        |
| CVE-2016-10612 / GHSA-x56r-5r34-qg74 | CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H | Affected versions of `dalek-browser-ie-canary` insecurely download an executable over an unencrypted HTTP connection. **In scenarios where an attacker has a privileged network position**, it is possible to intercept the response and replace the executable with a malicious one, resulting in code execution on the system running `dalek-browser-ie-canary`. [...]                                                      |
| CVE-2016-10605 / GHSA-65q2-x652-xx84 | CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H | Affected versions of `dalek-browser-ie` insecurely download an executable over an unencrypted HTTP connection. **In scenarios where an attacker has a privileged network position**, it is possible to intercept the response and replace the executable with a malicious one, resulting in code execution on the system running `dalek-browser-ie`. [...]                                                                           |
| CVE-2016-10664 / GHSA-wx3q-6x7x-jjw4 | CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H | Affected versions of `mystem` insecurely download an executable over an unencrypted HTTP connection. **In scenarios where an attacker has a privileged network position**, it is possible to intercept the response and replace the executable with a malicious one, resulting in code execution on the system running `mystem`. [...]                                                                                                                                                                  |

They further underscore the need to reclassify the Attack Complexity for CVE-2016-1059 / GHSA-9gqh-q4cx-f2h9 to High.
                                                                                                     