### PR TITLE
[GHSA-xxcj-rhqg-m46g] Update AV, AC, and UI in CVSS 3.x

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-xxcj-rhqg-m46g/GHSA-xxcj-rhqg-m46g.json
+++ b/advisories/github-reviewed/2022/11/GHSA-xxcj-rhqg-m46g/GHSA-xxcj-rhqg-m46g.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
     }
   ],
   "affected": [


### PR DESCRIPTION
After reviewing the description and exploitation details for CVE-2022-41889 / GHSA-xxcj-rhqg-m46g, I believe the current CVSS 3.x vector assignment might not fully align with the nature of the vulnerability. The vulnerability targets the same module `tf.compat.v1.*` as CVE-2022-29205 / GHSA-54ch-gjq5-4976, and the exploitation path appears comparable. However, the following CVSS metrics for CVE-2022-41889 seem to overstate its complexity and attack requirements: CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H

More specifically:
- Attack Vector (AV): The vulnerability only requires the use of quantized tensors in `tf.compat.v1.*` within a local execution context. There is no evidence suggesting that network access (i.e., `AV:N`) is a prerequisite. 
- Attack Complexity (AC): The exploitation process for this issue does not appear to involve “a measurable amount of effort in preparation or execution against the vulnerable component,” as defined for `AC:H`. 
- User Interaction (UI): The description of CVE-2022-41889 does not mention explicit user action (e.g., running a specific script or interacting with an interface). The issue occurs during tensor handling within the vulnerable module, suggesting no user interaction is necessary. 

I believe the correct vector should be: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H, which matches the vector for CVE-2022-29205; it involves the almost identical exploration scenario.
