### PR TITLE
[GHSA-4cch-wxpw-8p28] Update Attack Complexity from Low to High

### DIFF
--- a/advisories/github-reviewed/2020/12/GHSA-4cch-wxpw-8p28/GHSA-4cch-wxpw-8p28.json
+++ b/advisories/github-reviewed/2020/12/GHSA-4cch-wxpw-8p28/GHSA-4cch-wxpw-8p28.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
The CVE-2020-26258 / GHSA-4cch-wxpw-8p28 should be rated with an Attack Complexity of High rather than Low because the manipulation of input streams to exploit the vulnerability demands significant effort and precise preparation, aligning with the criteria for a High complexity rating in [CVSS 3.x specification](https://www.first.org/cvss/v3.0/specification-document): “a measurable amount of effort in preparation or execution against the vulnerable component is required before a successful attack can be expected.” 

> The vulnerability may allow a remote attacker to request data from internal resources that are not publicly available only by manipulating the processed input stream.

Additionally, similar CVEs affecting the same package, `com.thoughtworks.xstream:xstream`, have consistently rated Attack Complexity as High due to analogous factors. 

| ID                                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                              | CVSS 3.x                                   |
|:-------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------|
| CVE-2021-21344 / GHSA-59jw-jqf4-3wq3 | The vulnerability may **allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream**. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.                                                                                                                                                                                                                                                                                                                                                                                                                    | CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:H/A:N |
| CVE-2021-21342 / GHSA-hvv8-336g-rx3m | The processed stream at unmarshalling time contains type information to recreate the formerly written objects. XStream creates therefore new instances based on these type information. An attacker can **manipulate the processed input stream and replace or inject objects, that result in a server-side forgery request**. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.                                                                                                                                                                                                                                                                                                 | CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:H/A:N |
| CVE-2021-21350 / GHSA-43gc-mjxg-gvrq | The vulnerability may **allow a remote attacker to execute arbitrary code only by manipulating the processed input stream**. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.                                                                                                                                                                                                                                                                                                                                                                                                                  | CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:H/A:N |
| CVE-2021-39153 / GHSA-2q8x-2p7f-574v | The vulnerability may **allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream**, if using the version out of the box with Java runtime version 14 to 8 or with JavaFX installed. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.                                                                                                                                                                                                                                                                                                                                                                                                                | CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H |
| CVE-2021-39150 / GHSA-cxfm-5m4g-x7xp | The vulnerability may **allow a remote attacker to request data from internal resources that are not publicly available only by manipulating the processed input stream** with a Java runtime version 14 to 8. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.                                                                                                                                                                                                                                                                                                | CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H |
| CVE-2021-39152 / GHSA-xw4p-crpj-vjx2 | The vulnerability may **allow a remote attacker to request data from internal resources that are not publicly available only by manipulating the processed input stream** with a Java runtime version 14 to 8. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.                                                                                                                                                                                                                                                                                                 | CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H |
| CVE-2020-26259 / GHSA-jfvx-7wrx-43fh | The vulnerability may **allow a remote attacker to delete arbitrary know files on the host as log as the executing process has sufficient rights only by manipulating the processed input stream**.                                                                                                                                                                                                                                                                                                                              | CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:N |