### PR TITLE
[GHSA-phf8-3qgv-rg5q] Update CVSS 3.x Privilege Required (PR) from None (N) to Low (L)

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-phf8-3qgv-rg5q/GHSA-phf8-3qgv-rg5q.json
+++ b/advisories/github-reviewed/2022/05/GHSA-phf8-3qgv-rg5q/GHSA-phf8-3qgv-rg5q.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+      "score": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
# Summary

The Privilege Required (PR) metric for CVE-2017-1000105 / GHSA-phf8-3qgv-rg5q should be revised from None to Low. This vulnerability enables users with lower privileges, such as Item/Read permissions, to elevate their access to higher privileges, like Run/Artifacts permissions, by modifying a Java system property. This scenario does not align with cases requiring no permissions or administrative privileges, justifying the proposed update.

## GHSA Description
> The optional **Run/Artifacts permission** can be enabled by setting a Java system property. Blue Ocean did not check this permission before providing access to archived artifacts, **Item/Read permission** was sufficient.


## CVSS 3.x Specifications

> The attacker is unauthorized prior to attack, and therefore does not require any access to settings or files of the vulnerable system to carry out an attack. (CVSS 3.x Specification for PR = N)

> The attacker requires privileges that provide significant (e.g., administrative) control over the vulnerable component allowing access to component-wide settings and files. (CVSS 3.x Specification for PR = H)


# Supporting Examples

- [CVE-2021-21650](https://github.com/advisories/GHSA-fvfc-8pqr-wjpv) (CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N)
> [...] This allows attackers with **Item/Read permission** to obtain information about artifacts uploaded to S3, if the optional **Run/Artifacts permission is enabled.**
- [CVE-2022-30954](https://github.com/advisories/GHSA-5m4q-x28v-q6wp) (CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N)
> Jenkins Rundeck Plugin 3.6.11 and earlier does not perform **Run/Artifacts permission checks** in multiple HTTP endpoints, **allowing attackers with Item/Read permission to obtain information about build artifacts of a given job**, if the optional Run/Artifacts permission is enabled.
