### PR TITLE
[GHSA-733r-8xcp-w9mr] Update User Interaction (UI) for None (N) to Required (R)

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-733r-8xcp-w9mr/GHSA-733r-8xcp-w9mr.json
+++ b/advisories/github-reviewed/2024/01/GHSA-733r-8xcp-w9mr/GHSA-733r-8xcp-w9mr.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
# Summary

The User Interaction (UI) requirement for CVE-2024-21641 / GHSA-733r-8xcp-w9mr should be updated from None (N) to Required (R). This is because exploiting this vulnerability necessitates user action: logging into a “trusted domain” beforehand. This aligns with the CVSS 3.x specification, which states that user interaction is required if some action must be taken before the vulnerability can be exploited.

## GHSA Description

>   The Flarum `/logout` route includes a **redirect parameter that allows any third party to redirect users from a (trusted) domain of the Flarum installation to redirect to any link**. Sample: `example.com/logout?return=https://google.com`. For logged-in users, the logout must be confirmed. Guests are immediately redirected. This could be used by spammers to redirect to a web address using a trusted domain of a running Flarum installation.

## CVSS 3.x Specifications

| Metric Value | Description                                                  |
| :----------- | :----------------------------------------------------------- |
| None (N)     | The vulnerable system can be exploited without interaction from any user. |
| Required (R) | Successful exploitation of this vulnerability requires a user to **take some action before the vulnerability can be exploited**. For example, a successful exploit may only be possible during the installation of an application by a system administrator. |

# Supporting Examples

Notably, the following CVEs, though related to different software, describe similar scenarios and have been assigned UI:R:

-   CVE-2021-32645 / GHSA-4r8q-gv9j-3xx6 (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N)

    >   In some situations, it is possible to have **open redirects where users can be redirected from your site to any other site using a specially crafted URL**.
    >   This is only the case for installations where the default Hostname Identification is used and the environment uses tenants that have `force_https` set to `true` (default: `false`)

-   CVE-2021-29456 / GHSA-36f2-fcrx-fp4j (CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N)

    >   Utilizing a HTTP query parameter an attacker is able to **redirect users from the web application to any domain**. The URL of the intended redirect should always be checked for safety prior to forwarding the user. Other endpoints of the web application already do this, they check both that the domain is using the HTTPS protocol and that it exists on a domain associated with the application.
    >
    >   An attacker is able to **use this unintended functionality to redirect users to malicious sites**. This particular security issue allows the attacker to make a phishing attempt seem much more trustworthy to a user of the web application as the initial site before redirection is familiar to them, as well as the actual URL which they have theoretically visited frequently.
    >
    >   While this security issue does not directly impact the security of the web application, it is still not an acceptable scenario for the reasons mentioned above.

-   CVE-2022-21651 / GHSA-c53v-qmrx-93hg (CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:N/A:N)

    >   Arbitrary redirect while using certain URLs