### PR TITLE
[GHSA-9xfw-jjq2-7v8h] Update CVSS 3.x Scope (S) from Changed (C) to Unchanged (U) 

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-9xfw-jjq2-7v8h/GHSA-9xfw-jjq2-7v8h.json
+++ b/advisories/github-reviewed/2024/02/GHSA-9xfw-jjq2-7v8h/GHSA-9xfw-jjq2-7v8h.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:L"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:L/A:L"
     }
   ],
   "affected": [


### PR DESCRIPTION
# Summary

The Scope (S) classification of CVE-2024-24768 / GHSA-9xfw-jjq2-7v8h should be revised from Changed (C) to Unchanged (U). The reason is that the leakage of cookies does not grant attackers access "beyond the security scope" when they use the cookies to impersonate users.

## GHSA Description

>   The https cookie that comes with the panel does not have the Secure keyword, which may cause the cookie to be sent in plain text when accessing http accidentally.

## CVSS 3.x Specifications

| Metric Value  | Description                                                  |
| :------------ | :----------------------------------------------------------- |
| Unchanged (U) | An exploited vulnerability can only **affect resources managed by the *same* security authority**. In this case, the vulnerable component and the impacted component are either the same, or both are managed by the same security authority. |
| Changed (C)   | An exploited vulnerability can **affect resources *beyond* the security scope managed by the security authority of the vulnerable component**. In this case, the vulnerable component and the impacted component are different and managed by different security authorities. |

# Supporting Examples

Similar scenarios are described in the following CVEs for various software, all of which are rated as `S:U`:

-   CVE-2015-3207 / GHSA-rqph-25q9-9jhp (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N)

    >   In Openshift Origin the cookies being set in console have no 'secure', 'HttpOnly' attributes

-   CVE-2014-9634 / GHSA-g7cf-wg27-qw87 (CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N)

    >   Jenkins before 1.586 does not set the secure flag on session cookies when run on Tomcat 7.0.41 or later, which makes it easier for remote attackers to capture cookies by intercepting their transmission within an HTTP session.

-   CVE-2023-0055 / GHSA-m3g7-wrrq-v5c8 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N)

    >   Sensitive Cookie in HTTPS Session Without 'Secure' Attribute in GitHub repository pyload/pyload prior to 0.5.0b3.dev32. The Secure attribute for sensitive cookies in HTTPS sessions is not set, which could cause the user agent to send those cookies in plaintext over an HTTP session. This issue is patched in version 0.5.0b3.dev32.
