### PR TITLE
 [GHSA-mr75-899x-qcxq] Revising CVSS 3.x Confidentiality (C) Rating from High (H) to Low (L)

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-mr75-899x-qcxq/GHSA-mr75-899x-qcxq.json
+++ b/advisories/github-reviewed/2022/05/GHSA-mr75-899x-qcxq/GHSA-mr75-899x-qcxq.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
# Summary

The Confidentiality (C) rating for CVE-2020-2322 / GHSA-mr75-899x-qcxq should be adjusted from High (H) to Low (L). While permission elevation from `Overall/Read` to `Overall/Administer` allows attackers to access information that would otherwise be restricted (meeting the criteria for “some restricted information” under `C:L`), the vulnerability does not result in the disclosure of sensitive information such as passwords or encryption keys.

## GHSA Description

>   Jenkins Chaos Monkey Plugin 0.3 and earlier does not perform permission checks in several HTTP endpoints.
>
>   This allows attackers with **Overall/Read permission to generate load and to generate memory leaks.**
>
>   Jenkins Chaos Monkey Plugin 0.4 requires **Overall/Administer permission to generate load and to generate memory leaks.**

## CVSS 3.x Specification 

| Metric Value | Description                                                  |
| :----------- | :----------------------------------------------------------- |
| High (H)     | There is a total loss of confidentiality, resulting in all resources within the impacted component being divulged to the attacker. Alternatively, access to only some restricted information is obtained, but the disclosed information presents a direct, serious impact. For example, an attacker steals the administrator's password, or private encryption keys of a web server. |
| Low (L)      | There is some loss of confidentiality. Access to some restricted information is obtained, but the attacker does not have control over what information is obtained, or the amount or kind of loss is limited. The information disclosure does not cause a direct, serious loss to the impacted component. |
| None (N)     | There is no loss of confidentiality within the impacted component. |

# Supporting Examples

Other CVEs related to Jenkins plugins with similar permission elevation scenarios have consistently been rated as C:L:

-   CVE-2021-21674 / GHSA-c4c3-3cgh-vvrh (CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N)

    >   Jenkins requests-plugin Plugin 2.2.6 and earlier does not perform a permission check in an HTTP endpoint.
    >
    >   This allows attackers with **Overall/Read permission** to view the list of pending requests.
    >
    >   Jenkins requests-plugin Plugin 2.2.7 requires **Overall/Administer permission** to view the list of pending requests.
    >
    >   The previous sentence originally stated that Overall/Read permission was newly required. This statement was incorrect and has been fixed on 2021-07-05.

-   CVE-2023-37949 / GHSA-4hm4-94g6-f23f (CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N)

    >   Jenkins Orka by MacStadium Plugin 1.33 and earlier does not perform a permission check in an HTTP endpoint.
    >
    >   This allows attackers with **Overall/Read permission** to connect to an attacker-specified URL using attacker-specified credentials IDs obtained through another method, capturing credentials stored in Jenkins.
    >
    >   Orka by MacStadium Plugin 1.34 requires **Overall/Administer permission** to access the affected HTTP endpoint.

-   CVE-2022-34785 / GHSA-qv56-j8fg-39h6 (CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N)

    >   Jenkins build-metrics Plugin 1.3 and earlier does not perform a permission check in multiple HTTP endpoints.
    >
    >   This allows attackers with **Overall/Read permission** to obtain information about jobs otherwise inaccessible to them.
    >
    >   As of publication of this advisory, there is no fix.
(END)