### PR TITLE
[GHSA-4g9r-vxhx-9pgx] Updating Confidentiality and Integrity of CVSS 3.x Rating

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-4g9r-vxhx-9pgx/GHSA-4g9r-vxhx-9pgx.json
+++ b/advisories/github-reviewed/2024/02/GHSA-4g9r-vxhx-9pgx/GHSA-4g9r-vxhx-9pgx.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:C/C:N/I:N/A:H"
     }
   ],
   "affected": [


### PR DESCRIPTION
# Summary

The Confidentiality (C) and Integrity (I) ratings for CVE-2024-25710 / GHSA-4g9r-vxhx-9pgx should both be updated from High (H) to None (N), as the infinite loop neither exposes sensitive information nor enables attackers to modify files. The Availability (A) rating, however, is appropriate, as this vulnerability can lead to a Denial of Service (DoS) by exhausting system resources.

## GHSA Description

>   Loop with Unreachable Exit Condition ('**Infinite Loop**') vulnerability in Apache Commons Compress. This issue affects Apache Commons Compress: from 1.3 through 1.25.0.

## CVSS 3.x Specifications

### Confidentiality

| Metric Value | Description                                                  |
| :----------- | :----------------------------------------------------------- |
| High (H)     | There is a total loss of confidentiality, resulting in all resources within the impacted component being divulged to the attacker. Alternatively, access to only some restricted information is obtained, but the disclosed information presents a direct, serious impact. For example, an attacker steals the administrator's password, or private encryption keys of a web server. |
| Low (L)      | There is some loss of confidentiality. Access to some restricted information is obtained, but the attacker does not have control over what information is obtained, or the amount or kind of loss is limited. The information disclosure does not cause a direct, serious loss to the impacted component. |
| None (N)     | There is no loss of confidentiality within the impacted component. |

### Integrity

| Metric Value | Description                                                  |
| :----------- | :----------------------------------------------------------- |
| High (H)     | There is a total loss of integrity, or a complete loss of protection. For example, the attacker is able to modify any/all files protected by the impacted component. Alternatively, only some files can be modified, but malicious modification would present a direct, serious consequence to the impacted component. |
| Low (L)      | Modification of data is possible, but the attacker does not have control over the consequence of a modification, or the amount of modification is limited. The data modification does not have a direct, serious impact on the impacted component. |
| None (N)     | There is no loss of integrity within the impacted component. |

# Supporting Examples

The following CVEs involving infinite loops have all rated `C:N/I:N`:

-   CVE-2019-12402 / GHSA-53x6-4x5p-rrvv (CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H)

    >   The file name encoding algorithm used internally in Apache Commons Compress 1.15 to 1.18 can get into an **infinite loop** when faced with specially crafted inputs. This can lead to a **denial of service** attack if an attacker can choose the file names inside of an archive created by Compress.

-   CVE-2018-11771 / GHSA-hrmr-f5m6-m9pq (CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H)

    >   When reading a specially crafted ZIP archive, the read method of Apache Commons Compress 1.7 to 1.17's ZipArchiveInputStream can fail to return the correct EOF indication after the end of the stream has been reached. When combined with a java.io.InputStreamReader this can lead to an **infinite stream**, which can be used to mount a **denial of service** attack against services that use Compress' zip package.

-   CVE-2018-12418 / GHSA-5xqr-grq4-qwgx (CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H)

    >   Archive.java in Junrar before 1.0.1, as used in Apache Tika and other products, is affected by a **denial of service** vulnerability due to an **infinite loop** when handling corrupt RAR files.

