### PR TITLE
[GHSA-93m7-c69f-5cfj] Updating Confidentiality and Integrity of CVSS 3.x Rating

### DIFF
--- a/advisories/github-reviewed/2022/10/GHSA-93m7-c69f-5cfj/GHSA-93m7-c69f-5cfj.json
+++ b/advisories/github-reviewed/2022/10/GHSA-93m7-c69f-5cfj/GHSA-93m7-c69f-5cfj.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
     }
   ],
   "affected": [


### PR DESCRIPTION
# Summary

The CIA triad of CVE-2020-25614 / GHSA-93m7-c69f-5cfj should be updated from `C:H/I:H/A:H` to `C:N/I:N/A:H`. While the description explicitly identifies a Denial of Service (DoS) scenario, justifying `A:H`, the inability to parse XML as described does not result in the exposure of sensitive information or unauthorized file modifications.

>   xmlquery before 1.3.1 lacks a check for whether a LoadURL response is in the XML format, which allows attackers to cause a **denial of service** (SIGSEGV) at xmlquery.(*Node).InnerText or possibly have unspecified other impact.


# Supporting Examples

For reference, other CVEs that describe XML parsing failures have consistently been rated as `C:N/I:N/A:H`:

-   CVE-2022-23476 / GHSA-qv4q-mr5r-qprj (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H)

    >   Nokogiri `1.13.8, 1.13.9` fails to check the return value from `xmlTextReaderExpand` in the method `Nokogiri::XML::Reader#attribute_hash`. This can lead to a **null pointer exception** when invalid markup is being parsed.
    >
    >   For applications using `XML::Reader` to parse untrusted inputs, this may potentially be a vector for a **denial of service attack**.

-   CVE-2020-7711 / GHSA-mqqv-chpx-vq25 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H)

    >   This affects all versions of package github.com/russellhaering/goxmldsig prior to 1.1.1. There is a crash on **nil-pointer dereference** caused by sending **malformed XML signatures**. This issue is patched in version 1.1.1.

-   CVE-2021-3537 / GHSA-286v-pcf5-25rc (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H)

    >   A vulnerability found in libxml2 in versions before 2.9.11 shows that it did not propagate errors while **parsing XML mixed content**, causing a NULL dereference. If an untrusted XML document was parsed in recovery mode and post-validated, the flaw could be used to crash the application. The highest threat from this vulnerability is to **system availability**.

