### PR TITLE
[GHSA-76mp-659p-rw65] Updating CVSS 3.x Availability Rating

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-76mp-659p-rw65/GHSA-76mp-659p-rw65.json
+++ b/advisories/github-reviewed/2021/05/GHSA-76mp-659p-rw65/GHSA-76mp-659p-rw65.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
# Summary

The Availability (A) rating for CVE-2021-32620 / GHSA-76mp-659p-rw65 should be revised from High (H) to None (N). This is because the vulnerability does not disrupt the wiki’s functionality or hinder access for others, as seen in typical Denial-of-Service (DoS) attacks.

>   A user disabled on a wiki using email verification for registration can **re-activate himself** by using the activation link provided for his registration.

# Supporting Examples

Notably, a similar CVE for the same package has already been rated as `A:N`:

-   CVE-2022-36090 / GHSA-jgc8-gvcx-9vfx (CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N)

    >   Some resources are missing a check for inactive (not yet activated or disabled) users in XWiki, including the REST service: so **a disabled user can enable themselves using a REST call**. On the same way some resources handler created by extensions are not protected by default: so an inactive users could perform actions for such extensions.