### PR TITLE
[GHSA-p5v9-g8w8-5q4v] Update CVSS 3.x Availability Rating

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-p5v9-g8w8-5q4v/GHSA-p5v9-g8w8-5q4v.json
+++ b/advisories/github-reviewed/2022/11/GHSA-p5v9-g8w8-5q4v/GHSA-p5v9-g8w8-5q4v.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H"
     }
   ],
   "affected": [


### PR DESCRIPTION
# Summary

The Availability (A) rating for CVE-2022-41930 / GHSA-p5v9-g8w8-5q4v should be updated from None (N) to High (H). Disabling any user on Wiki fully denies access to resources within the impacted component, which aligns with the CVSS 3.x specification for a High Availability impact.

>   Any user (logged in or not) with access to the page XWiki.XWikiUserProfileSheet can enable or disable any user profile. This might allow to a disabled user to re-enable themselves, or to an attacker to **disable any user of the wiki**.

# Supporting Examples

-   CVE-2017-8382 / GHSA-c4v8-2hg8-jv77 (CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:U/C:N/I:N/A:H)

    >   admidio 3.2.8 has CSRF in `adm_program/modules/members/members_function.php` with an impact of **deleting arbitrary user accounts**.