### PR TITLE
[GHSA-5357-c2jx-v7qh] Authlib has algorithm confusion with asymmetric public keys

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-5357-c2jx-v7qh/GHSA-5357-c2jx-v7qh.json
+++ b/advisories/github-reviewed/2024/06/GHSA-5357-c2jx-v7qh/GHSA-5357-c2jx-v7qh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-5357-c2jx-v7qh",
-  "modified": "2024-07-26T21:36:55Z",
+  "modified": "2024-08-15T21:21:29Z",
   "published": "2024-06-09T21:30:33Z",
   "aliases": [
     "CVE-2024-37568"
@@ -29,6 +29,25 @@
             },
             {
               "fixed": "1.3.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "joserfc"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.11.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
* Added another pypi package - joserfc which is affected by the same vulnerability.