### PR TITLE
[GHSA-9w7j-q3xw-p9vh] Hyperledger Fabric subject to Denial of Service via non-validated request

### DIFF
--- a/advisories/github-reviewed/2022/09/GHSA-9w7j-q3xw-p9vh/GHSA-9w7j-q3xw-p9vh.json
+++ b/advisories/github-reviewed/2022/09/GHSA-9w7j-q3xw-p9vh/GHSA-9w7j-q3xw-p9vh.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9w7j-q3xw-p9vh",
-  "modified": "2022-09-28T14:12:31Z",
+  "modified": "2023-01-27T05:07:16Z",
   "published": "2022-09-25T00:00:26Z",
   "aliases": [
     "CVE-2022-35253"
@@ -9,10 +9,7 @@
   "summary": "Hyperledger Fabric subject to Denial of Service via non-validated request",
   "details": "A vulnerability exists in Hyperledger Fabric < 2.4 could allow an attacker to construct a non-validated request that could cause a denial of service attack.  The peer gateway service tries to extract channel and chaincode information from the signed proposal, but it doesn't check the proposal fields for validity. Therefore a malformed proposal might end up crashing the peer service. This issue has been patched in 2.4.6. There are no known workarounds.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-    }
+
   ],
   "affected": [
     {
@@ -62,7 +59,7 @@
       "CWE-20",
       "CWE-400"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2022-09-28T14:12:31Z",
     "nvd_published_at": "2022-09-23T14:15:00Z"


### PR DESCRIPTION
**Updates**
- CVSS v3
- Severity

**Comments**
CVE has been marked “REJECT” in the NVD CVE list. These CVEs are stored in the NVD, but do not show up in search results.
Hence this CVE shouldn’t be reported in any search results/exports.
https://nvd.nist.gov/vuln/detail/CVE-2022-35253
