### PR TITLE
Update GHSA-4x9r-j582-cgr8.json fixed versions

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-4x9r-j582-cgr8/GHSA-4x9r-j582-cgr8.json
+++ b/advisories/github-reviewed/2022/07/GHSA-4x9r-j582-cgr8/GHSA-4x9r-j582-cgr8.json
@@ -32,13 +32,31 @@
               "introduced": "0"
             },
             {
+              "fixed": "3.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.apache.spark:spark-parent_2.12"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.1.1"
+            },
+            {
               "fixed": "3.1.3"
             }
           ]
         }
       ]
     },
-    "affected": [
     {
       "package": {
         "ecosystem": "Maven",
@@ -57,6 +75,7 @@
           ]
         }
       ]
+    },
     {
       "package": {
         "ecosystem": "PyPI",
@@ -68,6 +87,25 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "3.1.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "pyspark"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.1.1"
             },
             {
               "fixed": "3.1.3"

--- a/advisories/github-reviewed/2022/07/GHSA-4x9r-j582-cgr8/GHSA-4x9r-j582-cgr8.json
+++ b/advisories/github-reviewed/2022/07/GHSA-4x9r-j582-cgr8/GHSA-4x9r-j582-cgr8.json
@@ -51,25 +51,6 @@
               "introduced": "3.1.1"
             },
             {
-              "fixed": "3.1.3"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.apache.spark:spark-parent_2.12"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.2.0"
-            },
-            {
               "fixed": "3.2.2"
             }
           ]
@@ -106,25 +87,6 @@
           "events": [
             {
               "introduced": "3.1.1"
-            },
-            {
-              "fixed": "3.1.3"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "PyPI",
-        "name": "pyspark"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.2.0"
             },
             {
               "fixed": "3.2.2"

--- a/advisories/github-reviewed/2022/07/GHSA-4x9r-j582-cgr8/GHSA-4x9r-j582-cgr8.json
+++ b/advisories/github-reviewed/2022/07/GHSA-4x9r-j582-cgr8/GHSA-4x9r-j582-cgr8.json
@@ -32,12 +32,13 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.0.3"
+              "fixed": "3.1.3"
             }
           ]
         }
       ]
     },
+    "affected": [
     {
       "package": {
         "ecosystem": "Maven",
@@ -48,7 +49,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.1.1"
+              "introduced": "3.2.0"
             },
             {
               "fixed": "3.2.2"
@@ -56,7 +57,6 @@
           ]
         }
       ]
-    },
     {
       "package": {
         "ecosystem": "PyPI",
@@ -70,7 +70,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "3.0.3"
+              "fixed": "3.1.3"
             }
           ]
         }
@@ -86,7 +86,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "3.1.1"
+              "introduced": "3.2.0"
             },
             {
               "fixed": "3.2.2"


### PR DESCRIPTION
Update fixed versions for Maven and PyPI ecosystems.

Change `last_affected` to `fixed` to more closely match the recommendations in: https://lists.apache.org/thread/p847l3kopoo5bjtmxrcwk21xp6tjxqlc

> Upgrade to supported Apache Spark maintenance release 3.1.3, 3.2.2, or 3.3.0 or later

This could be replaced with:
```
{
  {"introduced": "0"},
  {"last_affected": "3.0.3"}
},
{
  {"introduced": "3.1.0"},
  {"fixed": "3.1.3"}
},
{
  {"introduced": "3.2.0"},
  {"fixed": "3.2.2"}
}
```

But given there is no version between `3.0.3` and `3.1.0` this seems unnecessary and potentially confusing.
- https://mvnrepository.com/artifact/org.apache.spark/spark-parent
- https://pypi.org/project/pyspark/#history

This change follows the OSV format recommendations to use `fixed` instead of `last_affected`: https://ossf.github.io/osv-schema/#requirements