### PR TITLE
Update GHSA-xq3w-v528-46rv.json

### DIFF
--- a/advisories/github-reviewed/2024/11/GHSA-xq3w-v528-46rv/GHSA-xq3w-v528-46rv.json
+++ b/advisories/github-reviewed/2024/11/GHSA-xq3w-v528-46rv/GHSA-xq3w-v528-46rv.json
@@ -32,13 +32,13 @@
               "introduced": "0"
             },
             {
-              "fixed": "4.1.115"
+              "fixed": "4.1.115.Final"
             }
           ]
         }
       ],
       "database_specific": {
-        "last_known_affected_version_range": "<= 4.1.114"
+        "last_known_affected_version_range": "<= 4.1.114.Final"
       }
     }
   ],


### PR DESCRIPTION
Appended ".Final" to pinpoint to the exact version, as per maven repository information.

Ref:
- https://mvnrepository.com/artifact/io.netty/netty-common/4.1.115.Final
- https://mvnrepository.com/artifact/io.netty/netty-common/4.1.114.Final