### PR TITLE
[GHSA-hxf3-vgpm-fv9p] CycloneDX cdxgen may execute code contained within build-related files

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-hxf3-vgpm-fv9p/GHSA-hxf3-vgpm-fv9p.json
+++ b/advisories/github-reviewed/2024/10/GHSA-hxf3-vgpm-fv9p/GHSA-hxf3-vgpm-fv9p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hxf3-vgpm-fv9p",
-  "modified": "2025-02-03T13:28:09Z",
+  "modified": "2025-02-03T13:28:13Z",
   "published": "2024-10-28T00:30:48Z",
   "aliases": [
     "CVE-2024-50611"
@@ -11,11 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:L/AC:L/AT:P/PR:H/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/E:P"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
     }
   ],
   "affected": [
@@ -73,7 +69,7 @@
     "cwe_ids": [
       "CWE-94"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2024-10-28T15:05:26Z",
     "nvd_published_at": "2024-10-27T22:15:03Z"


### PR DESCRIPTION
**Updates**
- CVSS v3
- CVSS v4
- Severity

**Comments**
No biggie, but while the github issue was indeed created by prabhu, I'm the researcher he mentioned who notified him (privately) in the first place and created the POC :) He definitely deserves a credit (especially for fixing it) but I'm the one who discovered it, reported it (responsible disclosure to prabhu) with the POC and submited this CVE to mitre. 

Note: prabhu DID ask if I want to be credited on the github issue, and I was late to reply so I guess he assumed I prefer to be anonymous :) So to clarify, he did nothing wrong and he deserves the credit on this too. (and deserves kudos for releasing a fix recently)

Evidence: 

- https://github.com/CycloneDX/cdxgen/issues/1328#issuecomment-2622865072
- https://github.com/CycloneDX/cdxgen/releases/tag/v11.1.7

p.s. ignore the change requested on the CVSS, the form didn't let me submit with the 
CVSS:4.0/AV:L/AC:L/AT:P/PR:H/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/E:P value, so had to change it to CVSS3 to make it work
Thanks!