### PR TITLE
[GHSA-gvwq-6fmx-28xm] node-opcua-alarm-condition prototype pollution vulnerability

### DIFF
--- a/advisories/github-reviewed/2025/02/GHSA-gvwq-6fmx-28xm/GHSA-gvwq-6fmx-28xm.json
+++ b/advisories/github-reviewed/2025/02/GHSA-gvwq-6fmx-28xm/GHSA-gvwq-6fmx-28xm.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gvwq-6fmx-28xm",
-  "modified": "2025-04-10T12:50:02Z",
+  "modified": "2025-04-10T12:50:03Z",
   "published": "2025-02-06T06:31:26Z",
   "aliases": [
     "CVE-2024-57086"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:H"
     }
   ],
   "affected": [
@@ -42,10 +42,6 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/node-opcua/node-opcua/issues/1433#issuecomment-2791824350"
-    },
-    {
-      "type": "WEB",
       "url": "https://gist.github.com/tariqhawis/30acc3632cf595ca5825b7ec2b2f795a"
     },
     {
@@ -61,7 +57,7 @@
     "cwe_ids": [
       "CWE-1321"
     ],
-    "severity": "HIGH",
+    "severity": "CRITICAL",
     "github_reviewed": true,
     "github_reviewed_at": "2025-04-10T12:50:02Z",
     "nvd_published_at": "2025-02-05T22:15:32Z"


### PR DESCRIPTION
**Updates**
- CVSS v3
- References
- Severity

**Comments**
Removed an issue link unrelated to the vulnerability.
Details: the removed issue link is opened by a user to confirm the status of the vulnerability, which is already fixed b y the maintainer based on our original private report in Nov, 2024.
The credited user should be replaced by the original one (tariqhawis).