### PR TITLE
Add affected `pax-logging-log4j2` to CVE-2021-45105

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-p6xc-xr62-6r2g/GHSA-p6xc-xr62-6r2g.json
+++ b/advisories/github-reviewed/2021/12/GHSA-p6xc-xr62-6r2g/GHSA-p6xc-xr62-6r2g.json
@@ -71,6 +71,25 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.ops4j.pax.logging:pax-logging-log4j2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.8.0"
+            },
+            {
+              "fixed": "2.0.13"
+            }
+          ]
+        }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
The `pax-logging-log4j2` artifact shades `log4j-core` with minimal modifications.

The correspondence between `pax-logging-log4j2` versions and the embedded `log4j-core` version is given by the table below:

| `pax-logging-log4j2` version | `log4j-core` version |
|------------------------------|----------------------|
| 2.0.10                       | 2.14.1               |
| 2.0.11                       | 2.15.0               |
| 2.0.12                       | 2.16.0               |
| 2.0.13                       | 2.17.0               |
| 2.0.14                       | 2.17.1               |