### PR TITLE
[GHSA-c678-jfcj-6jmf] A vulnerability was found in PyTorch 2.6.0+cu124. It has...

### DIFF
--- a/advisories/unreviewed/2025/03/GHSA-c678-jfcj-6jmf/GHSA-c678-jfcj-6jmf.json
+++ b/advisories/unreviewed/2025/03/GHSA-c678-jfcj-6jmf/GHSA-c678-jfcj-6jmf.json
@@ -1,23 +1,40 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-c678-jfcj-6jmf",
-  "modified": "2025-03-10T12:30:56Z",
+  "modified": "2025-03-10T12:31:02Z",
   "published": "2025-03-10T12:30:55Z",
   "aliases": [
     "CVE-2025-2148"
   ],
+  "summary": "Changes for vulnerable version range ",
   "details": "A vulnerability was found in PyTorch 2.6.0+cu124. It has been declared as critical. Affected by this vulnerability is the function torch.ops.profiler._call_end_callbacks_on_jit_fut of the component Tuple Handler. The manipulation of the argument None leads to memory corruption. The attack can be launched remotely. The complexity of an attack is rather high. The exploitation appears to be difficult.",
   "severity": [
     {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
-    },
-    {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:P/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N/E:X/CR:X/IR:X/AR:X/MAV:X/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:X/V:X/RE:X/U:X"
+      "score": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:P/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
     }
   ],
-  "affected": [],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "torch"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 1.6.0"
+      }
+    }
+  ],
   "references": [
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- CVSS v4
- Summary

**Comments**
The Vulnerability was introduced in 1.6.0-rc1 and has not been fixed yet. Just need to handle the parameters and validate as this is a compile-time error.