### PR TITLE
fix: `pax-logging-log4j2` ranges affected by CVE-2021-45105

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-p6xc-xr62-6r2g/GHSA-p6xc-xr62-6r2g.json
+++ b/advisories/github-reviewed/2021/12/GHSA-p6xc-xr62-6r2g/GHSA-p6xc-xr62-6r2g.json
@@ -85,6 +85,63 @@
               "introduced": "1.8.0"
             },
             {
+              "fixed": "1.9.2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.ops4j.pax.logging:pax-logging-log4j2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.10.0"
+            },
+            {
+              "fixed": "1.10.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.ops4j.pax.logging:pax-logging-log4j2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.11.0"
+            },
+            {
+              "fixed": "1.11.12"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.ops4j.pax.logging:pax-logging-log4j2"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0"
+            },
+            {
               "fixed": "2.0.13"
             }
           ]


### PR DESCRIPTION
This PR fixes the ranges of `pax-logging-log4j2` affected by CVE-2021-45105.

In my previous PRs for CVE-2021-45105 (#5503) all versions 1.x of `pax-logging-log4j2` were listed as affected. As it turns out, this is incorrect, since 7 security releases of version 1.x were created to address those issues, as summarized by the table below:

| PAX Logging version | Log4j Core version | Fixed CVEs                     |
|---------------------|--------------------|--------------------------------|
| 1.9.2               | 2.12.4             | all 4 CVEs                     |
| 1.10.8              | 2.12.2             | CVE-2021-44228, CVE-2021-45046 |
| 1.10.9              | 2.12.4             | CVE-2021-45105, CVE-2021-44832 |
| 1.11.10             | 2.15.0             | CVE-2021-44228                 |
| 1.11.11             | 2.16.0             | CVE-2021-45046                 |
| 1.11.12             | 2.17.0             | CVE-2021-45105                 |
| 1.11.13             | 2.17.1             | CVE-2021-44832                 |