### PR TITLE
[GHSA-4vp2-mj4m-69m4] ThinkAdmin insecure unserialize vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4vp2-mj4m-69m4/GHSA-4vp2-mj4m-69m4.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4vp2-mj4m-69m4/GHSA-4vp2-mj4m-69m4.json
@@ -47,6 +47,18 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/zoujingli/ThinkAdmin"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/zoujingli/ThinkAdmin/commit/6ccd4055fc40d2d7d154920a1859a7c19774bd1a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/zoujingli/ThinkAdmin/commit/640a61ae0772dcd5209d74dff8ad373e61e8ad8c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/zoujingli/ThinkAdmin/commit/b8a2ded90866a285e9022c842e546d8a6fa5fa6d"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:


- References

Comments:
Add 3 patch commits:
https://github.com/zoujingli/ThinkAdmin/commit/6ccd4055fc40d2d7d154920a1859a7c19774bd1a
https://github.com/zoujingli/ThinkAdmin/commit/640a61ae0772dcd5209d74dff8ad373e61e8ad8c
https://github.com/zoujingli/ThinkAdmin/commit/b8a2ded90866a285e9022c842e546d8a6fa5fa6d



