### PR TITLE
[GHSA-2qm5-r82g-5hcx] ThinkAdmin directory traversal vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-2qm5-r82g-5hcx/GHSA-2qm5-r82g-5hcx.json
+++ b/advisories/github-reviewed/2022/05/GHSA-2qm5-r82g-5hcx/GHSA-2qm5-r82g-5hcx.json
@@ -41,6 +41,14 @@
     {
       "type": "WEB",
       "url": "http://packetstormsecurity.com/files/159177/ThinkAdmin-6-Arbitrary-File-Read.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/zoujingli/ThinkAdmin/commit/ff2ab47cfabd4784effbf72a2a386c5d25c43a9a"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/zoujingli/ThinkAdmin/commit/f28abaccb9db4c37a32d237c7c76e392d7f544f1"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:


- References

Comments:
Add 2 patch commits:
https://github.com/zoujingli/ThinkAdmin/commit/b8a2ded90866a285e9022c842e546d8a6fa5fa6d
https://github.com/zoujingli/ThinkAdmin/commit/ff2ab47cfabd4784effbf72a2a386c5d25c43a9a