### PR TITLE
[GHSA-68x5-4jg5-gjgg] Moodle CSRF risk in analytics management of models

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-68x5-4jg5-gjgg/GHSA-68x5-4jg5-gjgg.json
+++ b/advisories/github-reviewed/2024/05/GHSA-68x5-4jg5-gjgg/GHSA-68x5-4jg5-gjgg.json
@@ -89,6 +89,10 @@
     {
       "type": "WEB",
       "url": "http://git.moodle.org/gw?p=moodle.git&a=search&h=HEAD&st=commit&s=MDL-81059"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/498a766263743ee649f6874e440a94517a077e2e"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:

- References

Comments:
Add a patch commit:
https://github.com/moodle/moodle/commit/498a766263743ee649f6874e440a94517a077e2e