### PR TITLE
[GHSA-gq9f-8rj4-w7jc] Moodle CSRF risk in admin preset tool management of presets

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-gq9f-8rj4-w7jc/GHSA-gq9f-8rj4-w7jc.json
+++ b/advisories/github-reviewed/2024/05/GHSA-gq9f-8rj4-w7jc/GHSA-gq9f-8rj4-w7jc.json
@@ -85,6 +85,10 @@
     {
       "type": "WEB",
       "url": "https://moodle.org/mod/forum/discuss.php?d=458389"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/03e93da556201291e4a345d353a06d08d5d04dd6"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:


- References

Comments:
Add a patch commit:
https://github.com/moodle/moodle/commit/03e93da556201291e4a345d353a06d08d5d04dd6