### PR TITLE
[GHSA-vvh5-7v3m-j3mj] Moodle Unsanitized HTML in site log for config_log_created

### DIFF
--- a/advisories/github-reviewed/2024/05/GHSA-vvh5-7v3m-j3mj/GHSA-vvh5-7v3m-j3mj.json
+++ b/advisories/github-reviewed/2024/05/GHSA-vvh5-7v3m-j3mj/GHSA-vvh5-7v3m-j3mj.json
@@ -89,6 +89,10 @@
     {
       "type": "WEB",
       "url": "http://git.moodle.org/gw?p=moodle.git&a=search&h=HEAD&st=commit&s=MDL-80585"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/cd85e090f3feb06e6eff65d1499a67353d82d3cb"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:

- References

Comments:
Add a patch commit:
https://github.com/moodle/moodle/commit/cd85e090f3feb06e6eff65d1499a67353d82d3cb