### PR TITLE
[GHSA-hhw2-pqhf-vmx2] Use after free in actix-utils

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-hhw2-pqhf-vmx2/GHSA-hhw2-pqhf-vmx2.json
+++ b/advisories/github-reviewed/2021/08/GHSA-hhw2-pqhf-vmx2/GHSA-hhw2-pqhf-vmx2.json
@@ -51,6 +51,10 @@
     {
       "type": "WEB",
       "url": "https://rustsec.org/advisories/RUSTSEC-2020-0045.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/actix/actix-net/commit/0dca1a705ad1ff4885b3491ecb809a808e1de66c"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:

- References

Comments:
Add a patch commit:
https://github.com/actix/actix-net/commit/f48e3f4cb0cf5779b43d5ec465a646253d96057f
The patch commit [f48e3f4](https://github.com/actix/actix-net/commit/f48e3f4cb0cf5779b43d5ec465a646253d96057f) was identified from issue [#160](https://github.com/actix/actix-net/issues/160), where it was marked as completed in [PR #161](https://github.com/actix/actix-net/pull/161). This commit is the one merged to address the issue.