### PR TITLE
[GHSA-rqgx-hpg4-456r] Use-after-free in actix-codec

### DIFF
--- a/advisories/github-reviewed/2021/08/GHSA-rqgx-hpg4-456r/GHSA-rqgx-hpg4-456r.json
+++ b/advisories/github-reviewed/2021/08/GHSA-rqgx-hpg4-456r/GHSA-rqgx-hpg4-456r.json
@@ -51,7 +51,12 @@
     {
       "type": "WEB",
       "url": "https://rustsec.org/advisories/RUSTSEC-2020-0049.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/actix/actix-net/commit/c41b5d8dd4235ccca84d0b687996615c0c64d956"
     }
+    
   ],
   "database_specific": {
     "cwe_ids": [


### PR DESCRIPTION
Updates:

- References

Comments:
Add a patch commit:
https://github.com/actix/actix-net/commit/c41b5d8dd4235ccca84d0b687996615c0c64d956
The patch commit [c41b5d8](https://github.com/actix/actix-net/commit/c41b5d8dd4235ccca84d0b687996615c0c64d956) was identified from issue [#91](https://github.com/actix/actix-net/issues/91), where it was referenced as the fix in [this comment](https://github.com/actix/actix-net/issues/91#issuecomment-660659406).