### PR TITLE
[GHSA-c85r-fwc7-45vc] Rancher permissions on 'namespaces' in any API group grants 'edit' permissions on namespaces in 'core'

### DIFF
--- a/advisories/github-reviewed/2024/02/GHSA-c85r-fwc7-45vc/GHSA-c85r-fwc7-45vc.json
+++ b/advisories/github-reviewed/2024/02/GHSA-c85r-fwc7-45vc/GHSA-c85r-fwc7-45vc.json
@@ -93,6 +93,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/rancher/rancher"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rancher/rancher/commit/649fdad268d8ecc748e9fdcca2ddcfdc900f9eaa"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:

- References

Comments:
Add a patch commit:
https://github.com/rancher/rancher/commit/649fdad268d8ecc748e9fdcca2ddcfdc900f9eaa