### PR TITLE
[GHSA-v2rh-5v88-rgvh] Moodle context freezing 

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-v2rh-5v88-rgvh/GHSA-v2rh-5v88-rgvh.json
+++ b/advisories/github-reviewed/2022/05/GHSA-v2rh-5v88-rgvh/GHSA-v2rh-5v88-rgvh.json
@@ -46,6 +46,11 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/moodle/moodle/commit/5ee3cbc624c1c4d39adc08c2121a1738d6b5e700",
+      "summary": "This patch commit is on another branch."
+    },
+    {
+      "type": "WEB",
       "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-3852"
     },
     {


### PR DESCRIPTION
**Updates**
 * References

 **Comments**
 * This patch is the same fix on a different branch as the existing patch. They share the same commit msgs. 
* Add a patch commit https://github.com/moodle/moodle/commit/5ee3cbc624c1c4d39adc08c2121a1738d6b5e700 as it is another fix on another branch for the same vulnerability.