### PR TITLE
[GHSA-9rmm-8fp4-26hv] phpMyAdmin Denial Of Service (DOS) attack

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9rmm-8fp4-26hv/GHSA-9rmm-8fp4-26hv.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9rmm-8fp4-26hv/GHSA-9rmm-8fp4-26hv.json
@@ -83,6 +83,16 @@
       "url": "https://github.com/phpmyadmin/phpmyadmin/commit/4767f24ea4c1e3822ce71a636c341e8ad8d07aa6"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/phpmyadmin/phpmyadmin/commit/abb3685c8702de887988fee31a97ef4d80d856a1",
+      "summary": "This patch commit is on another branch."
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/phpmyadmin/phpmyadmin/commit/805225a28c1428d7809e613c731c2126960e98df",
+      "summary": "This patch commit is on another branch."
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/phpmyadmin/composer"
     },


### PR DESCRIPTION
**Updates**
 * References

 **Comments**
 * These patches are all the same fix on different branches as the existing patch. They share the same commit msgs. 
* Add a patch commit https://github.com/phpmyadmin/phpmyadmin/commit/abb3685c8702de887988fee31a97ef4d80d856a1 as it is another fix on another branch for the same vulnerability.
* Add a patch commit https://github.com/phpmyadmin/phpmyadmin/commit/805225a28c1428d7809e613c731c2126960e98df as it is another fix on another branch for the same vulnerability.