### PR TITLE
[GHSA-xh29-r2w5-wx8m]  Nokogiri Improperly Handles Unexpected Data Type

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-xh29-r2w5-wx8m/GHSA-xh29-r2w5-wx8m.json
+++ b/advisories/github-reviewed/2022/05/GHSA-xh29-r2w5-wx8m/GHSA-xh29-r2w5-wx8m.json
@@ -50,6 +50,11 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/sparklemotion/nokogiri/commit/83cc451c3f29df397caa890afc3b714eae6ab8f7",
+      "summary": "This patch commit is on another branch."
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/nokogiri/CVE-2022-29181.yml"
     },
     {


### PR DESCRIPTION
**Updates**
 * References

 **Comments**
 * This patch is the same fix on a different branch as the existing patch. They share the same commit msgs. 
* Add a patch commit https://github.com/sparklemotion/nokogiri/commit/83cc451c3f29df397caa890afc3b714eae6ab8f7 as it is another fix on another branch for the same vulnerability.