### PR TITLE
[GHSA-hvf8-h2qh-37m9] IPC messages delivered to the wrong frame in Electron

### DIFF
--- a/advisories/github-reviewed/2021/01/GHSA-hvf8-h2qh-37m9/GHSA-hvf8-h2qh-37m9.json
+++ b/advisories/github-reviewed/2021/01/GHSA-hvf8-h2qh-37m9/GHSA-hvf8-h2qh-37m9.json
@@ -92,6 +92,16 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/puma/puma/commit/436c71807f00e07070902a03f79fd3e130eb6b18",
+      "summary": "This patch commit is on another branch."
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/puma/puma/commit/fb6ad8f8013ab5cdbb2f444cbfabd0b4fde71139",
+      "summary": "This patch commit is on another branch."
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/electron/electron/releases/tag/v9.4.0"
     },
     {


### PR DESCRIPTION
**Updates**
 * References

 **Comments**
 * These patches are all the same fix on different branches as the existing patch. They share the same commit msgs. 
* Add a patch commit https://github.com/puma/puma/commit/436c71807f00e07070902a03f79fd3e130eb6b18 as it is another fix on another branch for the same vulnerability.
* Add a patch commit https://github.com/puma/puma/commit/fb6ad8f8013ab5cdbb2f444cbfabd0b4fde71139 as it is another fix on another branch for the same vulnerability.