### PR TITLE
[GHSA-6vhp-hp77-6w52] Trac HTML WikiProcessor cross-site scripting (XSS) vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/04/GHSA-6vhp-hp77-6w52/GHSA-6vhp-hp77-6w52.json
+++ b/advisories/github-reviewed/2022/04/GHSA-6vhp-hp77-6w52/GHSA-6vhp-hp77-6w52.json
@@ -32,10 +32,7 @@
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 0.9-stable"
-      }
+      ]
     }
   ],
   "references": [

--- a/advisories/github-reviewed/2022/04/GHSA-6vhp-hp77-6w52/GHSA-6vhp-hp77-6w52.json
+++ b/advisories/github-reviewed/2022/04/GHSA-6vhp-hp77-6w52/GHSA-6vhp-hp77-6w52.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-6vhp-hp77-6w52",
+  "modified": "2024-11-18T20:49:48Z",
+  "published": "2022-05-01T02:29:20Z",
+  "aliases": [
+    "CVE-2005-4644"
+  ],
+  "summary": "Trac HTML WikiProcessor cross-site scripting (XSS) vulnerability",
+  "details": "Cross-site scripting (XSS) vulnerability in the HTML WikiProcessor in Edgewall Trac 0.9.2 allows remote attackers to inject arbitrary web script or HTML via javascript in the SRC attribute of an IMG tag.",
+  "severity": [
+    {
+      "type": "CVSS_V4",
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:N/VA:N/SC:L/SI:L/SA:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "trac"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.10"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 0.9-stable"
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2005-4644"
+    },
+    {
+      "type": "WEB",
+      "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/24183"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pypa/advisory-database/tree/main/vulns/trac/PYSEC-2005-1.yaml"
+    },
+    {
+      "type": "WEB",
+      "url": "https://web.archive.org/web/20140722192945/http://secunia.com/advisories/18465"
+    },
+    {
+      "type": "WEB",
+      "url": "https://web.archive.org/web/20151104154255/http://secunia.com/advisories/18555"
+    },
+    {
+      "type": "WEB",
+      "url": "https://web.archive.org/web/20200302063657/http://www.securityfocus.com/bid/16198"
+    },
+    {
+      "type": "WEB",
+      "url": "http://projects.edgewall.com/trac/ticket/2473"
+    },
+    {
+      "type": "WEB",
+      "url": "http://trac.edgewall.org/ticket/2473"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.debian.org/security/2006/dsa-951"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-79"
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true,
+    "github_reviewed_at": "2024-04-29T14:29:37Z",
+    "nvd_published_at": "2005-12-31T05:00:00Z"
+  }
+}


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
Correcting patched version: https://github.com/pypa/advisory-database/blob/main/vulns/trac/PYSEC-2005-1.yaml