### PR TITLE
[GHSA-f3gv-cwwh-758m] io.jmix.localfs:jmix-localfs affected by DoS in the Local File Storage

### DIFF
--- a/advisories/github-reviewed/2025/04/GHSA-f3gv-cwwh-758m/GHSA-f3gv-cwwh-758m.json
+++ b/advisories/github-reviewed/2025/04/GHSA-f3gv-cwwh-758m/GHSA-f3gv-cwwh-758m.json
@@ -74,6 +74,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/jmix-framework/jmix"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jmix-framework/jmix/commit/cc97e6ff974b9e7af8160fab39cc5866169daa37"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:

References
Comments:
Adding a patch commit:
https://github.com/jmix-framework/jmix/commit/cc97e6ff974b9e7af8160fab39cc5866169daa37
This commit corresponds to the same fix included in 2.4.0, as seen in:
https://github.com/jmix-framework/jmix/commit/c589ef4e2b25620770b8036f4ad05f1a6250cb6a