### PR TITLE
[GHSA-x27v-f838-jh93] io.jmix.rest:jmix-rest allows XSS in the /files Endpoint of the Generic REST API

### DIFF
--- a/advisories/github-reviewed/2025/04/GHSA-x27v-f838-jh93/GHSA-x27v-f838-jh93.json
+++ b/advisories/github-reviewed/2025/04/GHSA-x27v-f838-jh93/GHSA-x27v-f838-jh93.json
@@ -74,6 +74,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/jmix-framework/jmix"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/jmix-framework/jmix/commit/c589ef4e2b25620770b8036f4ad05f1a6250cb6a"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:


- References

Comments:
Adding a patch commit:
https://github.com/jmix-framework/jmix/commit/cc97e6ff974b9e7af8160fab39cc5866169daa37