### PR TITLE
[GHSA-5xm9-x7x4-4j5x] Elasticsearch Vulnerable to Stack Overflow due to a Large Recursion

### DIFF
--- a/advisories/github-reviewed/2025/04/GHSA-5xm9-x7x4-4j5x/GHSA-5xm9-x7x4-4j5x.json
+++ b/advisories/github-reviewed/2025/04/GHSA-5xm9-x7x4-4j5x/GHSA-5xm9-x7x4-4j5x.json
@@ -72,6 +72,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/elastic/elasticsearch"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/elastic/elasticsearch/commit/097fc0654f9305e01402a06c82926bb04ebe5495"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:

- References

Comments:
Adding a patch commit:
https://github.com/elastic/elasticsearch/commit/097fc0654f9305e01402a06c82926bb04ebe5495
Limits nested depth in Well-KnownText and GeometryCollection parsing to replace StackOverflow with ParseException.