### PR TITLE
[GHSA-ghfh-p92w-j4mg] Elasticsearch Potential Node Crash due to Large Recursion in `innerForbidCircularReferences` Function

### DIFF
--- a/advisories/github-reviewed/2025/04/GHSA-ghfh-p92w-j4mg/GHSA-ghfh-p92w-j4mg.json
+++ b/advisories/github-reviewed/2025/04/GHSA-ghfh-p92w-j4mg/GHSA-ghfh-p92w-j4mg.json
@@ -47,6 +47,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/elastic/elasticsearch"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/elastic/elasticsearch/commit/a02dc7165c75f12701f8d47a2bdefe5283735267"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:

- References

Comments:
Adding a patch commit:
https://github.com/elastic/elasticsearch/commit/a02dc7165c75f12701f8d47a2bdefe5283735267