### PR TITLE
[GHSA-pw39-f3m5-cxfc] Elasticsearch Uncaught Exception leading to crash

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-pw39-f3m5-cxfc/GHSA-pw39-f3m5-cxfc.json
+++ b/advisories/github-reviewed/2024/03/GHSA-pw39-f3m5-cxfc/GHSA-pw39-f3m5-cxfc.json
@@ -47,6 +47,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/elastic/elasticsearch"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/elastic/elasticsearch/commit/a59180459a3cb30b71399d778943cab4ac2191c4"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:

- References

Comments:
Adding a patch commit:
https://github.com/elastic/elasticsearch/commit/a59180459a3cb30b71399d778943cab4ac2191c4