### PR TITLE
[GHSA-5qmp-9x47-92q8] Rancher's SAML-based login via CLI can be denied by unauthenticated users

### DIFF
--- a/advisories/github-reviewed/2025/02/GHSA-5qmp-9x47-92q8/GHSA-5qmp-9x47-92q8.json
+++ b/advisories/github-reviewed/2025/02/GHSA-5qmp-9x47-92q8/GHSA-5qmp-9x47-92q8.json
@@ -89,6 +89,14 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/rancher/rancher"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rancher/rancher/pull/48616"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rancher/rancher/commit/bedd911b9b321436faa2d9e20a161f6ac396aa74"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:


- References

Comments:
Per the v2.8.13 release notes https://github.com/rancher/rancher/releases?page=7, adding pr https://github.com/rancher/rancher/pull/48616 and the corresponding patch commit https://github.com/rancher/rancher/commit/bedd911b9b321436faa2d9e20a161f6ac396aa74