### PR TITLE
[GHSA-6jwp-4wvj-6597] Apache Pinot Vulnerable to Authentication Bypass

### DIFF
--- a/advisories/github-reviewed/2025/04/GHSA-6jwp-4wvj-6597/GHSA-6jwp-4wvj-6597.json
+++ b/advisories/github-reviewed/2025/04/GHSA-6jwp-4wvj-6597/GHSA-6jwp-4wvj-6597.json
@@ -55,6 +55,18 @@
     {
       "type": "WEB",
       "url": "http://www.openwall.com/lists/oss-security/2025/03/27/8"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/pinot/releases/tag/release-1.3.0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/pinot/pull/14383"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/apache/pinot/commit/1b87488aeaf4836e3ef25b426ebbf1ad5a68e68f"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
Updates:


- References

Comments:
Per the v1.3.0 release notes https://github.com/apache/pinot/releases/tag/release-1.3.0, adding pr https://github.com/apache/pinot/pull/14383 and the corresponding patch commit https://github.com/apache/pinot/commit/1b87488aeaf4836e3ef25b426ebbf1ad5a68e68f