### PR TITLE
[GHSA-w578-j992-554x] Ansible fails to properly mark lookup-plugin results as unsafe

### DIFF
--- a/advisories/github-reviewed/2018/09/GHSA-w578-j992-554x/GHSA-w578-j992-554x.json
+++ b/advisories/github-reviewed/2018/09/GHSA-w578-j992-554x/GHSA-w578-j992-554x.json
@@ -54,6 +54,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/ansible/ansible/commit/fd30f5328986f9e1da434474481f32bf918a600c"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/ansible/ansible/commit/f0e348f5eeb70c1fb3127d90891da43b5c0a9d29"
+    },
+    {
+      "type": "WEB",
       "url": "https://access.redhat.com/errata/RHSA-2017:1244"
     },
     {


### PR DESCRIPTION
**Updates**
 * References

 **Comments**
 * These patches are migrated to other branches from the existing patch commit https://github.com/ansible/ansible/commit/ed56f51f185a1ffd7ea57130d260098686fcc7c2. 
* Add a patch commit https://github.com/ansible/ansible/commit/fd30f5328986f9e1da434474481f32bf918a600c migrated to another branch.
* Add a patch commit https://github.com/ansible/ansible/commit/f0e348f5eeb70c1fb3127d90891da43b5c0a9d29 migrated to another branch.