### PR TITLE
[GHSA-qhrx-hcm6-pmrw] Unsafe deserialization in SmtpTransport in CakePHP

### DIFF
--- a/advisories/github-reviewed/2019/12/GHSA-qhrx-hcm6-pmrw/GHSA-qhrx-hcm6-pmrw.json
+++ b/advisories/github-reviewed/2019/12/GHSA-qhrx-hcm6-pmrw/GHSA-qhrx-hcm6-pmrw.json
@@ -84,6 +84,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/cakephp/cakephp/commit/81412fbe2cb88a304dbeeece1955bc0aec98edb1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/cakephp/cakephp/commit/c25b91bf7c72db43c01b47a634fd02112ff9f1cd"
+    },
+    {
+      "type": "WEB",
       "url": "https://bakery.cakephp.org/2019/04/23/cakephp_377_3615_3518_released.html"
     },
     {


### PR DESCRIPTION
**Updates**
 * References

 **Comments**
 * These patches are migrated to other branches from the existing patch commit https://github.com/cakephp/cakephp/commit/1a74e798309192a9895c9cedabd714ceee345f4e. 
* Add a patch commit https://github.com/cakephp/cakephp/commit/81412fbe2cb88a304dbeeece1955bc0aec98edb1 migrated to another branch.
* Add a patch commit https://github.com/cakephp/cakephp/commit/c25b91bf7c72db43c01b47a634fd02112ff9f1cd migrated to another branch.