### PR TITLE
[GHSA-c52f-pq47-2r9j] plugin.yaml file allows for duplicate entries in helm

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-c52f-pq47-2r9j/GHSA-c52f-pq47-2r9j.json
+++ b/advisories/github-reviewed/2021/05/GHSA-c52f-pq47-2r9j/GHSA-c52f-pq47-2r9j.json
@@ -72,6 +72,22 @@
       "url": "https://github.com/helm/helm/commit/d9ef5ce8bad512e325390c0011be1244b8380e4b"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/helm/helm/commit/f2ede29480b507b7d8bb152dd8b6b86248b00658"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/helm/helm/commit/b0296c0522e837d65f944beefa3fb64fd08ac304"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/helm/helm/commit/c8d6b01d72c9604e43ee70d0d78fadd54c2d8499"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/helm/helm/commit/ac7c07c37d87e09797f714fb57aa5e9cb99d9450"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/helm/helm"
     }


### PR DESCRIPTION
**Updates**
 * References

 **Comments**
 * These patches are migrated to other branches from the existing patch commit https://github.com/helm/helm/commit/d9ef5ce8bad512e325390c0011be1244b8380e4b. 
* Add a patch commit https://github.com/helm/helm/commit/f2ede29480b507b7d8bb152dd8b6b86248b00658 migrated to another branch.
* Add a patch commit https://github.com/helm/helm/commit/b0296c0522e837d65f944beefa3fb64fd08ac304 migrated to another branch.
* Add a patch commit https://github.com/helm/helm/commit/c8d6b01d72c9604e43ee70d0d78fadd54c2d8499 migrated to another branch.
* Add a patch commit https://github.com/helm/helm/commit/ac7c07c37d87e09797f714fb57aa5e9cb99d9450 migrated to another branch.