### PR TITLE
[GHSA-j4f2-536g-r55m] Resource exhaustion in engine.io

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-j4f2-536g-r55m/GHSA-j4f2-536g-r55m.json
+++ b/advisories/github-reviewed/2022/02/GHSA-j4f2-536g-r55m/GHSA-j4f2-536g-r55m.json
@@ -46,6 +46,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/socketio/engine.io/commit/58e274c437e9cbcf69fd913c813aad8fbd253703"
+    },
+    {
+      "type": "WEB",
       "url": "https://blog.caller.xyz/socketio-engineio-dos"
     },
     {


### PR DESCRIPTION
**Updates**
 * References

 **Comments**
 * This patch is migrated to another branch from the existing patch commit https://github.com/socketio/engine.io/commit/734f9d1268840722c41219e69eb58318e0b2ac6b. 
* Add a patch commit https://github.com/socketio/engine.io/commit/58e274c437e9cbcf69fd913c813aad8fbd253703 migrated to another branch.