### PR TITLE
[GHSA-xhfx-hgmf-v6vp] Potential Host Header Poisoning on misconfigured servers 

### DIFF
--- a/advisories/github-reviewed/2021/03/GHSA-xhfx-hgmf-v6vp/GHSA-xhfx-hgmf-v6vp.json
+++ b/advisories/github-reviewed/2021/03/GHSA-xhfx-hgmf-v6vp/GHSA-xhfx-hgmf-v6vp.json
@@ -49,6 +49,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/octobercms/library/commit/f29865ae3db7a03be7c49294cd93980ec457f10d"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/octobercms/october/commit/555ab61f2313f45d7d5d138656420ead536c5d30"
+    },
+    {
+      "type": "WEB",
       "url": "https://packagist.org/packages/october/backend"
     }
   ],


### PR DESCRIPTION
**Updates**
 * References

 **Comments**
 * These patches are migrated to other branches from the existing patch commit https://github.com/octobercms/october/commit/f638d3f78cfe91d7f6658820f9d5e424306a3db0. 
* Add a patch commit https://github.com/octobercms/library/commit/f29865ae3db7a03be7c49294cd93980ec457f10d migrated to another branch.
* Add a patch commit https://github.com/octobercms/october/commit/555ab61f2313f45d7d5d138656420ead536c5d30 migrated to another branch.