### PR TITLE
[GHSA-7chv-rrw6-w6fc] XStream is vulnerable to a Remote Command Execution attack

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-7chv-rrw6-w6fc/GHSA-7chv-rrw6-w6fc.json
+++ b/advisories/github-reviewed/2021/05/GHSA-7chv-rrw6-w6fc/GHSA-7chv-rrw6-w6fc.json
@@ -49,6 +49,10 @@
       "url": "https://github.com/x-stream/xstream/commit/24fac82191292c6ae25f94508d28b9823f83624f"
     },
     {
+      "type": "WEB",
+      "url": "https://github.com/x-stream/xstream/commit/f0c4a8d861b68ffc3119cfbbbd632deee624e227"
+    },
+    {
       "type": "PACKAGE",
       "url": "https://github.com/x-stream/xstream"
     },


### PR DESCRIPTION
**Updates**
 * References

 **Comments**
 * This patch is migrated to another branch from the existing patch commit https://github.com/x-stream/xstream/commit/24fac82191292c6ae25f94508d28b9823f83624f. 
* Add a patch commit https://github.com/x-stream/xstream/commit/f0c4a8d861b68ffc3119cfbbbd632deee624e227 migrated to another branch.