### PR TITLE
[GHSA-887c-mr87-cxwp] PyTorch Improper Resource Shutdown or Release vulnerability

### DIFF
--- a/advisories/github-reviewed/2025/04/GHSA-887c-mr87-cxwp/GHSA-887c-mr87-cxwp.json
+++ b/advisories/github-reviewed/2025/04/GHSA-887c-mr87-cxwp/GHSA-887c-mr87-cxwp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-887c-mr87-cxwp",
-  "modified": "2025-05-30T17:13:51Z",
+  "modified": "2025-05-30T17:13:52Z",
   "published": "2025-04-16T21:30:59Z",
   "aliases": [
     "CVE-2025-3730"
@@ -9,10 +9,6 @@
   "summary": "PyTorch Improper Resource Shutdown or Release vulnerability",
   "details": "A vulnerability, which was classified as problematic, was found in PyTorch 2.6.0. Affected is the function torch.nn.functional.ctc_loss of the file aten/src/ATen/native/LossCTC.cpp. The manipulation leads to denial of service. An attack has to be approached locally. The exploit has been disclosed to the public and may be used. The name of the patch is 46fc5d8e360127361211cb237d5f9eef0223e567. It is recommended to apply a patch to fix this issue.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:L/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N"
@@ -32,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.7.0"
+              "last_affected": "2.7.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
GHSA-887c-mr87-cxwp, since the fix exists but has not yet been incorporated into a tagged release, the vulnerable version range was set to <= 2.7.0, when this was the latest release, with no patched version specified. The same behavior was observed since the release of v2.7.1, for which the advisory entry should be readjusted to <= 2.7.1, since this latest release does not include the fix yet.