### PR TITLE
[GHSA-9fq2-x9r6-wfmf] Numpy Deserialization of Untrusted Data

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9fq2-x9r6-wfmf/GHSA-9fq2-x9r6-wfmf.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9fq2-x9r6-wfmf/GHSA-9fq2-x9r6-wfmf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9fq2-x9r6-wfmf",
-  "modified": "2024-10-08T12:38:39Z",
+  "modified": "2024-10-08T12:38:40Z",
   "published": "2022-05-24T22:00:57Z",
   "aliases": [
     "CVE-2019-6446"
@@ -9,10 +9,6 @@
   "summary": "Numpy Deserialization of Untrusted Data",
   "details": "** DISPUTED **   An issue was discovered in NumPy 1.16.0 and earlier. It uses the pickle Python module unsafely, which allows remote attackers to execute arbitrary code via a crafted serialized object, as demonstrated by a numpy.load call. NOTE: third parties dispute this issue because it is  a behavior that might have legitimate applications in (for example)  loading serialized Python object arrays from trusted and authenticated  sources.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
@@ -32,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.16.0"
+              "fixed": "1.17.0"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.16.0"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
Based on commit - https://github.com/numpy/numpy/pull/12889/files#diff-75d0951a28f1727cc71e0fa8a858a3f18d089e2da7511aa6bbaab6e0eb638b5f, the patched version is 1.17.0. The CVE description is misinforming about the non effected versions which are <=1.16.0. But patched is in 1.17.0 and there are multiple release tags between like 1.16.1, 1.16.2...