### PR TITLE
[GHSA-wx5j-54mm-rqqq] HTTP request smuggling in netty

### DIFF
--- a/advisories/github-reviewed/2021/12/GHSA-wx5j-54mm-rqqq/GHSA-wx5j-54mm-rqqq.json
+++ b/advisories/github-reviewed/2021/12/GHSA-wx5j-54mm-rqqq/GHSA-wx5j-54mm-rqqq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wx5j-54mm-rqqq",
-  "modified": "2023-08-04T20:07:19Z",
+  "modified": "2023-08-16T05:02:15Z",
   "published": "2021-12-09T19:09:17Z",
   "aliases": [
     "CVE-2021-43797"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.0.0"
+              "introduced": "0"
             },
             {
               "fixed": "4.1.71.Final"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This will be our last PR in the near term, thank you sincerely for your support and assistance throughout our research.

We are writing to request an update to the affected version range for  CVE-2021-43797 in the GitHub Advisory Database. 

According to the official NVD listing: https://nvd.nist.gov/vuln/detail/CVE-2021-43797
The vulnerability affects Netty prior to version 4.1.71.Final, which means pre-release versions for 4.x are affected.

However, the current GitHub advisory version range only covers:
≥ 4.0.0, < 4.1.71.Final

We have validated this through manual testing, and to support this claim, we have provided working PoCs:
https://github.com/poc-effectiveness/PoCAdaptation/tree/main/Adapted/CVE-2021-43797