### PR TITLE
[GHSA-2gxp-6r36-m97r] Corrected severity on advisory

### DIFF
--- a/advisories/github-reviewed/2025/07/GHSA-2gxp-6r36-m97r/GHSA-2gxp-6r36-m97r.json
+++ b/advisories/github-reviewed/2025/07/GHSA-2gxp-6r36-m97r/GHSA-2gxp-6r36-m97r.json
@@ -12,7 +12,7 @@
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:L/A:L"
-    },
+    }
   ],
   "affected": [
     {

--- a/advisories/github-reviewed/2025/07/GHSA-2gxp-6r36-m97r/GHSA-2gxp-6r36-m97r.json
+++ b/advisories/github-reviewed/2025/07/GHSA-2gxp-6r36-m97r/GHSA-2gxp-6r36-m97r.json
@@ -13,10 +13,6 @@
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:L/A:L"
     },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:N/VA:N/SC:L/SI:L/SA:N/E:P"
-    }
   ],
   "affected": [
     {
@@ -61,7 +57,7 @@
     "cwe_ids": [
       "CWE-79"
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2025-07-21T14:08:40Z",
     "nvd_published_at": "2025-07-21T21:15:25Z"


### PR DESCRIPTION
Corrected severity on advisory so that is it consistent with CVSS 3.1 score and [CVE record](https://www.cve.org/CVERecord?id=CVE-2025-53528)

Additionally, I would like to point out that the description on the CVE record mentions that the patched version is 5.4.4 when the bug is actually fixed in version 5.4.3 as can be verified below:
- https://github.com/zmievsa/cadwyn/blob/5.4.3/CHANGELOG.md#fixed
- https://github.com/zmievsa/cadwyn/blob/5.4.3/cadwyn/applications.py#L393