### PR TITLE
Update GHSA-mqcp-p2hv-vw6x.json

### DIFF
--- a/advisories/github-reviewed/2025/07/GHSA-mqcp-p2hv-vw6x/GHSA-mqcp-p2hv-vw6x.json
+++ b/advisories/github-reviewed/2025/07/GHSA-mqcp-p2hv-vw6x/GHSA-mqcp-p2hv-vw6x.json
@@ -69,7 +69,7 @@
     "cwe_ids": [
       "CWE-78"
     ],
-    "severity": "LOW",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2025-07-21T19:33:25Z",
     "nvd_published_at": "2025-07-20T03:15:22Z"


### PR DESCRIPTION
Dear GitHub Security Team,

I am writing to kindly request a severity update for the CVE entry associated with my HackerOne report [#3260153](https://hackerone.com/reports/3260153), which is currently listed as **Low severity** in the GitHub Advisory Database.

However, as clearly outlined in my original HackerOne report, this vulnerability was assessed and acknowledged as **High severity**, considering its real-world impact and exploitation potential. To ensure consistency between the HackerOne disclosure and the GitHub CVE advisory, I respectfully request that the severity level in the GitHub database be updated to **High**.

Thank you for your attention and support.

Best regards,