### PR TITLE
Correctly annotate affected package

### DIFF
--- a/advisories/github-reviewed/2025/06/GHSA-prpj-rchp-9j5h/GHSA-prpj-rchp-9j5h.json
+++ b/advisories/github-reviewed/2025/06/GHSA-prpj-rchp-9j5h/GHSA-prpj-rchp-9j5h.json
@@ -18,14 +18,14 @@
     {
       "package": {
         "ecosystem": "Go",
-        "name": "github.com/openbao/openbao/api/v2"
+        "name": "github.com/openbao/openbao"
       },
       "ranges": [
         {
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.2.2"
+              "introduced": "0"
             },
             {
               "fixed": "2.3.1"


### PR DESCRIPTION
This vulnerability was incorrectly edited by GitHub staff without consulting the project and has now resulted in incorrect reports propagating downstream.

As noted in the original report, this affects the rotation endpoints on the server; it does not impact the client API package.

See also: https://github.com/openbao/openbao/security/advisories/GHSA-prpj-rchp-9j5h