### PR TITLE
Note remediation for GHSA-jg74-mwgw-v6x3

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-jg74-mwgw-v6x3/GHSA-jg74-mwgw-v6x3.json
+++ b/advisories/github-reviewed/2024/09/GHSA-jg74-mwgw-v6x3/GHSA-jg74-mwgw-v6x3.json
@@ -49,6 +49,9 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "2.0.2"
             }
           ]
         }


### PR DESCRIPTION
This was not assigned a separate CVE as HashiCorp unilaterally disclosed this without referencing the project. This has been remediated for a while.

See also: https://openbao.org/docs/release-notes/2-0-0/#202
See also: https://github.com/openbao/openbao/pull/561
See also: https://github.com/openbao/openbao/commit/d5b4e922469830ac335b21dc0e8f9878c501a884