### PR TITLE
[GHSA-6v2p-p543-phr9] golang.org/x/oauth2 Improper Validation of Syntactic Correctness of Input vulnerability

### DIFF
--- a/advisories/github-reviewed/2025/07/GHSA-6v2p-p543-phr9/GHSA-6v2p-p543-phr9.json
+++ b/advisories/github-reviewed/2025/07/GHSA-6v2p-p543-phr9/GHSA-6v2p-p543-phr9.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-6v2p-p543-phr9",
-  "modified": "2025-07-18T17:27:22Z",
+  "modified": "2025-07-18T17:27:23Z",
   "published": "2025-07-18T17:27:22Z",
   "aliases": [
     "CVE-2025-22868"
   ],
-  "summary": "golang.org/x/oauth2 Improper Validation of Syntactic Correctness of Input vulnerability",
+  "summary": "golang.org/x/oauth2/jws Improper Validation of Syntactic Correctness of Input vulnerability",
   "details": "An attacker can pass a malicious malformed token which causes unexpected memory to be consumed during parsing.",
   "severity": [
     {


### PR DESCRIPTION
**Updates**
- Summary

**Comments**
According to both https://nvd.nist.gov/vuln/detail/CVE-2025-22868 and the original https://pkg.go.dev/vuln/GO-2025-3488 this is a vulnerabilty in oauth2/jws, not oauth2.