### PR TITLE
[GHSA-xh69-987w-hrp8] resolv vulnerable to DoS via insufficient DNS domain name length validation

### DIFF
--- a/advisories/github-reviewed/2025/07/GHSA-xh69-987w-hrp8/GHSA-xh69-987w-hrp8.json
+++ b/advisories/github-reviewed/2025/07/GHSA-xh69-987w-hrp8/GHSA-xh69-987w-hrp8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xh69-987w-hrp8",
-  "modified": "2025-07-15T22:56:19Z",
+  "modified": "2025-07-15T22:56:20Z",
   "published": "2025-07-15T14:37:08Z",
   "aliases": [
     "CVE-2025-24294"
@@ -11,11 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
-    },
-    {
-      "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/E:U"
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
     }
   ],
   "affected": [
@@ -104,7 +100,7 @@
       "CWE-1284",
       "CWE-400"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2025-07-15T14:37:08Z",
     "nvd_published_at": "2025-07-12T04:15:46Z"


### PR DESCRIPTION
**Updates**
- CVSS v3
- CVSS v4
- Severity

**Comments**
I'm reporter of this vulnerability, It would be great if this matches the cvss3.1 of https://nvd.nist.gov/vuln/detail/CVE-2025-24294