### PR TITLE
[GHSA-q4rv-gq96-w7c5] **UNSUPPORTED WHEN ASSIGNED** GzipHandler causes part of request body to be seen as request body of a separate request

### DIFF
--- a/advisories/github-reviewed/2025/05/GHSA-q4rv-gq96-w7c5/GHSA-q4rv-gq96-w7c5.json
+++ b/advisories/github-reviewed/2025/05/GHSA-q4rv-gq96-w7c5/GHSA-q4rv-gq96-w7c5.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q4rv-gq96-w7c5",
-  "modified": "2025-05-08T19:28:34Z",
+  "modified": "2025-05-08T20:29:40Z",
   "published": "2025-05-08T19:28:34Z",
   "aliases": [
     "CVE-2024-13009"
   ],
-  "summary": "**UNSUPPORTED WHEN ASSIGNED** GzipHandler causes part of request body to be seen as request body of a separate request",
+  "summary": "GzipHandler causes part of request body to be seen as request body of a separate request",
   "details": "In Eclipse Jetty versions 9.4.0 to 9.4.56 a buffer can be incorrectly released when confronted with a gzip error when inflating a request body. This can result in corrupted and/or inadvertent sharing of data between requests.",
   "severity": [
     {


### PR DESCRIPTION
**Updates**
- Summary

**Comments**
It is unclear to me what the value of the current title is as this CVE is fixed in `9.4.57.v20241219`, which technically may mean that it is "still supported" 