### PR TITLE
Improve GHSA-67mf-3cr5-8w23

### DIFF
--- a/advisories/github-reviewed/2025/08/GHSA-67mf-3cr5-8w23/GHSA-67mf-3cr5-8w23.json
+++ b/advisories/github-reviewed/2025/08/GHSA-67mf-3cr5-8w23/GHSA-67mf-3cr5-8w23.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-67mf-3cr5-8w23",
-  "modified": "2025-08-12T19:36:18Z",
+  "modified": "2025-09-01T14:26:21Z",
   "published": "2025-08-12T12:30:32Z",
   "aliases": [
     "CVE-2025-8885"
@@ -142,7 +142,29 @@
               "introduced": "1.0.0"
             },
             {
-              "fixed": "2.1.0"
+              "fixed": "1.2.6"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.2.5"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.bouncycastle:bc-fips"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0"
+            },
+            {
+              "fixed": "2.0.1"
             }
           ]
         }


### PR DESCRIPTION
Update version ranges as per updated https://github.com/bcgit/bc-java/wiki/CVE%E2%80%902025%E2%80%908885

1.0.2.6 & 2.0.1 are fixed versions.

1.0.2.5 & 2.0.0 are vulnerable.
