### PR TITLE
[GHSA-67mf-3cr5-8w23] Fix typo in bc-fips version 1.0.2.6 is correct

### DIFF
--- a/advisories/github-reviewed/2025/08/GHSA-67mf-3cr5-8w23/GHSA-67mf-3cr5-8w23.json
+++ b/advisories/github-reviewed/2025/08/GHSA-67mf-3cr5-8w23/GHSA-67mf-3cr5-8w23.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-67mf-3cr5-8w23",
-  "modified": "2025-09-02T22:48:35Z",
+  "modified": "2025-09-0eT10:22:01Z",
   "published": "2025-08-12T12:30:32Z",
   "aliases": [
     "CVE-2025-8885"
@@ -142,7 +142,7 @@
               "introduced": "1.0.0"
             },
             {
-              "fixed": "1.0.26"
+              "fixed": "1.0.2.6"
             }
           ]
         }


### PR DESCRIPTION
The version 1.0.26 does not exist, the latest version in 1.0.x version stream is 1.0.2.6.

See:
- https://github.com/bcgit/bc-java/wiki/CVE%E2%80%902025%E2%80%908885
- https://mvnrepository.com/artifact/org.bouncycastle/bc-fips

Fixes:
- https://github.com/github/advisory-database/pull/6077
