### PR TITLE
Update introduced version in GHSA advisory (CVE-2025-55173)

### DIFF
--- a/advisories/github-reviewed/2025/08/GHSA-xv57-4mr9-wg8v/GHSA-xv57-4mr9-wg8v.json
+++ b/advisories/github-reviewed/2025/08/GHSA-xv57-4mr9-wg8v/GHSA-xv57-4mr9-wg8v.json
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.9.9"
             },
             {
               "fixed": "14.2.31"


### PR DESCRIPTION
Fixes the issue where security vulnerability is incorrectly applied to projects that depend on the v0.4 version of `next` which is a totally different product than one started at v0.9.9.

It was already discussed before, see #179 for context

This problem was already fixed for some previous vulnerabilities of `next`, but constantly gets back, when new vulnerability is introduced

Note: I wasn't able to introduce this change via suggest form as it exposes just "Affected versions" field, which logically would have to be `>=0.9.9, < 14.2.31` but that value is not accepted (Looks as another bug worth reporting)