### PR TITLE
Add credits section to GHSA-88v8-v46g-6c9w.json

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-88v8-v46g-6c9w/GHSA-88v8-v46g-6c9w.json
+++ b/advisories/github-reviewed/2023/01/GHSA-88v8-v46g-6c9w/GHSA-88v8-v46g-6c9w.json
@@ -57,14 +57,16 @@
       "url": "https://security.snyk.io/vuln/SNYK-JS-SERVST-3244896"
     }
   ],
-  "credits": [ {
-    "name": "Liran Tal",
-    "contact": [
-      "https://x.com/liran_tal",
-      "mailto:liran@lirantal.com"
-    ],
-    "type": "FINDER"
-  } ],
+  "credits": [
+    {
+      "name": "Liran Tal",
+      "contact": [
+        "https://x.com/liran_tal",
+        "mailto:liran@lirantal.com"
+      ],
+      "type": "FINDER"
+    }
+  ],
   "database_specific": {
     "cwe_ids": [
       "CWE-22"


### PR DESCRIPTION
Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original disclosure report and references provided in this CVE