### PR TITLE
Add credits section to GHSA-vcxh-qvgr-9fw9.json

### DIFF
--- a/advisories/github-reviewed/2023/05/GHSA-vcxh-qvgr-9fw9/GHSA-vcxh-qvgr-9fw9.json
+++ b/advisories/github-reviewed/2023/05/GHSA-vcxh-qvgr-9fw9/GHSA-vcxh-qvgr-9fw9.json
@@ -57,14 +57,16 @@
       "url": "https://security.snyk.io/vuln/SNYK-JS-MSTATIC-3244915"
     }
   ],
-  "credits": [ {
-    "name": "Liran Tal",
-    "contact": [
-      "https://x.com/liran_tal",
-      "mailto:liran@lirantal.com"
-    ],
-    "type": "FINDER"
-  } ],
+  "credits": [
+    {
+      "name": "Liran Tal",
+      "contact": [
+        "https://x.com/liran_tal",
+        "mailto:liran@lirantal.com"
+      ],
+      "type": "FINDER"
+    }
+  ],
   "database_specific": {
     "cwe_ids": [
       "CWE-22"

--- a/advisories/github-reviewed/2023/05/GHSA-vcxh-qvgr-9fw9/GHSA-vcxh-qvgr-9fw9.json
+++ b/advisories/github-reviewed/2023/05/GHSA-vcxh-qvgr-9fw9/GHSA-vcxh-qvgr-9fw9.json
@@ -57,6 +57,14 @@
       "url": "https://security.snyk.io/vuln/SNYK-JS-MSTATIC-3244915"
     }
   ],
+  "credits": [ {
+    "name": "Liran Tal",
+    "contact": [
+      "https://x.com/liran_tal",
+      "mailto:liran@lirantal.com"
+    ],
+    "type": "FINDER"
+  } ],
   "database_specific": {
     "cwe_ids": [
       "CWE-22"


### PR DESCRIPTION
Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original disclosure report and references provided in this CVE