### PR TITLE
Add credits section to GHSA-5g97-whc9-8g7j.json

### DIFF
--- a/advisories/github-reviewed/2023/03/GHSA-5g97-whc9-8g7j/GHSA-5g97-whc9-8g7j.json
+++ b/advisories/github-reviewed/2023/03/GHSA-5g97-whc9-8g7j/GHSA-5g97-whc9-8g7j.json
@@ -80,6 +80,14 @@
       "url": "https://security.snyk.io/vuln/SNYK-JS-NUBOSOFTWARENODESTATIC-3149927"
     }
   ],
+  "credits": [ {
+    "name": "Liran Tal",
+    "contact": [
+      "https://x.com/liran_tal",
+      "mailto:liran@lirantal.com"
+    ],
+    "type": "FINDER"
+  } ],
   "database_specific": {
     "cwe_ids": [
       "CWE-22"


### PR DESCRIPTION
Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original disclosure report and references provided in this CVE