### PR TITLE
Add credits section to GHSA-6f9p-g466-f8v8.json

### DIFF
--- a/advisories/github-reviewed/2023/09/GHSA-6f9p-g466-f8v8/GHSA-6f9p-g466-f8v8.json
+++ b/advisories/github-reviewed/2023/09/GHSA-6f9p-g466-f8v8/GHSA-6f9p-g466-f8v8.json
@@ -57,6 +57,16 @@
       "url": "https://security.snyk.io/vuln/SNYK-JS-BLAMER-5731318"
     }
   ],
+  "credits": [
+    {
+      "name": "Liran Tal",
+      "contact": [
+        "https://x.com/liran_tal",
+        "mailto:liran@lirantal.com"
+      ],
+      "type": "FINDER"
+    }
+  ],
   "database_specific": {
     "cwe_ids": [
       "CWE-88"


### PR DESCRIPTION
Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original disclosure report and references provided in this CVE