### PR TITLE
Update GHSA-v834-rhv4-65m3.json

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-v834-rhv4-65m3/GHSA-v834-rhv4-65m3.json
+++ b/advisories/github-reviewed/2023/10/GHSA-v834-rhv4-65m3/GHSA-v834-rhv4-65m3.json
@@ -57,6 +57,16 @@
       "url": "https://security.snyk.io/vuln/SNYK-JS-STATICSERVER-5722341"
     }
   ],
+  "credits": [
+    {
+      "name": "Liran Tal",
+      "contact": [
+        "https://x.com/liran_tal",
+        "mailto:liran@lirantal.com"
+      ],
+      "type": "FINDER"
+    }
+  ],
   "database_specific": {
     "cwe_ids": [
       "CWE-22"


### PR DESCRIPTION
Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original disclosure report and references provided in this CVE