### PR TITLE
Update GHSA-3r3j-4vrw-884j.json

### DIFF
--- a/advisories/github-reviewed/2025/07/GHSA-3r3j-4vrw-884j/GHSA-3r3j-4vrw-884j.json
+++ b/advisories/github-reviewed/2025/07/GHSA-3r3j-4vrw-884j/GHSA-3r3j-4vrw-884j.json
@@ -57,6 +57,16 @@
       "url": "https://security.snyk.io/vuln/SNYK-JS-FILESBUCKETSERVER-9510944"
     }
   ],
+  "credits": [
+    {
+      "name": "Liran Tal",
+      "contact": [
+        "https://x.com/liran_tal",
+        "mailto:liran@lirantal.com"
+      ],
+      "type": "FINDER"
+    }
+  ],
   "database_specific": {
     "cwe_ids": [
       "CWE-22"


### PR DESCRIPTION
Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original disclosure report and references provided in this CVE