### PR TITLE
Update GHSA-vm77-mr48-27wj.json

### DIFF
--- a/advisories/github-reviewed/2025/03/GHSA-vm77-mr48-27wj/GHSA-vm77-mr48-27wj.json
+++ b/advisories/github-reviewed/2025/03/GHSA-vm77-mr48-27wj/GHSA-vm77-mr48-27wj.json
@@ -49,6 +49,16 @@
       "url": "https://security.snyk.io/vuln/SNYK-JS-NOSSRF-9510842"
     }
   ],
+  "credits": [
+    {
+      "name": "Liran Tal",
+      "contact": [
+        "https://x.com/liran_tal",
+        "mailto:liran@lirantal.com"
+      ],
+      "type": "FINDER"
+    }
+  ],
   "database_specific": {
     "cwe_ids": [
       "CWE-918"


### PR DESCRIPTION
Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original disclosure report and references provided in this CVE