### PR TITLE
Add credits section to GHSA-9h3q-32c7-r533.json

### DIFF
--- a/advisories/github-reviewed/2025/07/GHSA-9h3q-32c7-r533/GHSA-9h3q-32c7-r533.json
+++ b/advisories/github-reviewed/2025/07/GHSA-9h3q-32c7-r533/GHSA-9h3q-32c7-r533.json
@@ -57,6 +57,16 @@
       "url": "https://security.snyk.io/vuln/SNYK-JS-PRIVATEIP-9510757"
     }
   ],
+  "credits": [
+    {
+      "name": "Liran Tal",
+      "contact": [
+        "https://x.com/liran_tal",
+        "mailto:liran@lirantal.com"
+      ],
+      "type": "FINDER"
+    }
+  ],
   "database_specific": {
     "cwe_ids": [
       "CWE-918"


### PR DESCRIPTION
Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original disclosure report and references provided in this CVE