### PR TITLE
Add credits section to GHSA-c2fv-2fmj-9xrx.json

### DIFF
--- a/advisories/github-reviewed/2025/07/GHSA-c2fv-2fmj-9xrx/GHSA-c2fv-2fmj-9xrx.json
+++ b/advisories/github-reviewed/2025/07/GHSA-c2fv-2fmj-9xrx/GHSA-c2fv-2fmj-9xrx.json
@@ -65,6 +65,16 @@
       "url": "https://security.snyk.io/vuln/SNYK-JS-SSRFCHECK-9510756"
     }
   ],
+  "credits": [
+    {
+      "name": "Liran Tal",
+      "contact": [
+        "https://x.com/liran_tal",
+        "mailto:liran@lirantal.com"
+      ],
+      "type": "FINDER"
+    }
+  ],
   "database_specific": {
     "cwe_ids": [
       "CWE-918"


### PR DESCRIPTION
Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original disclosure report and references provided in this CVE