### PR TITLE
[GHSA-86rg-pf4c-5grg] add credit for CVE-2023-6944

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-86rg-pf4c-5grg/GHSA-86rg-pf4c-5grg.json
+++ b/advisories/github-reviewed/2024/01/GHSA-86rg-pf4c-5grg/GHSA-86rg-pf4c-5grg.json
@@ -35,6 +35,15 @@
       ]
     }
   ],
+  "credits": [
+    {
+      "name": "Josephine Pfeifffer",
+      "contact": [
+        "mailto:hi@josie.lol"
+      ],
+      "type": "FINDER"
+    }
+  ],
   "references": [
     {
       "type": "ADVISORY",


### PR DESCRIPTION
Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original disclosure report and references provided in this CVE