### PR TITLE
Add credits section to GHSA-27w5-gj5q-82fv.json

### DIFF
--- a/advisories/github-reviewed/2025/09/GHSA-27w5-gj5q-82fv/GHSA-27w5-gj5q-82fv.json
+++ b/advisories/github-reviewed/2025/09/GHSA-27w5-gj5q-82fv/GHSA-27w5-gj5q-82fv.json
@@ -57,6 +57,16 @@
       "url": "https://security.snyk.io/vuln/SNYK-JS-NUBOSOFTWARENODESTATIC-3330728"
     }
   ],
+  "credits": [
+    {
+      "name": "Liran Tal",
+      "contact": [
+        "https://x.com/liran_tal",
+        "mailto:liran@lirantal.com"
+      ],
+      "type": "FINDER"
+    }
+  ],
   "database_specific": {
     "cwe_ids": [
       "CWE-400"


### PR DESCRIPTION
Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original disclosure report and references provided in this CVE