### PR TITLE
Add credits for vulnerability finder

### DIFF
--- a/advisories/github-reviewed/2025/09/GHSA-9c4g-fp4r-prrv/GHSA-9c4g-fp4r-prrv.json
+++ b/advisories/github-reviewed/2025/09/GHSA-9c4g-fp4r-prrv/GHSA-9c4g-fp4r-prrv.json
@@ -53,6 +53,16 @@
       "url": "https://security.snyk.io/vuln/SNYK-JS-CHECKBRANCHES-2766494"
     }
   ],
+  "credits": [
+    {
+      "name": "Liran Tal",
+      "contact": [
+        "https://x.com/liran_tal",
+        "mailto:liran@lirantal.com"
+      ],
+      "type": "FINDER"
+    }
+  ],
   "database_specific": {
     "cwe_ids": [
       "CWE-77",


### PR DESCRIPTION
Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original disclosure report and references provided in this CVE