### PR TITLE
Add withdrawal date for GHSA-vc8w-jr9v-vj7f advisory

### DIFF
--- a/advisories/github-reviewed/2024/07/GHSA-vc8w-jr9v-vj7f/GHSA-vc8w-jr9v-vj7f.json
+++ b/advisories/github-reviewed/2024/07/GHSA-vc8w-jr9v-vj7f/GHSA-vc8w-jr9v-vj7f.json
@@ -3,6 +3,7 @@
   "id": "GHSA-vc8w-jr9v-vj7f",
   "modified": "2025-08-01T18:34:16Z",
   "published": "2024-07-11T18:31:14Z",
+  "withdrawn": "2025-08-01T14:15:31Z",
   "aliases": [
     "CVE-2024-6531"
   ],


### PR DESCRIPTION
This CVE has been withdrawn according to:
https://nvd.nist.gov/vuln/detail/CVE-2024-6531
https://www.herodevs.com/vulnerability-directory/cve-2024-6531?nes-for-bootstrap