### PR TITLE
[GHSA-gj5f-73vh-wpf7] cross-zip is vulnerable to Directory Traversal through selective use of zip/unzip operations

### DIFF
--- a/advisories/github-reviewed/2025/10/GHSA-gj5f-73vh-wpf7/GHSA-gj5f-73vh-wpf7.json
+++ b/advisories/github-reviewed/2025/10/GHSA-gj5f-73vh-wpf7/GHSA-gj5f-73vh-wpf7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gj5f-73vh-wpf7",
-  "modified": "2025-10-10T23:49:44Z",
+  "modified": "2025-10-10T23:49:45Z",
   "published": "2025-10-10T06:30:55Z",
   "aliases": [
     "CVE-2025-11569"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N/E:P"
+      "score": "CVSS:4.0/AV:P/AC:H/AT:P/PR:H/UI:A/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -61,7 +61,7 @@
     "cwe_ids": [
       "CWE-22"
     ],
-    "severity": "HIGH",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2025-10-10T23:49:44Z",
     "nvd_published_at": "2025-10-10T05:15:32Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v4
- Severity

**Comments**
This GHSA is absolute nonsense, the entire premise of this NPM module is "given a path, make me a zip" and the GHSA is claiming that the API itself is directory traversal. i.e. the fact they can pass in a path and have it generate a zip is directory traversal. By that logic the `cat`, `ls`, `cd`, `tail`, `zip` commands are also all vulnerable... Absolutely absurd....