### PR TITLE
[GHSA-9965-vmph-33xx] validator.js has a URL validation bypass vulnerability in its isURL function

### DIFF
--- a/advisories/github-reviewed/2025/10/GHSA-9965-vmph-33xx/GHSA-9965-vmph-33xx.json
+++ b/advisories/github-reviewed/2025/10/GHSA-9965-vmph-33xx/GHSA-9965-vmph-33xx.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-9965-vmph-33xx",
+  "modified": "2025-10-13T20:08:59Z",
+  "published": "2025-09-30T18:30:25Z",
+  "aliases": [
+    "CVE-2025-56200"
+  ],
+  "summary": "validator.js has a URL validation bypass vulnerability in its isURL function",
+  "details": "A URL validation bypass vulnerability exists in validator.js before version 13.15.15. The isURL() function uses '://' as a delimiter to parse protocols, while browsers use ':' as the delimiter. This parsing difference allows attackers to bypass protocol and domain validation by crafting URLs leading to XSS and Open Redirect attacks.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "validator"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "13.15.15"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-56200"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/validatorjs/validator.js/issues/2600"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/validatorjs/validator.js/pull/2608"
+    },
+    {
+      "type": "WEB",
+      "url": "https://gist.github.com/junan-98/27ae092aa40e2a057d41a0f95148f666"
+    },
+    {
+      "type": "WEB",
+      "url": "https://gist.github.com/junan-98/a93130505b258b9e4ec9f393e7533596"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/validatorjs/validator.js"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/validatorjs/validator.js/releases/tag/13.15.15"
+    },
+    {
+      "type": "WEB",
+      "url": "http://validatorjs.com"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-79"
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true,
+    "github_reviewed_at": "2025-10-13T20:08:58Z",
+    "nvd_published_at": "2025-09-30T18:15:50Z"
+  }
+}


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
Updated patch version