### PR TITLE
[GHSA-9965-vmph-33xx] validator.js has a URL validation bypass vulnerability in its isURL function

### DIFF
--- a/advisories/github-reviewed/2025/09/GHSA-9965-vmph-33xx/GHSA-9965-vmph-33xx.json
+++ b/advisories/github-reviewed/2025/09/GHSA-9965-vmph-33xx/GHSA-9965-vmph-33xx.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9965-vmph-33xx",
-  "modified": "2025-10-13T20:08:58Z",
+  "modified": "2025-10-13T20:08:59Z",
   "published": "2025-09-30T18:30:25Z",
   "aliases": [
     "CVE-2025-56200"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "13.15.15"
+              "fixed": "13.15.20"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 13.15.15"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
A new version of the package with a patch of the vulnerability has been released.