### PR TITLE
Add credits section to GHSA-m35w-xx8c-6xc7.json

### DIFF
--- a/advisories/github-reviewed/2025/11/GHSA-m35w-xx8c-6xc7/GHSA-m35w-xx8c-6xc7.json
+++ b/advisories/github-reviewed/2025/11/GHSA-m35w-xx8c-6xc7/GHSA-m35w-xx8c-6xc7.json
@@ -53,6 +53,16 @@
       "url": "http://www.openwall.com/lists/oss-security/2025/11/04/5"
     }
   ],
+  "credits": [
+    {
+      "name": "Liran Tal",
+      "contact": [
+        "https://x.com/liran_tal",
+        "mailto:liran@lirantal.com"
+      ],
+      "type": "FINDER"
+    }
+  ],
   "database_specific": {
     "cwe_ids": [
       "CWE-284"


### PR DESCRIPTION
Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original disclosure report and references provided in this CVE

From the referenced source: https://lists.apache.org/thread/6tswlphj0pqn9zf25594r3c1vzvfj40h

> Credit:
> Liran Tal, (liran@lirantal.com) (finder)

<img width="1746" height="1742" alt="image" src="https://github.com/user-attachments/assets/28993bdb-388d-4e0b-a932-8d41662b8826" />
