### PR TITLE
[GHSA-mh29-5h37-fv8m] js-yaml has prototype pollution in merge (<<)

### DIFF
--- a/advisories/github-reviewed/2025/11/GHSA-mh29-5h37-fv8m/GHSA-mh29-5h37-fv8m.json
+++ b/advisories/github-reviewed/2025/11/GHSA-mh29-5h37-fv8m/GHSA-mh29-5h37-fv8m.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mh29-5h37-fv8m",
-  "modified": "2025-11-14T14:29:48Z",
+  "modified": "2025-11-14T14:29:49Z",
   "published": "2025-11-14T14:29:48Z",
   "aliases": [
     "CVE-2025-64718"
@@ -25,10 +25,29 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.0.0"
             },
             {
               "fixed": "4.1.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "js-yaml"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.14.2"
             }
           ]
         }
@@ -47,6 +66,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/nodeca/js-yaml/commit/383665ff4248ec2192d1274e934462bb30426879"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nodeca/js-yaml/commit/5278870a17454fe8621dbd8c445c412529525266"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
Updated the version ranges to reflect that there is a new version for the 3.x series (as seen on the [`v3` branch](https://github.com/nodeca/js-yaml/blob/v3/CHANGELOG.md))