### PR TITLE
[GHSA-hgrr-935x-pq79] Apache Tomcat Vulnerable to Improper Resource Shutdown or Release

### DIFF
--- a/advisories/github-reviewed/2025/10/GHSA-hgrr-935x-pq79/GHSA-hgrr-935x-pq79.json
+++ b/advisories/github-reviewed/2025/10/GHSA-hgrr-935x-pq79/GHSA-hgrr-935x-pq79.json
@@ -63,7 +63,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "9.0.0.40"
+              "introduced": "9.0.0.M1"
             },
             {
               "fixed": "9.0.110"
@@ -82,7 +82,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "8.5.60"
+              "introduced": "8.5.0"
             },
             {
               "last_affected": "8.5.100"
@@ -139,7 +139,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "9.0.0.40"
+              "introduced": "9.0.0.M1"
             },
             {
               "fixed": "9.0.110"
@@ -158,7 +158,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "8.5.60"
+              "introduced": "8.5.0"
             },
             {
               "last_affected": "8.5.100"
@@ -215,7 +215,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "9.0.0.40"
+              "introduced": "9.0.0.M1"
             },
             {
               "fixed": "9.0.110"
@@ -234,7 +234,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "8.5.60"
+              "introduced": "8.5.0"
             },
             {
               "last_affected": "8.5.100"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The description lists version 8.5.0 and 9.0.0.M1 as the lower bounds of affected versions for 8.5 and 9 while the Affected Versions section lists 8.5.60 and 9.0.0.40 as the lower bounds. 8.5.0 and 9.0.0.M1 are the correct lower bounds so this change corrects the Affected Versions section to have the correct values.