### PR TITLE
[GHSA-vrpq-qp53-qv56] Eclipse JGit XML External Entity (XXE) Vulnerability

### DIFF
--- a/advisories/github-reviewed/2025/05/GHSA-vrpq-qp53-qv56/GHSA-vrpq-qp53-qv56.json
+++ b/advisories/github-reviewed/2025/05/GHSA-vrpq-qp53-qv56/GHSA-vrpq-qp53-qv56.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vrpq-qp53-qv56",
-  "modified": "2025-10-14T13:43:08Z",
+  "modified": "2025-10-14T13:43:09Z",
   "published": "2025-05-21T21:31:37Z",
   "aliases": [
     "CVE-2025-4949"
@@ -82,7 +82,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "6.0.0.202111291000-r"
             },
             {
               "fixed": "6.10.1.202505221210-r"
@@ -90,6 +90,28 @@
           ]
         }
       ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.eclipse.jgit:org.eclipse.jgit"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "5.13.4.202507202350-r"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 5.13.4.202507202350-r"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**

- Affected products

**Comments**

Additional patched versions

https://projects.eclipse.org/projects/technology.jgit/releases/5.13.4

https://www.cve.org/CVERecord?id=CVE-2025-4949