### PR TITLE
Add alias CVE-2025-55182 to GHSA-9qr9-h5gf-34mp

### DIFF
--- a/advisories/github-reviewed/2025/12/GHSA-9qr9-h5gf-34mp/GHSA-9qr9-h5gf-34mp.json
+++ b/advisories/github-reviewed/2025/12/GHSA-9qr9-h5gf-34mp/GHSA-9qr9-h5gf-34mp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9qr9-h5gf-34mp",
-  "modified": "2025-12-04T08:53:18Z",
+  "modified": "2025-12-03T19:07:11Z",
   "published": "2025-12-03T19:07:11Z",
   "aliases": [
     "CVE-2025-66478",


### PR DESCRIPTION
### Summary
This PR adds `CVE-2025-55182` as an alias to this advisory.

### Details
According to NVD, `CVE-2025-66478` has been **REJECTED** as a duplicate of `CVE-2025-55182`.
This change adds the active CVE ID to the aliases to correctly map this vulnerability.

### References
* **Rejected CVE:** https://nvd.nist.gov/vuln/detail/CVE-2025-66478
* **Active CVE:** https://nvd.nist.gov/vuln/detail/CVE-2025-55182