### PR TITLE
[GHSA-225v-733h-9gwv] Clash Verge Rev thru 2.2.3 forces the installation of...

### DIFF
--- a/advisories/unreviewed/2025/10/GHSA-225v-733h-9gwv/GHSA-225v-733h-9gwv.json
+++ b/advisories/unreviewed/2025/10/GHSA-225v-733h-9gwv/GHSA-225v-733h-9gwv.json
@@ -1,19 +1,43 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-225v-733h-9gwv",
-  "modified": "2025-10-08T15:32:26Z",
+  "modified": "2025-10-08T15:33:30Z",
   "published": "2025-10-07T15:30:26Z",
   "aliases": [
     "CVE-2025-50505"
   ],
-  "details": "Clash Verge Rev thru 2.2.3 forces the installation of system services(clash-verge-service) by default and exposes key functions through the unauthorized HTTP API `/start_clash`, allowing local users to submit arbitrary bin_path parameters and pass them directly to the service process for execution, resulting in local privilege escalation.",
+  "summary": "[Local Privilege Escalation] Unauthorized RESTful API exposure of Clash Verge Rev 2.2.3 ",
+  "details": "Clash Verge Rev `v2.2.3` forces the installation of system services(`clash-verge-service`) by default and exposes key functions through the unauthorized HTTP API `/start_clash`, allowing local users to submit arbitrary bin_path parameters and pass them directly to the service process for execution, resulting in local privilege escalation.\n\n> [!IMPORTANT]\n> \n> This has already been fixed with Clash Verge Rev `v2.3.0` and later versions.",
   "severity": [
     {
       "type": "CVSS_V3",
       "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
     }
   ],
-  "affected": [],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "crates.io",
+        "name": "clash-verge"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.3.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.2.3"
+      }
+    }
+  ],
   "references": [
     {
       "type": "ADVISORY",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- Summary

**Comments**
The Clash Verge Rev Main GUI now communicates with its service and Mihomo Core process via Unix Socket (`.sock` file) or Windows Named Pipe (`\\.\pipe\` URL) by default for security reason. This CVE/NVD/GHSA should be marked as fixed.