### PR TITLE
[GHSA-vj76-c3g6-qr5v] tar-fs has a symlink validation bypass if destination directory is predictable with a specific tarball

### DIFF
--- a/advisories/github-reviewed/2025/09/GHSA-vj76-c3g6-qr5v/GHSA-vj76-c3g6-qr5v.json
+++ b/advisories/github-reviewed/2025/09/GHSA-vj76-c3g6-qr5v/GHSA-vj76-c3g6-qr5v.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vj76-c3g6-qr5v",
-  "modified": "2025-11-03T21:34:35Z",
+  "modified": "2025-11-03T21:34:36Z",
   "published": "2025-09-24T18:57:04Z",
   "aliases": [
     "CVE-2025-59343"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N"
+      "score": "CVSS:4.0/AV:N/AC:H/AT:P/PR:H/UI:A/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- CVSS v4

**Comments**
commit all those change