### PR TITLE
[GHSA-95qg-89c2-w5hj] theshit vulnerable to unsafe loading of user-owned Python rules when running as root

### DIFF
--- a/advisories/github-reviewed/2025/12/GHSA-95qg-89c2-w5hj/GHSA-95qg-89c2-w5hj.json
+++ b/advisories/github-reviewed/2025/12/GHSA-95qg-89c2-w5hj/GHSA-95qg-89c2-w5hj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-95qg-89c2-w5hj",
-  "modified": "2025-12-30T23:45:52Z",
+  "modified": "2025-12-30T23:45:53Z",
   "published": "2025-12-30T23:45:51Z",
   "aliases": [
     "CVE-2025-69257"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [
@@ -57,7 +57,7 @@
     "cwe_ids": [
       "CWE-269"
     ],
-    "severity": "MODERATE",
+    "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2025-12-30T23:45:51Z",
     "nvd_published_at": "2025-12-30T20:16:01Z"


### PR DESCRIPTION
**Updates**
- CVSS v3
- Severity

**Comments**
AC has been changed to low because the vulnerability always works when incorrect permissions are present.