### PR TITLE
[GHSA-54mj-vcvj-q3v5] Umbraco CMS has an arbitrary file upload vulnerability

### DIFF
--- a/advisories/github-reviewed/2025/12/GHSA-54mj-vcvj-q3v5/GHSA-54mj-vcvj-q3v5.json
+++ b/advisories/github-reviewed/2025/12/GHSA-54mj-vcvj-q3v5/GHSA-54mj-vcvj-q3v5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-54mj-vcvj-q3v5",
-  "modified": "2026-01-03T00:24:47Z",
+  "modified": "2026-01-03T00:24:48Z",
   "published": "2025-12-22T21:30:33Z",
   "aliases": [
     "CVE-2025-67288"
@@ -10,12 +10,8 @@
   "details": "An arbitrary file upload vulnerability in Umbraco CMS v16.3.3 allows attackers to execute arbitrary code via uploading a crafted PDF file.",
   "severity": [
     {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
-    },
-    {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:N/VA:N/SC:H/SI:H/SA:H/E:P"
+      "score": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -62,7 +58,7 @@
       "CWE-434",
       "CWE-79"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2025-12-22T22:47:47Z",
     "nvd_published_at": "2025-12-22T19:15:49Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- CVSS v4
- Severity

**Comments**
Hi there!

I represent the security team at Umbraco HQ, and I have reviewed CVE-2025-67288 internally. I can conclude that this advisory describes a vulnerability that is already documented under CVE-2023-49279 and does not represent a new issue. The underlying root cause, exploitation conditions, and impact are identical to the earlier CVE. The only difference is the example file type referenced (PDF instead of SVG), but the issue is not file-type specific and has already been addressed as a class of behavior.

Additionally, the PDF-based example is technically inaccurate in modern browser environments. JavaScript execution in PDFs is sandboxed and does not allow access to cookies or meaningful browser context, meaning it does not meet the criteria for XSS in practice. This has been confirmed both through Chromium's security documentation and internal testing.

Because:
- The issue is a duplicate of CVE-2023-49279 (https://github.com/advisories/GHSA-6xmx-85x3-4cv2),
- No new attack surface or product behavior is introduced,
- The PDF example does not constitute a valid XSS vector
- CVE.org has already updated the CVE with the dispute (https://www.cve.org/CVERecord?id=CVE-2025-67288)
- It's stated in the official Umbraco CMS documentation that server-side file validation is the implementors own responsibility, since the CMS doesn't ship with a built-in mechanism.

I believe this advisory should be removed, or atleast merged with the existing CVE/advisory to avoid confusion and unnecessary concern for our users. Thank you!

Kind regards,
Anders
Umbraco Security Team