### PR TITLE
[GHSA-4hjh-wcwx-xvwj] Axios is vulnerable to DoS attack through lack of data size check

### DIFF
--- a/advisories/github-reviewed/2025/09/GHSA-4hjh-wcwx-xvwj/GHSA-4hjh-wcwx-xvwj.json
+++ b/advisories/github-reviewed/2025/09/GHSA-4hjh-wcwx-xvwj/GHSA-4hjh-wcwx-xvwj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4hjh-wcwx-xvwj",
-  "modified": "2025-09-29T19:03:57Z",
+  "modified": "2025-09-29T19:03:58Z",
   "published": "2025-09-11T21:07:55Z",
   "aliases": [
     "CVE-2025-58754"
@@ -44,7 +44,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.28.0"
             },
             {
               "fixed": "0.30.2"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The vulnerability only affects versions that have data URL support via the `fromDataURI` helper, which was added in v0.28.0.