### PR TITLE
GHSA-mmqv-m45h-q2hp: Fix reference to non-existing version 0.0.0

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-mmqv-m45h-q2hp/GHSA-mmqv-m45h-q2hp.json
+++ b/advisories/github-reviewed/2020/09/GHSA-mmqv-m45h-q2hp/GHSA-mmqv-m45h-q2hp.json
@@ -18,7 +18,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0.0.0"
+              "introduced": "0"
             },
             {
               "fixed": "15.3.0"


### PR DESCRIPTION
Using `"0"` instead, which is a special value allowed by the OSV spec (https://ossf.github.io/osv-schema/#special-values)