### PR TITLE
GHSA-q4rr-64r9-fwgf: Fix `affected` ranges to includes versions prior to v1.0.0

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-q4rr-64r9-fwgf/GHSA-q4rr-64r9-fwgf.json
+++ b/advisories/github-reviewed/2022/05/GHSA-q4rr-64r9-fwgf/GHSA-q4rr-64r9-fwgf.json
@@ -25,26 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.0"
-            },
-            {
-              "last_affected": "1.10"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Go",
-        "name": "k8s.io/kubernetes"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "1.11.0"
+              "introduced": "0"
             },
             {
               "fixed": "1.11.8"


### PR DESCRIPTION
as per the description in the `details` field.

Additionally, 1.0 and 1.10 are not valid versions for Go packages according to https://go.dev/doc/modules/version-numbers