### PR TITLE
Fix version ranges for GHSA-xvmh-25jw-gmmm

### DIFF
--- a/advisories/github-reviewed/2026/01/GHSA-xvmh-25jw-gmmm/GHSA-xvmh-25jw-gmmm.json
+++ b/advisories/github-reviewed/2026/01/GHSA-xvmh-25jw-gmmm/GHSA-xvmh-25jw-gmmm.json
@@ -28,7 +28,83 @@
               "introduced": "0"
             },
             {
-              "last_affected": "5.1.1"
+              "last_affected": "4.1.21"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.2.0"
+            },
+            {
+              "last_affected": "4.4.11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.5.0"
+            },
+            {
+              "last_affected": "4.5.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.0.0"
+            },
+            {
+              "last_affected": "5.0.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "moodle/moodle"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.1.0"
+            },
+            {
+              "last_affected": "5.1.0"
             }
           ]
         }


### PR DESCRIPTION
Ranges taken from https://moodle.org/mod/forum/discuss.php?d=471297#p1892199

Note that I tried to submit this improvement via https://github.com/advisories/GHSA-xvmh-25jw-gmmm/improve

But I got "We were not able to process your request because some field values were not properly filled: vulnerable version ranges is invalid. Please revisit the form and submit it again with the values corrected." while trying to submit this as version range: `<4.1.22 || >=4.2.0,<4.4.12 || >=4.5.0,<4.5.8 || >=5.0.0,<5.0.4 || 5.1.0`

This is a [valid range for Composer](https://semver.madewithlove.com/?package=moodle%2Fmoodle&constraint=<4.1.22+%7C%7C+>%3D4.2.0,<4.4.12+%7C%7C+>%3D4.5.0,<4.5.8+%7C%7C+>%3D5.0.0,<5.0.4+%7C%7C+5.1.0&stability=dev)

So I reverted to the good ol' editing json, and I hope I did it correctly. But it'd be great if the form was fixed.