### PR TITLE
Update GHSA-8259-2x72-2gvc.json

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-8259-2x72-2gvc/GHSA-8259-2x72-2gvc.json
+++ b/advisories/github-reviewed/2024/09/GHSA-8259-2x72-2gvc/GHSA-8259-2x72-2gvc.json
@@ -62,11 +62,20 @@
     },
     {
       "type": "WEB",
-      "url": "https://gitlab.eclipse.org/security/cve-assignement/-/issues/28"
+      "url": "https://gitlab.eclipse.org/security/cve-assignment/-/issues/28"
     },
     {
       "type": "WEB",
       "url": "https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/234"
+    }
+  ],
+  "credits": [
+    {
+      "name": "Philipp Neuschwander",
+      "contact": [
+        "https://www.linkedin.com/in/philipp-neuschwander/"
+      ],
+      "type": "FINDER"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
# Credits for vulnerability finder

Inline with Open Source Vulnerability format and as supported in version 1.4.0 - adding credits field per original vulnerability report and references provided in this CVE

# Updated Reference Link

Eclipse Foundation moved 'security/cve-assignement' to 'security/cve-assignment'; link updated