### PR TITLE
[GHSA-p5wg-g6qr-c7cg] eslint has a Stack Overflow when serializing objects with circular references

### DIFF
--- a/advisories/github-reviewed/2026/01/GHSA-p5wg-g6qr-c7cg/GHSA-p5wg-g6qr-c7cg.json
+++ b/advisories/github-reviewed/2026/01/GHSA-p5wg-g6qr-c7cg/GHSA-p5wg-g6qr-c7cg.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p5wg-g6qr-c7cg",
-  "modified": "2026-01-29T14:58:17Z",
+  "modified": "2026-01-29T14:58:19Z",
   "published": "2026-01-26T18:31:29Z",
   "aliases": [
     "CVE-2025-50537"
   ],
-  "summary": "eslint has a Stack Overflow when serializing objects with circular references",
+  "summary": "Not a vulnerability",
   "details": "There is a Stack Overflow vulnerability in eslint before 9.26.0 when serializing objects with circular references in `eslint/lib/shared/serialization.js`. The exploit is triggered via the `RuleTester.run()` method, which validates test cases and checks for duplicates. During validation, the internal function `checkDuplicateTestCase()` is called, which in turn uses the `isSerializable()` function for serialization checks. When a circular reference object is passed in, `isSerializable()` enters infinite recursion, ultimately causing a Stack Overflow.",
   "severity": [
     {
@@ -58,9 +58,7 @@
     }
   ],
   "database_specific": {
-    "cwe_ids": [
-      "CWE-674"
-    ],
+    "cwe_ids": [],
     "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2026-01-29T14:58:17Z",


### PR DESCRIPTION
**Updates**
- CWEs
- Summary

**Comments**
A possible stack overflow in eslint shouldn't be a security vulnerability. Eslint is running on trusted or semi trusted input, if it fails in this manor its not going to cause service outages, data leakages or remote access. By allowing 'security issues' like this into the database you are undermining trust in the database as a whole. 

This should be getting reoported on eslint issues on their repo, not in the vulnerability db