### PR TITLE
[GHSA-vm6g-8r4h-22x8] Qwik City CSRF protection middleware does not work properly for content type header with parameters (eg. multipart/form-data)

### DIFF
--- a/advisories/github-reviewed/2026/02/GHSA-vm6g-8r4h-22x8/GHSA-vm6g-8r4h-22x8.json
+++ b/advisories/github-reviewed/2026/02/GHSA-vm6g-8r4h-22x8/GHSA-vm6g-8r4h-22x8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-vm6g-8r4h-22x8",
-  "modified": "2026-02-03T20:59:18Z",
+  "modified": "2026-02-03T20:59:20Z",
   "published": "2026-02-03T20:59:18Z",
   "aliases": [
     "CVE-2026-25155"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:H/A:N"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:H/I:H/A:H"
     }
   ],
   "affected": [


### PR DESCRIPTION
**Updates**
- CVSS v3

**Comments**
cd YOUR-LISTED-DIRECTORY