### PR TITLE
Add CVSS 3.1, CWE, and CVE alias for GHSA-52rh-5rpj-c3w6 (node-irc)

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-52rh-5rpj-c3w6/GHSA-52rh-5rpj-c3w6.json
+++ b/advisories/github-reviewed/2022/05/GHSA-52rh-5rpj-c3w6/GHSA-52rh-5rpj-c3w6.json
@@ -3,10 +3,17 @@
   "id": "GHSA-52rh-5rpj-c3w6",
   "modified": "2022-05-05T16:00:50Z",
   "published": "2022-05-05T16:00:50Z",
-  "aliases": [],
+  "aliases": [
+    "CVE-2022-29166"
+  ],
   "summary": "Improper handling of multiline messages in node-irc",
   "details": "node-irc is a socket wrapper for the IRC protocol that extends Node.js' EventEmitter. The vulnerability allows an attacker to manipulate a Matrix user into executing IRC commands by having them reply to a maliciously crafted message. Incorrect handling of a CR character allowed for making part of the message be sent to the IRC server verbatim rather than as a message to the channel.\nThe vulnerability has been patched in node-irc version 1.2.1.",
-  "severity": [],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+    }
+  ],
   "affected": [
     {
       "package": {
@@ -37,6 +44,10 @@
       "url": "https://github.com/matrix-org/node-irc/security/advisories/GHSA-52rh-5rpj-c3w6"
     },
     {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-29166"
+    },
+    {
       "type": "WEB",
       "url": "https://github.com/matrix-org/node-irc/commit/2976c856df37660a9d664e94c857c796de2e34f7"
     },
@@ -54,7 +65,10 @@
     }
   ],
   "database_specific": {
-    "cwe_ids": [],
+    "cwe_ids": [
+      "CWE-93",
+      "CWE-74"
+    ],
     "severity": "HIGH",
     "github_reviewed": true,
     "github_reviewed_at": "2022-05-05T16:00:50Z",


### PR DESCRIPTION
## Changes

Added missing security metadata to GHSA-52rh-5rpj-c3w6 (Improper handling of multiline messages in node-irc / `matrix-org-irc`).

**Added:**
- CVSS 3.1 vector: `AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H` (8.0 High)
- CWE-93 (CRLF Injection), CWE-74 (Injection)
- CVE-2022-29166 alias
- NVD reference link

## Reason for change

This advisory was missing CVSS scoring, CWE classification, and its CVE alias entirely. The companion advisory for `matrix-appservice-irc` ([GHSA-37hr-348p-rmf4](https://github.com/matrix-org/matrix-appservice-irc/security/advisories/GHSA-37hr-348p-rmf4)) already has CVE-2022-29166 assigned, and the root cause is the same bug in node-irc's `_splitMessage` function.

## CVSS justification

- **PR:L** rather than PR:N because the attacker needs a Matrix account and room membership in a bridged room to deliver the payload
- **UI:R** because the victim has to reply to the crafted message for the injection to fire
- **C:H/I:H/A:H** because arbitrary IRC command execution lets the attacker read private channels, send messages as the victim, or force disconnects

## Supporting links

- Fix (core regex): https://github.com/matrix-org/node-irc/commit/e3eb9c15f8240e9c92365f5ffc3944469229771b
- Fix (action refactor): https://github.com/matrix-org/node-irc/commit/2976c856df37660a9d664e94c857c796de2e34f7
- NVD entry: https://nvd.nist.gov/vuln/detail/CVE-2022-29166
- Release notes: https://matrix.org/blog/2022/05/04/0-34-0-security-release-for-matrix-appservice-irc-high-severity