### PR TITLE
Add CVSS 3.1 score for GHSA-w7q7-vjp8-7jv4 (typeorm SQL Injection)

### DIFF
--- a/advisories/github-reviewed/2019/06/GHSA-w7q7-vjp8-7jv4/GHSA-w7q7-vjp8-7jv4.json
+++ b/advisories/github-reviewed/2019/06/GHSA-w7q7-vjp8-7jv4/GHSA-w7q7-vjp8-7jv4.json
@@ -6,7 +6,12 @@
   "aliases": [],
   "summary": "SQL Injection in typeorm",
   "details": "Versions of `typeorm` before 0.1.15 are vulnerable to SQL Injection. Field names are not properly validated allowing attackers to inject SQL statements and execute arbitrary SQL queries.\n\n\n## Recommendation\n\nUpgrade to version 0.1.15",
-  "severity": [],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    }
+  ],
   "affected": [
     {
       "package": {
@@ -29,6 +34,10 @@
     }
   ],
   "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/typeorm/typeorm"
+    },
     {
       "type": "WEB",
       "url": "https://github.com/typeorm/typeorm/commit/d46c8b0e6c0db56bb5976a4917e9f67a43715111"


### PR DESCRIPTION
## Changes

Added missing CVSS scoring to GHSA-w7q7-vjp8-7jv4 (SQL Injection in typeorm).

**Added:**
- CVSS 3.1 vector: `AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H` (9.8 Critical)
- PACKAGE reference to the typeorm repo

## Reason for change

This advisory had no CVSS score at all. The vulnerability allows unauthenticated attackers to inject arbitrary SQL through unvalidated field names passed to typeorm's `find()` API, so the score should reflect full network-accessible SQL injection with no auth required.

## CVSS justification

- **PR:N/UI:N** because typeorm is used in web apps where user input reaches query methods without requiring authentication at the ORM layer
- **C:H/I:H/A:H** because SQL injection gives full read/write/delete access to the database

The scoring is consistent with the related typeorm SQL injection CVE-2022-33171, which NVD scored identically at 9.8.

## Supporting links

- Fix commit: https://github.com/typeorm/typeorm/commit/d46c8b0e6c0db56bb5976a4917e9f67a43715111
- HackerOne report: https://hackerone.com/reports/319458
- npm advisory: https://www.npmjs.com/advisories/800
- Related vuln for reference: https://nvd.nist.gov/vuln/detail/CVE-2022-33171