### PR TITLE
Add CVSS 3.1 score for GHSA-vmhw-fhj6-m3g5 (angular-http-server Path Traversal)

### DIFF
--- a/advisories/github-reviewed/2019/05/GHSA-vmhw-fhj6-m3g5/GHSA-vmhw-fhj6-m3g5.json
+++ b/advisories/github-reviewed/2019/05/GHSA-vmhw-fhj6-m3g5/GHSA-vmhw-fhj6-m3g5.json
@@ -6,7 +6,12 @@
   "aliases": [],
   "summary": "Path Traversal in angular-http-server",
   "details": "Versions of `angular-http-server` before 1.4.4 are vulnerable to path traversal.\n\n\n## Recommendation\n\nUpdate to version 1.4.4 or later.",
-  "severity": [],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+    }
+  ],
   "affected": [
     {
       "package": {
@@ -29,6 +34,10 @@
     }
   ],
   "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/simonh1000/angular-http-server"
+    },
     {
       "type": "WEB",
       "url": "https://github.com/simonh1000/angular-http-server/commit/8bafc9577161469f5dea01e0b98ea9c525d063e9"


### PR DESCRIPTION
## Changes

Added missing CVSS scoring to GHSA-vmhw-fhj6-m3g5 (Path Traversal in angular-http-server).

**Added:**
- CVSS 3.1 vector: `AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N` (7.5 High)
- PACKAGE reference to the angular-http-server repo

## Reason for change

This advisory had no CVSS score. The vulnerability is a path traversal on a static file HTTP server with no authentication, allowing unauthenticated remote read of arbitrary files on the host filesystem.

## CVSS justification

- **PR:N** because `angular-http-server` is a static file server with no auth mechanism at all (no login, no sessions, no middleware). The related CVE-2018-3713 was scored PR:L by NVD, but that seems incorrect for a server with zero authentication.
- **C:H** because the attacker can read arbitrary files limited only by the process's OS-level permissions
- **I:N/A:N** because the path traversal uses `fs.readFileSync` which is read-only and does not affect availability

## Context

This advisory (HackerOne #330349) represents a bypass of the incomplete fix for CVE-2018-3713 (GHSA-4rvg-955w-h68q). The v1.4.3 fix used a naive `path.normalize().replace(/^(\.\.[\/\\])+/, '')` approach which was bypassed. The v1.4.4 fix improved the check, though the vulnerability was only fully resolved in v1.6.0.

## Supporting links

- Fix commit: https://github.com/simonh1000/angular-http-server/commit/8bafc9577161469f5dea01e0b98ea9c525d063e9
- HackerOne report: https://hackerone.com/reports/330349
- npm advisory: https://www.npmjs.com/advisories/656
- Related original vuln: https://nvd.nist.gov/vuln/detail/CVE-2018-3713