### PR TITLE
Add CVSS 3.1 score for GHSA-6426-9fv3-65x8 (Django SQL Injection)

### DIFF
--- a/advisories/github-reviewed/2026/02/GHSA-6426-9fv3-65x8/GHSA-6426-9fv3-65x8.json
+++ b/advisories/github-reviewed/2026/02/GHSA-6426-9fv3-65x8/GHSA-6426-9fv3-65x8.json
@@ -10,6 +10,10 @@
   "details": "An issue was discovered in 6.0 before 6.0.2, 5.2 before 5.2.11, and 4.2 before 4.2.28.\n\n`.QuerySet.order_by()` is subject to SQL injection in column aliases containing periods when the same alias is, using a suitably crafted dictionary, with dictionary expansion, used in `FilteredRelation`. Earlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\n\nDjango would like to thank Solomon Kebede for reporting this issue.",
   "severity": [
     {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
+    },
+    {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/E:U"
     }


### PR DESCRIPTION
## Changes

Added missing CVSS 3.1 scoring to GHSA-6426-9fv3-65x8 (Django SQL Injection via QuerySet.order_by()).

**Added:**
- CVSS 3.1 vector: `AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N` (5.4 Medium)

## Reason for change

This advisory had no CVSS 3.1 score. CISA-ADP has published CVSS 3.1 scoring for CVE-2026-1312 that should be propagated to the GitHub Advisory Database entry.

## CVSS justification

- **AV:N** because the SQL injection is exploitable through web requests to Django applications
- **AC:L** because exploitation requires only crafting column aliases with periods in `FilteredRelation` usage
- **PR:L** because the attacker needs some level of application access to influence query parameters passed to `order_by()`
- **UI:N** because no user interaction is needed
- **C:L/I:L** because the SQL injection vector via `order_by()` column aliases is limited in scope compared to full arbitrary SQL execution, constrained by the query context
- **A:N** because the injection point does not enable denial-of-service conditions

Scoring is consistent with CISA-ADP's published CVSS 3.1 assessment for CVE-2026-1312.

## Supporting links

- NVD entry: https://nvd.nist.gov/vuln/detail/CVE-2026-1312
- Django security release: https://www.djangoproject.com/weblog/2026/feb/03/security-releases/
- Fix commit: https://github.com/django/django/commit/005d60d97c4dfb117503bdb6f2facfcaf9315d84