### PR TITLE
Add CVSS 3.1 severity for GHSA-x4gp-pqpj-f43q

### DIFF
--- a/advisories/github-reviewed/2024/06/GHSA-x4gp-pqpj-f43q/GHSA-x4gp-pqpj-f43q.json
+++ b/advisories/github-reviewed/2024/06/GHSA-x4gp-pqpj-f43q/GHSA-x4gp-pqpj-f43q.json
@@ -8,7 +8,12 @@
   ],
   "summary": "curve25519-dalek has timing variability in `curve25519-dalek`'s `Scalar29::sub`/`Scalar52::sub`",
   "details": "Timing variability of any kind is problematic when working with  potentially secret values such as elliptic curve scalars, and such issues can potentially leak private keys and other secrets. Such a problem was recently discovered in `curve25519-dalek`.\n\nThe `Scalar29::sub` (32-bit) and `Scalar52::sub` (64-bit) functions contained usage of a mask value inside a loop where LLVM saw an opportunity to insert a branch instruction (`jns` on x86) to conditionally bypass this code section when the mask value is set to zero as can be seen in godbolt:\n\n- 32-bit (see L106): https://godbolt.org/z/zvaWxzvqv\n- 64-bit (see L48): https://godbolt.org/z/PczYj7Pda\n\nA similar problem was recently discovered in the Kyber reference implementation:\n\nhttps://groups.google.com/a/list.nist.gov/g/pqc-forum/c/hqbtIGFKIpU/m/cnE3pbueBgAJ\n\nAs discussed on that thread, one portable solution, which is also used in this PR, is to introduce a volatile read as an optimization barrier, which prevents the compiler from optimizing it away.\n\nThe fix can be validated in godbolt here:\n\n- 32-bit: https://godbolt.org/z/jc9j7eb8E\n- 64-bit: https://godbolt.org/z/x8d46Yfah\n\nThe problem was discovered and the solution independently verified by Alexander Wagner <alexander.wagner@aisec.fraunhofer.de> and Lea Themint <lea.thiemt@tum.de> using their DATA tool:\n\nhttps://github.com/Fraunhofer-AISEC/DATA",
-  "severity": [],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N"
+    }
+  ],
   "affected": [
     {
       "package": {


### PR DESCRIPTION
## Changes

Added CVSS 3.1 scoring to [GHSA-x4gp-pqpj-f43q](https://github.com/advisories/GHSA-x4gp-pqpj-f43q) (curve25519-dalek timing variability in scalar subtraction).

- **Vector:** `CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N` (5.1 Medium)

## CVSS justification

- **AV:L** - timing side-channel requires local access to observe execution timing differences
- **AC:H** - exploiting timing variability in `Scalar29::sub`/`Scalar52::sub` requires precise measurement and statistical analysis
- **C:H** - successful exploitation could leak secret scalar values used in cryptographic operations
- **I:N/A:N** - this is a read-only information leak; no data modification or service disruption

## References

- [NVD: CVE-2024-58262](https://nvd.nist.gov/vuln/detail/CVE-2024-58262)
- [Fix PR](https://github.com/dalek-cryptography/curve25519-dalek/pull/659)
- [RUSTSEC-2024-0344](https://rustsec.org/advisories/RUSTSEC-2024-0344.html)