### PR TITLE
Add CVSS 3.1 severity for GHSA-cgqf-3cq5-wvcj

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-cgqf-3cq5-wvcj/GHSA-cgqf-3cq5-wvcj.json
+++ b/advisories/github-reviewed/2024/03/GHSA-cgqf-3cq5-wvcj/GHSA-cgqf-3cq5-wvcj.json
@@ -8,7 +8,12 @@
   ],
   "summary": "Apollo Router's Compressed Payloads do not respect HTTP Payload Limits",
   "details": "### Impact\nThe Apollo Router is a configurable, high-performance graph router written in Rust to run a federated supergraph that uses Apollo Federation. Affected versions are subject to a Denial-of-Service (DoS) type vulnerability. When receiving compressed HTTP payloads, affected versions of the Router evaluate the `limits.http_max_request_bytes` configuration option after the entirety of the compressed payload is decompressed. If affected versions of the Router receive highly compressed payloads, this could result in significant memory consumption while the compressed payload is expanded. \n\n### Patches\nRouter version 1.40.2 has a fix for the vulnerability.\n\n### Workarounds\nIf you are unable to upgrade, you may be able to implement mitigations at proxies or load balancers positioned in front of your Router fleet (e.g. Nginx, HAProxy, or cloud-native WAF services) by creating limits on HTTP body upload size. \n",
-  "severity": [],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
+  ],
   "affected": [
     {
       "package": {


### PR DESCRIPTION
## Changes

Added CVSS 3.1 scoring to [GHSA-cgqf-3cq5-wvcj](https://github.com/advisories/GHSA-cgqf-3cq5-wvcj) (Apollo Router compressed payload limit bypass).

- **Vector:** `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H` (7.5 High)

## CVSS justification

- **AV:N** - exploitable over the network via GraphQL HTTP requests
- **AC:L/PR:N/UI:N** - any unauthenticated client can send compressed payloads exceeding the configured HTTP limit
- **A:H** - compressed payloads bypass size limits, allowing oversized requests that exhaust router memory and cause denial of service

## References

- [NVD: CVE-2024-28101](https://nvd.nist.gov/vuln/detail/CVE-2024-28101)
- [Security advisory](https://github.com/apollographql/router/security/advisories/GHSA-cgqf-3cq5-wvcj)
- [Fix commit](https://github.com/apollographql/router/commit/9e9527c73c8f34fc8438b09066163cd42520f413)