### PR TITLE
Add CVSS 3.1 severity for GHSA-5pf6-2qwx-pxm2

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-5pf6-2qwx-pxm2/GHSA-5pf6-2qwx-pxm2.json
+++ b/advisories/github-reviewed/2024/03/GHSA-5pf6-2qwx-pxm2/GHSA-5pf6-2qwx-pxm2.json
@@ -8,7 +8,12 @@
   ],
   "summary": "Go SDK for CloudEvents's use of WithRoundTripper to create a Client leaks credentials",
   "details": "### Impact\n_What kind of vulnerability is it? Who is impacted?_\nUsing cloudevents.WithRoundTripper to create a cloudevents.Client with an authenticated http.RoundTripper causes the go-sdk to leak credentials to arbitrary endpoints.\n\nThe relevant code is [here](https://github.com/cloudevents/sdk-go/blob/67e389964131d55d65cd14b4eb32d57a47312695/v2/protocol/http/protocol.go#L104-L110) (also inline, emphasis added):\n\n<pre>if p.Client == nil {\n  p.Client = **http.DefaultClient**\n}\n\nif p.roundTripper != nil {\n  p.Client.**Transport = p.roundTripper**\n}\n</pre>\n\nWhen the transport is populated with an authenticated transport such as:\n- [oauth2.Transport](https://pkg.go.dev/golang.org/x/oauth2#Transport)\n- [idtoken.NewClient(...).Transport](https://pkg.go.dev/google.golang.org/api/idtoken#NewClient)\n\n... then http.DefaultClient is modified with the authenticated transport and will start to send Authorization tokens to\n**any endpoint** it is used to contact!\n\nFound and patched by: @tcnghia and @mattmoor\n\n### Patches\nv.2.15.2\n",
-  "severity": [],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+    }
+  ],
   "affected": [
     {
       "package": {


### PR DESCRIPTION
adds NVD-sourced CVSS 3.1 severity score to this advisory which currently has no CVSS scoring.

- source: [NVD](https://nvd.nist.gov/vuln/detail/CVE-2024-28110)
- score: 7.5 (HIGH)
- vector: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N`