### PR TITLE
Add CVSS 3.1 severity for GHSA-9h9q-qhxg-89xr

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-9h9q-qhxg-89xr/GHSA-9h9q-qhxg-89xr.json
+++ b/advisories/github-reviewed/2024/09/GHSA-9h9q-qhxg-89xr/GHSA-9h9q-qhxg-89xr.json
@@ -8,7 +8,12 @@
   ],
   "summary": "Filament has unvalidated ColorColumn and ColorEntry values that can be used for Cross-site Scripting",
   "details": "### Summary\n\nIf values passed to a `ColorColumn` or `ColumnEntry` are not valid and contain a specific set of characters, applications are vulnerable to XSS attack against a user who opens a page on which a color column or entry is rendered.\n\nVersions of Filament from v3.0.0 through v3.2.114 are affected.\n\nPlease upgrade to Filament [v3.2.115](https://github.com/filamentphp/filament/releases/tag/v3.2.115).\n\n### PoC\n\nFor example, using a value such as:\n\n```html\nblue;\"><script>alert('There\\'s a security problem here')</script style=\"\n```\n\nWould get passed into the `@style()` Blade directive from Laravel to render the correct background color, where `$state` contains the value:\n\n```blade\n<div @style([\n    \"background-color: {$state}\" => $state,\n])></div>\n```\n\nSince Laravel does not escape special characters within the `@style` Blade directive, the effective output HTML would be:\n\n```html\n<div style=\"background-color: blue;\"><script>alert('There\\'s a security problem here')</script style=\"\"></div>\n```\n\nCreating the opportunity for arbitrary JS to run if it was stored in the database.\n\n### Response\n\nThis vulnerability (in `ColorColumn` only) was reported by @sv-LayZ, who reported the issue and patched the issue during the evening of 25/09/2024. Thank you Mattis.\n\nThe review process concluded on 27/09/2024, which revealed the issue was also present in `ColorEntry`. This was fixed the same day and Filament [v3.2.115](https://github.com/filamentphp/filament/releases/tag/v3.2.115) followed to escape any special characters while outputting inline styles like this:\n\n```blade\n<div @style([\n    'background-color: ' . e($state) => $state,\n])></div>\n```\n\nAlthough these components are no longer vulnerable to this type of XSS attack, it is good practice to validate colors, and since many Filament users may be accepting color input using the `ColorPicker` form component, [additional color validation documentation was published](https://filamentphp.com/docs/3.x/forms/fields/color-picker#color-picker-validation).",
-  "severity": [],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+    }
+  ],
   "affected": [
     {
       "package": {


### PR DESCRIPTION
adds CNA-sourced CVSS 3.1 severity score to this advisory which currently has no CVSS scoring.

- source: [NVD](https://nvd.nist.gov/vuln/detail/CVE-2024-47186) (CNA-provided by `security-advisories@github.com`)
- score: 6.1 (MEDIUM)
- vector: `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N`