### PR TITLE
Add CVSS 3.1 severity for GHSA-c2f9-4jmm-v45m

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-c2f9-4jmm-v45m/GHSA-c2f9-4jmm-v45m.json
+++ b/advisories/github-reviewed/2024/03/GHSA-c2f9-4jmm-v45m/GHSA-c2f9-4jmm-v45m.json
@@ -8,7 +8,12 @@
   ],
   "summary": "Shopware's session is persistent in Cache for 404 pages",
   "details": "### Impact\n\nThe Symfony Session Handler, pop's the Session Cookie and assign it to the Response. Since Shopware 6.5.8.0 the 404 pages, are cached, to improve the performance of 404 pages. So the cached Response, contains a Session Cookie when the Browser accessing the 404 page, has no cookies yet. The Symfony Session Handler is in use, when no explicit Session configuration has been done.\nWhen Redis is in use for Sessions using the PHP Redis extension, this exploiting code is not used.\n\n### Patches\nUpdate to Shopware version 6.5.8.7\n\n### Workarounds\nUsing Redis for Sessions, as this does not trigger the exploit code. Example configuration for Redis\n\n```ini\n# php.ini\nsession.save_handler = redis\nsession.save_path = \"tcp://127.0.0.1:6379\"\n```\n\n## Consequences\n\nAs an guest browser session has been cached on a 404 page, every missing image or directly reaching a 404 page will logout the customer or clear his cart.\n",
-  "severity": [],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+    }
+  ],
   "affected": [
     {
       "package": {


### PR DESCRIPTION
adds CNA-sourced CVSS 3.1 severity score to this advisory which currently has no CVSS scoring.

- source: [NVD](https://nvd.nist.gov/vuln/detail/CVE-2024-27917) (CNA-provided)
- score: 7.5 (HIGH)
- vector: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N`