### PR TITLE
Add CVSS 3.1 severity for GHSA-qjm7-55vv-3c5f

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-qjm7-55vv-3c5f/GHSA-qjm7-55vv-3c5f.json
+++ b/advisories/github-reviewed/2023/01/GHSA-qjm7-55vv-3c5f/GHSA-qjm7-55vv-3c5f.json
@@ -8,7 +8,12 @@
   ],
   "summary": "mel-spintax has Inefficient Regular Expression Complexity",
   "details": "A vulnerability was found in melnaron mel-spintax. It has been rated as problematic. Affected by this issue is some unknown functionality of the file `lib/spintax.js`. The manipulation of the argument text leads to inefficient regular expression complexity. The name of the patch is 37767617846e27b87b63004e30216e8f919637d3. It is recommended to apply a patch to fix this issue. The identifier of this vulnerability is VDB-218456.",
-  "severity": [],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L"
+    }
+  ],
   "affected": [
     {
       "package": {


### PR DESCRIPTION
adds CNA-sourced CVSS 3.1 severity score to this advisory which currently has no CVSS scoring.

- source: [NVD](https://nvd.nist.gov/vuln/detail/CVE-2018-25077) (CNA-provided)
- score: 3.5 (LOW)
- vector: `CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L`