### PR TITLE
Add CVSS 3.1 severity for GHSA-vm74-j4wq-82xj

### DIFF
--- a/advisories/github-reviewed/2023/01/GHSA-vm74-j4wq-82xj/GHSA-vm74-j4wq-82xj.json
+++ b/advisories/github-reviewed/2023/01/GHSA-vm74-j4wq-82xj/GHSA-vm74-j4wq-82xj.json
@@ -8,7 +8,12 @@
   ],
   "summary": "Sisimai Inefficient Regular Expression Complexity vulnerability",
   "details": "A vulnerability has been found in Sisimai up to 4.25.14p11 and classified as problematic. This vulnerability affects the function `to_plain` of the file `lib/sisimai/string.rb`. The manipulation leads to inefficient regular expression complexity. The exploit has been disclosed to the public and may be used. Upgrading to version 4.25.14p12 is able to address this issue. The name of the patch is 51fe2e6521c9c02b421b383943dc9e4bbbe65d4e. It is recommended to upgrade the affected component. The identifier of this vulnerability is VDB-218452.",
-  "severity": [],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L"
+    }
+  ],
   "affected": [
     {
       "package": {


### PR DESCRIPTION
adds CNA-sourced CVSS 3.1 severity score to this advisory which currently has no CVSS scoring.

- source: [NVD](https://nvd.nist.gov/vuln/detail/CVE-2022-4891) (CNA-provided)
- score: 3.5 (LOW)
- vector: `CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L`