### PR TITLE
[GHSA-xfhx-r7ww-5995] Google Keras Allocates Resources Without Limits or Throttling in the HDF5 weight loading component

### DIFF
--- a/advisories/github-reviewed/2026/01/GHSA-xfhx-r7ww-5995/GHSA-xfhx-r7ww-5995.json
+++ b/advisories/github-reviewed/2026/01/GHSA-xfhx-r7ww-5995/GHSA-xfhx-r7ww-5995.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-xfhx-r7ww-5995",
-  "modified": "2026-01-15T20:11:41Z",
+  "modified": "2026-01-15T20:11:51Z",
   "published": "2026-01-15T15:31:19Z",
   "aliases": [
     "CVE-2026-0897"
@@ -36,6 +36,28 @@
       "database_specific": {
         "last_known_affected_version_range": "<= 3.13.0"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "keras"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.0.0"
+            },
+            {
+              "fixed": "3.12.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.12.0"
+      }
     }
   ],
   "references": [
@@ -46,6 +68,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/keras-team/keras/pull/21880"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/keras-team/keras/pull/22081"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The security fix was backported to 3.12.1: https://github.com/keras-team/keras/pull/22081