### PR TITLE
[GHSA-378v-28hj-76wf] bn.js affected by an infinite loop

### DIFF
--- a/advisories/github-reviewed/2026/02/GHSA-378v-28hj-76wf/GHSA-378v-28hj-76wf.json
+++ b/advisories/github-reviewed/2026/02/GHSA-378v-28hj-76wf/GHSA-378v-28hj-76wf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-378v-28hj-76wf",
-  "modified": "2026-02-20T21:18:31Z",
+  "modified": "2026-02-20T21:18:32Z",
   "published": "2026-02-20T06:30:39Z",
   "aliases": [
     "CVE-2026-2739"
@@ -10,12 +10,8 @@
   "details": "This affects versions of the package bn.js before 5.2.3. Calling maskn(0) on any BN instance corrupts the internal state, causing toString(), divmod(), and other methods to enter an infinite loop, hanging the process indefinitely.",
   "severity": [
     {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
-    },
-    {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N/E:P"
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -32,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "5.2.3"
+              "fixed": "5.2.3,4.12.3"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 5.2.3"
+      }
     }
   ],
   "references": [
@@ -81,7 +80,7 @@
     "cwe_ids": [
       "CWE-835"
     ],
-    "severity": "MODERATE",
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2026-02-20T21:18:31Z",
     "nvd_published_at": "2026-02-20T05:17:53Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3
- CVSS v4
- Severity

**Comments**
https://github.com/indutny/bn.js/issues/316#issuecomment-3924217358

4.12.3 has been released as well to address the vulnerability 