### PR TITLE
Fix for GHSA-378v-28hj-76wf has been backported to bn.js 4.12.3

### DIFF
--- a/advisories/github-reviewed/2026/02/GHSA-378v-28hj-76wf/GHSA-378v-28hj-76wf.json
+++ b/advisories/github-reviewed/2026/02/GHSA-378v-28hj-76wf/GHSA-378v-28hj-76wf.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-378v-28hj-76wf",
-  "modified": "2026-02-20T21:18:31Z",
+  "modified": "2026-02-23T14:44:00Z",
   "published": "2026-02-20T06:30:39Z",
   "aliases": [
     "CVE-2026-2739"
   ],
   "summary": "bn.js affected by an infinite loop",
-  "details": "This affects versions of the package bn.js before 5.2.3. Calling maskn(0) on any BN instance corrupts the internal state, causing toString(), divmod(), and other methods to enter an infinite loop, hanging the process indefinitely.",
+  "details": "This affects versions of the package bn.js prior to 4.12.3, and versions 5.0.0 up to but not including 5.2.3. Calling maskn(0) on any BN instance corrupts the internal state, causing toString(), divmod(), and other methods to enter an infinite loop, hanging the process indefinitely.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -30,6 +30,25 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "4.12.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "bn.js"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.0.0"
             },
             {
               "fixed": "5.2.3"
@@ -62,6 +81,10 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/indutny/bn.js/commit/67ecb35dabaf252001b649c12d69c4b57deac6f6"
+    },
+    {
+      "type": "WEB",
       "url": "https://gist.github.com/Kr0emer/02370d18328c28b5dd7f9ac880d22a91"
     },
     {
@@ -71,6 +94,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/indutny/bn.js/releases/tag/v5.2.3"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/indutny/bn.js/releases/tag/v4.12.3"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
The fix for GHSA-378v-28hj-76wf is not only available for 5.2.3. It's also been fixed for 4.12.3.
See: https://github.com/indutny/bn.js/commit/67ecb35dabaf252001b649c12d69c4b57deac6f6

Some libraries depend on version 4.x, so this fix might be important for several dependents.