### PR TITLE
[GHSA-wp52-r2fp-4vmr] pdfmake is vulnerable to server-side request forgery (SSRF)

### DIFF
--- a/advisories/github-reviewed/2026/03/GHSA-wp52-r2fp-4vmr/GHSA-wp52-r2fp-4vmr.json
+++ b/advisories/github-reviewed/2026/03/GHSA-wp52-r2fp-4vmr/GHSA-wp52-r2fp-4vmr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-wp52-r2fp-4vmr",
-  "modified": "2026-03-11T21:12:09Z",
+  "modified": "2026-03-11T21:12:10Z",
   "published": "2026-03-10T21:32:15Z",
   "aliases": [
     "CVE-2026-26801"
@@ -55,6 +55,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/bpampuch/pdfmake/releases/tag/0.3.6"
+    },
+    {
+      "type": "WEB",
+      "url": "https://mariopepe.github.io/cve-2026-26801-pdfmake-ssrf"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- References

**Comments**
I am the original discoverer of this vulnerability. I reported it to MITRE (CVE-2026-26801), coordinated the disclosure with the maintainer, and the fix was released in 0.3.6. Adding my writeup as a reference and requesting analyst credit for Mario Pepe (https://github.com/mariopepe).
