### PR TITLE
[GHSA-wp52-r2fp-4vmr] Add reference and discoverer credits

### DIFF
--- a/advisories/github-reviewed/2026/03/GHSA-wp52-r2fp-4vmr/GHSA-wp52-r2fp-4vmr.json
+++ b/advisories/github-reviewed/2026/03/GHSA-wp52-r2fp-4vmr/GHSA-wp52-r2fp-4vmr.json
@@ -61,6 +61,15 @@
       "url": "https://mariopepe.github.io/cve-2026-26801-pdfmake-ssrf"
     }
   ],
+  "credits": [
+    {
+      "name": "Mario Pepe",
+      "contact": [
+        "https://github.com/mariopepe"
+      ],
+      "type": "FINDER"
+    }
+  ],
   "database_specific": {
     "cwe_ids": [
       "CWE-918"


### PR DESCRIPTION
**Updates**
- Added discoverer writeup reference
- Added credits field (FINDER)

**Comments**
I am the original discoverer of CVE-2026-26801. I reported it to MITRE, coordinated the disclosure with the pdfmake maintainer, and the fix was released in 0.3.6.

Adding my writeup as a reference and credits per OSV 1.4.0 schema, consistent with PRs #6397, #6229, and #6748.