### PR TITLE
[GHSA-jx49-fphc-w293] Improper Restriction of XML External Entity Reference...

### DIFF
--- a/advisories/unreviewed/2026/03/GHSA-jx49-fphc-w293/GHSA-jx49-fphc-w293.json
+++ b/advisories/unreviewed/2026/03/GHSA-jx49-fphc-w293/GHSA-jx49-fphc-w293.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jx49-fphc-w293",
-  "modified": "2026-03-19T12:30:33Z",
+  "modified": "2026-03-19T12:30:41Z",
   "published": "2026-03-19T12:30:32Z",
   "aliases": [
     "CVE-2026-3511"
   ],
+  "summary": "Improper Restriction of XML External Entity Reference in slovensko-digital/autogram",
   "details": "Improper Restriction of XML External Entity Reference vulnerability in XMLUtils.java in Slovensko.Digital Autogram allows remote unauthenticated attacker to conduct SSRF (Server Side Request Forgery) attacks and obtain unauthorized access to local files on filesystems running the vulnerable application. Successful exploitation requires the victim to visit a specially crafted website that sends request containing a specially crafted XML document to /sign endpoint of the local HTTP server run by the application.",
   "severity": [
     {
@@ -13,7 +14,27 @@
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
     }
   ],
-  "affected": [],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "digital.slovensko.autogram"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.7.2"
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "references": [
     {
       "type": "ADVISORY",
@@ -22,6 +43,10 @@
     {
       "type": "WEB",
       "url": "https://blog.binary.house/2026/03/pripadova-studia-ako-sme-s-claude-code.html"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/slovensko-digital/autogram"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
Added affected package (digital.slovensko.autogram on Maven), affected version range (< 2.7.2), and patched version (2.7.2) based on the official release notes at https://github.com/slovensko-digital/autogram/releases/tag/v2.7.2