### PR TITLE
[GHSA-mwcc-7vpp-xmv9] MongoDB driver extension affected by mongoc_bulk_operation_t's read of invalid memory

### DIFF
--- a/advisories/github-reviewed/2025/11/GHSA-mwcc-7vpp-xmv9/GHSA-mwcc-7vpp-xmv9.json
+++ b/advisories/github-reviewed/2025/11/GHSA-mwcc-7vpp-xmv9/GHSA-mwcc-7vpp-xmv9.json
@@ -50,6 +50,14 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/mongodb/mongo-c-driver/commit/775998df7c672161989bf678723a60d73bb15e01"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/mongodb/mongo-php-driver/commit/7bc80b71a088ed33a3f35ce772884c04937920b4"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/mongodb/mongo-c-driver/releases/tag/1.30.6"
     },
     {


### PR DESCRIPTION
**Updates**
* references

**Comments**
* Add a patch commit [mongodb/mongo-c-driver@775998d](https://github.com/mongodb/mongo-c-driver/commit/775998df7c67): The commit message states "Fix CVE-2025-12119".
* Add a patch commit [mongodb/mongo-php-driver@7bc80b7](https://github.com/mongodb/mongo-php-driver/commit/7bc80b71a088ed33a3f35ce772884c04937920b4): This is a patch for mongodb/mongo-php-driver on the v2.x branch.