### PR TITLE
[GHSA-8gc5-j5rx-235r] fast-xml-parser affected by numeric entity expansion bypassing all entity expansion limits (incomplete fix for CVE-2026-26278)

### DIFF
--- a/advisories/github-reviewed/2026/03/GHSA-8gc5-j5rx-235r/GHSA-8gc5-j5rx-235r.json
+++ b/advisories/github-reviewed/2026/03/GHSA-8gc5-j5rx-235r/GHSA-8gc5-j5rx-235r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8gc5-j5rx-235r",
-  "modified": "2026-03-20T21:22:15Z",
+  "modified": "2026-03-20T21:22:16Z",
   "published": "2026-03-17T19:45:41Z",
   "aliases": [
     "CVE-2026-33036"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "4.0.0-beta.3"
+              "introduced": "5.0.0"
             },
             {
               "fixed": "5.5.6"
@@ -35,6 +35,28 @@
       ],
       "database_specific": {
         "last_known_affected_version_range": "<= 5.5.5"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "fast-xml-parser"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.0.0-beta.3"
+            },
+            {
+              "fixed": "4.5.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 4.5.4"
       }
     }
   ],
@@ -49,11 +71,19 @@
     },
     {
       "type": "WEB",
+      "url": "https://github.com/NaturalIntelligence/fast-xml-parser/issues/807"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/NaturalIntelligence/fast-xml-parser/commit/bd26122c838e6a55e7d7ac49b4ccc01a49999a01"
     },
     {
       "type": "PACKAGE",
       "url": "https://github.com/NaturalIntelligence/fast-xml-parser"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/NaturalIntelligence/fast-xml-parser/releases/tag/v4.5.5"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The issue has been fixed on 4.x release, update the affected version accordingly.