### PR TITLE
[GHSA-mwjc-5j4x-r686] AVideo has an unauthenticated decrypt oracle leaking any ciphertext

### DIFF
--- a/advisories/github-reviewed/2026/03/GHSA-mwjc-5j4x-r686/GHSA-mwjc-5j4x-r686.json
+++ b/advisories/github-reviewed/2026/03/GHSA-mwjc-5j4x-r686/GHSA-mwjc-5j4x-r686.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mwjc-5j4x-r686",
-  "modified": "2026-03-20T21:55:12Z",
+  "modified": "2026-03-20T21:55:17Z",
   "published": "2026-03-20T21:55:12Z",
   "aliases": [],
   "summary": "AVideo has an unauthenticated decrypt oracle leaking any ciphertext",


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The advisory is missing its associated CVE ID.

This vulnerability has been assigned CVE-2026-33512 by GitHub CNA (or another CNA if applicable), but the CVE is not currently reflected in the public advisory.

Please update the advisory to include the correct CVE identifier.

References:

https://github.com/WWBN/AVideo/security/advisories/GHSA-mwjc-5j4x-r686