### PR TITLE
GHSA-m964-fjrh-xxq2: update fix commit reference and affected artifact

### DIFF
--- a/advisories/github-reviewed/2025/06/GHSA-m964-fjrh-xxq2/GHSA-m964-fjrh-xxq2.json
+++ b/advisories/github-reviewed/2025/06/GHSA-m964-fjrh-xxq2/GHSA-m964-fjrh-xxq2.json
@@ -18,7 +18,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.seata:seata-config-core"
+        "name": "org.apache.seata:seata-server"
       },
       "ranges": [
         {
@@ -42,7 +42,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/apache/incubator-seata/commit/7eda23e948312ed52c3336de70a11f4d2ab06a48"
+      "url": "https://github.com/apache/incubator-seata/commit/20cd9625d23f99b71fefc83b8db96c14092a9950"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
Also updated https://www.cve.org/CVERecord?id=CVE-2025-32897