### PR TITLE
[GHSA-xwc8-rf6m-xr86] hnswlib Double Free vulnerability

### DIFF
--- a/advisories/github-reviewed/2023/07/GHSA-xwc8-rf6m-xr86/GHSA-xwc8-rf6m-xr86.json
+++ b/advisories/github-reviewed/2023/07/GHSA-xwc8-rf6m-xr86/GHSA-xwc8-rf6m-xr86.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-xwc8-rf6m-xr86",
+  "modified": "2023-11-11T05:03:29Z",
+  "published": "2023-06-30T21:30:26Z",
+  "aliases": [
+    "CVE-2023-37365"
+  ],
+  "summary": "Mark as fixed in hnswlib 0.8.0",
+  "details": "The vulnerability was fixed by capping the M parameter to 10000, preventing the double-free condition. The fix was merged via PR #508 (original fix by @emollier in #484, integrated by @jlmelville in #508) and is included in version 0.8.0 released on PyPI on 2023-12-03.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "hnswlib"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.8.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 0.7.0"
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-37365"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nmslib/hnswlib/issues/467"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/nmslib/hnswlib/pull/508"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/nmslib/hnswlib"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-415"
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true,
+    "github_reviewed_at": "2023-06-30T22:12:53Z",
+    "nvd_published_at": "2023-06-30T19:15:09Z"
+  }
+}


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References
- Summary

**Comments**
The advisory currently shows no patched version. The fix was merged in PR https://github.com/nmslib/hnswlib/pull/508 and included in version 0.8.0 (PyPI, 2023-12-03). Updating to reflect the fixed version so downstream scanners correctly identify patched installations.