### PR TITLE
[GHSA-29r8-gvx4-r9w3] Authentication Bypass in extension "E-Mail MFA Provider" (mfa_email)

### DIFF
--- a/advisories/github-reviewed/2026/03/GHSA-29r8-gvx4-r9w3/GHSA-29r8-gvx4-r9w3.json
+++ b/advisories/github-reviewed/2026/03/GHSA-29r8-gvx4-r9w3/GHSA-29r8-gvx4-r9w3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-29r8-gvx4-r9w3",
-  "modified": "2026-03-18T16:17:23Z",
+  "modified": "2026-03-18T16:17:26Z",
   "published": "2026-03-17T09:31:28Z",
   "aliases": [
     "CVE-2026-4208"
@@ -28,11 +28,36 @@
               "introduced": "0"
             },
             {
-              "last_affected": "2.0.0"
+              "fixed": "2.0.1"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.0.0"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Packagist",
+        "name": "ralffreit/mfa-email"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.0.7"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.0.5"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The vulnerability has been addressed in the following releases:

v2.0.1: https://github.com/MrSilaz/mfa_email/releases/tag/v2.0.1
v1.0.7: https://github.com/MrSilaz/mfa_email/releases/tag/v1.0.7

The patched versions should be updated to >= 1.0.7 and >= 2.0.1 accordingly.