### PR TITLE
[GHSA-pwjx-qhcg-rvj4] webpki: CRLs not considered authoritative by Distribution Point due to faulty matching logic

### DIFF
--- a/advisories/github-reviewed/2026/03/GHSA-pwjx-qhcg-rvj4/GHSA-pwjx-qhcg-rvj4.json
+++ b/advisories/github-reviewed/2026/03/GHSA-pwjx-qhcg-rvj4/GHSA-pwjx-qhcg-rvj4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pwjx-qhcg-rvj4",
-  "modified": "2026-03-23T17:40:52Z",
+  "modified": "2026-03-23T17:40:54Z",
   "published": "2026-03-20T21:51:17Z",
   "aliases": [],
   "summary": "webpki: CRLs not considered authoritative by Distribution Point due to faulty matching logic",
@@ -23,7 +23,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0.101.0"
+              "introduced": "0.102.0-alpha.0"
             },
             {
               "fixed": "0.103.10"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Narrower set of version affected than was originally reported (according to https://rustsec.org/advisories/RUSTSEC-2026-0049.html)