### PR TITLE
[GHSA-m59h-42jf-cphr] Sprig Plugin for Craft CMS potentially discloses sensitive information via Sprig Playground

### DIFF
--- a/advisories/github-reviewed/2026/03/GHSA-m59h-42jf-cphr/GHSA-m59h-42jf-cphr.json
+++ b/advisories/github-reviewed/2026/03/GHSA-m59h-42jf-cphr/GHSA-m59h-42jf-cphr.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-m59h-42jf-cphr",
-  "modified": "2026-03-23T20:25:37Z",
+  "modified": "2026-03-23T20:25:40Z",
   "published": "2026-03-23T20:25:37Z",
   "aliases": [
     "CVE-2026-27131"
   ],
   "summary": "Sprig Plugin for Craft CMS potentially discloses sensitive information via Sprig Playground",
-  "details": "Admin users, and users with explicit permission to access the Sprig Playground, could potentially expose the security key, credentials, and other sensitive configuration data, in addition to running the `hashData()` signing function.\n\nThis issue was mitigated in versions 3.15.2 and 2.15.2 by disabling access to the Sprig Playground entirely when `devMode` is disabled, by default. It is possible to override this behaviour using a new `enablePlaygroundWhenDevModeDisabled` that defaults to `false`.",
+  "details": "Admin users, and users with explicit permission to access the Sprig Playground, could potentially expose the security key, credentials, and other sensitive configuration data, in addition to running the `hashData()` signing function.\n\nThis issue was mitigated in versions 3.7.2 and 2.15.2 by disabling access to the Sprig Playground entirely when `devMode` is disabled, by default. It is possible to override this behaviour using a new `enablePlaygroundWhenDevModeDisabled` that defaults to `false`.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -28,7 +28,7 @@
               "introduced": "3.0.0"
             },
             {
-              "fixed": "3.15.2"
+              "fixed": "3.7.2"
             }
           ]
         }


### PR DESCRIPTION
This was patched in version 3.7.2 (not 3.15.2 as initially reported). I’ve already updated this in https://github.com/putyourlightson/craft-sprig/security/advisories/GHSA-m59h-42jf-cphr

Sorry for screwing up and I hope this can be merged soon, thanks!