### PR TITLE
[GHSA-8g9r-9wjw-37j4] Keycloak: Improper Access Control Leading to MFA Deletion and Account Takeover in Keycloak Account REST API

### DIFF
--- a/advisories/github-reviewed/2026/03/GHSA-8g9r-9wjw-37j4/GHSA-8g9r-9wjw-37j4.json
+++ b/advisories/github-reviewed/2026/03/GHSA-8g9r-9wjw-37j4/GHSA-8g9r-9wjw-37j4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8g9r-9wjw-37j4",
-  "modified": "2026-03-12T17:26:37Z",
+  "modified": "2026-03-12T17:26:38Z",
   "published": "2026-03-11T18:30:33Z",
   "aliases": [
     "CVE-2026-3429"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "26.5.5"
+              "last_affected": "26.5.6"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
<=26.5.5 implies 26.5.6 is not vulnerable which is not the case. Keycloak is currently in the process of backporting the fix(https://github.com/keycloak/keycloak/pull/47413) to 26.5, and the patch is likely to be included in the next release (~26.5.7)