### PR TITLE
[GHSA-88q6-jcjg-hvmw] jose-swift has JWT Signature Verification Bypass via None Algorithm

### DIFF
--- a/advisories/github-reviewed/2026/01/GHSA-88q6-jcjg-hvmw/GHSA-88q6-jcjg-hvmw.json
+++ b/advisories/github-reviewed/2026/01/GHSA-88q6-jcjg-hvmw/GHSA-88q6-jcjg-hvmw.json
@@ -9,7 +9,7 @@
   "severity": [
     {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:N/SC:N/SI:N/SA:N/E:P"
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -26,11 +26,14 @@
               "introduced": "0"
             },
             {
-              "last_affected": "6.0.1"
+              "fixed": "6.0.2"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 6.0.1"
+      }
     }
   ],
   "references": [
@@ -47,7 +50,7 @@
     "cwe_ids": [
       "CWE-327"
     ],
-    "severity": "HIGH",
+    "severity": "CRITICAL",
     "github_reviewed": true,
     "github_reviewed_at": "2026-01-09T19:39:30Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v4
- Severity

**Comments**
I only wanted to add a patched version, **PLEASE** do not take in the CVSS change. Somehow the exploit maturity being PoC is not accepted anymore, some verifier somewhere must have changed...

In any case, fixed version is [6.0.2](https://github.com/beatt83/jose-swift/releases/tag/6.0.2), the changes are linked.
Thx much and have a nice day.