### PR TITLE
[GHSA-9848-v244-962p] Apache Struts XSS

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-9848-v244-962p/GHSA-9848-v244-962p.json
+++ b/advisories/github-reviewed/2022/05/GHSA-9848-v244-962p/GHSA-9848-v244-962p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-9848-v244-962p",
-  "modified": "2024-04-30T08:46:50Z",
+  "modified": "2024-04-30T08:46:51Z",
   "published": "2022-05-14T02:21:24Z",
   "aliases": [
     "CVE-2012-1007"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
As written in the CVE itself and in  debian https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=657870 and redhat https://bugzilla.redhat.com/show_bug.cgi?id=788286, this CVE affects example apps of struts and not the jar itself.
also snyk removed this as a non vuln: https://security.snyk.io/vuln/SNYK-JAVA-STRUTS-30178

I don't believe this is even a vuln in struts1