### PR TITLE
[GHSA-72hv-8253-57qq] jackson-core: Number Length Constraint Bypass in Async Parser Leads to Potential DoS Condition

### DIFF
--- a/advisories/github-reviewed/2026/02/GHSA-72hv-8253-57qq/GHSA-72hv-8253-57qq.json
+++ b/advisories/github-reviewed/2026/02/GHSA-72hv-8253-57qq/GHSA-72hv-8253-57qq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-72hv-8253-57qq",
-  "modified": "2026-03-27T14:26:32Z",
+  "modified": "2026-03-27T14:26:33Z",
   "published": "2026-02-28T02:01:05Z",
   "aliases": [],
   "summary": "jackson-core: Number Length Constraint Bypass in Async Parser Leads to Potential DoS Condition",
@@ -87,25 +87,6 @@
             },
             {
               "fixed": "2.21.1"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "com.fasterxml.jackson.core:jackson-core"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "3.0.0"
-            },
-            {
-              "fixed": "3.1.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The 3.x versions belong to tools.jackson.core:jackson-core (different Maven namespace). The vendor advisory (https://github.com/FasterXML/jackson-core/security/advisories/GHSA-72hv-8253-57qq) does NOT list the 3.x range for com.fasterxml.jackson.core.