### PR TITLE
[GHSA-653v-rqx9-j85p] deep-object-diff vulnerable to Prototype Pollution

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-653v-rqx9-j85p/GHSA-653v-rqx9-j85p.json
+++ b/advisories/github-reviewed/2022/11/GHSA-653v-rqx9-j85p/GHSA-653v-rqx9-j85p.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-653v-rqx9-j85p",
-  "modified": "2022-11-16T20:50:01Z",
+  "modified": "2023-01-28T05:03:20Z",
   "published": "2022-11-04T12:00:25Z",
   "aliases": [
     "CVE-2022-41713"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.1.6"
+              "introduced": "0"
             },
             {
               "fixed": "1.1.9"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
If the safe version is 1.1.9, then the correct “Affected version” should be “< 1.1.9”.  See SNYK report https://security.snyk.io/vuln/SNYK-JS-DEEPOBJECTDIFF-3104594