### PR TITLE
[GHSA-rvhj-8chj-8v3c] A command injection vulnerability exists in mlflow/mlflow...

### DIFF
--- a/advisories/unreviewed/2026/03/GHSA-rvhj-8chj-8v3c/GHSA-rvhj-8chj-8v3c.json
+++ b/advisories/unreviewed/2026/03/GHSA-rvhj-8chj-8v3c/GHSA-rvhj-8chj-8v3c.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rvhj-8chj-8v3c",
-  "modified": "2026-03-31T15:31:56Z",
+  "modified": "2026-03-31T15:32:03Z",
   "published": "2026-03-31T15:31:56Z",
   "aliases": [
     "CVE-2026-0596"
   ],
+  "summary": "Command injection in mlflow when serving models with enable_mlserver=True",
   "details": "A command injection vulnerability exists in mlflow/mlflow when serving a model with `enable_mlserver=True`. The `model_uri` is embedded directly into a shell command executed via `bash -c` without proper sanitization. If the `model_uri` contains shell metacharacters, such as `$()` or backticks, it allows for command substitution and execution of attacker-controlled commands. This vulnerability affects the latest version of mlflow/mlflow and can lead to privilege escalation if a higher-privileged service serves models from a directory writable by lower-privileged users.",
   "severity": [
     {
@@ -13,11 +14,35 @@
       "score": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
     }
   ],
-  "affected": [],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "mlflow"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "3.1.4"
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "references": [
     {
       "type": "ADVISORY",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-0596"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/mlflow/mlflow"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- Source code location
- Summary

**Comments**
Adding affected package mapping. CVE-2026-0596 describes a command injection in the mlflow Python package (PyPI: mlflow) when serving models with enable_mlserver=True. The vulnerability is in the model serving code path where model_uri is passed unsanitized to bash -c. The CVE description explicitly names mlflow/mlflow as the affected project. No patched version has been published as of mlflow 3.1.4.