### PR TITLE
[GHSA-mf92-479x-3373] Spring Security HTTP Headers Are not Written Under Some Conditions

### DIFF
--- a/advisories/github-reviewed/2026/03/GHSA-mf92-479x-3373/GHSA-mf92-479x-3373.json
+++ b/advisories/github-reviewed/2026/03/GHSA-mf92-479x-3373/GHSA-mf92-479x-3373.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mf92-479x-3373",
-  "modified": "2026-03-20T20:42:25Z",
+  "modified": "2026-03-20T20:42:26Z",
   "published": "2026-03-20T00:31:28Z",
   "aliases": [
     "CVE-2026-22732"
@@ -25,10 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "5.7.0"
             },
             {
-              "last_affected": "5.7.14"
+              "last_affected": "5.7.21"
             }
           ]
         }
@@ -47,7 +47,7 @@
               "introduced": "5.8.0"
             },
             {
-              "last_affected": "5.8.16"
+              "last_affected": "5.8.23"
             }
           ]
         }
@@ -63,10 +63,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "6.0.0"
+              "introduced": "6.3.0"
             },
             {
-              "last_affected": "6.3.10"
+              "last_affected": "6.3.14"
             }
           ]
         }
@@ -85,7 +85,7 @@
               "introduced": "6.4.0"
             },
             {
-              "last_affected": "6.4.13"
+              "last_affected": "6.4.14"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Adjust bounds to mirror vendor advisory https://spring.io/security/cve-2026-22732

```
5.7.0 - 5.7.21
5.8.0 - 5.8.23
6.3.0 - 6.3.14
6.4.0 - 6.4.14
```