### PR TITLE
[GHSA-8gvc-j273-4wm5] Vitest browser mode serves arbitrary files

### DIFF
--- a/advisories/github-reviewed/2025/02/GHSA-8gvc-j273-4wm5/GHSA-8gvc-j273-4wm5.json
+++ b/advisories/github-reviewed/2025/02/GHSA-8gvc-j273-4wm5/GHSA-8gvc-j273-4wm5.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8gvc-j273-4wm5",
-  "modified": "2025-02-04T22:03:47Z",
+  "modified": "2025-02-04T22:03:49Z",
   "published": "2025-02-04T16:51:08Z",
   "aliases": [
     "CVE-2025-24963"
@@ -38,6 +38,44 @@
       "package": {
         "ecosystem": "npm",
         "name": "@vitest/browser"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.0.0"
+            },
+            {
+              "fixed": "3.0.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@vitest/ui"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.4"
+            },
+            {
+              "fixed": "2.1.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@vitest/ui"
       },
       "ranges": [
         {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The vulnerability also affects @vitest/ui, according to the changes in these commits:
https://github.com/vitest-dev/vitest/commit/2d62051f13b4b0939b2f7e94e88006d830dc4d1f
https://github.com/vitest-dev/vitest/commit/ed9aeba212df04b83ed01810780663ff2cdd0adf