### PR TITLE
[GHSA-prjq-f4q3-fvfr] github.com/russellhaering/gosaml2 is vulnerable to NULL Pointer Dereference

### DIFF
--- a/advisories/github-reviewed/2022/11/GHSA-prjq-f4q3-fvfr/GHSA-prjq-f4q3-fvfr.json
+++ b/advisories/github-reviewed/2022/11/GHSA-prjq-f4q3-fvfr/GHSA-prjq-f4q3-fvfr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-prjq-f4q3-fvfr",
-  "modified": "2024-05-20T19:38:33Z",
+  "modified": "2024-05-20T19:38:35Z",
   "published": "2022-11-15T19:05:07Z",
   "aliases": [
     "CVE-2020-7731"
@@ -58,6 +58,10 @@
     {
       "type": "WEB",
       "url": "https://github.com/russellhaering/gosaml2/security/advisories/GHSA-prjq-f4q3-fvfr"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-7731"
     },
     {
       "type": "WEB",


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
`GHSA-prjq-f4q3-fvfr` lists CVE-2020-7711 in its aliases field but has no references of type ADVISORY. I suggest adding [CVE-2020-7731](https://nvd.nist.gov/vuln/detail/CVE-2020-7731) as an advisory reference because it references the `github.com/russellhaering/gosaml2` package.