### PR TITLE
[GHSA-hp5w-3hxx-vmwf] Payload has Unvalidated Input in Password Recovery Endpoints

### DIFF
--- a/advisories/github-reviewed/2026/04/GHSA-hp5w-3hxx-vmwf/GHSA-hp5w-3hxx-vmwf.json
+++ b/advisories/github-reviewed/2026/04/GHSA-hp5w-3hxx-vmwf/GHSA-hp5w-3hxx-vmwf.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hp5w-3hxx-vmwf",
-  "modified": "2026-04-01T16:08:02Z",
+  "modified": "2026-04-01T16:08:06Z",
   "published": "2026-04-01T16:08:02Z",
   "aliases": [
     "CVE-2026-34751"
   ],
-  "summary": "Payload has Unvalidated Input in Password Recovery Endpoints",
+  "summary": "Pre-Authentication Account Takeover via Parameter Injection in Password Recovery",
   "details": "### Impact\n\nA vulnerability in the password recovery flow could allow an unauthenticated attacker to perform actions on behalf of a user who initiates a password reset.\n\nUsers are affected if:\n\n- They are using Payload version **< v3.79.1** with any auth-enabled collection using the built-in `forgot-password` functionality.\n\n### Patches\n\nInput validation and URL construction in the password recovery flow have been hardened.\n\nUsers should upgrade to **v3.79.1** or later.\n\n### Workarounds\n\nThere are no complete workarounds. Upgrading to **v3.79.1** is recommended.",
   "severity": [
     {


### PR DESCRIPTION
**Updates**
- Summary

**Comments**
Original title "Unvalidated Input in Password Recovery Endpoints" is generic and does not convey the actual impact. Updated title clearly describes the attack scenario a pre-authentication account takeover through parameter injection in the password recovery flow. No changes to severity, affected versions, or patches.