### PR TITLE
[GHSA-j3q9-mxjg-w52f] path-to-regexp vulnerable to Denial of Service via sequential optional groups

### DIFF
--- a/advisories/github-reviewed/2026/03/GHSA-j3q9-mxjg-w52f/GHSA-j3q9-mxjg-w52f.json
+++ b/advisories/github-reviewed/2026/03/GHSA-j3q9-mxjg-w52f/GHSA-j3q9-mxjg-w52f.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-j3q9-mxjg-w52f",
-  "modified": "2026-03-27T22:23:27Z",
+  "modified": "2026-03-27T22:23:30Z",
   "published": "2026-03-27T22:23:27Z",
   "aliases": [
     "CVE-2026-4926"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The less "<8.4.0" was pinging all sorts of alert for versions such as 6.3.* which shouldn't be vulnerable.  Patch version should be the implied upper limit