### PR TITLE
[GHSA-hc5h-pmr3-3497] OpenClaw: /pair approve command path omitted caller scope subsetting and reopened device pairing escalation

### DIFF
--- a/advisories/github-reviewed/2026/04/GHSA-hc5h-pmr3-3497/GHSA-hc5h-pmr3-3497.json
+++ b/advisories/github-reviewed/2026/04/GHSA-hc5h-pmr3-3497/GHSA-hc5h-pmr3-3497.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-hc5h-pmr3-3497",
+  "modified": "2026-03-31T23:50:24Z",
+  "published": "2026-03-31T23:50:22Z",
+  "aliases": [],
+  "summary": "OpenClaw: /pair approve command path omitted caller scope subsetting and reopened device pairing escalation",
+  "details": "## Summary\n\nThe `/pair approve` command path called device approval without forwarding caller scopes into the core approval check.\n\n## Impact\n\nA caller that held pairing privileges but not admin privileges could approve a pending device request asking for broader scopes, including admin access.\n\n## Affected Component\n\n`extensions/device-pair/index.ts, src/infra/device-pairing.ts`\n\n## Fixed Versions\n\n- Affected: `<= 2026.3.24`\n- Patched: `>= 2026.3.28`\n- Latest stable `2026.3.28` contains the fix.\n\n## Fix\n\nFixed by commit `4ee4960de2` (`Pairing: forward caller scopes during approval`).",
+  "severity": [
+    {
+      "type": "CVSS_V4",
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "openclaw"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2026.3.28"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2026.3.24"
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/openclaw/openclaw/security/advisories/GHSA-hc5h-pmr3-3497"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/openclaw/openclaw/commit/4ee4960de2330b5322127f925f3687dc6f105be1"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/openclaw/openclaw"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-863"
+    ],
+    "severity": "CRITICAL",
+    "github_reviewed": true,
+    "github_reviewed_at": "2026-03-31T23:50:22Z",
+    "nvd_published_at": null
+  }
+}


### PR DESCRIPTION
**Updates**
- CVSS v4
- Severity

**Comments**
**Severity: Critical (changed from High)**

This advisory (GHSA-hc5h-pmr3-3497) is a regression of GHSA-hf68-49fm-59cq — same vuln class, same impact, just reopened through a code path (`/pair approve`) that the original fix didn't cover.

Both advisories share:
- Same root cause: caller scopes not forwarded during device pair approval
- Same impact: operator.pairing → operator.admin privilege escalation
- Same affected component: device-pairing.ts approval logic
- Same CWE class: incorrect authorization / improper privilege management

GHSA-hf68-49fm-59cq is rated Critical. A regression doesn't reduce impact — exploitability and consequences are the same. The only difference is the entry point (CLI `/pair approve` vs. RPC `device.pair.approve`), which doesn't change the severity of the privilege escalation.

This advisory should be aligned with GHSA-hf68-49fm-59cq at Critical to reflect the identical impact.