### PR TITLE
Upgrade Github actions to latest versions

### DIFF
--- a/.github/workflows/create_staging_branch.yaml
+++ b/.github/workflows/create_staging_branch.yaml
@@ -16,7 +16,7 @@ jobs:
   ensure-base-is-staging:
     runs-on: ubuntu-latest
     steps:
-     - uses: actions/checkout@v2
+     - uses: actions/checkout@v4
      - name: ensure base is staging
        env:
          PR_AUTHOR: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/delete_staging_and_head_branches.yaml
+++ b/.github/workflows/delete_staging_and_head_branches.yaml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
-     - uses: actions/checkout@v2
+     - uses: actions/checkout@v4
      - name: Delete staging and head branches
        env:
          STAGING_BRANCH: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use a newer version of the `actions/checkout` action. Both workflows now use version 4 instead of version 2, which ensures better security, improved performance, and continued support.

**Workflow updates:**

* Upgraded `actions/checkout` from version 2 to version 4 in `.github/workflows/create_staging_branch.yaml` to ensure compatibility and take advantage of the latest improvements.
* Upgraded `actions/checkout` from version 2 to version 4 in `.github/workflows/delete_staging_and_head_branches.yaml` for the same reasons.