### PR TITLE
Improve GHSA-jm43-hrq7-r7w6

### DIFF
--- a/advisories/github-reviewed/2025/06/GHSA-jm43-hrq7-r7w6/GHSA-jm43-hrq7-r7w6.json
+++ b/advisories/github-reviewed/2025/06/GHSA-jm43-hrq7-r7w6/GHSA-jm43-hrq7-r7w6.json
@@ -83,13 +83,13 @@
           "events": [
             {
               "introduced": "7.4.5"
+            },
+            {
+              "last_affected": "7.4.6"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 8.0-milestone-1"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
I updated the "affected versions" of [GHSA-jm43-hrq7-r7w6](https://github.com/xwiki/xwiki-platform/security/advisories/GHSA-jm43-hrq7-r7w6) to be more accurate and the affected versions (we noticed false positive).