### PR TITLE
[GHSA-8mc5-53m5-3qj2] Fix Affected Products section to include tomcat-coyote instead of tomcat-catalina

### DIFF
--- a/advisories/github-reviewed/2026/04/GHSA-8mc5-53m5-3qj2/GHSA-8mc5-53m5-3qj2.json
+++ b/advisories/github-reviewed/2026/04/GHSA-8mc5-53m5-3qj2/GHSA-8mc5-53m5-3qj2.json
@@ -22,7 +22,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat-catalina"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -41,7 +41,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat-catalina"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -60,7 +60,7 @@
     {
       "package": {
         "ecosystem": "Maven",
-        "name": "org.apache.tomcat:tomcat-catalina"
+        "name": "org.apache.tomcat:tomcat-coyote"
       },
       "ranges": [
         {
@@ -203,6 +203,10 @@
     {
       "type": "WEB",
       "url": "https://lists.apache.org/thread/1nl9zqft0ksqlhlkd3j4obyjz1ghoyn7"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.herodevs.com/vulnerability-directory/cve-2026-32990"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- References

**Comments**
The code change to fix the CVE was made in `tomcat-coyote`, not `tomcat-catalina`. The specific commit (for the Tomcat 9 fix) is https://github.com/apache/tomcat/commit/95f7778248cac46d03e6af04de9c72a598be3a53 (See Tomcat 9.0.116 [release notes](https://tomcat.apache.org/security-9.html#Fixed_in_Apache_Tomcat_9.0.116)). The only functional change is in `org/apache/tomcat/util/**` which is part of `tomcat-coyote` and not `tomcat-catalina` (see [build.xml](https://github.com/apache/tomcat/blob/9.0.x/build.xml#L772-L781))