### PR TITLE
Adjust CVSS severity scores in GHSA-3p68-rc4w-qgx5

### DIFF
--- a/advisories/github-reviewed/2026/04/GHSA-3p68-rc4w-qgx5/GHSA-3p68-rc4w-qgx5.json
+++ b/advisories/github-reviewed/2026/04/GHSA-3p68-rc4w-qgx5/GHSA-3p68-rc4w-qgx5.json
@@ -11,11 +11,11 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:L"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
     },
     {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:L/VA:L/SC:H/SI:L/SA:L"
+      "score": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:L/VA:N/SC:L/SI:L/SA:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
Updated severity scores for CVSS V3 and V4 in the GHSA-3p68-rc4w-qgx5 advisory to reflect changes in vulnerability assessment.