### PR TITLE
Revise vulnerability report for Axios library

### DIFF
--- a/advisories/github-reviewed/2026/04/GHSA-fvcv-3m26-pcqx/GHSA-fvcv-3m26-pcqx.json
+++ b/advisories/github-reviewed/2026/04/GHSA-fvcv-3m26-pcqx/GHSA-fvcv-3m26-pcqx.json
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
     }
   ],
   "affected": [


### PR DESCRIPTION
This pull request updates the CVSS v3 severity score in the advisory file to reflect a revised assessment of the vulnerability's risk.

- **Security Advisory Update:**
  * [`GHSA-fvcv-3m26-pcqx.json`](diffhunk://#diff-33bc77f3d92aaa531463d9256731c88c91c6724ab26a12eb09b87d2ad189edb8L14-R14): Changed the CVSS v3 vector string to indicate higher attack complexity, no user interaction, unchanged scope, and reduced impact on confidentiality, integrity, and availability.