### PR TITLE
[GHSA-355h-qmc2-wpwf] Jetty has HTTP Request Smuggling via Chunked Extension Quoted-String Parsing

### DIFF
--- a/advisories/github-reviewed/2026/04/GHSA-355h-qmc2-wpwf/GHSA-355h-qmc2-wpwf.json
+++ b/advisories/github-reviewed/2026/04/GHSA-355h-qmc2-wpwf/GHSA-355h-qmc2-wpwf.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-355h-qmc2-wpwf",
-  "modified": "2026-04-14T23:40:31Z",
+  "modified": "2026-04-14T23:40:32Z",
   "published": "2026-04-14T23:40:31Z",
   "aliases": [
     "CVE-2026-2332"
@@ -116,14 +116,11 @@
               "introduced": "9.4.0"
             },
             {
-              "fixed": "9.4.60"
+              "last_affected": "9.4.59"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 9.4.59"
-      }
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
This had 9.4.60 listed as a patched version. But there is no such version per https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/ . So I removed it from the 9 Patched Versions field -- not sure if that's the clearest way to do that.

https://jetty.org/download.html has latest on the 9 series as "9.4.58.v20250814 (EOL)"