### PR TITLE
[GHSA-cjmm-f4jc-qw8r] DOMPurify ADD_ATTR predicate skips URI validation

### DIFF
--- a/advisories/github-reviewed/2026/04/GHSA-cjmm-f4jc-qw8r/GHSA-cjmm-f4jc-qw8r.json
+++ b/advisories/github-reviewed/2026/04/GHSA-cjmm-f4jc-qw8r/GHSA-cjmm-f4jc-qw8r.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cjmm-f4jc-qw8r",
-  "modified": "2026-04-03T03:46:07Z",
+  "modified": "2026-04-03T03:46:08Z",
   "published": "2026-04-03T03:46:07Z",
   "aliases": [],
   "summary": "DOMPurify ADD_ATTR predicate skips URI validation",
@@ -26,7 +26,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "3.3.2"
+              "fixed": "2.5.9, 3.3.2"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
2.5.9 also has a patch for this