### PR TITLE
[GHSA-8623-9fwr-4cxv] Quick-Media Batik Codec FIX package has Code Injection vulnerability

### DIFF
--- a/advisories/github-reviewed/2026/01/GHSA-8623-9fwr-4cxv/GHSA-8623-9fwr-4cxv.json
+++ b/advisories/github-reviewed/2026/01/GHSA-8623-9fwr-4cxv/GHSA-8623-9fwr-4cxv.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8623-9fwr-4cxv",
-  "modified": "2026-01-28T15:52:10Z",
+  "modified": "2026-01-28T15:52:11Z",
   "published": "2026-01-27T09:30:30Z",
   "aliases": [
     "CVE-2026-24806"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:L/VA:L/SC:N/SI:N/SA:N/S:N/AU:Y/R:U/V:C/RE:M/U:Amber"
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -54,10 +54,8 @@
     }
   ],
   "database_specific": {
-    "cwe_ids": [
-      "CWE-94"
-    ],
-    "severity": "MODERATE",
+    "cwe_ids": [],
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2026-01-28T15:52:10Z",
     "nvd_published_at": "2026-01-27T09:15:50Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v4
- CWEs
- Severity

**Comments**
All the explanation that is given about this vulnerability is a patch (https://github.com/liuyueyi/quick-media/commit/e52fceee32775a6be8ed1e394fbe94f4f8db036a) which results in a compilation error. The code which was patched was correct:

https://github.com/liuyueyi/quick-media/blob/f600bc7960f957df4c4d53c3bb414c571f4c190d/plugins/svg-plugin/batik-codec-fix/src/main/java/org/apache/batik/ext/awt/image/codec/png/PNGImageEncoder.java#L91-L93

and the `PNGImageEncoder.java` file cannot be compiled after the patch, because it references a `buffer` field which is not there. Actually, that tree is not even compiled during the `quick-media` build so no one noticed. The patch was most likely intended to apply to a different `write` method:

https://github.com/liuyueyi/quick-media/blob/f600bc7960f957df4c4d53c3bb414c571f4c190d/plugins/svg-plugin/batik-codec-fix/src/main/java/org/apache/batik/ext/awt/image/codec/png/PNGImageEncoder.java#L238

But even if the checks were added there, the practical difference would be that in case of a negative `len` the code would silently do nothing instead of throwing an exception, which is what it is supposed to do. The security implications are unclear, if any (again we are talking about a file which is not part of the deliverables of that project).

This "Code Injection vulnerability" is bogus.