### PR TITLE
[GHSA-23f4-hfmq-94mj] Quick-Media Batik Codec FIX Package has Buffer Overflow Vulnerability in PNG Codec

### DIFF
--- a/advisories/github-reviewed/2026/01/GHSA-23f4-hfmq-94mj/GHSA-23f4-hfmq-94mj.json
+++ b/advisories/github-reviewed/2026/01/GHSA-23f4-hfmq-94mj/GHSA-23f4-hfmq-94mj.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-23f4-hfmq-94mj",
-  "modified": "2026-01-28T15:58:39Z",
+  "modified": "2026-01-28T15:58:40Z",
   "published": "2026-01-27T09:30:30Z",
   "aliases": [
     "CVE-2026-24807"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:L/VA:L/SC:N/SI:N/SA:N/S:N/AU:Y/R:U/V:C/RE:M/U:Amber"
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -54,11 +54,8 @@
     }
   ],
   "database_specific": {
-    "cwe_ids": [
-      "CWE-120",
-      "CWE-190"
-    ],
-    "severity": "MODERATE",
+    "cwe_ids": [],
+    "severity": "LOW",
     "github_reviewed": true,
     "github_reviewed_at": "2026-01-28T15:58:39Z",
     "nvd_published_at": "2026-01-27T09:15:50Z"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v4
- CWEs
- Severity

**Comments**
This vulnerability references a patch which is modifying correct code. In the pre-patch code, the bounds are checked by a call to a `RandomAccessFile` field, which implements the [DataOutput](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/DataOutput.html#write(byte%5B%5D,int,int)) interface. And the thing is writing to a file, not a buffer.

This "Buffer Overflow Vulnerability" is bogus: no buffer is involved and the `RandomAccessFile` works as intended.