### PR TITLE
[GHSA-cq8v-f236-94qc] Rand is unsound with a custom logger using rand::rng()

### DIFF
--- a/advisories/github-reviewed/2026/04/GHSA-cq8v-f236-94qc/GHSA-cq8v-f236-94qc.json
+++ b/advisories/github-reviewed/2026/04/GHSA-cq8v-f236-94qc/GHSA-cq8v-f236-94qc.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cq8v-f236-94qc",
-  "modified": "2026-04-14T01:03:36Z",
+  "modified": "2026-04-14T01:03:37Z",
   "published": "2026-04-14T01:03:36Z",
   "aliases": [],
   "summary": "Rand is unsound with a custom logger using rand::rng()",
-  "details": "It has been reported (by @lopopolo) that the `rand` library is [unsound](https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#soundness-of-code--of-a-library) (i.e. that safe code using the public API can cause Undefined Behaviour) when all the following conditions are met:\n\n- The `log` and `thread_rng` features are enabled\n- A [custom logger](https://docs.rs/log/latest/log/#implementing-a-logger) is defined\n- The custom logger accesses `rand::rng()` (previously `rand::thread_rng()`) and calls any `TryRng` (previously `RngCore`) methods on `ThreadRng`\n- The `ThreadRng` (attempts to) reseed while called from the custom logger (this happens every 64 kB of generated data)\n- Trace-level logging is enabled or warn-level logging is enabled and the random source (the `getrandom` crate) is unable to provide a new seed\n\n`TryRng` (previously `RngCore`) methods for `ThreadRng` use `unsafe` code to cast `*mut BlockRng<ReseedingCore>` to `&mut BlockRng<ReseedingCore>`. When all the above conditions are met this results in an aliased mutable reference, violating the Stacked Borrows rules. Miri is able to detect this violation in sample code. Since construction of [aliased mutable references is Undefined Behaviour](https://doc.rust-lang.org/stable/nomicon/references.html), the behaviour of optimized builds is hard to predict.\n\nAffected versions of `rand` are `>= 0.7, < 0.9.3` and `0.10.0`.",
+  "details": "It has been reported (by @lopopolo) that the `rand` library is [unsound](https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#soundness-of-code--of-a-library) (i.e. that safe code using the public API can cause Undefined Behaviour) when all the following conditions are met:\n\n- The `log` and `thread_rng` features are enabled\n- A [custom logger](https://docs.rs/log/latest/log/#implementing-a-logger) is defined\n- The custom logger accesses `rand::rng()` (previously `rand::thread_rng()`) and calls any `TryRng` (previously `RngCore`) methods on `ThreadRng`\n- The `ThreadRng` (attempts to) reseed while called from the custom logger (this happens every 64 kB of generated data)\n- Trace-level logging is enabled or warn-level logging is enabled and the random source (the `getrandom` crate) is unable to provide a new seed\n\n`TryRng` (previously `RngCore`) methods for `ThreadRng` use `unsafe` code to cast `*mut BlockRng<ReseedingCore>` to `&mut BlockRng<ReseedingCore>`. When all the above conditions are met this results in an aliased mutable reference, violating the Stacked Borrows rules. Miri is able to detect this violation in sample code. Since construction of [aliased mutable references is Undefined Behaviour](https://doc.rust-lang.org/stable/nomicon/references.html), the behaviour of optimized builds is hard to predict.\n\nAffected versions of `rand` are `>= 0.7, < 0.8.6`, `>= 0.9, < 0.9.3` and `0.10.0`.",
   "severity": [],
   "affected": [
     {
@@ -19,6 +19,25 @@
           "events": [
             {
               "introduced": "0.7.0"
+            },
+            {
+              "fixed": "0.8.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "crates.io",
+        "name": "rand"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0.9.0"
             },
             {
               "fixed": "0.9.3"
@@ -54,6 +73,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/rust-random/rand/pull/1763"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rust-random/rand/pull/1764"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rust-random/rand/pull/1772"
     },
     {
       "type": "PACKAGE",


### PR DESCRIPTION
**Updates**
- Affected products
- Description
- References

**Comments**
The fix has been backported to `0.8.6` as well