### PR TITLE
[GHSA-rg7c-g689-fr3x] Google Agent Development Kit (ADK) has a Code Injection and Missing Authentication vulnerability

### DIFF
--- a/advisories/github-reviewed/2026/04/GHSA-rg7c-g689-fr3x/GHSA-rg7c-g689-fr3x.json
+++ b/advisories/github-reviewed/2026/04/GHSA-rg7c-g689-fr3x/GHSA-rg7c-g689-fr3x.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-rg7c-g689-fr3x",
-  "modified": "2026-04-14T22:29:08Z",
+  "modified": "2026-04-14T22:29:10Z",
   "published": "2026-04-13T09:31:33Z",
   "aliases": [
     "CVE-2026-4810"
@@ -11,7 +11,7 @@
   "severity": [
     {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H/E:P/U:Amber"
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H"
     }
   ],
   "affected": [
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.7.0"
             },
             {
               "fixed": "1.28.1"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v4

**Comments**
Adding the missing lower bound for the version range for affected versions.
Was: "< 1.28.1" 
Should be ">= 1.7.0 ,  < 1.28.1 "
