### PR TITLE
[GHSA-28xh-wpgr-7fm8] Command Injection in open

### DIFF
--- a/advisories/github-reviewed/2019/06/GHSA-28xh-wpgr-7fm8/GHSA-28xh-wpgr-7fm8.json
+++ b/advisories/github-reviewed/2019/06/GHSA-28xh-wpgr-7fm8/GHSA-28xh-wpgr-7fm8.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-28xh-wpgr-7fm8",
-  "modified": "2020-08-31T18:31:51Z",
+  "modified": "2023-01-09T05:01:44Z",
   "published": "2019-06-20T15:35:49Z",
   "aliases": [],
   "summary": "Command Injection in open",
@@ -18,7 +18,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.0.2"
             },
             {
               "fixed": "6.0.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
  - `open@0.0.0` (270-byte tarball, 295-byte package.json): contains only package/package.json — no lib/, no vendor/, no JS at all. Pure stub. shasum: 7b5f1e7b, published 2012-04-14.
  - `open@0.0.2` (first real release — 0.0.1 does not exist on npm): contains lib/open.js with both the vulnerable escape() function and the exec(opener + ' "' + escape(target) + '"', callback)
  command-execution sink.
  - The vulnerable code path is demonstrably absent from 0.0.0 and first introduced in 0.0.2.