### PR TITLE
[GHSA-29xr-v42j-r956] thenify before 3.3.1 made use of unsafe calls to `eval`.

### DIFF
--- a/advisories/github-reviewed/2022/07/GHSA-29xr-v42j-r956/GHSA-29xr-v42j-r956.json
+++ b/advisories/github-reviewed/2022/07/GHSA-29xr-v42j-r956/GHSA-29xr-v42j-r956.json
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.0.0"
             },
             {
               "fixed": "3.3.1"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
  - 1.0.0's `index.js` is a 32‑line file that only monkey-patches `Array.prototype.then / Array.prototype.catch` on the global prototype.
  - No `module.exports` — the package has no callable export surface. You cannot pass a user-named function into it.
  - No `thenify()` function, no `createWrapper()`, and no eval / new Function anywhere in the source (confirmed: only unthenify matches the substring scan).
  - The CWE-94 sink (interpolating an attacker-controlled `fn.name` into an `eval('(function ' + name + '() {...})')` template) literally does not exist in 1.0.0 — there is no code path that constructs source from any input, let alone user-controlled input.
