### PR TITLE
[GHSA-7mg4-w3w5-x5pc] Prototype pollution in json-pointer

### DIFF
--- a/advisories/github-reviewed/2021/05/GHSA-7mg4-w3w5-x5pc/GHSA-7mg4-w3w5-x5pc.json
+++ b/advisories/github-reviewed/2021/05/GHSA-7mg4-w3w5-x5pc/GHSA-7mg4-w3w5-x5pc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-7mg4-w3w5-x5pc",
-  "modified": "2025-03-05T19:04:37Z",
+  "modified": "2025-03-05T19:04:38Z",
   "published": "2021-05-10T18:37:47Z",
   "aliases": [
     "CVE-2020-7709"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.3.0"
             },
             {
               "fixed": "0.6.1"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The prototype-pollution sink requires `api.set()` to traverse into an inherited property like `__proto__` or `constructor.prototype`.

In `0.0.2–0.2.2`, the traversal is gated by `!obj.hasOwnProperty(tok)`, which is false for inherited names. The code therefore enters the create branch and executes `obj['__proto__'] = {}`, replacing the local object's prototype with a fresh `{}` instead of navigating into `Object.prototype`.

Global pollution is not reachable through any of the three standard vectors:

- `__proto__`
- `constructor.prototype`
- `prototype`

The exploitable shape first appears in `0.3.0`, when the guard was rewritten to `!(tok in obj)`, which treats inherited properties as present and thus navigates into them.

Fix commit `1dbd1ed` (PR `#34`) is written against that `0.3.0+` shape.