### PR TITLE
[GHSA-86wf-436m-h424] Resource Exhaustion Denial of Service in http-proxy-agent 

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-86wf-436m-h424/GHSA-86wf-436m-h424.json
+++ b/advisories/github-reviewed/2022/01/GHSA-86wf-436m-h424/GHSA-86wf-436m-h424.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-86wf-436m-h424",
-  "modified": "2021-03-31T21:09:25Z",
+  "modified": "2023-02-01T05:05:10Z",
   "published": "2022-01-06T20:30:13Z",
   "aliases": [
     "CVE-2019-10196"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.1.0"
             },
             {
               "fixed": "2.1.0"
@@ -57,7 +57,7 @@
     "cwe_ids": [
       "CWE-665"
     ],
-    "severity": "MODERATE",
+    "severity": "CRITICAL",
     "github_reviewed": true,
     "github_reviewed_at": "2021-03-22T22:28:09Z",
     "nvd_published_at": "2021-03-19T20:15:00Z"


### PR DESCRIPTION
**Updates**
- Affected products
- Severity

**Comments**
In 0.0.1 and 0.0.2 the Proxy-Authorization injection code `this.proxy.auth → req.setHeader('Proxy-Authorization', ...)` does not exist — the auth feature was first introduced in 0.1.0.

The suggested change aligns the lower bound with the first release containing the Proxy-Authorization injection, not the initial scaffolding releases that predated the auth feature.