### PR TITLE
[GHSA-884p-74jh-xrg2] Command Injection in tree-kill

### DIFF
--- a/advisories/github-reviewed/2020/09/GHSA-884p-74jh-xrg2/GHSA-884p-74jh-xrg2.json
+++ b/advisories/github-reviewed/2020/09/GHSA-884p-74jh-xrg2/GHSA-884p-74jh-xrg2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-884p-74jh-xrg2",
-  "modified": "2023-11-08T20:05:23Z",
+  "modified": "2023-11-29T22:32:28Z",
   "published": "2020-09-04T16:57:20Z",
   "aliases": [
     "CVE-2019-15599"
@@ -20,7 +20,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.0.4"
             },
             {
               "fixed": "1.2.2"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
CVE-2019-15599 is exploitable only through the Windows branch `exec('taskkill /pid ' + pid + ' /T /F')`, which was first added in `0.0.4` when `process.platform === 'win32'` support was introduced.

Versions `0.0.1–0.0.3` are Unix-only and invoke `spawn('ps', [...])` exclusively—argv form, no shell, no attacker-controlled string interpolation—so the vulnerable sink does not exist.

Fix commit `deee138a` (`1.2.2`) guards the same `exec` call with `parseInt`/`Number.isNaN`, confirming it as the sole sink.