### PR TITLE
[GHSA-8r6j-v8pm-fqw3] Code injection in fsevents

### DIFF
--- a/advisories/github-reviewed/2023/10/GHSA-8r6j-v8pm-fqw3/GHSA-8r6j-v8pm-fqw3.json
+++ b/advisories/github-reviewed/2023/10/GHSA-8r6j-v8pm-fqw3/GHSA-8r6j-v8pm-fqw3.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-8r6j-v8pm-fqw3",
-  "modified": "2023-10-16T22:21:52Z",
+  "modified": "2023-11-28T19:01:57Z",
   "published": "2023-10-06T21:30:49Z",
   "aliases": [
     "CVE-2023-45311"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.0.0"
             },
             {
               "fixed": "1.2.11"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The entire vulnerability surface — `node-pre-gyp` fetching a prebuilt native binary from an S3 bucket at install time — was introduced in `1.0.0`.

All 15 `0.x` versions (`0.1.1`, `0.1.3–0.1.6`, `0.2.0`, `0.3.0–0.3.8`) compile the native addon locally via `node-gyp` and load it through `require('./build/Release/fswatch')` (`0.1.x`) or `require('./build/Release/fse')` (`0.2.x`/`0.3.x`).

They declare:

- no `node-pre-gyp` dependency
- no `binary.host` field
- no reference to `fsevents-binaries.s3-us-west-2.amazonaws.com`

So the S3-hijack / tarball-substitution class of attack covered by this advisory cannot apply to them.

`1.0.0`’s `package.json` is the first to add:

- `"node-pre-gyp"` as a dependency
- the install script `node-pre-gyp install --fallback-to-build`
- the `binary.host` S3 URL

So the introduced version should be `1.0.0`, not `0.0.0`.