### PR TITLE
[GHSA-f6v4-cf5j-vf3w] dset Prototype Pollution vulnerability

### DIFF
--- a/advisories/github-reviewed/2024/09/GHSA-f6v4-cf5j-vf3w/GHSA-f6v4-cf5j-vf3w.json
+++ b/advisories/github-reviewed/2024/09/GHSA-f6v4-cf5j-vf3w/GHSA-f6v4-cf5j-vf3w.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-f6v4-cf5j-vf3w",
-  "modified": "2024-09-11T23:11:10Z",
+  "modified": "2024-09-11T23:11:36Z",
   "published": "2024-09-11T06:30:39Z",
   "aliases": [
     "CVE-2024-21529"
@@ -9,10 +9,6 @@
   "summary": "dset Prototype Pollution vulnerability",
   "details": "Versions of the package dset before 3.1.4 are vulnerable to Prototype Pollution via the dset function due improper user input sanitization. This vulnerability allows the attacker to inject malicious object property using the built-in Object property __proto__, which is recursively assigned to all the objects in the program.",
   "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:L"
-    },
     {
       "type": "CVSS_V4",
       "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:H/VA:L/SC:N/SI:N/SA:N"
@@ -29,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "1.0.0"
             },
             {
               "fixed": "3.1.4"


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v3

**Comments**
The vulnerable `keys[i]` assignment sink is first introduced in 1.0.0's `dist/dset.js`. 0.0.0 cannot express the prototype-pollution vulnerability because it exports no code.