### PR TITLE
[GHSA-gpvj-q7fp-jcch] simplehttpserver allows directory traversal and file listing

### DIFF
--- a/advisories/github-reviewed/2018/09/GHSA-gpvj-q7fp-jcch/GHSA-gpvj-q7fp-jcch.json
+++ b/advisories/github-reviewed/2018/09/GHSA-gpvj-q7fp-jcch/GHSA-gpvj-q7fp-jcch.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-gpvj-q7fp-jcch",
-  "modified": "2023-09-12T20:49:06Z",
+  "modified": "2023-09-12T20:49:07Z",
   "published": "2018-09-06T03:22:59Z",
   "aliases": [
     "CVE-2018-3787"
@@ -28,7 +28,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.2.1"
+              "fixed": "0.2.0"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
- `simplehttpserver.js` SHA256 is identical for 0.2.0 and 0.2.1 (8de441e8…); `cli.js` also identical.
- The 0.1.1 → 0.2.0 diff adds the exact path-traversal guard: regex /(\/|^)\.\.(\/|$)/ + path.relative(webroot, pathname) rejection, returning 404 for traversal attempts.
- Therefore the fix shipped in 0.2.0; 0.2.1 contains no additional security change. Fixed version should be 0.2.0, and 0.2.0 should be marked not-affected against the "< 0.2.1" range.