### PR TITLE
[GHSA-hx9m-jf43-8ffr] seroval affected by Denial of Service via RegExp serialization

### DIFF
--- a/advisories/github-reviewed/2026/01/GHSA-hx9m-jf43-8ffr/GHSA-hx9m-jf43-8ffr.json
+++ b/advisories/github-reviewed/2026/01/GHSA-hx9m-jf43-8ffr/GHSA-hx9m-jf43-8ffr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hx9m-jf43-8ffr",
-  "modified": "2026-01-22T15:43:55Z",
+  "modified": "2026-01-22T15:43:56Z",
   "published": "2026-01-21T16:57:06Z",
   "aliases": [
     "CVE-2026-23956"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.2.0"
             },
             {
               "fixed": "1.4.1"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
`seroval@0.1.0` exports only `serialize()` and does not include any deserialization code path. The vulnerable `deserialize()` function—whose implementation passes attacker-controlled input to indirect evaluation via `(0, eval)(source)` (see `src/index.ts:90`)—is first introduced in `0.2.0`.

Because `0.1.0` contains no eval-backed deserializer, it provides no sink through which a malicious payload can be executed.

Accordingly, the correct introduced version is `0.2.0`, which is the first release that actually contains the vulnerable sink. This aligns the affected range with the first version in which the bug is reachable.