### PR TITLE
[GHSA-mwv9-gp5h-frr4] Sveltejs devalue's `devalue.parse` and `devalue.unflatten` emit objects with `__proto__` own properties

### DIFF
--- a/advisories/github-reviewed/2026/03/GHSA-mwv9-gp5h-frr4/GHSA-mwv9-gp5h-frr4.json
+++ b/advisories/github-reviewed/2026/03/GHSA-mwv9-gp5h-frr4/GHSA-mwv9-gp5h-frr4.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-mwv9-gp5h-frr4",
-  "modified": "2026-03-12T16:38:15Z",
+  "modified": "2026-03-12T19:41:57Z",
   "published": "2026-03-12T16:38:15Z",
   "aliases": [],
   "summary": "Sveltejs devalue's `devalue.parse` and `devalue.unflatten` emit objects with `__proto__` own properties",
@@ -9,7 +9,7 @@
   "severity": [
     {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N/E:U"
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
     }
   ],
   "affected": [
@@ -23,7 +23,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "4.0.0"
             },
             {
               "fixed": "5.6.4"
@@ -54,7 +54,7 @@
     "cwe_ids": [
       "CWE-1321"
     ],
-    "severity": "LOW",
+    "severity": "MODERATE",
     "github_reviewed": true,
     "github_reviewed_at": "2026-03-12T16:38:15Z",
     "nvd_published_at": null


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v4
- Severity

**Comments**
The advisory identifies `parse` and `unflatten` as the relevant sinks. These functions can produce objects in which `__proto__` is preserved as an own property, creating a prototype-pollution hazard when downstream code later performs unsafe merges such as `Object.assign(target, result)` on the parsed output.

Neither sink existed before `4.0.0`. The `1.x`, `2.x`, and `3.x` lines of `devalue` were serialization-only: they exposed a single function that converted a JavaScript value into a string. Those releases had no deserialization path, no string-to-object parser, and no opportunity for `__proto__` handling to introduce this bug class.

Version `4.0.0` is the first release that introduced deserialization as part of a broader API redesign. Its entire `index.js` is:

~~~js
export { uneval } from './src/uneval.js';
export { parse } from './src/parse.js';
export { stringify } from './src/stringify.js';

export function devalue() {
  throw new Error('The `devalue` export has been removed. Use `uneval` instead');
}
~~~

This release renamed the former `devalue` serializer to `uneval` and introduced `parse` as the corresponding deserialization entry point. `unflatten` was exported later in the `5.x` line, but both advisory-listed sinks trace back to the `4.0.0` restructuring that first added the vulnerable API surface.

The following 14 versions are currently included in the advisory’s affected range even though they do not expose the vulnerable API surface and should therefore be excluded:

- `1.0.0`, `1.0.1`, `1.0.2`, `1.0.3`, `1.0.4`, `1.1.0`, `1.1.1`
- `2.0.0`, `2.0.1`
- `3.0.1`, `3.1.0`, `3.1.1`, `3.1.2`, `3.1.3`

All fourteen are serializer-only releases.

## Evidence

- npm registry tarballs inspected: `1.0.0`, `1.1.1`, `2.0.1`, `3.1.3`, `4.0.0`, `5.6.3`, `5.6.4`
- `ripgrep` for `parse|unflatten|hydrate` in `1.x`, `2.x`, and `3.x` main bundles returns zero matches
- `3.1.3` `types/devalue.d.ts` exposes only `export function devalue(value: any): string;`
- `4.0.0` `types/index.d.ts` adds `export { parse } from './src/parse.js'`, marking the first appearance of the sink
- `4.0.0` `index.js` explicitly throws from the legacy `devalue` export, confirming that the API was restructured rather than merely extended
- Backend PoC non-exploitation on `1.x` through `3.x` is expected, because the PoC imports `parse` or `unflatten`, which are undefined in those versions

## Conclusion

The affected range should begin at `4.0.0`, not in the `1.x` line. Versions `1.x`, `2.x`, and `3.x` do not contain `parse`, `unflatten`, or any comparable deserialization sink, so including them produces false positives.