### PR TITLE
[GHSA-px4h-xg32-q955] ReDoS in normalize-url

### DIFF
--- a/advisories/github-reviewed/2021/06/GHSA-px4h-xg32-q955/GHSA-px4h-xg32-q955.json
+++ b/advisories/github-reviewed/2021/06/GHSA-px4h-xg32-q955/GHSA-px4h-xg32-q955.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-px4h-xg32-q955",
-  "modified": "2021-10-27T17:04:15Z",
+  "modified": "2023-11-29T22:10:49Z",
   "published": "2021-06-08T23:11:43Z",
   "aliases": [
     "CVE-2021-33502"
@@ -15,25 +15,6 @@
     }
   ],
   "affected": [
-    {
-      "package": {
-        "ecosystem": "npm",
-        "name": "normalize-url"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "4.3.0"
-            },
-            {
-              "fixed": "4.5.1"
-            }
-          ]
-        }
-      ]
-    },
     {
       "package": {
         "ecosystem": "npm",
@@ -67,6 +48,25 @@
             },
             {
               "fixed": "6.0.1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "normalize-url"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.4.1"
+            },
+            {
+              "fixed": "4.5.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Versions `4.3.0` and `4.4.0` do not contain the vulnerable regular expression and should be classified as **not affected**. The correct introduced version is `4.4.1`.

Version `4.3.0` contains no `normalizeDataURL` function and no `data:` URL handling at all; the source has zero occurrences of `"data"`. Version `4.4.0` introduces `normalizeDataURL`, but the implementation uses `^data:(.*?),(.*)$`, which consists of a single lazy group followed by a greedy trailing `.*` and does not include the optional hash fragment group. That regex shape does not exhibit the catastrophic backtracking behavior described in the advisory.

The vulnerable pattern first appears in `4.4.1`, which ships `^data:(.*?),(.*?)(?:#(.*))?$`. That is the exact regex later fixed in `4.5.1` by commit `b1fdb51`, which replaces the broad wildcard groups with constrained character classes (`[^,]*?` / `[^#]*?`).

Runtime PoC ReDoS testing matches the source analysis: exploitation fails on `4.3.0` and `4.4.0`, and succeeds on `4.4.1` and later affected versions.

Accordingly, the introduced version should be `4.4.1`, and the affected range should be narrowed from `>= 4.3.0, < 4.5.1` to `>= 4.4.1, < 4.5.1`.