### PR TITLE
[GHSA-p93r-85wp-75v3] Covert timing channel vulnerability in Legion of the...

### DIFF
--- a/advisories/unreviewed/2026/04/GHSA-p93r-85wp-75v3/GHSA-p93r-85wp-75v3.json
+++ b/advisories/unreviewed/2026/04/GHSA-p93r-85wp-75v3/GHSA-p93r-85wp-75v3.json
@@ -1,19 +1,40 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-p93r-85wp-75v3",
-  "modified": "2026-04-17T18:31:50Z",
+  "modified": "2026-04-17T18:32:00Z",
   "published": "2026-04-17T18:31:50Z",
   "aliases": [
     "CVE-2026-5598"
   ],
+  "summary": "Bouncy Castle timing attack",
   "details": "Covert timing channel vulnerability in Legion of the Bouncy Castle Inc. BC-JAVA core on all (core modules).\n Non-constant time comparisons risk private key leakage in FrodoKEM.\n\nThis issue affects BC-JAVA: from 2.17.3 before 1.84.",
   "severity": [
     {
       "type": "CVSS_V4",
-      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H/E:X/CR:X/IR:X/AR:X/MAV:X/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:X/V:X/RE:X/U:X"
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H"
     }
   ],
-  "affected": [],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.bouncycastle:bcprov-jdk15to18"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.8.4"
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "references": [
     {
       "type": "ADVISORY",
@@ -21,7 +42,7 @@
     },
     {
       "type": "WEB",
-      "url": "https://github.com/bcgit/bc-java/wiki/CVE%E2%80%902026%E2%80%905998"
+      "url": "https://github.com/bcgit/bc-java/wiki/CVE%E2%80%902026%E2%80%905598"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
**Updates**
- Affected products
- CVSS v4
- References
- Summary

**Comments**
the patched version was missing and the bc-java wiki link was wrong