### PR TITLE
[GHSA-6qvv-pj99-48qm] @adonisjs/http-server has an Open Redirect vulnerability

### DIFF
--- a/advisories/github-reviewed/2026/04/GHSA-6qvv-pj99-48qm/GHSA-6qvv-pj99-48qm.json
+++ b/advisories/github-reviewed/2026/04/GHSA-6qvv-pj99-48qm/GHSA-6qvv-pj99-48qm.json
@@ -47,7 +47,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "7.3.1"
+              "fixed": "7.3.1"
             }
           ]
         }


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The vulnerability has been fixed in @adonisjs/core version 7.3.1: https://github.com/adonisjs/core/releases/tag/v7.3.1