### PR TITLE
[GHSA-74fj-2j2h-c42q] Exposure of sensitive information in follow-redirects

### DIFF
--- a/advisories/github-reviewed/2022/01/GHSA-74fj-2j2h-c42q/GHSA-74fj-2j2h-c42q.json
+++ b/advisories/github-reviewed/2022/01/GHSA-74fj-2j2h-c42q/GHSA-74fj-2j2h-c42q.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-74fj-2j2h-c42q",
-  "modified": "2022-01-20T15:34:48Z",
+  "modified": "2025-02-12T05:11:06Z",
   "published": "2022-01-12T22:46:26Z",
   "aliases": [
     "CVE-2022-0155"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.0.6"
             },
             {
               "fixed": "1.14.7"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Empirical POC-based runtime testing confirms follow-redirects 0.0.1-0.0.5 do not leak Cookie headers on cross-host redirects. Versions 0.0.1-0.0.3 rebuild the redirect via a bare `module.exports[__proto__].get(redirectUrl)` call that forwards only the URL, so the original requests Cookie header never reaches the second hop. Versions 0.0.4-0.0.5 start forwarding some header state but still do not trigger the cross-host leak path. Cross-host header forwarding (and thus the vulnerability) landed in 0.0.6.