### PR TITLE
[GHSA-pw2r-vq6v-hr8c] Exposure of Sensitive Information to an Unauthorized Actor in follow-redirects

### DIFF
--- a/advisories/github-reviewed/2022/02/GHSA-pw2r-vq6v-hr8c/GHSA-pw2r-vq6v-hr8c.json
+++ b/advisories/github-reviewed/2022/02/GHSA-pw2r-vq6v-hr8c/GHSA-pw2r-vq6v-hr8c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pw2r-vq6v-hr8c",
-  "modified": "2022-02-14T22:27:56Z",
+  "modified": "2023-07-21T19:16:17Z",
   "published": "2022-02-10T00:00:31Z",
   "aliases": [
     "CVE-2022-0536"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.0.4"
             },
             {
               "fixed": "1.14.8"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Empirical POC-based runtime testing confirms follow-redirects 0.0.1-0.0.3 do not leak Authorization on HTTPS->HTTP scheme downgrade because the redirect code path (module.exports[proto].get(redirectUrl)) does not forward any headers from the original request. Versions 0.0.4+ started forwarding headers and do exhibit the scheme-downgrade leak.