### PR TITLE
[GHSA-jchw-25xp-jwwc] Follow Redirects improperly handles URLs in the url.parse() function

### DIFF
--- a/advisories/github-reviewed/2024/01/GHSA-jchw-25xp-jwwc/GHSA-jchw-25xp-jwwc.json
+++ b/advisories/github-reviewed/2024/01/GHSA-jchw-25xp-jwwc/GHSA-jchw-25xp-jwwc.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jchw-25xp-jwwc",
-  "modified": "2025-11-04T16:48:07Z",
+  "modified": "2025-11-04T16:48:09Z",
   "published": "2024-01-02T06:30:30Z",
   "aliases": [
     "CVE-2023-26159"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.0.6"
             },
             {
               "fixed": "1.15.4"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Empirical POC-based runtime testing confirms follow-redirects 0.0.1-0.0.5 do not exhibit the url.parse / WHATWG-URL differential. The try-new-URL / catch-url.parse fallback that makes this exploitable was introduced in 0.0.6 when the URL handling code path was rewritten. Prior versions used url.resolve + a simple redirect call with no WHATWG URL parsing step at all.