### PR TITLE
[GHSA-cxjh-pqwp-8mfp] follow-redirects' Proxy-Authorization header kept across hosts

### DIFF
--- a/advisories/github-reviewed/2024/03/GHSA-cxjh-pqwp-8mfp/GHSA-cxjh-pqwp-8mfp.json
+++ b/advisories/github-reviewed/2024/03/GHSA-cxjh-pqwp-8mfp/GHSA-cxjh-pqwp-8mfp.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-cxjh-pqwp-8mfp",
-  "modified": "2024-04-02T17:54:20Z",
+  "modified": "2024-04-02T17:54:22Z",
   "published": "2024-03-14T17:19:42Z",
   "aliases": [
     "CVE-2024-28849"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.0.6"
             },
             {
               "fixed": "1.15.6"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Empirical POC-based runtime testing confirms follow-redirects 0.0.1-0.0.5 do not leak Proxy-Authorization on cross-host redirects - same mechanism as GHSA-74fj-2j2h-c42q: the redirect code path in those versions does not forward any headers on cross-host redirects (0.0.1-0.0.3 forwards nothing at all; 0.0.4-0.0.5 has no cross-host code path). Cross-host header forwarding landed in 0.0.6.