### PR TITLE
[GHSA-r4q5-vmmm-2653] follow-redirects leaks Custom Authentication Headers to Cross-Domain Redirect Targets

### DIFF
--- a/advisories/github-reviewed/2026/04/GHSA-r4q5-vmmm-2653/GHSA-r4q5-vmmm-2653.json
+++ b/advisories/github-reviewed/2026/04/GHSA-r4q5-vmmm-2653/GHSA-r4q5-vmmm-2653.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-r4q5-vmmm-2653",
-  "modified": "2026-04-14T01:11:11Z",
+  "modified": "2026-04-14T01:11:12Z",
   "published": "2026-04-14T01:11:11Z",
   "aliases": [],
   "summary": "follow-redirects leaks Custom Authentication Headers to Cross-Domain Redirect Targets",
@@ -23,7 +23,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "0.0.6"
             },
             {
               "fixed": "1.16.0"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Empirical POC-based runtime testing confirms follow-redirects 0.0.1-0.0.5 do not leak custom sensitive headers on cross-host redirects - same mechanism as GHSA-74fj-2j2h-c42q. The sensitiveHeaders option the advisory describes is a late addition, but the underlying cross-host header-forwarding behavior the leak depends on is what determines applicability, and that behavior was introduced in 0.0.6.