### PR TITLE
[GHSA-hcp2-x6j4-29j7] RustCrypto: Signatures has timing side-channel in ML-DSA decomposition

### DIFF
--- a/advisories/github-reviewed/2026/01/GHSA-hcp2-x6j4-29j7/GHSA-hcp2-x6j4-29j7.json
+++ b/advisories/github-reviewed/2026/01/GHSA-hcp2-x6j4-29j7/GHSA-hcp2-x6j4-29j7.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-hcp2-x6j4-29j7",
-  "modified": "2026-01-29T03:41:14Z",
+  "modified": "2026-01-29T03:41:15Z",
   "published": "2026-01-13T15:10:03Z",
   "aliases": [
     "CVE-2026-22705"
@@ -28,11 +28,14 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.1.0-rc.2"
+              "fixed": ">= 0.1.0-rc.3"
             }
           ]
         }
-      ]
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 0.1.0-rc.3"
+      }
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
It was reported that the version number was incorrect: https://github.com/RustCrypto/signatures/issues/1307