### PR TITLE
fix: correct ECOSYSTEM fixed versions in GHSA-4j5j-58j7-6c3w (dulwich) and GHSA-pfr9-2p92-qrhq (dbn)

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4j5j-58j7-6c3w/GHSA-4j5j-58j7-6c3w.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4j5j-58j7-6c3w/GHSA-4j5j-58j7-6c3w.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4j5j-58j7-6c3w",
-  "modified": "2024-09-20T17:38:53Z",
+  "modified": "2026-04-21T00:00:00Z",
   "published": "2022-05-17T04:14:03Z",
   "aliases": [
     "CVE-2014-9706"
   ],
   "summary": "Dulwich Arbitrary code execution via commit with directory path starting with .git",
-  "details": "The `build_index_from_tree` function in index.py in Dulwich before 0.9.9 allows remote attackers to execute arbitrary code via a commit with a directory path starting with `.git/`, which is not properly handled when checking out a working tree.",
+  "details": "The `build_index_from_tree` function in index.py in Dulwich before 0.10.0 allows remote attackers to execute arbitrary code via a commit with a directory path starting with `.git/`, which is not properly handled when checking out a working tree.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -32,7 +32,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.9.9"
+              "fixed": "0.10.0"
             }
           ]
         }

--- a/advisories/github-reviewed/2024/10/GHSA-pfr9-2p92-qrhq/GHSA-pfr9-2p92-qrhq.json
+++ b/advisories/github-reviewed/2024/10/GHSA-pfr9-2p92-qrhq/GHSA-pfr9-2p92-qrhq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pfr9-2p92-qrhq",
-  "modified": "2024-10-09T14:34:24Z",
+  "modified": "2026-04-21T00:00:00Z",
   "published": "2024-10-09T14:34:24Z",
   "aliases": [],
   "summary": "Databento Binary Encoding (DBN) has a heap buffer overflow using c_chars_to_str function",
@@ -30,7 +30,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.22.0"
+              "fixed": "0.22.1"
             }
           ]
         }


### PR DESCRIPTION
## Summary

Two advisories list incorrect `fixed` versions in their ECOSYSTEM range. For both, `git merge-base --is-ancestor <fix_commit> <release_tag>` returns false — the fix commit is not in the ancestry of the claimed-fixed release tag, so the artifact cannot contain the fix.

| Advisory | Package | Wrong fixed | Correct fixed | Root cause |
|---|---|---|---|---|
| GHSA-4j5j-58j7-6c3w | dulwich (PyPI) | 0.9.9 | **0.10.0** | Fix commit `091638be3c89` postdates the 0.9.9 tag; first appears in 0.10.0 |
| GHSA-pfr9-2p92-qrhq | dbn (crates.io) | 0.22.0 | **0.22.1** | Fix commit `339efb90fdb9` authored 2024-10-08, seven days after the v0.22.0 tag (2024-10-01) |

Note: RUSTSEC-2024-0377 (the Rust advisory for dbn) already has this correct with `patched = ["> 0.22.0"]`. This PR aligns the GHSA to match.

## Changes

- `GHSA-4j5j-58j7-6c3w`: `fixed: "0.9.9"` -> `fixed: "0.10.0"`, details text updated
- `GHSA-pfr9-2p92-qrhq`: `fixed: "0.22.0"` -> `fixed: "0.22.1"`