### PR TITLE
fix: correct GHSA-4j5j-58j7-6c3w dulwich fixed version 0.9.9 -> 0.10.0

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-4j5j-58j7-6c3w/GHSA-4j5j-58j7-6c3w.json
+++ b/advisories/github-reviewed/2022/05/GHSA-4j5j-58j7-6c3w/GHSA-4j5j-58j7-6c3w.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-4j5j-58j7-6c3w",
-  "modified": "2024-09-20T17:38:53Z",
+  "modified": "2026-04-21T00:00:00Z",
   "published": "2022-05-17T04:14:03Z",
   "aliases": [
     "CVE-2014-9706"
   ],
   "summary": "Dulwich Arbitrary code execution via commit with directory path starting with .git",
-  "details": "The `build_index_from_tree` function in index.py in Dulwich before 0.9.9 allows remote attackers to execute arbitrary code via a commit with a directory path starting with `.git/`, which is not properly handled when checking out a working tree.",
+  "details": "The `build_index_from_tree` function in index.py in Dulwich before 0.10.0 allows remote attackers to execute arbitrary code via a commit with a directory path starting with `.git/`, which is not properly handled when checking out a working tree.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -32,7 +32,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.9.9"
+              "fixed": "0.10.0"
             }
           ]
         }


### PR DESCRIPTION
`git merge-base --is-ancestor 091638be3c89f46f42c3b1d57dc1504af5729176 dulwich-0.9.9` returns false — the fix commit is not in the ancestry of the 0.9.9 release tag. The 0.9.9 artifact on PyPI ships `dulwich/index.py` byte-identical to the pre-fix state (missing path validation in `build_index_from_tree()`). The fix first appears in 0.10.0.

- `fixed: "0.9.9"` -> `fixed: "0.10.0"`
- Updated details prose accordingly