### PR TITLE
fix: correct GHSA-pfr9-2p92-qrhq dbn fixed version 0.22.0 -> 0.22.1

### DIFF
--- a/advisories/github-reviewed/2024/10/GHSA-pfr9-2p92-qrhq/GHSA-pfr9-2p92-qrhq.json
+++ b/advisories/github-reviewed/2024/10/GHSA-pfr9-2p92-qrhq/GHSA-pfr9-2p92-qrhq.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-pfr9-2p92-qrhq",
-  "modified": "2024-10-09T14:34:24Z",
+  "modified": "2026-04-21T00:00:00Z",
   "published": "2024-10-09T14:34:24Z",
   "aliases": [],
   "summary": "Databento Binary Encoding (DBN) has a heap buffer overflow using c_chars_to_str function",
@@ -30,7 +30,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0.22.0"
+              "fixed": "0.22.1"
             }
           ]
         }


### PR DESCRIPTION
`git merge-base --is-ancestor 339efb90fdb980920a5e8829008abc1114f4bfdd v0.22.0` returns false — the fix commit was authored 2024-10-08, seven days after the v0.22.0 tag (2024-10-01). The 0.22.0 crate ships `rust/dbn/src/record/conv.rs` byte-identical to the pre-fix state.

Note: RUSTSEC-2024-0377 already has this correct with `patched = ["> 0.22.0"]`. This PR aligns the GHSA to match.

- `fixed: "0.22.0"` -> `fixed: "0.22.1"`