### PR TITLE
fix: correct GHSA-887w-45rq-vxgf sqlalchemy fixed version 1.2.18 -> 1.3.0b1

### DIFF
--- a/advisories/github-reviewed/2019/04/GHSA-887w-45rq-vxgf/GHSA-887w-45rq-vxgf.json
+++ b/advisories/github-reviewed/2019/04/GHSA-887w-45rq-vxgf/GHSA-887w-45rq-vxgf.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-887w-45rq-vxgf",
-  "modified": "2024-10-28T14:20:14Z",
+  "modified": "2026-04-22T00:00:00Z",
   "published": "2019-04-16T15:50:41Z",
   "aliases": [
     "CVE-2019-7164"
   ],
   "summary": "SQLAlchemy vulnerable to SQL Injection via order_by parameter",
-  "details": "SQLAlchemy through 1.2.17 and 1.3.x through 1.3.0b2 allows SQL Injection via the order_by parameter.",
+  "details": "SQLAlchemy through 1.2.18 and 1.3.x through 1.3.0b2 allows SQL Injection via the order_by parameter. The fix (commit 30307c4) was never backported to the 1.2.x release branch; users on 1.2.x must upgrade to 1.3.0b3 or later.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -51,7 +51,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "1.2.18"
+              "fixed": "1.3.0b1"
             }
           ]
         }

--- a/advisories/github-reviewed/2019/04/GHSA-887w-45rq-vxgf/GHSA-887w-45rq-vxgf.json
+++ b/advisories/github-reviewed/2019/04/GHSA-887w-45rq-vxgf/GHSA-887w-45rq-vxgf.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-887w-45rq-vxgf",
-  "modified": "2026-04-22T00:00:00Z",
+  "modified": "2026-04-24T15:30:00Z",
   "published": "2019-04-16T15:50:41Z",
   "aliases": [
     "CVE-2019-7164"
   ],
   "summary": "SQLAlchemy vulnerable to SQL Injection via order_by parameter",
-  "details": "SQLAlchemy through 1.2.18 and 1.3.x through 1.3.0b2 allows SQL Injection via the order_by parameter. The fix (commit 30307c4) was never backported to the 1.2.x release branch; users on 1.2.x must upgrade to 1.3.0b3 or later.",
+  "details": "SQLAlchemy before 1.3.0b3 allows SQL Injection via the order_by parameter. The fix (commit 30307c4) was applied only to the main branch and was never backported to the 1.2.x release line; all 1.2.x versions remain vulnerable.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -29,29 +29,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.3.0b1"
-            },
-            {
-              "fixed": "1.3.0b3"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "PyPI",
-        "name": "SQLAlchemy"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
               "introduced": "0"
             },
             {
-              "fixed": "1.3.0b1"
+              "fixed": "1.3.0b3"
             }
           ]
         }


### PR DESCRIPTION
`git merge-base --is-ancestor 30307c4616ad67c01ddae2e1e8e34fabf6028414 rel_1_2_18` returns false — the fix commit was never backported to the 1.2.x release branch. The PyPI artifact for SQLAlchemy 1.2.18 ships `lib/sqlalchemy/sql/compiler.py` byte-identical to the pre-fix state. The entire 1.2.x series remains vulnerable.

The fix only exists on the main branch starting at 1.3.0b3. The 1.3.0b1-1.3.0b2 range (already correctly marked as affected) is unchanged.

**Change:** second ECOSYSTEM range `fixed: "1.2.18"` -> `fixed: "1.3.0b1"`, meaning users on any 1.2.x version must upgrade to 1.3.x to get the fix. Updated details text to reflect this.

Opened on behalf of the SQLAlchemy maintainers (@CaselIT, @zzzeek) per https://github.com/sqlalchemy/sqlalchemy/issues/13252#issuecomment-4292363052