### PR TITLE
[GHSA-wf44-4mgj-rwvx] OpenStack Neutron Improper Input Validation vulnerability

### DIFF
--- a/advisories/github-reviewed/2022/05/GHSA-wf44-4mgj-rwvx/GHSA-wf44-4mgj-rwvx.json
+++ b/advisories/github-reviewed/2022/05/GHSA-wf44-4mgj-rwvx/GHSA-wf44-4mgj-rwvx.json
@@ -20,7 +20,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2000"
             },
             {
               "fixed": "2014.2.4"


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
Neutron stopped using the year as their major version around 10 years ago so this alert fires as a false positive because the latest release from 2026 is "28.0.0"