### PR TITLE
[GHSA-792x-6vq6-j8r9] Spring Integration File Support: FTP/SFTP/SMB server can write arbitrary files anywhere on the client filesystem

### DIFF
--- a/advisories/github-reviewed/2026/06/GHSA-792x-6vq6-j8r9/GHSA-792x-6vq6-j8r9.json
+++ b/advisories/github-reviewed/2026/06/GHSA-792x-6vq6-j8r9/GHSA-792x-6vq6-j8r9.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-792x-6vq6-j8r9",
-  "modified": "2026-07-24T20:35:04Z",
+  "modified": "2026-07-24T20:35:05Z",
   "published": "2026-06-11T09:31:55Z",
   "aliases": [
     "CVE-2026-40987"
@@ -45,13 +45,13 @@
           "events": [
             {
               "introduced": "6.5.0"
+            },
+            {
+              "fixed": "6.5.9"
             }
           ]
         }
-      ],
-      "database_specific": {
-        "last_known_affected_version_range": "< 6.5.9"
-      }
+      ]
     },
     {
       "package": {


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The description suggests that version "< 6.5.9" are affected. So I concluded that that version equal to 6.5.9 are not affected. Hence, I added the fix version 6.5.9 to the 6.5 line.