### PR TITLE
[GHSA-jx74-cqjv-2c67] Flyto2 Core: Unauthenticated flyto-verification /run: callback_url SSRF and internal runner-secret exfiltration

### DIFF
--- a/advisories/github-reviewed/2026/07/GHSA-jx74-cqjv-2c67/GHSA-jx74-cqjv-2c67.json
+++ b/advisories/github-reviewed/2026/07/GHSA-jx74-cqjv-2c67/GHSA-jx74-cqjv-2c67.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-jx74-cqjv-2c67",
-  "modified": "2026-07-30T14:47:41Z",
+  "modified": "2026-07-30T14:47:43Z",
   "published": "2026-07-30T14:47:41Z",
   "aliases": [
     "CVE-2026-67426"
@@ -25,7 +25,7 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "0"
+              "introduced": "2.26.5"
             },
             {
               "fixed": "2.26.7"
@@ -33,9 +33,9 @@
           ]
         }
       ],
-      "database_specific": {
-        "last_known_affected_version_range": "<= 2.26.6"
-      }
+      "versions": [
+        "2.26.5"
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
**Updates**
- Affected products

**Comments**
The whole verification subsystem - file, function, console script - is absent from every published wheel through 2.26.4. Seems like to only vulnerable one is 2.26.5