### PR TITLE
Add affected Maven package and version range to GHSA-crf3-v9rr-v7hj (CVE-2026-16723, com.alibaba:fastjson)

### DIFF
--- a/advisories/unreviewed/2026/07/GHSA-crf3-v9rr-v7hj/GHSA-crf3-v9rr-v7hj.json
+++ b/advisories/unreviewed/2026/07/GHSA-crf3-v9rr-v7hj/GHSA-crf3-v9rr-v7hj.json
@@ -13,7 +13,27 @@
       "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
     }
   ],
-  "affected": [],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.alibaba:fastjson"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.2.68"
+            },
+            {
+              "fixed": "1.2.84"
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "references": [
     {
       "type": "ADVISORY",
@@ -22,6 +42,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/alibaba/fastjson2/wiki/Security-Advisory:-Remote-Code-Execution-in-fastjson-1.2.68%E2%80%931.2.83"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/alibaba/fastjson"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/alibaba/fastjson/releases/tag/1.2.84"
     }
   ],
   "database_specific": {


### PR DESCRIPTION
This advisory is currently published with an empty `affected` array, so it carries no package or version information. That makes it invisible to tooling that resolves advisories to Maven coordinates, even though the affected package and the fixed version are both public.

This PR adds the affected package and range, based on the upstream advisory linked from the record:

- **Package:** `com.alibaba:fastjson` (Maven)
- **Introduced:** `1.2.68`
- **Fixed:** `1.2.84`

### Supporting references

- The upstream advisory, [Security Advisory: Remote Code Execution in fastjson 1.2.68–1.2.83](https://github.com/alibaba/fastjson2/wiki/Security-Advisory:-Remote-Code-Execution-in-fastjson-1.2.68%E2%80%931.2.83) (already referenced in the record), scopes the vulnerability to fastjson 1.2.68 through 1.2.83 and states that fastjson ≤ 1.2.60 is not affected because the vulnerable code path does not exist. Its first remediation step is to upgrade to `com.alibaba:fastjson:1.2.84`; enabling SafeMode and switching to the `1.2.83_noneautotype` build are listed as alternatives for users who cannot upgrade.
- The `details` text already in this record likewise describes the range as "fastjson 1.2.68 through 1.2.83".
- [`alibaba/fastjson` release 1.2.84](https://github.com/alibaba/fastjson/releases/tag/1.2.84) was published 2026-07-29, after this advisory was imported on 2026-07-23, which is why the record predates the fix. The artifact is available on Maven Central at [`com/alibaba/fastjson/1.2.84`](https://repo1.maven.org/maven2/com/alibaba/fastjson/1.2.84/).

I have also added a `PACKAGE` reference to the upstream repository and a `WEB` reference to the 1.2.84 release, to support the `fixed` event.

Note that the upstream advisory title still describes 1.2.83 as "the last 1.x release", which was accurate when it was written but no longer is.
