### PR TITLE
[GHSA-q3j6-qgpj-74h6] fast-uri vulnerable to path traversal via percent-encoded dot segments

### DIFF
--- a/advisories/github-reviewed/2026/05/GHSA-q3j6-qgpj-74h6/GHSA-q3j6-qgpj-74h6.json
+++ b/advisories/github-reviewed/2026/05/GHSA-q3j6-qgpj-74h6/GHSA-q3j6-qgpj-74h6.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-q3j6-qgpj-74h6",
-  "modified": "2026-05-08T17:15:09Z",
+  "modified": "2026-05-08T17:15:11Z",
   "published": "2026-05-08T17:15:09Z",
   "aliases": [
     "CVE-2026-6321"
   ],
   "summary": "fast-uri vulnerable to path traversal via percent-encoded dot segments",
-  "details": "### Impact\n\n`fast-uri` v3.1.0 and earlier decodes percent-encoded path separators (`%2F`) and dot segments (`%2E`) before applying dot-segment removal in `normalize()` and `equal()`. This makes encoded path data behave like real `/` and `..`, so distinct URIs collapse onto the same normalized path.\n\nFor example, `http://example.com/public/%2e%2e/admin` normalizes to `http://example.com/admin`, and `equal()` considers them the same URI.\n\nApplications that normalize or compare attacker-controlled URLs to enforce path-based policy can be bypassed. A path that looks confined under an allowed prefix can normalize to a different location.\n\n### Patches\n\nUpgrade to `fast-uri` >= 3.1.1.\n\n### Workarounds\n\nNone. Upgrade to the patched version.",
+  "details": "### Impact\n\n`fast-uri` v3.1.0 and earlier decodes percent-encoded path separators (`%2F`) and dot segments (`%2E`) before applying dot-segment removal in `normalize()` and `equal()`. This makes encoded path data behave like real `/` and `..`, so distinct URIs collapse onto the same normalized path.\n\nFor example, `http://example.com/public/%2e%2e/admin` normalizes to `http://example.com/admin`, and `equal()` considers them the same URI.\n\nApplications that normalize or compare attacker-controlled URLs to enforce path-based policy can be bypassed. A path that looks confined under an allowed prefix can normalize to a different location.\n\n### Patches\n\nUpgrade to `fast-uri` >= 3.1.1, `fast-uri` >= 2.4.1\n\n### Workarounds\n\nNone. Upgrade to the patched version.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -35,6 +35,28 @@
       ],
       "database_specific": {
         "last_known_affected_version_range": "<= 3.1.0"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "fast-uri"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.4.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.4.0"
       }
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
`fast-uri@2.4.1` backported the fixes for this. See release notes: https://github.com/fastify/fast-uri/releases/tag/v2.4.1