### PR TITLE
[GHSA-v39h-62p7-jpjc] fast-uri vulnerable to host confusion via percent-encoded authority delimiters

### DIFF
--- a/advisories/github-reviewed/2026/05/GHSA-v39h-62p7-jpjc/GHSA-v39h-62p7-jpjc.json
+++ b/advisories/github-reviewed/2026/05/GHSA-v39h-62p7-jpjc/GHSA-v39h-62p7-jpjc.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.4.0",
   "id": "GHSA-v39h-62p7-jpjc",
-  "modified": "2026-05-08T19:13:01Z",
+  "modified": "2026-05-08T19:13:02Z",
   "published": "2026-05-08T19:13:01Z",
   "aliases": [
     "CVE-2026-6322"
   ],
   "summary": "fast-uri vulnerable to host confusion via percent-encoded authority delimiters",
-  "details": "### Impact\n\n`fast-uri` v3.1.1 and earlier decodes percent-encoded authority delimiters (`%40` as `@`, `%3A` as `:`) inside the host component and serializes them back as raw characters. This changes the URI structure, turning a hostname into userinfo plus a different host.\n\nFor example, `http://trusted.com%40evil.com/` normalizes to `http://trusted.com@evil.com/`, which reparses as host `evil.com` with userinfo `trusted.com`.\n\nApplications that normalize untrusted URLs before host allowlist checks, redirect validation, or outbound request routing can be steered to a different authority than the original URL appeared to contain.\n\n### Patches\n\nUpgrade to `fast-uri` >= 3.1.2.\n\n### Workarounds\n\nNone. Upgrade to the patched version.",
+  "details": "### Impact\n\n`fast-uri` v3.1.1 and earlier decodes percent-encoded authority delimiters (`%40` as `@`, `%3A` as `:`) inside the host component and serializes them back as raw characters. This changes the URI structure, turning a hostname into userinfo plus a different host.\n\nFor example, `http://trusted.com%40evil.com/` normalizes to `http://trusted.com@evil.com/`, which reparses as host `evil.com` with userinfo `trusted.com`.\n\nApplications that normalize untrusted URLs before host allowlist checks, redirect validation, or outbound request routing can be steered to a different authority than the original URL appeared to contain.\n\n### Patches\n\nUpgrade to `fast-uri` >= 3.1.2, `fast-uri` >= 2.4.1\n\n### Workarounds\n\nNone. Upgrade to the patched version.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -35,6 +35,28 @@
       ],
       "database_specific": {
         "last_known_affected_version_range": "<= 3.1.1"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "fast-uri"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.4.1"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 2.4.0"
       }
     }
   ],


### PR DESCRIPTION
**Updates**
- Affected products
- Description

**Comments**
`fast-uri@2.4.1` backported the fixes for this. See release notes: https://github.com/fastify/fast-uri/releases/tag/v2.4.1