### PR TITLE
Collect staging branches for pull requests opened from forks

### DIFF
--- a/.github/workflows/delete_staging_and_head_branches_writer.yaml
+++ b/.github/workflows/delete_staging_and_head_branches_writer.yaml
@@ -160,35 +160,56 @@ jobs:
             printf '%s\n' "${pr_number}"
           }
 
-          # Caches every open pull request's base ref once per run. A sweep checks hundreds
-          # of staging branches, so asking per branch would cost one request each; the whole
-          # set fits in a handful of paginated requests instead.
-          load_open_pr_bases() {
-            local file
+          # Caches, once per run, every ref in this repository that an open pull request is
+          # still using. A staging branch is normally the base of a pull request, but the
+          # curation flow can also open one with a staging branch as its head, and either
+          # use has to keep the branch alive. Both come back in the same listing, so
+          # covering the head case costs no additional requests. A sweep checks hundreds of
+          # branches, so asking per branch would cost one request each; the whole set fits
+          # in a handful of paginated requests instead.
+          load_open_pr_refs() {
+            local file raw
 
-            [[ -z "${OPEN_PR_BASES_FILE}" ]] || return 0
+            [[ -z "${OPEN_PR_REFS_FILE}" ]] || return 0
 
-            file="$(mktemp)"
+            raw="$(mktemp)"
             if ! gh api --paginate "repos/${REPOSITORY}/pulls?state=open&per_page=100" \
-              --jq '.[] | [.base.ref, (.number | tostring)] | @tsv' > "${file}"; then
-              rm -f "${file}"
+              --jq '.[] | [(.number | tostring), .base.ref, (.head.ref // ""), (.head.repo.full_name // "")] | @tsv' > "${raw}"; then
+              rm -f "${raw}"
               echo "::error::Failed to list the open pull requests of ${REPOSITORY}." >&2
               return 1
             fi
-            OPEN_PR_BASES_FILE="${file}"
+
+            file="$(mktemp)"
+            # A head ref is only indexed when it lives in this repository; a fork's branch
+            # shares no namespace with ours and must not mask a deletable staging branch.
+            if ! awk -F'\t' -v repo="${REPOSITORY}" 'BEGIN { OFS = "\t" }
+              { print $2, $1; if ($4 == repo && $3 != "") print $3, $1 }' "${raw}" > "${file}"; then
+              rm -f "${raw}" "${file}"
+              echo "::error::Failed to index the open pull requests of ${REPOSITORY}." >&2
+              return 1
+            fi
+            rm -f "${raw}"
+            OPEN_PR_REFS_FILE="${file}"
           }
 
-          # Prints the number of an open pull request that still targets the branch as its
-          # base. Returns 0 when one exists, 1 when none does, and 2 when the lookup failed,
-          # so that a failed lookup is never mistaken for "nothing is using this branch".
-          open_pr_targeting_base() {
+          # Prints the number of an open pull request that is still using the ref, as either
+          # its base or its head. Returns 0 when one exists, 1 when none does, and 2 when the
+          # lookup failed, so that a failed lookup is never mistaken for "nothing is using
+          # this branch". The cache is loaded by the caller rather than here: this function
+          # is used from a command substitution, and anything it populated would be discarded
+          # along with that subshell, silently refetching the whole list once per branch.
+          open_pr_using_ref() {
             local branch="$1"
             local matched="" rc=0
 
-            load_open_pr_bases || return 2
+            if [[ -z "${OPEN_PR_REFS_FILE}" ]]; then
+              echo "::error::The open pull request cache was not loaded before searching for ${branch}." >&2
+              return 2
+            fi
             matched="$(awk -F'\t' -v branch="${branch}" \
               '$1 == branch { print $2; found = 1; exit } END { exit(found ? 0 : 1) }' \
-              "${OPEN_PR_BASES_FILE}")" || rc=$?
+              "${OPEN_PR_REFS_FILE}")" || rc=$?
             if (( rc == 1 )); then
               return 1
             fi
@@ -311,16 +332,23 @@ jobs:
           delete_staging_branch() {
             local pr_number="$1"
             local branch="$2"
-            local blocking_pr lookup_status=0
+            local blocking_pr delete_status=0 lookup_status=0
 
             if ! is_staging_branch_for_pr "${branch}" "${pr_number}"; then
               echo "::error::Refusing to delete ${branch}: it is not the staging branch of pull request ${pr_number}."
               return 1
             fi
 
-            blocking_pr="$(open_pr_targeting_base "${branch}")" || lookup_status=$?
+            # Loaded from this shell rather than from inside the command substitution below,
+            # so the cache survives and the open pull requests are listed once per run.
+            if ! load_open_pr_refs; then
+              echo "::error::Could not determine whether staging branch ${branch} is still in use, so it was left in place."
+              return 1
+            fi
+
+            blocking_pr="$(open_pr_using_ref "${branch}")" || lookup_status=$?
             if (( lookup_status == 0 )); then
-              echo "::warning::Staging branch ${branch} is still the base of open pull request #${blocking_pr}; leaving it in place."
+              echo "::warning::Staging branch ${branch} is still in use by open pull request #${blocking_pr}; leaving it in place."
               record_skip "${pr_number}" "${branch}" "${blocking_pr}"
               return 0
             fi
@@ -329,7 +357,15 @@ jobs:
               return 1
             fi
 
-            delete_branch "${branch}" || return 1
+            # No SHA is passed, so delete_branch cannot currently return 3. It is handled
+            # anyway so that adding a SHA guard here later cannot turn a legitimate "still
+            # in use by an open pull request" skip into a run failure.
+            delete_branch "${branch}" || delete_status=$?
+            if (( delete_status == 3 )); then
+              record_skip "${pr_number}" "${branch}" "${BLOCKING_PR}"
+              return 0
+            fi
+            (( delete_status == 0 )) || return 1
             return 0
           }
 
@@ -591,7 +627,7 @@ jobs:
                 echo "| Metric | Count |"
                 echo "| --- | ---: |"
                 echo "| Staging branches inspected | ${INSPECTED_COUNT} |"
-                echo "| Pull requests reconciled | ${RECONCILE_COUNT} |"
+                echo "| Pull requests attempted | ${RECONCILE_COUNT} |"
                 echo "| Deferred to the next sweep | ${DEFERRED_COUNT} |"
                 echo "| Left in place (branch still used by an open pull request) | ${skipped_count} |"
                 echo "| Pull request failures | ${PROCESS_FAILURES} |"
@@ -615,7 +651,7 @@ jobs:
 
           cleanup() {
             rm -f "${SKIPPED_FILE}"
-            [[ -z "${OPEN_PR_BASES_FILE}" ]] || rm -f "${OPEN_PR_BASES_FILE}"
+            [[ -z "${OPEN_PR_REFS_FILE}" ]] || rm -f "${OPEN_PR_REFS_FILE}"
           }
 
           TRIAGE_CHUNK_SIZE=50
@@ -632,7 +668,7 @@ jobs:
           MAX_RECONCILE_PER_RUN=400
           SWEEP=0
           BLOCKING_PR=""
-          OPEN_PR_BASES_FILE=""
+          OPEN_PR_REFS_FILE=""
           SKIPPED_FILE="$(mktemp)"
           # An EXIT trap keeps the summary accurate even when the run ends in failure.
           trap 'write_job_summary || true; cleanup' EXIT

--- a/.github/workflows/delete_staging_and_head_branches_writer.yaml
+++ b/.github/workflows/delete_staging_and_head_branches_writer.yaml
@@ -160,6 +160,45 @@ jobs:
             printf '%s\n' "${pr_number}"
           }
 
+          # Caches every open pull request's base ref once per run. A sweep checks hundreds
+          # of staging branches, so asking per branch would cost one request each; the whole
+          # set fits in a handful of paginated requests instead.
+          load_open_pr_bases() {
+            local file
+
+            [[ -z "${OPEN_PR_BASES_FILE}" ]] || return 0
+
+            file="$(mktemp)"
+            if ! gh api --paginate "repos/${REPOSITORY}/pulls?state=open&per_page=100" \
+              --jq '.[] | [.base.ref, (.number | tostring)] | @tsv' > "${file}"; then
+              rm -f "${file}"
+              echo "::error::Failed to list the open pull requests of ${REPOSITORY}." >&2
+              return 1
+            fi
+            OPEN_PR_BASES_FILE="${file}"
+          }
+
+          # Prints the number of an open pull request that still targets the branch as its
+          # base. Returns 0 when one exists, 1 when none does, and 2 when the lookup failed,
+          # so that a failed lookup is never mistaken for "nothing is using this branch".
+          open_pr_targeting_base() {
+            local branch="$1"
+            local matched="" rc=0
+
+            load_open_pr_bases || return 2
+            matched="$(awk -F'\t' -v branch="${branch}" \
+              '$1 == branch { print $2; found = 1; exit } END { exit(found ? 0 : 1) }' \
+              "${OPEN_PR_BASES_FILE}")" || rc=$?
+            if (( rc == 1 )); then
+              return 1
+            fi
+            if (( rc != 0 )); then
+              echo "::error::Failed to search the open pull requests of ${REPOSITORY}." >&2
+              return 2
+            fi
+            printf '%s\n' "${matched}"
+          }
+
           request_ref() {
             local body_file="$1"
             local method="$2"
@@ -263,9 +302,40 @@ jobs:
             printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "${SKIPPED_FILE}"
           }
 
+          # Removes the staging branch a closed pull request targeted. The branch always
+          # lives in this repository even when the pull request came from a fork, and its
+          # name encodes the pull request number, so it cannot be claimed by a later one.
+          # It is still confirmed to be unused immediately before deletion, because this
+          # workflow can write to the repository and the branch listing it works from is
+          # minutes old by the time the sweep reaches this point.
+          delete_staging_branch() {
+            local pr_number="$1"
+            local branch="$2"
+            local blocking_pr lookup_status=0
+
+            if ! is_staging_branch_for_pr "${branch}" "${pr_number}"; then
+              echo "::error::Refusing to delete ${branch}: it is not the staging branch of pull request ${pr_number}."
+              return 1
+            fi
+
+            blocking_pr="$(open_pr_targeting_base "${branch}")" || lookup_status=$?
+            if (( lookup_status == 0 )); then
+              echo "::warning::Staging branch ${branch} is still the base of open pull request #${blocking_pr}; leaving it in place."
+              record_skip "${pr_number}" "${branch}" "${blocking_pr}"
+              return 0
+            fi
+            if (( lookup_status != 1 )); then
+              echo "::error::Could not determine whether staging branch ${branch} is still in use, so it was left in place."
+              return 1
+            fi
+
+            delete_branch "${branch}" || return 1
+            return 0
+          }
+
           process_pr() {
             local advisory_file_pages base_ref base_repo expected_staging_branch head_ref head_repo head_sha
-            local delete_status=0 fetch_status=0 pr_json pr_number="$1" state
+            local delete_status=0 fetch_status=0 head_is_local=1 pr_json pr_number="$1" state
             expected_staging_branch="${2:-}"
 
             if ! is_pr_number "${pr_number}"; then
@@ -322,12 +392,15 @@ jobs:
               return 0
             fi
 
+            # Most advisory improvements are opened from a fork, so the head branch is not
+            # ours to delete and its SHA guards nothing in this repository. That is a reason
+            # to leave the head branch alone, not a reason to abandon the staging branch it
+            # targeted, which is what the fork-only path below collects.
             if [[ "${head_repo}" != "${REPOSITORY}" ]]; then
-              echo "Pull request ${pr_number} head repo is ${head_repo}, not ${REPOSITORY}; skipping."
-              return 0
+              head_is_local=0
             fi
 
-            if [[ ! "${head_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            if (( head_is_local )) && [[ ! "${head_sha}" =~ ^[0-9a-f]{40}$ ]]; then
               echo "::error::Pull request ${pr_number} has an unexpected head SHA: ${head_sha}"
               return 1
             fi
@@ -342,6 +415,12 @@ jobs:
             if ! grep -qx 'true' <<<"${advisory_file_pages}"; then
               echo "Pull request ${pr_number} does not modify advisories/; skipping."
               return 0
+            fi
+
+            if (( ! head_is_local )); then
+              echo "Pull request ${pr_number} was opened from ${head_repo:-a deleted fork}; leaving its head branch alone and collecting staging branch ${base_ref}."
+              delete_staging_branch "${pr_number}" "${base_ref}"
+              return $?
             fi
 
             if [[ "${head_ref}" == "${base_ref}" ]]; then
@@ -383,7 +462,7 @@ jobs:
             query='query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) {'
             while IFS=$'\t' read -r pr_number _; do
               is_pr_number "${pr_number}" || continue
-              query+=" pr${pr_number}: pullRequest(number: ${pr_number}) { number state baseRefName headRepository { nameWithOwner } }"
+              query+=" pr${pr_number}: pullRequest(number: ${pr_number}) { number state baseRefName }"
             done < "${chunk_file}"
             query+=' } }'
 
@@ -418,14 +497,21 @@ jobs:
 
             # A failing jq must not be masked by the trailing cleanup, otherwise the
             # batch would be silently dropped without being counted as a failure.
-            if ! jq -r --arg repo "${REPOSITORY}" '
+            # Pull requests opened from a fork are included on purpose: their staging
+            # branch is in this repository even though their head branch is not. Requiring
+            # the base to be the pull request's own staging branch keeps the ones that were
+            # retargeted at main out of the reconciliation loop, and process_pr re-validates
+            # both facts over REST before anything is deleted.
+            if ! jq -r '
               .data.repository
               | to_entries[]
               | .value
               | select(. != null)
               | select(.state == "CLOSED" or .state == "MERGED")
-              | select(.headRepository != null and .headRepository.nameWithOwner == $repo)
-              | [(.number | tostring), .baseRefName]
+              | . as $pr
+              | select(($pr.baseRefName // "")
+                  | endswith("/advisory-improvement-" + ($pr.number | tostring)))
+              | [($pr.number | tostring), $pr.baseRefName]
               | @tsv
             ' "${response}"; then
               rm -f "${response}" "${errors}"
@@ -506,16 +592,17 @@ jobs:
                 echo "| --- | ---: |"
                 echo "| Staging branches inspected | ${INSPECTED_COUNT} |"
                 echo "| Pull requests reconciled | ${RECONCILE_COUNT} |"
-                echo "| Left in place (branch reused by an open pull request) | ${skipped_count} |"
+                echo "| Deferred to the next sweep | ${DEFERRED_COUNT} |"
+                echo "| Left in place (branch still used by an open pull request) | ${skipped_count} |"
                 echo "| Pull request failures | ${PROCESS_FAILURES} |"
                 echo "| Triage batches failed | ${TRIAGE_FAILURES} |"
                 echo
               fi
 
               if (( skipped_count > 0 )); then
-                echo "<details><summary>Head branch reused by a newer pull request (${skipped_count})</summary>"
+                echo "<details><summary>Branch still in use by an open pull request (${skipped_count})</summary>"
                 echo
-                echo "Each of these branches was verified to still be the head ref of an open pull request, so deleting it would break that pull request and it was left alone. They are collected automatically once that pull request is closed. No action is needed."
+                echo "Each of these branches was verified to still be in use by an open pull request, either as its head ref or as its base, so deleting it would break that pull request and it was left alone. They are collected automatically once that pull request is closed. No action is needed."
                 echo
                 while IFS=$'\t' read -r pr branch blocking_pr; do
                   echo "- \`${branch}\` — left over from #${pr}, still in use by open pull request #${blocking_pr}"
@@ -526,17 +613,29 @@ jobs:
             } >> "${GITHUB_STEP_SUMMARY}"
           }
 
+          cleanup() {
+            rm -f "${SKIPPED_FILE}"
+            [[ -z "${OPEN_PR_BASES_FILE}" ]] || rm -f "${OPEN_PR_BASES_FILE}"
+          }
+
           TRIAGE_CHUNK_SIZE=50
           TRIAGE_FAILURES=0
           PROCESS_FAILURES=0
           MISSING_PR_IS_ERROR=0
           INSPECTED_COUNT=0
           RECONCILE_COUNT=0
+          DEFERRED_COUNT=0
+          # Deleting refs is destructive, so a sweep works a bounded slice rather than the
+          # whole backlog at once. Whatever is left over is picked up by the next scheduled
+          # sweep, which keeps a single run's blast radius and runtime bounded without
+          # needing anyone to drive the cleanup manually.
+          MAX_RECONCILE_PER_RUN=400
           SWEEP=0
           BLOCKING_PR=""
+          OPEN_PR_BASES_FILE=""
           SKIPPED_FILE="$(mktemp)"
           # An EXIT trap keeps the summary accurate even when the run ends in failure.
-          trap 'write_job_summary || true; rm -f "${SKIPPED_FILE}"' EXIT
+          trap 'write_job_summary || true; cleanup' EXIT
 
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_run" ]]; then
             PR_NUMBER="${WORKFLOW_RUN_PR_NUMBER}"
@@ -553,6 +652,13 @@ jobs:
             TARGETS_FILE="$(mktemp)"
             collect_reconciliation_targets > "${TARGETS_FILE}"
             RECONCILE_COUNT="$(wc -l < "${TARGETS_FILE}" | tr -d ' ')"
+            if (( RECONCILE_COUNT > MAX_RECONCILE_PER_RUN )); then
+              DEFERRED_COUNT=$(( RECONCILE_COUNT - MAX_RECONCILE_PER_RUN ))
+              head -n "${MAX_RECONCILE_PER_RUN}" "${TARGETS_FILE}" > "${TARGETS_FILE}.capped"
+              mv "${TARGETS_FILE}.capped" "${TARGETS_FILE}"
+              RECONCILE_COUNT="${MAX_RECONCILE_PER_RUN}"
+              echo "::notice::Reconciling ${MAX_RECONCILE_PER_RUN} staging branch(es) this run and deferring ${DEFERRED_COUNT} to the next sweep."
+            fi
             echo "Reconciling ${RECONCILE_COUNT} staging branch(es)."
 
             # A single unreconcilable pull request must not stop the sweep, otherwise

--- a/.github/workflows/delete_staging_and_head_branches_writer.yaml
+++ b/.github/workflows/delete_staging_and_head_branches_writer.yaml
@@ -319,8 +319,15 @@ jobs:
           # Records a branch that was deliberately left in place, along with the open pull
           # request that is using it, so the job summary can report it without the run
           # having to fail.
+          # Callers run under "if ! process_pr", which disables set -e for everything they
+          # call, so a failed write here has to be returned and propagated by hand. A skip
+          # that cannot be recorded is reported as a failure rather than dropped, because
+          # the job summary is the only record of which branches were left in place.
           record_skip() {
-            printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "${SKIPPED_FILE}"
+            if ! printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "${SKIPPED_FILE}"; then
+              echo "::error::Could not record that branch $2 was left in place for pull request $1."
+              return 1
+            fi
           }
 
           # Removes the staging branch a closed pull request targeted. The branch always
@@ -349,7 +356,7 @@ jobs:
             blocking_pr="$(open_pr_using_ref "${branch}")" || lookup_status=$?
             if (( lookup_status == 0 )); then
               echo "::warning::Staging branch ${branch} is still in use by open pull request #${blocking_pr}; leaving it in place."
-              record_skip "${pr_number}" "${branch}" "${blocking_pr}"
+              record_skip "${pr_number}" "${branch}" "${blocking_pr}" || return 1
               return 0
             fi
             if (( lookup_status != 1 )); then
@@ -362,7 +369,7 @@ jobs:
             # in use by an open pull request" skip into a run failure.
             delete_branch "${branch}" || delete_status=$?
             if (( delete_status == 3 )); then
-              record_skip "${pr_number}" "${branch}" "${BLOCKING_PR}"
+              record_skip "${pr_number}" "${branch}" "${BLOCKING_PR}" || return 1
               return 0
             fi
             (( delete_status == 0 )) || return 1
@@ -462,7 +469,7 @@ jobs:
             if [[ "${head_ref}" == "${base_ref}" ]]; then
               delete_branch "${base_ref}" "${head_sha}" || delete_status=$?
               if (( delete_status == 3 )); then
-                record_skip "${pr_number}" "${base_ref}" "${BLOCKING_PR}"
+                record_skip "${pr_number}" "${base_ref}" "${BLOCKING_PR}" || return 1
                 return 0
               fi
               (( delete_status == 0 )) || return 1
@@ -477,7 +484,7 @@ jobs:
             # Never delete the staging branch when the head branch could not be removed.
             delete_branch "${head_ref}" "${head_sha}" || delete_status=$?
             if (( delete_status == 3 )); then
-              record_skip "${pr_number}" "${head_ref}" "${BLOCKING_PR}"
+              record_skip "${pr_number}" "${head_ref}" "${BLOCKING_PR}" || return 1
               return 0
             fi
             if (( delete_status != 0 )); then


### PR DESCRIPTION
## Problem

The scheduled sweep now inspects every staging branch and reconciles none:

```
Inspected 1463 staging branches.
Reconciling 0 staging branch(es).
```

That is not the backlog being drained. The sweep has exhausted the only population it was ever capable of seeing.

`process_pr` bailed out entirely on any pull request whose head branch was on a fork:

```bash
if [[ "${head_repo}" != "${REPOSITORY}" ]]; then
  echo "Pull request ${pr_number} head repo is ${head_repo}, not ${REPOSITORY}; skipping."
  return 0
fi
```

That guard is correct for the *head* branch — a contributor's fork is not ours to write to. But it was applied to the whole pull request, so the **staging branch** was abandoned too, even though the staging branch always lives in this repository and is exactly what the sweep exists to collect. `triage_chunk` had the matching filter (`select(.headRepository.nameWithOwner == $repo)`), which is why triage surfaced 4 candidates rather than hundreds.

Most advisory improvements arrive from a fork, so the workflow was cleaning up after the minority and permanently leaking the majority.

## Current state of the repository

All 1,463 staging branches resolved against the API:

| Category | Count | Today |
| --- | ---: | --- |
| Open pull request | 327 | Correctly left alone |
| **Fork head, closed/merged, base is its own staging branch** | **965** | **Silently skipped — safe to delete** |
| In-repo head, base is `main` (curation topology) | 99 | Out of scope |
| Pull request deleted (orphans) | 64 | Out of scope |
| Other | 8 | Out of scope |

The 965 are 646 closed and 319 merged.

## Change

A fork head now means "leave the head branch alone", not "skip the pull request". The staging branch it targeted is collected by a new `delete_staging_branch`.

Every existing gate still applies, in the same order: the pull request must be closed, its base must be this repository, its base must still be the branch observed in the branch listing, `is_staging_branch_for_pr` must confirm the base encodes *this* pull request's number, and it must modify `advisories/`. `delete_staging_branch` re-validates the branch against the pull request number, and confirms no open pull request is using the ref before deleting.

Net effect: for pull request *N*, the only ref that can be deleted is `<single-segment-prefix>/advisory-improvement-N`. `main` is not reachable.

Because deleting refs is destructive, a sweep now reconciles at most `MAX_RECONCILE_PER_RUN` (400) branches and defers the rest to the next scheduled sweep, so no single run has an unbounded blast radius or runtime. The backlog drains automatically over ~3 sweeps.

## Validation

**Live dry run of the real selection logic** against this repository (read-only — `collect_reconciliation_targets` only lists and triages):

```
Inspected 1463 staging branches.
triage_failures=0
indexed open-PR refs: 514
targets that would be BLOCKED (left in place): 0
targets that would be DELETED: 965
```

The 965 selected match, exactly and with zero difference, a set derived independently by resolving every branch through a separate GraphQL pass. Cross-checked against the live API:

- 0 selected branches belong to an open pull request
- 0 selected branches are the base of any of the 330 open pull requests
- 0 selected branches are the head of any open pull request
- 0 selected branches have a deleted pull request

**71 assertions pass** against the real script body extracted from this workflow, covering fork paths (closed, open, deleted fork, unusable head SHA, base retargeted at `main`, base in another repository, retargeted since the listing, does not touch `advisories/`), the open-PR cache contract, and regressions on the in-repository path (head deleted before base, `head_ref == base_ref`, bad head SHA still fails, reused head still returns 3 and preserves the base).

`actionlint`, `bash -n`, and `shellcheck` are clean.

## Review findings fixed in the second commit

A code review caught that the open-PR cache **never took effect**: `open_pr_targeting_base` was only called from a command substitution, so the global it assigned died with the subshell and the full paginated listing was refetched *per branch* — roughly 1,600 wasted requests per run, which would exhaust the token budget, fail every remaining pull request once it did, and leak a temp file per branch. The load now happens in `delete_staging_branch`, which runs in the caller's shell, and an unloaded cache is treated as a failed lookup rather than as "nothing is using this branch". Regression test asserts the listing is fetched **once per run**.

A security review found **no vulnerabilities**, and separately confirmed the same caching bug. It flagged one asymmetry: the check only considered pull requests using a branch as their *base*, not as their *head*. No open pull request is in that state today, but the curation flow can open a staging-branch → `main` pull request, so head refs are now indexed too — restricted to refs in this repository so a fork branch of the same name cannot mask a deletable staging branch. Both refs are already in the listing, so this costs no extra requests.

## Rollout

No new permissions, no new triggers. First scheduled sweep after merge will reconcile 400 and report `Deferred to the next sweep | 565` in the job summary; the backlog reaches zero after the third sweep, then the steady state is a handful per sweep as pull requests close.

Watch the first run's summary for a non-zero "Left in place" or "Pull request failures". Reverting restores the previous behavior; no branch deletion is irreversible in a way that loses data, since merged work is in `main` and closed pull requests retain their diffs.

## Still open, deliberately not addressed here

- **64 orphaned staging branches** whose pull request no longer exists. The sweep logs a warning and leaves them; there is no pull request left to validate against, so collecting them needs a separate decision.
- **99 branches** whose pull request targets `main` rather than its own staging branch — a different topology that this workflow was not written to reconcile.